### PR TITLE
fix: remove attention mask shift in flex attention implementation

### DIFF
--- a/specforge/modeling/draft/flex_attention.py
+++ b/specforge/modeling/draft/flex_attention.py
@@ -109,14 +109,14 @@ def compile_friendly_create_block_mask(
 
 
 def generate_eagle3_mask(
-    seq_lengths: torch.Tensor, Q_LEN: int, KV_LEN: int, shift_left: int = 0
+    seq_lengths: torch.Tensor, Q_LEN: int, KV_LEN: int, lck: int = 0
 ):
 
     def causal_mask(b, h, q_idx, kv_idx):
         # Causal will keep shrinking by 1 diagnol due to appended suffix
         # Shirnk the causal by diagnol
-        causal_mask = q_idx - shift_left >= kv_idx
-        padding_mask = kv_idx < seq_lengths[b]
+        causal_mask = q_idx >= kv_idx
+        padding_mask = (kv_idx < seq_lengths[b]) & (q_idx < seq_lengths[b])
         return causal_mask & padding_mask
 
     def suffix_mask(b, h, q_idx, kv_idx):
@@ -126,5 +126,5 @@ def generate_eagle3_mask(
         return suffix_mask & padding_mask & diagnol_mask
 
     mask_mod = or_masks(causal_mask, suffix_mask)
-    mask_mod.__name__ = f"eagle3_mask_Q_{Q_LEN}_KV_{KV_LEN}_shift_left_{shift_left}"
+    mask_mod.__name__ = f"eagle3_mask_Q_{Q_LEN}_KV_{KV_LEN}_lck_{lck}"
     return mask_mod

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -621,7 +621,7 @@ class LlamaFlexAttention(LlamaAttention):
                 seq_lengths=seq_lengths,
                 Q_LEN=q_len,
                 KV_LEN=key_cache.shape[-2],
-                shift_left=lck,
+                lck=lck,
             ),
             B=bsz,
             H=1,  # Rely on broadcast

--- a/tests/test_utils/test_flex_attention.py
+++ b/tests/test_utils/test_flex_attention.py
@@ -275,7 +275,7 @@ class TestEagle3FlexMask(unittest.TestCase):
         seq_lengths = torch.tensor([S], device="cuda", dtype=torch.int32)
         block_mask = compile_friendly_create_block_mask(
             mask_mod=generate_eagle3_mask(
-                seq_lengths=seq_lengths, Q_LEN=Q_LEN, KV_LEN=KV_LEN, shift_left=128 * 2
+                seq_lengths=seq_lengths, Q_LEN=Q_LEN, KV_LEN=KV_LEN, lck=128 * 2
             ),
             B=1,
             H=1,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The implementation of EAGLE-3 uses an unnecessary attention mask shift. Here's an example when lck(current ttt_length)=2.

<img width="507" height="236" alt="image" src="https://github.com/user-attachments/assets/a8e072ad-1f7b-43a8-8a48-46fcec5905bc" />

## Modifications

<!-- Describe the changes made in this PR. -->

Remove the attention shift:

<img width="505" height="234" alt="image" src="https://github.com/user-attachments/assets/db29fdc4-3246-4e9a-a7cc-055ebadaa681" />


## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
