### PR TITLE
[Bugfix] Add check for dist-timeout

### DIFF
--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -327,7 +327,7 @@ def main():
     args = parse_args()
 
     # args.dist_timeout is defined in sglang.srt.server_args.ServerArgs and is in seconds.
-    if args.dist_timeout:
+    if args.dist_timeout is not None:
         if args.dist_timeout <= 0:
             raise ValueError(
                 f"--dist-timeout must be a positive number of seconds, but got {args.dist_timeout}"


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add check for dist-timeout when preparing offline training dataset.
cmd 
```
torchrun --nproc_per_node=8     scripts/prepare_hidden_states.py     --model-path /root/Qwen3-32B     --enable-aux-hidden-states     --data-path /mnt/sharegpt.jsonl     --chat-template qwen     --max-length 16384     --tp-size 8   --batch-size 4     --mem-frac=0.75     --num-samples 1000 
```
<img width="2108" height="906" alt="image" src="https://github.com/user-attachments/assets/5a883af1-5762-4522-bcf0-0ae38593e429" />

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
scripts/prepare_hidden_states.py
<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
