### PR TITLE
fix: do not save embedding layer to draft model weights

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -335,7 +335,7 @@ def main():
                 draft_model_state_dict = {
                     k.replace("draft_model.", ""): v
                     for k, v in model_state_dict.items()
-                    if "draft_model." in k
+                    if "draft_model." in k and "embed" not in k.lower()
                 }
 
                 if dist.get_rank() == 0:

--- a/scripts/train_eagle3_online.py
+++ b/scripts/train_eagle3_online.py
@@ -397,7 +397,7 @@ def main():
                 draft_model_state_dict = {
                     k.replace("draft_model.", ""): v
                     for k, v in model_state_dict.items()
-                    if "draft_model." in k
+                    if "draft_model." in k and "embed" not in k.lower()
                 }
 
                 if dist.get_rank() == 0:

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -1,10 +1,9 @@
 import json
 import os
-from typing import Optional, Union
 import warnings
+from typing import Optional, Union
 
 import torch
-from transformers import modeling_utils
 from transformers import AutoConfig
 from transformers import AutoModelForCausalLM as AutoModelForCausalLMBase
 from transformers import (
@@ -13,6 +12,7 @@ from transformers import (
     LlamaConfig,
     PretrainedConfig,
     Qwen3MoeConfig,
+    modeling_utils,
 )
 
 from specforge.utils import default_torch_dtype
@@ -43,32 +43,30 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         # get the model class from the
         _model_cls = cls._model_mapping[type(config)]
         return _model_cls(config)
-    
+
     @classmethod
     def from_pretrained(
         cls,
-        pretrained_model_name_or_path : Union[str, os.PathLike[str]],
+        pretrained_model_name_or_path: Union[str, os.PathLike[str]],
         *model_args,
-        **kwargs
+        **kwargs,
     ):
         original_warn = modeling_utils.logger.warning
-        
+
         def filtered_warning(msg):
             if "embed_tokens.weight" in str(msg) and "initialized" in str(msg):
                 return
             original_warn(msg)
-        
+
         modeling_utils.logger.warning = filtered_warning
-        
+
         try:
             model = super().from_pretrained(
-                pretrained_model_name_or_path,
-                *model_args,
-                **kwargs
+                pretrained_model_name_or_path, *model_args, **kwargs
             )
         finally:
             modeling_utils.logger.warning = original_warn
-            
+
         return model
 
 


### PR DESCRIPTION


## Motivation

SpecForge does not remove the weights of the Embedding layer when saving the Draft Model's weights.

## Modifications

- Do not save Draft Model's embedding layer
- Modify AutoEagle3DraftModel to suppress warnings for missing embedding layer

## Related Issues

Fixes #122 

## Accuracy Test

This PR does not affect model-side code .


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
