### PR TITLE
Always set `tie_word_embeddings` to False in AutoDraftModelConfig

### DIFF
--- a/configs/qwen3-4b-eagle3.json
+++ b/configs/qwen3-4b-eagle3.json
@@ -21,7 +21,7 @@
   "rope_scaling": null,
   "rope_theta": 1000000,
   "sliding_window": null,
-  "tie_word_embeddings": true,
+  "tie_word_embeddings": false,
   "torch_dtype": "bfloat16",
   "transformers_version": "4.51.0",
   "use_cache": true,

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -143,6 +143,7 @@ class AutoDraftModelConfig:
             config = json.load(f)
         
         if "tie_word_embeddings" in config:
+            print("Set draft model tie_word_embeddings to False")
             config["tie_word_embeddings"] = False
 
         # check for architectures

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -141,6 +141,9 @@ class AutoDraftModelConfig:
         """
         with open(config_path, "r") as f:
             config = json.load(f)
+        
+        if "tie_word_embeddings" in config:
+            config["tie_word_embeddings"] = False
 
         # check for architectures
         architectures = config.get("architectures", None)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
In the configs/qwen3-4b-eagle3.json, "tie_embedding_weights" is set to true, which causes an issue when staring a resume.

When calling from_pretrained in huggingface, if tie_embedding_weights is true, it ties the lm_head's weight with embedding layer's weights. In doing so, it forces the draft's lm_head to match the shape of the target's
https://github.com/huggingface/transformers/blob/e446372f76fea9b2768c311286659420ec139348/src/transformers/modeling_utils.py#L5031

But in eagle3, the lm_head depends on draft_vocab_size. And in most cases, we'll be using a smaller draft_vocab_size. So it seems safer to always set tie_word_embeddings to false.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues
https://github.com/sgl-project/SpecForge/issues/139
<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
