### PR TITLE
Pass only `draft_model` into BF16Optimizer

### DIFF
--- a/scripts/train_eagle3_online.py
+++ b/scripts/train_eagle3_online.py
@@ -283,6 +283,10 @@ def main():
                 .eval()
                 .cuda()
             )
+
+    for p in target_model.parameters():
+        p.requires_grad = False
+
     print_with_rank("Initialized target model")
 
     # load model with resume


### PR DESCRIPTION
Target model weights are converted into fp32 and passed to AdamW just for no reason, which causes OOM