### PR TITLE
[Bugfix] Resolve Triton `OutOfResources` error on AMD GPUs.

### DIFF
--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -38,6 +38,11 @@ def _calculate_settings(n):
         num_warps = 16
     elif BLOCK_SIZE >= 2048:
         num_warps = 8
+
+    # AMD GPU (ROCm)
+    if hasattr(torch.version, 'hip') and torch.version.hip is not None:
+        num_warps //= 2
+
     return BLOCK_SIZE, num_warps
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When I was training on AMD MI308X GPUs using this framework, I encountered the following issue:

```
File "/home/zhaode.wzd/workspace/SpecForge/scripts/train_eagle3_online.py", line 673, in <module>
main()
File "/home/zhaode.wzd/workspace/SpecForge/scripts/train_eagle3_online.py", line 512, in main
plosses, _, acces = eagle3_model(
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
return forward_call(*args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/distributed/fsdp/fully_sharded_data_parallel.py", line 854, in forward
output = self._fsdp_wrapped_module(*args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1773, in _wrapped_call_impl
return self._call_impl(*args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1784, in _call_impl
return forward_call(*args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/specforge/core/eagle3.py", line 271, in forward
loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/torch/autograd/function.py", line 576, in apply
return super().apply(*args, **kwargs)  # type: ignore[misc]
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/specforge/core/loss.py", line 180, in forward
log_softmax_forward_kernel[grid](
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/triton/runtime/jit.py", line 390, in <lambda>
return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/triton/runtime/jit.py", line 617, in run
kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/triton/compiler/compiler.py", line 498, in getattribute
self._init_handles()
File "/home/zhaode.wzd/.local/lib/python3.10/site-packages/triton/compiler/compiler.py", line 494, in _init_handles
raise OutOfResources(self.metadata.num_warps * warp_size, self.n_max_threads, "threads")
out of resource: threads, Required: 2048, Hardware limit: 1024. Reducing block sizes or num_stages may help.
```
## Modifications

Reuce the `num_warps` to fit the threads of AMD GPU.

## Related Issues

None

## Accuracy Test

None

## Benchmark & Profiling

None

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
