### PR TITLE
Fix FP32→BF16 redundant allocation during model init

### DIFF
--- a/scripts/train_eagle3_online.py
+++ b/scripts/train_eagle3_online.py
@@ -293,18 +293,19 @@ def main():
     if draft_model_last_checkpoint:
         draft_model = (
             AutoEagle3DraftModel.from_pretrained(
-                draft_model_last_checkpoint, attention_backend=args.attention_backend
+                draft_model_last_checkpoint, attention_backend=args.attention_backend,
+                torch_dtype=torch.bfloat16
             )
             .cuda()
-            .to(torch.bfloat16)
+            
         )
     else:
         draft_model = (
             AutoEagle3DraftModel.from_config(
-                draft_model_config, attention_backend=args.attention_backend
+                draft_model_config, attention_backend=args.attention_backend,
+                torch_dtype=torch.bfloat16
             )
             .cuda()
-            .to(torch.bfloat16)
         )
     draft_model.load_embedding(args.target_model_path, embedding_key=args.embedding_key)
     draft_model.freeze_embedding()

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -39,7 +39,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
     }
 
     @classmethod
-    def from_config(cls, config: PretrainedConfig,torch_dtype=None, **config_kwargs):
+    def from_config(cls, config: PretrainedConfig, torch_dtype=None, **config_kwargs):
         """
         This class method takes a configuration object and create its model based on the
         _model_mapping class variable.
@@ -54,7 +54,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         _model_cls = cls._model_mapping[type(config)]
         model = _model_cls(config, **config_kwargs)
 
-        #If a dtype is passed, convert it
+        # Convert model to specified dtype if provided
         if torch_dtype is not None:
             model = model.to(dtype=torch_dtype)
         return model

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -39,7 +39,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
     }
 
     @classmethod
-    def from_config(cls, config: PretrainedConfig, **config_kwargs):
+    def from_config(cls, config: PretrainedConfig,torch_dtype=None, **config_kwargs):
         """
         This class method takes a configuration object and create its model based on the
         _model_mapping class variable.
@@ -52,7 +52,12 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         """
         # get the model class from the
         _model_cls = cls._model_mapping[type(config)]
-        return _model_cls(config, **config_kwargs)
+        model = _model_cls(config, **config_kwargs)
+
+        #If a dtype is passed, convert it
+        if torch_dtype is not None:
+            model = model.to(dtype=torch_dtype)
+        return model
 
     @classmethod
     def from_pretrained(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Using `.cuda().to(torch.bfloat16)` causes FP32 weights to be moved to GPU and then reallocated in BF16, leaving both copies in memory during cast.
Peak memory usage (`Max Allocated`) significantly higher, and `Reserved` never drops due to allocator caching.
 Observed on qwen3-14B with its 1.3B draft model: ~4GB extra peak VRAM.
## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

Before (master branch):

Allocated: 10822.71 MB | Reserved: 15242 MB

After (this PR):

Allocated: 10822.71 MB | Reserved: 11092 MB


## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
