### PR TITLE
Fix flex attention when seq_len < 128 RuntimeError: No valid triton configs. OutOfMemoryError

### DIFF
--- a/examples/run_llama3_eagle3_online.sh
+++ b/examples/run_llama3_eagle3_online.sh
@@ -19,9 +19,4 @@ torchrun \
     --max-length 2048 \
     --chat-template llama3 \
     --cache-dir $ROOT_DIR/cache \
-    # --logger-backend mlflow \
-    # --mlflow-experiment $USER/llama3-8b-eagle3-specforge \
-    # --mlflow-run-name $USER/llama3-8b-eagle3-specforge-run-$(date +%Y%m%d-%H%M%S) \
-    # --mlflow-tracking-uri http://mlflow.grid1.ard.grid.linkedin.com:31812 \
-    # --eval-data-split 0.01 \
     --attention-backend flex_attention

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch.nn.attention.flex_attention import create_block_mask
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from transformers import GenerationMixin, LlamaConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache
@@ -487,10 +487,12 @@ class LlamaFlexAttention(LlamaAttention):
         seq_lengths -= lck
         # TODO: Remove the usage of uncompiled create_block_mask after
         # https://github.com/pytorch/pytorch/issues/160018
-        if q_len > 128:
-            create_block_mask_func = compile_friendly_create_block_mask
-        else:
+        if q_len < 128:
             create_block_mask_func = create_block_mask
+            flex_attention_func = flex_attention
+        else:
+            create_block_mask_func = compile_friendly_create_block_mask
+            flex_attention_func = compile_friendly_flex_attention
 
         block_mask = create_block_mask_func(
             mask_mod=generate_eagle3_mask(
@@ -505,8 +507,7 @@ class LlamaFlexAttention(LlamaAttention):
             KV_LEN=key_cache.shape[-2],
             device=query_states.device,
         )
-
-        attn_output = compile_friendly_flex_attention(
+        attn_output = flex_attention_func(
             query=query_states,
             key=key_cache.contiguous(),
             value=value_cache.contiguous(),

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -487,7 +487,7 @@ class LlamaFlexAttention(LlamaAttention):
         seq_lengths -= lck
         # TODO: Remove the usage of uncompiled create_block_mask after
         # https://github.com/pytorch/pytorch/issues/160018
-        if q_len < 128:
+        if q_len <= 128:
             create_block_mask_func = create_block_mask
             flex_attention_func = flex_attention
         else:

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -44,7 +44,7 @@ class TestFlexAttention(unittest.TestCase):
         }
         self.config = LlamaConfig(**self.config_dict)
 
-        self.seq_lengths = [256, 300, 512, 800, 1024, 2048]
+        self.seq_lengths = [128, 200, 256, 300, 512, 800, 1024, 2048]
         self.dtype = torch.float32
 
     def test_forward_pass_comparison(self):

--- a/tests/test_flex_attention.py
+++ b/tests/test_flex_attention.py
@@ -44,7 +44,7 @@ class TestFlexAttention(unittest.TestCase):
         }
         self.config = LlamaConfig(**self.config_dict)
 
-        self.seq_lengths = [128, 256, 300, 512, 800, 1024, 2048]
+        self.seq_lengths = [256, 300, 512, 800, 1024, 2048]
         self.dtype = torch.float32
 
     def test_forward_pass_comparison(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Fix RuntimeError: No valid triton configs. OutOfMemoryError

## Modifications

Use non-compiled version for seq_len <= 128. This is acceptable as it won't use much memory.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test
test_eagle3_flex_mask (__main__.TestEagle3FlexMask) ... ok
test_backward_pass_gradient_comparison (__main__.TestFlexAttention)
Test backward pass comparing gradients between LlamaAttention and LlamaFlexAttention. ... ok
test_forward_pass_comparison (__main__.TestFlexAttention)
Test forward pass comparison between LlamaAttention and LlamaFlexAttention. ... ok

----------------------------------------------------------------------
Ran 3 tests in 15.825s

OK


<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
