### PR TITLE
Optimize loss calculation with in-place gradients calculation ~40% memory save

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -57,7 +57,7 @@ def parse_args():
     parser.add_argument("--eval-data-path", type=str, default=None)
     parser.add_argument("--eval-hidden-states-path", type=str, default=None)
     parser.add_argument("--num-epochs", type=int, default=10)
-    parser.add_argument("--draft-global-batch-size", type=int, default=16)
+    parser.add_argument("--draft-global-batch-size", type=int, default=2)
     parser.add_argument("--draft-micro-batch-size", type=int, default=1)
     parser.add_argument("--learning-rate", type=float, default=1e-4)
     parser.add_argument("--max-length", type=int, default=2048)
@@ -174,7 +174,7 @@ def main():
     set_seed(args.seed)
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     print_with_rank("Initialized distributed environment")
-    args.dp_size = dist.get_world_size()
+    args.dp_size = dist.get_world_size() // args.tp_size
     args.draft_accumulation_steps = (
         args.draft_global_batch_size // args.dp_size // args.draft_micro_batch_size
     )

--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -57,7 +57,7 @@ def parse_args():
     parser.add_argument("--eval-data-path", type=str, default=None)
     parser.add_argument("--eval-hidden-states-path", type=str, default=None)
     parser.add_argument("--num-epochs", type=int, default=10)
-    parser.add_argument("--draft-global-batch-size", type=int, default=2)
+    parser.add_argument("--draft-global-batch-size", type=int, default=16)
     parser.add_argument("--draft-micro-batch-size", type=int, default=1)
     parser.add_argument("--learning-rate", type=float, default=1e-4)
     parser.add_argument("--max-length", type=int, default=2048)

--- a/specforge/benchmarks/benchmark_flex_attention.py
+++ b/specforge/benchmarks/benchmark_flex_attention.py
@@ -168,12 +168,10 @@ def benchmark_function(
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
                 torch.cuda.reset_peak_memory_stats()
-
         # Record initial memory
         initial_memory = 0
         if torch.cuda.is_available():
             initial_memory = torch.cuda.memory_allocated()
-
         hidden_states = [
             torch.randn(
                 BATCH_SIZE,
@@ -202,7 +200,6 @@ def benchmark_function(
         if torch.cuda.is_available():
             peak_memory = torch.cuda.max_memory_allocated()
             current_memory = torch.cuda.memory_allocated()
-
         results_per_seq_len.append(
             {
                 "seq_len": seq_len,
@@ -214,6 +211,9 @@ def benchmark_function(
 
         print(f"  Time: {end_time - start_time:.3f}s")
         print(f"  Peak memory: {peak_memory / 1024**3:.3f} GB")
+        print(
+            f"  Memory increase: {(current_memory - initial_memory) / 1024**3:.3f} GB"
+        )
 
     return results_per_seq_len
 

--- a/specforge/benchmarks/benchmark_loss.py
+++ b/specforge/benchmarks/benchmark_loss.py
@@ -1,0 +1,183 @@
+import argparse
+import gc
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+
+from specforge.core.loss import LogSoftmaxLoss, _compute_loss
+
+TTT_LENGTH = 7
+
+
+def benchmark_loss_method(
+    loss_method: str,
+    test_configs: list,
+):
+    """Benchmark a loss computation method for speed and GPU memory usage."""
+    print(f"\n=== Benchmarking {loss_method} Loss ===")
+
+    results = []
+
+    for config in test_configs:
+        B, T, V = config
+        print(f"\nTesting config: B={B}, T={T}, V={V}")
+
+        # Clear GPU cache
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats()
+
+        # Create tensors outside timing measurement
+        target = torch.softmax(
+            torch.randn(B, T, V, device="cuda", dtype=torch.float32), dim=-1
+        )
+        position_mask = torch.ones((B, T, 1), dtype=torch.bool, device="cuda")
+
+        # Pre-allocate logits tensors for each TTT step
+        logits_list = []
+        for i in range(TTT_LENGTH):
+            logits = torch.randn(
+                B, T, V, device="cuda", requires_grad=True, dtype=torch.float32
+            )
+            logits_list.append(logits)
+
+        torch.cuda.synchronize()  # Ensure all operations are complete
+        start_time = time.time()
+
+        plosses = []
+        for i in range(TTT_LENGTH):
+            logits = logits_list[i]
+            if loss_method == "triton":
+                loss = LogSoftmaxLoss.apply(logits, target, position_mask)
+            else:
+                loss = _compute_loss(logits, target, position_mask)
+            plosses.append(loss)
+
+        ploss_weight = [0.8**i for i in range(len(plosses))]
+        ploss = (
+            sum([ploss_weight[i] * plosses[i] for i in range(len(plosses))])
+            / TTT_LENGTH
+        )
+        ploss.backward()
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        end_time = time.time()
+        total_time = end_time - start_time
+        # Record memory usage
+        peak_memory = 0
+        if torch.cuda.is_available():
+            peak_memory = torch.cuda.max_memory_allocated()
+
+        results.append(
+            {
+                "B": B,
+                "T": T,
+                "V": V,
+                "time_total": total_time,
+                "peak_memory": peak_memory,
+            }
+        )
+
+        print(f"  Total time (forward + backward): {total_time*1000:.3f}ms")
+        print(f"  Peak memory: {peak_memory / 1024**3:.3f} GB")
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Benchmark loss computation methods")
+    parser.add_argument(
+        "--num-runs", type=int, default=5, help="Number of runs for averaging"
+    )
+    args = parser.parse_args()
+
+    print("PyTorch version:", torch.__version__)
+    if torch.cuda.is_available():
+        print("CUDA available:", torch.cuda.is_available())
+        print("GPU:", torch.cuda.get_device_name())
+        print(
+            "GPU memory:",
+            torch.cuda.get_device_properties(0).total_memory / 1024**3,
+            "GB",
+        )
+    else:
+        print("CUDA not available - running on CPU")
+
+    # Define test configurations (B, T, V)
+    test_configs = [
+        (1, 1024, 32000),
+        (1, 1024, 64000),
+        (1, 4096, 32000),
+        (1, 4096, 64000),
+        (1, 8192, 32000),
+        (1, 8192, 64000),
+        (1, 16384, 32000),
+    ]
+
+    print(f"Testing configurations: {test_configs}")
+
+    # Run benchmarks
+    print("\n" + "=" * 60)
+    pytorch_results = benchmark_loss_method("pytorch", test_configs)
+
+    print("\n" + "=" * 60)
+    triton_results = benchmark_loss_method("triton", test_configs)
+
+    # Print results summary
+    print(f"\n=== Performance Summary ===")
+    print(f"Configurations tested: {len(test_configs)}")
+
+    # Print detailed results table
+    print(
+        f"\n{'Config (B,T,V)':<15} {'PyTorch (ms)':<15} {'Triton (ms)':<15} {'Speedup':<10} {'PyTorch Mem (GB)':<18} {'Triton Mem (GB)':<15} {'Memory Save':<12}"
+    )
+    print("-" * 115)
+
+    for i, config in enumerate(test_configs):
+        B, T, V = config
+        config_str = f"({B},{T},{V})"
+
+        pytorch_result = next(
+            (r for r in pytorch_results if r["B"] == B and r["T"] == T and r["V"] == V),
+            None,
+        )
+        triton_result = next(
+            (r for r in triton_results if r["B"] == B and r["T"] == T and r["V"] == V),
+            None,
+        )
+
+        if pytorch_result and triton_result:
+            pytorch_time_str = f"{pytorch_result['time_total']*1000:.2f}"
+            pytorch_mem_str = f"{pytorch_result['peak_memory']/1024**3:.2f}"
+
+            triton_time_str = f"{triton_result['time_total']*1000:.2f}"
+            triton_mem_str = f"{triton_result['peak_memory']/1024**3:.2f}"
+
+            if triton_result["time_total"] > 0:
+                speedup = pytorch_result["time_total"] / triton_result["time_total"]
+                speedup_str = f"{speedup:.2f}x"
+            else:
+                speedup_str = "N/A"
+
+            # Calculate memory savings percentage
+            if pytorch_result["peak_memory"] > 0:
+                memory_save_pct = (
+                    (pytorch_result["peak_memory"] - triton_result["peak_memory"])
+                    / pytorch_result["peak_memory"]
+                ) * 100
+                memory_save_str = f"{memory_save_pct:.1f}%"
+            else:
+                memory_save_str = "N/A"
+
+            print(
+                f"{config_str:<15} {pytorch_time_str:<15} {triton_time_str:<15} {speedup_str:<10} {pytorch_mem_str:<18} {triton_mem_str:<15} {memory_save_str:<12}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -1,0 +1,244 @@
+"""
+This file incorporates code from Unsloth licensed under the Apache License, Version 2.0.
+See the original Unsloth repository at https://github.com/unslothai/unsloth.
+The idea of in-place backward pass is from Liger-Kernel.
+See the original Liger-Kernel repository at https://github.com/linkedin/Liger-Kernel.
+"""
+
+import torch
+import torch.nn as nn
+import triton
+import triton.language as tl
+
+
+# Reference implementation
+@torch.compile(dynamic=None)
+def _compute_loss(logits, target_p, position_mask):
+    logits = logits.float()
+    out_logp = nn.LogSoftmax(dim=2)(logits)
+    plogp = target_p * out_logp
+    loss = -torch.sum(position_mask * plogp, 2).mean()
+    return loss
+
+
+def _calculate_settings(n):
+    # reference: https://github.com/unslothai/unsloth/blob/fd753fed99ed5f10ef8a9b7139588d9de9ddecfb/unsloth/kernels/utils.py#L43
+
+    MAX_FUSED_SIZE = 65536
+    BLOCK_SIZE = triton.next_power_of_2(n)
+    if BLOCK_SIZE > MAX_FUSED_SIZE:
+        raise RuntimeError(
+            f"Cannot launch Triton kernel since n = {n} exceeds the recommended Triton blocksize = {MAX_FUSED_SIZE}."
+        )
+
+    num_warps = 4
+    if BLOCK_SIZE >= 32768:
+        num_warps = 32
+    elif BLOCK_SIZE >= 8192:
+        num_warps = 16
+    elif BLOCK_SIZE >= 2048:
+        num_warps = 8
+    return BLOCK_SIZE, num_warps
+
+
+@triton.jit
+def log_softmax_forward_kernel(
+    logits_ptr,
+    logits_stride,
+    target_ptr,
+    target_stride,
+    position_mask_ptr,
+    position_mask_stride,
+    loss_ptr,
+    loss_stride,
+    m_ptr,
+    d_ptr,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    program_id = tl.program_id(0).to(tl.int64)
+    logits_ptr += program_id * logits_stride
+    target_ptr += program_id * target_stride
+    position_mask_ptr += program_id * position_mask_stride
+    position_mask = tl.load(position_mask_ptr)
+    if position_mask == 0:
+        return
+
+    m = float("-inf")
+    d = 0.0
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        logits_block = tl.load(
+            logits_ptr + offsets, mask=mask, other=float("-inf")
+        ).cast(tl.float32)
+        # Find block maximum, but only from valid elements
+        block_max = tl.max(tl.where(mask, logits_block, float("-inf")))
+        m_new = tl.maximum(m, block_max)
+        # Update denominator with proper numerical stability
+        d = d * tl.exp(m - m_new) + tl.sum(
+            tl.where(mask, tl.exp(logits_block - m_new), 0.0)
+        )
+        m = m_new
+
+    loss = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        logits_block = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(
+            tl.float32
+        )
+        target_block = tl.load(target_ptr + offsets, mask=mask, other=0.0).cast(
+            tl.float32
+        )
+        # log-softmax: log(exp(x - max) / sum) = (x - max) - log(sum)
+        normalized_logits = logits_block - m
+        log_normalizer = tl.log(d)
+        log_softmax_logits = normalized_logits - log_normalizer
+        weighted_log_prob = target_block * log_softmax_logits
+        loss += tl.sum(tl.where(mask, weighted_log_prob, 0.0))
+
+    loss_ptr += program_id * loss_stride
+    m_ptr += program_id
+    d_ptr += program_id
+    tl.store(loss_ptr, -loss)
+    tl.store(m_ptr, m.to(tl.float32))
+    tl.store(d_ptr, d.to(tl.float32))
+
+
+@triton.jit
+def log_softmax_backward_kernel(
+    logits_ptr,
+    logits_stride,
+    target_ptr,
+    target_stride,
+    position_mask_ptr,
+    grad_output_ptr,
+    scaling_factor,
+    m_ptr,
+    d_ptr,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    program_id = tl.program_id(0).to(tl.int64)
+    logits_ptr += program_id * logits_stride
+    target_ptr += program_id * target_stride
+    position_mask_ptr += program_id
+
+    position_mask = tl.load(position_mask_ptr)
+    if position_mask == 0:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            tl.store(logits_ptr + offsets, 0.0, mask=mask)
+        return
+
+    m_ptr += program_id
+    d_ptr += program_id
+    m = tl.load(m_ptr).to(tl.float32)
+    d = tl.load(d_ptr).to(tl.float32)
+    grad_output = tl.load(grad_output_ptr).to(tl.float32)
+    grad_output = grad_output * scaling_factor
+
+    # First pass: compute sum of (target * grad_output)
+    target_grad_sum = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        target_block = tl.load(target_ptr + offsets, mask=mask, other=0.0).cast(
+            tl.float32
+        )
+        target_grad_sum += tl.sum(tl.where(mask, target_block * grad_output, 0.0))
+
+    # Second pass: compute log-softmax gradients
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        logits_block = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(
+            tl.float32
+        )
+        target_block = tl.load(target_ptr + offsets, mask=mask, other=0.0).cast(
+            tl.float32
+        )
+        softmax_prob = tl.exp(logits_block - m) / d
+        normalized_grad = softmax_prob * target_grad_sum
+        grad_block = -(target_block * grad_output - normalized_grad)
+        tl.store(logits_ptr + offsets, grad_block.to(tl.float32), mask=mask)
+
+
+class LogSoftmaxLoss(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, target, position_mask):
+        B, T, V = logits.shape
+        loss = torch.zeros((B * T, 1), device=logits.device)
+        logits_flat = logits.view(B * T, V).contiguous()
+        target_flat = target.view(B * T, V).contiguous()
+        position_mask_flat = position_mask.view(B * T, 1).contiguous().bool()
+        grid = (B * T,)
+        m = torch.zeros((B * T,), device=logits.device, dtype=torch.float32)
+        d = torch.zeros((B * T,), device=logits.device, dtype=torch.float32)
+        BLOCK_SIZE, num_warps = _calculate_settings(V)
+        log_softmax_forward_kernel[grid](
+            logits_flat,
+            logits_flat.stride(0),
+            target_flat,
+            target_flat.stride(0),
+            position_mask_flat,
+            position_mask_flat.stride(0),
+            loss,
+            loss.stride(0),
+            m,
+            d,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+
+        # Save for backward
+        ctx.save_for_backward(logits.detach(), target, position_mask, m, d)
+        return loss.squeeze(1).mean()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, target, position_mask, m, d = ctx.saved_tensors
+        B, T, V = logits.shape
+        # The reference uses .mean() which divides by B*T, not by number of valid positions
+        scaling_factor = 1.0 / (B * T)  # Match reference implementation exactly
+        logits = logits.view(B * T, V).contiguous()
+        target = target.view(B * T, V).contiguous()
+        position_mask = position_mask.view(B * T, 1).contiguous().bool()
+        grid = (B * T,)
+        BLOCK_SIZE, num_warps = _calculate_settings(V)
+        log_softmax_backward_kernel[grid](
+            logits,
+            logits.stride(0),
+            target,
+            target.stride(0),
+            position_mask,
+            grad_output,
+            scaling_factor,
+            m,
+            d,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        logits = logits.view(B, T, V)
+        return logits, None, None, None, None
+
+
+if __name__ == "__main__":
+    device = "cuda"
+    B, T, V = 1, 1024, 16000
+    logits = torch.randn(B, T, V, device=device, requires_grad=True)
+    logits2 = logits.clone().detach().requires_grad_(True)
+    target = torch.randn(B, T, V, device=device)
+    position_mask = torch.randint(0, 2, (B, T, 1), dtype=torch.bool, device=device)
+    position_mask = torch.ones((B, T, 1), dtype=torch.bool, device=device)
+    output1 = LogSoftmaxLoss.apply(logits, target, position_mask)
+    output2 = _compute_loss(logits2, target, position_mask)
+    torch.testing.assert_close(output1, output2, rtol=1e-4, atol=1e-4)
+    output1.backward()
+    output2.backward()
+    torch.testing.assert_close(logits.grad, logits2.grad, rtol=1e-4, atol=1e-4)

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -723,7 +723,7 @@ class LlamaDecoderLayer(nn.Module):
         self,
         input_emb: torch.Tensor,
         hidden_states: torch.Tensor,
-        cache_hidden: List[List[torch.Tensor]] = [],
+        cache_hidden: List[List[torch.Tensor]] = None,
         attention_mask: Optional[torch.Tensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Cache] = None,

--- a/tests/test_utils/test_flex_attention.py
+++ b/tests/test_utils/test_flex_attention.py
@@ -20,15 +20,11 @@ from specforge.modeling.draft.llama3_eagle import (
 )
 from specforge.utils import padding
 
+from .utils import norm_tensor
+
 dynamo.config.recompile_limit = 64
 TTT_LENGTH = 7
 torch.manual_seed(0)
-
-
-def norm_tensor(shape, device, dtype, std=0.02):
-    t = torch.empty(shape, device=device, dtype=dtype)
-    torch.nn.init.trunc_normal_(t, mean=0.0, std=std)
-    return t
 
 
 class TestFlexAttention(unittest.TestCase):

--- a/tests/test_utils/test_loss.py
+++ b/tests/test_utils/test_loss.py
@@ -1,0 +1,88 @@
+import unittest
+
+import torch
+import torch.nn as nn
+
+from specforge.core.loss import LogSoftmaxLoss, _compute_loss
+
+from .utils import norm_tensor
+
+
+class TestLogSoftmaxLoss(unittest.TestCase):
+
+    TTT_LENGTH = 7
+
+    def _test_loss_and_gradient_calculation(self, B, T, V):
+        if not torch.cuda.is_available():
+            device = "cpu"
+        else:
+            device = "cuda"
+
+        logits = norm_tensor((B, T, V), device, torch.float32)
+        logits2 = logits.clone().detach().requires_grad_(True)
+        target = norm_tensor((B, T, V), device, torch.float32)
+        position_mask = torch.randint(0, 2, (B, T, 1), dtype=torch.bool, device=device)
+
+        output1 = LogSoftmaxLoss.apply(logits, target, position_mask)
+        output2 = _compute_loss(logits2, target, position_mask)
+        torch.testing.assert_close(output1, output2, rtol=1e-4, atol=1e-4)
+
+        output1.backward()
+        output2.backward()
+        torch.testing.assert_close(logits.grad, logits2.grad, rtol=1e-4, atol=1e-4)
+
+    def test_loss(self):
+        B = [1, 2, 4]
+        T = [1024, 2048, 4096, 6000]
+        V = [4096, 8192, 10000]
+        for b in B:
+            for t in T:
+                for v in V:
+                    self._test_loss_and_gradient_calculation(b, t, v)
+
+    def test_ttt_loss_accumulation(self):
+        if not torch.cuda.is_available():
+            device = "cpu"
+        else:
+            device = "cuda"
+
+        B, T, V = 1, 1024, 3200
+        plosses = []
+        plosses_compare = []
+        logits_list = [
+            norm_tensor((B, T, V), device, torch.float32)
+            for _ in range(self.TTT_LENGTH)
+        ]
+        logits_list_copy = [
+            logits.clone().detach().requires_grad_(True) for logits in logits_list
+        ]
+        for i in range(self.TTT_LENGTH):
+            logits = logits_list[i]
+            logits2 = logits_list_copy[i]
+            target = norm_tensor((B, T, V), device, torch.float32)
+            position_mask = torch.randint(
+                0, 2, (B, T, 1), dtype=torch.bool, device=device
+            )
+
+            output1 = LogSoftmaxLoss.apply(logits, target, position_mask)
+            output2 = _compute_loss(logits2, target, position_mask)
+            torch.testing.assert_close(output1, output2, rtol=1e-4, atol=1e-4)
+            plosses.append(output1)
+            plosses_compare.append(output2)
+
+        ploss_weight = [0.8**i for i in range(len(plosses))]
+        ploss = (
+            sum([ploss_weight[i] * plosses[i] for i in range(len(plosses))])
+            / self.TTT_LENGTH
+        )
+        ploss_compare = (
+            sum([ploss_weight[i] * plosses_compare[i] for i in range(len(plosses))])
+            / self.TTT_LENGTH
+        )
+        torch.testing.assert_close(ploss, ploss_compare, rtol=1e-4, atol=1e-4)
+        ploss.backward()
+        ploss_compare.backward()
+        for i in range(self.TTT_LENGTH):
+            torch.testing.assert_close(
+                logits_list[i].grad, logits_list_copy[i].grad, rtol=1e-4, atol=1e-4
+            )

--- a/tests/test_utils/utils.py
+++ b/tests/test_utils/utils.py
@@ -1,0 +1,8 @@
+import torch
+import torch.nn.init
+
+
+def norm_tensor(shape, device, dtype, std=0.02):
+    t = torch.empty(shape, device=device, dtype=dtype, requires_grad=True)
+    torch.nn.init.trunc_normal_(t, mean=0.0, std=std)
+    return t


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The loss calculation on TTT steps of logits are taking up huge chunk of memory. According to the memory profiling, it is due to the intermediate tensors and gradients created during backward torch autograd.


<img width="1608" height="487" alt="Screenshot 2025-08-26 at 11 05 00 PM" src="https://github.com/user-attachments/assets/040bb7fa-1871-49ea-8fae-72a8270d4d3f" />


```??:0:torch::autograd::generated::EmbeddingBackward0::apply(std::vector<at::Tensor, std::allocator<at::Tensor> >&&)```



We would like to save the gradients into the logits instead of creating a separate tensor.

## Modifications

Added a triton implementation of log softmax calculation with in-place mod of input logits.


<!-- Describe the changes made in this PR. -->

## Related Issues

#112 
<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

Unit test added

## Benchmark & Profiling

```
Config (B,T,V)  PyTorch (ms)    Triton (ms)     Speedup    PyTorch Mem (GB)   Triton Mem (GB) Memory Save 
-------------------------------------------------------------------------------------------------------------------
(1,1024,32000)  449.08          435.22          1.03x      1.85               0.98            46.7%       
(1,1024,64000)  167.10          467.80          0.36x      3.68               2.81            23.4%       
(1,4096,32000)  127.67          7.03            18.15x     7.32               5.62            23.3%       
(1,4096,64000)  20.78           24.35           0.85x      14.65              11.23           23.3%       
(1,8192,32000)  20.48           13.56           1.51x      21.48              14.65           31.8%       
(1,8192,64000)  41.14           48.11           0.86x      29.30              22.46           23.3%       
(1,16384,32000) 41.11           26.95           1.53x      42.97              29.30           31.8%   
```

Also 50% faster

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
