### PR TITLE
Added requirements.txt into source dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ cache/
 outputs/
 wandb/
 .idea
+
+# macOS
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -200,4 +200,3 @@ wandb/
 .DS_Store
 
 .vscode/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.11.10
     hooks:
       - id: ruff
         args: [--select=F401, --fixable=F401]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,12 @@ from setuptools import find_packages, setup
 
 def read_requirements():
     with open(f"requirements.txt", "r") as f:
-        lines = f.read().splitlines()
-        # Filter out pip options and comments
-        return [line for line in lines if not line.startswith('--') and not line.startswith('#') and line.strip()]
+        requirements = []
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith(('#', '--')):
+                requirements.append(line)
+        return requirements
 
 
 def read_readme():

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,8 @@ from setuptools import find_packages, setup
 
 def read_requirements():
     with open(f"requirements.txt", "r") as f:
-        requirements = []
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith(('#', '--')):
-                requirements.append(line)
-        return requirements
+        lines = (line.strip() for line in f)
+        return [line for line in lines if line and not line.startswith(('#', '--'))]
 
 
 def read_readme():

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 def read_requirements():
     with open(f"requirements.txt", "r") as f:
         lines = (line.strip() for line in f)
-        return [line for line in lines if line and not line.startswith(('#', '--'))]
+        return [line for line in lines if line and not line.startswith(("#", "--"))]
 
 
 def read_readme():

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,9 @@ from setuptools import find_packages, setup
 
 def read_requirements():
     with open(f"requirements.txt", "r") as f:
-        return f.read().splitlines()
+        lines = f.read().splitlines()
+        # Filter out pip options and comments
+        return [line for line in lines if not line.startswith('--') and not line.startswith('#') and line.strip()]
 
 
 def read_readme():

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -141,7 +141,7 @@ class AutoDraftModelConfig:
         """
         with open(config_path, "r") as f:
             config = json.load(f)
-        
+
         if "tie_word_embeddings" in config:
             print("Set draft model tie_word_embeddings to False")
             config["tie_word_embeddings"] = False


### PR DESCRIPTION
## Motivation

pip install specforge fails due to missing requirements.txt.

This fixes #131 

## Modifications

Added MANIFEST.in to include requirements.txt

## Testing

Ran `python -m build` 
Ran `pip install dist/specforge-0.1.0-py3-none-any.whl` successfully