### PR TITLE
Fix load_embedding from small target models

### DIFF
--- a/specforge/modeling/draft/base.py
+++ b/specforge/modeling/draft/base.py
@@ -127,7 +127,7 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
         Load the embedding of the draft model.
 
         Args:
-            model_path (str): Path to the target model. Can be either a Hugging Face 
+            model_path (str): Path to the target model. Can be either a Hugging Face
             repository ID or a local directory path containing the model files.
         """
         if os.path.exists(model_path):

--- a/specforge/modeling/draft/base.py
+++ b/specforge/modeling/draft/base.py
@@ -150,7 +150,9 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
                     self.embed_tokens.weight.copy_(state_dict[embedding_key])
                     return
 
-                raise FileNotFoundError(f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}")
+                raise FileNotFoundError(
+                    f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}"
+                )
             if len(index_json_path) > 1:
                 raise FileNotFoundError(
                     f"Multiple index.json files found in {model_path}"

--- a/specforge/modeling/draft/base.py
+++ b/specforge/modeling/draft/base.py
@@ -139,17 +139,18 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
             if len(index_json_path) == 0:
                 # No index.json found, look for single model file
                 safetensors_path = os.path.join(model_path, "model.safetensors")
-
                 if os.path.exists(safetensors_path):
-                    # Load from single safetensors file
                     with safe_open(safetensors_path, framework="pt") as f:
-                        emb_tokens = f.get_tensor(embedding_key)
-                    self.embed_tokens.weight.copy_(emb_tokens)
+                        self.embed_tokens.weight.copy_(f.get_tensor(embedding_key))
                     return
-                else:
-                    raise FileNotFoundError(
-                        f"No index.json, model.safetensors found in {model_path}"
-                    )
+
+                pytorch_model_path = os.path.join(model_path, "pytorch_model.bin")
+                if os.path.exists(pytorch_model_path):
+                    state_dict = torch.load(pytorch_model_path, map_location="cpu")
+                    self.embed_tokens.weight.copy_(state_dict[embedding_key])
+                    return
+
+                raise FileNotFoundError(f"No index.json, model.safetensors or pytorch_model.bin found in {model_path}")
             if len(index_json_path) > 1:
                 raise FileNotFoundError(
                     f"Multiple index.json files found in {model_path}"


### PR DESCRIPTION
## Modifications

- Fixed load_embedding for draft model when target model is small and can fit in single model.safetensors file (no index.json)

## Test

Tested online training works with qwen1.7b model

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
