### PR TITLE
Support setting dist_timeout for prepare_hidden_states.py

### DIFF
--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -14,6 +14,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 from datasets import Dataset, load_dataset
+from datetime import timedelta
 from sglang.bench_one_batch import BenchArgs, load_model
 from sglang.srt.entrypoints.engine import _set_envs_and_config
 from sglang.srt.layers.logits_processor import LogitsProcessor, LogitsProcessorOutput
@@ -324,7 +325,10 @@ def parse_args():
 
 def main():
     args = parse_args()
-    torch.distributed.init_process_group(backend="nccl")
+
+    # args.dist_timeout is defined in sglang.srt.server_args.ServerArgs
+    torch.distributed.init_process_group(backend="nccl",
+                                         timeout=timedelta(minutes=args.dist_timeout))
     assert os.path.exists(
         args.data_path
     ), f"Dataset path {args.data_path} does not exist"

--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -328,7 +328,7 @@ def main():
 
     # args.dist_timeout is defined in sglang.srt.server_args.ServerArgs
     torch.distributed.init_process_group(backend="nccl",
-                                         timeout=timedelta(minutes=args.dist_timeout))
+                                         timeout=timedelta(seconds=args.dist_timeout))
     assert os.path.exists(
         args.data_path
     ), f"Dataset path {args.data_path} does not exist"


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

#### Problem: Barrier Timeout in Large Dataset Processing​​
When processing large datasets with `prepare_hidden_states.py`, the default NCCL barrier timeout frequently triggers the following error:
<img width="2514" height="569" alt="image" src="https://github.com/user-attachments/assets/7f7dc086-f38d-414a-90d5-be9dedeba1fb" />


## Modifications

<!-- Describe the changes made in this PR. -->

#### Solution: Align Timeout with SGLang's Configuration​​
Since `sglang.srt.server_args.ServerArgs` already defines `--dist-timeout` (in seconds), we avoided redundant definitions by ​​reusing this existing parameter​​ in `init_process_group`. However, `--dist-timeout` in `train_eagle3_offline.py` & `train_eagle3_online.py` is in minutes.
After the fix, large date set works fine:
<img width="2510" height="456" alt="image" src="https://github.com/user-attachments/assets/5ed21a3f-c6cb-4be2-8e6d-51ba74558951" />


## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
