### PR TITLE
Fix draft_vocab_size < #existing_tokens

### DIFF
--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -354,6 +354,14 @@ def process_token_dict_to_mappings(
             - d2t: A tensor mapping draft token ids to target token ids.
             - t2d: A tensor mapping target token ids to draft token ids.
     """
+    if len(token_dict) < draft_vocab_size:
+        existing_tokens = set(token_dict.keys())
+        missing_tokens = set(range(draft_vocab_size)) - existing_tokens
+        for token in missing_tokens:
+            token_dict[token] = 0
+            if len(token_dict) >= draft_vocab_size:
+                break
+
     total_frequency = sum(token_dict.values())
     top_N = token_dict.most_common(draft_vocab_size)
     top_N_frequency_sum = sum(freq for key, freq in top_N)


### PR DESCRIPTION
if the `draft_vocab_size` is larger then the number of unique tokens in the training set we will encounter the following error:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/mkamaleddine/SpecForge/scripts/train_eagle3_online.py", line 398, in <module>
[rank0]:     main()
[rank0]:   File "/home/mkamaleddine/SpecForge/scripts/train_eagle3_online.py", line 186, in main 
[rank0]:     draft_model.load_vocab_mapping(vocab_mapping_path)
[rank0]:   File "/home/mkamaleddine/SpecForge/specforge/modeling/draft/base.py", line 175, in load_vocab_mapping
[rank0]:     self.d2t.copy_(vocab_mapping["d2t"])
[rank0]: RuntimeError: The size of tensor a (32000) must match the size of tensor b (6054) at non-singleton dimension 0
```
This happens because the vocabulary mapping tensor (d2t) expects a size of draft_vocab_size, but the actual number of tokens in the dictionary is smaller.

This pull request resolves  this issue by extending token_dict with tokens with freq 0 to match the required  `draft_vocab_size`.



