### PR TITLE
Prepare hidden state script aux hidden state layers argument handle fix

### DIFF
--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -342,6 +342,11 @@ def main():
     else:
         torch.distributed.init_process_group(backend="nccl")
 
+    if args.aux_hidden_states_layers is not None:
+        args.aux_hidden_states_layers = [
+            int(layer) for layer in args.aux_hidden_states_layers.split(",")
+        ]
+
     assert os.path.exists(
         args.data_path
     ), f"Dataset path {args.data_path} does not exist"


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Currently the `--aux-hidden-state-layers` flag takes in a string, and the variable `args.aux_hidden_states_layers` is passed directly to the model's `set_eagle3_layers_to_capture` function which assumes the aux layer input to be a list of int.

## Modifications

Handle the aux hidden state layers properly before passed into model
