### PR TITLE
fix: enable custom max_len for building offline dataset

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -151,6 +151,7 @@ def main():
         )
         train_eagle3_dataset = build_offline_eagle3_dataset(
             args.train_hidden_states_path,
+            args.max_length,
         )
 
     train_dataloader = prepare_dp_dataloaders(
@@ -169,6 +170,7 @@ def main():
     if args.eval_data_path is not None:
         eval_eagle3_dataset = build_offline_eagle3_dataset(
             args.eval_hidden_states_path,
+            args.max_length,
         )
         eval_dataloader = prepare_dp_dataloaders(
             eval_eagle3_dataset,

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -273,9 +273,11 @@ class OfflineEagle3Dataset(torch.utils.data.Dataset):
 
 def build_offline_eagle3_dataset(
     hidden_states_path: str,
+    max_len: int = 2048,
 ) -> torch.utils.data.Dataset:
     return OfflineEagle3Dataset(
         list_local_files(hidden_states_path),
+        max_len=max_len,
     )
 
 


### PR DESCRIPTION
When buildind offline datasets, `max_len` does not actually accept the custom value but always defaults to `2048`.
<img width="340" height="122" alt="image" src="https://github.com/user-attachments/assets/f1ea9594-ad3e-4c78-9306-227fe103d650" />