### PR TITLE
Update server args in bench speedup

### DIFF
--- a/benchmarks/bench_model_speedup.py
+++ b/benchmarks/bench_model_speedup.py
@@ -202,7 +202,7 @@ def launch_sglang_server(
         sglang_args.extend(["--disable-radix-cache"])
 
     if server_args.ep_size:
-        sglang_args.extend(["--ep-size", server_args.ep_size])
+        sglang_args.extend(["--ep-size", str(server_args.ep_size)])
 
     if server_args.attention_backend:
         sglang_args.extend(["--attention-backend", server_args.attention_backend])

--- a/benchmarks/bench_model_speedup.py
+++ b/benchmarks/bench_model_speedup.py
@@ -198,8 +198,11 @@ def launch_sglang_server(
     if server_args.trust_remote_code:
         sglang_args.extend(["--trust-remote-code"])
 
-    if server_args.enable_ep_moe:
-        sglang_args.extend(["--enable-ep-moe"])
+    if server_args.disable_radix_cache:
+        sglang_args.extend(["--disable-radix-cache"])
+
+    if server_args.ep_size:
+        sglang_args.extend(["--ep-size", server_args.ep_size])
 
     if server_args.attention_backend:
         sglang_args.extend(["--attention-backend", server_args.attention_backend])


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

- `--enable-ep-moe ` is deprecated in SGLang, use `--ep-size` instead https://github.com/sgl-project/sglang/blob/4cb5a5235e49f08e9f47165fb7f95e35145fce43/python/sglang/srt/server_args.py#L2767
- add `--disable-radix-cache`
