### PR TITLE
Apply FSDP2 to offline training

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -9,8 +9,7 @@ import torch
 import torch.distributed as dist
 from accelerate.utils import set_seed
 from datasets import load_dataset
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import MixedPrecision, ShardingStrategy, StateDictType
+from torch.distributed.fsdp import fully_shard, MixedPrecisionPolicy
 from tqdm import tqdm
 from transformers import AutoTokenizer
 
@@ -21,7 +20,7 @@ from specforge.data import (
     generate_vocab_mapping_file,
     prepare_dp_dataloaders,
 )
-from specforge.distributed import destroy_distributed, get_dp_group, init_distributed
+from specforge.distributed import destroy_distributed, get_dp_group, init_distributed, get_dp_device_mesh
 from specforge.modeling.target.target_head import TargetHead
 from specforge.optimizer import BF16Optimizer
 from specforge.tracker import create_tracker, get_tracker_class
@@ -31,6 +30,7 @@ from specforge.utils import (
     print_on_rank0,
     print_with_rank,
     rank_0_priority,
+    get_full_optimizer_state,
 )
 
 
@@ -340,19 +340,10 @@ def main():
         length=args.ttt_length,
         attention_backend=args.draft_attention_backend,
     )
-    eagle3_model = FSDP(
-        eagle3_model,
-        use_orig_params=True,
-        mixed_precision=MixedPrecision(
-            param_dtype=torch.bfloat16,
-            buffer_dtype=torch.bfloat16,
-            reduce_dtype=torch.float32,
-            keep_low_precision_grads=False,
-        ),
-        sharding_strategy=ShardingStrategy.NO_SHARD,
-        ignored_modules=[],
-        process_group=get_dp_group(),
-    )
+    mp_policy = MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.float32)
+    fsdp_config = {"mesh": get_dp_device_mesh(), "mp_policy": mp_policy}
+    fully_shard(eagle3_model, **fsdp_config)
+
     print_with_rank(f"Initialized Eagle3 FSDP model")
     global_step, batch_index = 0, 0
     log_dict = defaultdict(float)
@@ -373,8 +364,8 @@ def main():
         # Run training
         train_dataloader.sampler.set_epoch(epoch + 1)
         draft_model.train()
-        epoch_acces = [[] for _ in range(eagle3_model.module.length)]
-        epoch_plosses = [[] for _ in range(eagle3_model.module.length)]
+        epoch_acces = [[] for _ in range(eagle3_model.length)]
+        epoch_plosses = [[] for _ in range(eagle3_model.length)]
 
         if dist.get_rank() == 0:
             progress_bar = tqdm(
@@ -530,33 +521,41 @@ def main():
                 os.makedirs(epoch_output_dir, exist_ok=True)
             dist.barrier()
 
-            with FSDP.state_dict_type(eagle3_model, StateDictType.FULL_STATE_DICT):
-                model_state_dict = eagle3_model.state_dict()
-                state_to_save = {
-                    "epoch": epoch,
-                    "args": args,
-                }
-                state_to_save.update(optimizer.state_dict())
-                draft_model_state_dict = {
-                    k.replace("draft_model.", ""): v
-                    for k, v in model_state_dict.items()
-                    if "draft_model." in k and "embed" not in k.lower()
-                }
+            model_state_dict = eagle3_model.state_dict()
 
-                if dist.get_rank() == 0:
-                    torch.save(
-                        state_to_save,
-                        os.path.join(epoch_output_dir, "training_state.pt"),
-                    )
-                    print_on_rank0(
-                        f"Saved full training state to {epoch_output_dir}/training_state.pt"
-                    )
-                    draft_model.save_pretrained(
-                        epoch_output_dir,
-                        state_dict=draft_model_state_dict,
-                    )
-                    print_on_rank0(f"Saved model configuration to {epoch_output_dir}")
-                dist.barrier()
+            state_to_save = {
+                "epoch": epoch,
+                "args": args,
+            }
+            
+            optimizer_state_dict = optimizer.state_dict()
+            optimizer_state_dict["optimizer_state_dict"] = get_full_optimizer_state(optimizer_state_dict["optimizer_state_dict"])
+            
+            state_to_save.update(optimizer_state_dict)
+
+            draft_model_state_dict = {
+                k.replace("draft_model.", ""): v
+                for k, v in model_state_dict.items()
+                if "draft_model." in k and "embed" not in k.lower()
+            }
+            for k, v in draft_model_state_dict.items():
+                if isinstance(v, torch.distributed.tensor.DTensor):
+                    draft_model_state_dict[k] = v.full_tensor()
+
+            if dist.get_rank() == 0:
+                torch.save(
+                    state_to_save,
+                    os.path.join(epoch_output_dir, "training_state.pt"),
+                )
+                print_on_rank0(
+                    f"Saved full training state to {epoch_output_dir}/training_state.pt"
+                )
+                draft_model.save_pretrained(
+                    epoch_output_dir,
+                    state_dict=draft_model_state_dict,
+                )
+                print_on_rank0(f"Saved model configuration to {epoch_output_dir}")
+            dist.barrier()
 
     # Close the tracker at the end of training
     tracker.close()

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -8,8 +8,8 @@ from specforge.utils import print_with_rank
 _DEVICE_MESH = None
 _TP_DEVICE_MESH = None
 _TP_GROUP = None
+_DP_DEVICE_MESH = None
 _DP_GROUP = None
-
 
 def get_tp_group():
     global _TP_GROUP
@@ -29,6 +29,10 @@ def get_device_mesh():
 def get_tp_device_mesh():
     global _TP_DEVICE_MESH
     return _TP_DEVICE_MESH
+
+def get_dp_device_mesh():
+    global _DP_DEVICE_MESH
+    return _DP_DEVICE_MESH
 
 
 def init_distributed(timeout: int = 10, tp_size: int = 1):
@@ -55,11 +59,12 @@ def init_distributed(timeout: int = 10, tp_size: int = 1):
 
     # we need to create a 1D submesh
     tp_device_mesh = dist.DeviceMesh.from_group(tp_group, device_type="cuda")
-    global _TP_GROUP, _DP_GROUP, _DEVICE_MESH, _TP_DEVICE_MESH
+    global _TP_GROUP, _DP_GROUP, _DEVICE_MESH, _TP_DEVICE_MESH, _DP_DEVICE_MESH
     _DEVICE_MESH = device_mesh
     _TP_GROUP = tp_group
     _TP_DEVICE_MESH = tp_device_mesh
     _DP_GROUP = dp_group
+    _DP_DEVICE_MESH = dist.DeviceMesh.from_group(dp_group, device_type="cuda")
 
 
 def destroy_distributed():


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
apply FSDP2 to the offline training pipeline.

On H100x4 GPUs, the training throughput shows an improvement of ~1.4× compared to the previous baseline.

The following command was used for testing
```
torchrun \
    --standalone \
    --nproc_per_node 4 \
    ./scripts/train_eagle3_offline.py \
    --target-model-path lmsys/gpt-oss-120b-bf16 \
    --draft-model-config ./configs/gpt-oss-120B-eagle3.json \
    --train-data-path ${TRAIN_DATA_PATH} \
    --train-hidden-states-path ${TRAIN_HS_PATH} \
    --output-dir ${OUTPUT_DIR} \
    --draft-global-batch-size 16 \
    --draft-micro-batch-size 1 \
    --num-epochs 10 \
    --learning-rate 1e-4 \
    --max-length 2048 \
    --chat-template gpt-oss
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
