### PR TITLE
fix: handle None test_ds in skipped messages count

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -191,8 +191,9 @@ def process_and_save_ds(train_ds, test_ds, output_path, proc_fn, dataset_name):
                 f.write(json.dumps(row) + "\n")
 
     if total_skipped_count > 0:
+        total_messages = len(train_ds) + (len(test_ds) if test_ds is not None else 0)
         print(
-            f"Skipped {total_skipped_count}/{len(train_ds)+len(test_ds)} messages for {dataset_name}"
+            f"Skipped {total_skipped_count}/{total_messages} messages for {dataset_name}"
         )
 
 


### PR DESCRIPTION
## Motivation

The problem occurs when test_ds is None due to split-eval being False by default
<img width="983" height="155" alt="截屏2025-09-15 11 59 23" src="https://github.com/user-attachments/assets/959274b8-1a57-4a28-ada4-6db380772f79" />


## Modifications

Explicitly handles the case when test_ds is None

## Related Issues

## Accuracy Test
<img width="982" height="55" alt="截屏2025-09-15 13 10 14" src="https://github.com/user-attachments/assets/82516446-7a3c-4294-aa53-0b8d5897b72f" />


## Benchmark & Profiling


## Checklist

