### PR TITLE
[BugFix] Fix calling `dist.get_rank` before `init_distributed` in `validate_wandb_args`

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -83,10 +83,7 @@ def parse_args():
 
     args = parser.parse_args()
 
-    # Validate wandb arguments
-    validate_wandb_args(parser, args)
-
-    return args
+    return parser, args
 
 
 def init_wandb(args):
@@ -106,10 +103,13 @@ def print_on_rank0(message):
 
 def main():
     # initialize
-    args = parse_args()
+    parser, args = parse_args()
     set_seed(args.seed)
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     print_with_rank(f"Initialized distributed environment")
+
+    # Validate wandb arguments
+    validate_wandb_args(parser, args)
 
     if args.wandb and dist.get_rank() == 0:
         init_wandb(args)

--- a/scripts/train_eagle3_online.py
+++ b/scripts/train_eagle3_online.py
@@ -86,10 +86,7 @@ def parse_args():
 
     args = parser.parse_args()
 
-    # Validate wandb arguments
-    validate_wandb_args(parser, args)
-
-    return args
+    return parser, args
 
 
 def init_wandb(args):
@@ -109,10 +106,13 @@ def print_on_rank0(message):
 
 def main():
     # initialize
-    args = parse_args()
+    parser, args = parse_args()
     set_seed(args.seed)
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     print_with_rank(f"Initialized distributed environment")
+
+    # Validate wandb arguments
+    validate_wandb_args(parser, args)
 
     if args.wandb and dist.get_rank() == 0:
         init_wandb(args)

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -32,7 +32,7 @@ def validate_wandb_args(parser, args):
     except (FileNotFoundError, netrc.NetrcParseError):
         pass
 
-    if args.wandb_key is None:
+    if args.wandb and args.wandb_key is None:
         if dist.get_rank() == 0:
             parser.error(
                 "When --wandb is enabled, you must provide a wandb API key via one of:\n"


### PR DESCRIPTION
After merging [PR #80](https://github.com/sgl-project/SpecForge/pull/80) , I discovered that the scripts `scripts/train_eagle3_offline.py` and `scripts/train_eagle3_online.py` fail to execute. The root cause is that `dist.get_rank()` is being called before `init_distributed()`, leading to initialization errors.
<img width="2309" height="834" alt="image" src="https://github.com/user-attachments/assets/905eb7a8-57e2-4a28-8021-697689ea9840" />
