### PR TITLE
(feat) add eaglechat dataset.

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -37,6 +37,7 @@ def parse_args():
         choices=[
             "ultrachat",
             "sharegpt",
+            "eaglechat",
             "perfectblend",
             "magpie-qwen2.5-pro-1m-v0.1",
             "sharegpt4v",
@@ -180,7 +181,7 @@ def process_and_save_ds(train_ds, test_ds, output_path, proc_fn, dataset_name):
             if row is None:
                 continue
             total_skipped_count += skipped_count
-            f.write(json.dumps(row) + "\n")
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
     if test_ds is not None:
         test_output_jsonl_path = output_path.joinpath(f"{dataset_name}_test.jsonl")
@@ -190,7 +191,7 @@ def process_and_save_ds(train_ds, test_ds, output_path, proc_fn, dataset_name):
                 if row is None:
                     continue
                 total_skipped_count += skipped_count
-                f.write(json.dumps(row) + "\n")
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
     if total_skipped_count > 0:
         total_messages = len(train_ds) + (len(test_ds) if test_ds is not None else 0)
@@ -232,6 +233,9 @@ def main():
             print("Loading dataset from custom data path: ", args.data_path)
             ds = load_dataset_from_path(Path(args.data_path))
         proc_fn = process_sharegpt_row
+    elif args.dataset == "eaglechat":
+        ds = load_dataset("zhaode/EagleChat")["train"]
+        proc_fn = lambda row: (row, 0)
     elif args.dataset == "perfectblend":
         ds = load_dataset("mlabonne/open-perfectblend")["train"]
         ds = ds.map(add_index, with_indices=True)

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -40,7 +40,7 @@ def _calculate_settings(n):
         num_warps = 8
 
     # AMD GPU (ROCm)
-    if hasattr(torch.version, 'hip') and torch.version.hip is not None:
+    if hasattr(torch.version, "hip") and torch.version.hip is not None:
         num_warps //= 2
 
     return BLOCK_SIZE, num_warps

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -11,6 +11,7 @@ _TP_GROUP = None
 _DP_DEVICE_MESH = None
 _DP_GROUP = None
 
+
 def get_tp_group():
     global _TP_GROUP
     return _TP_GROUP
@@ -29,6 +30,7 @@ def get_device_mesh():
 def get_tp_device_mesh():
     global _TP_DEVICE_MESH
     return _TP_DEVICE_MESH
+
 
 def get_dp_device_mesh():
     global _DP_DEVICE_MESH

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -222,6 +222,7 @@ def create_draft_config_from_target(
 
     return output_path
 
+
 def get_full_optimizer_state(optimizer_state_dict: dict):
     """
     Convert optimizer state dict with DTensor to full tensors for saving


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR aims to extend the functionality of the data preparation script (scripts/prepare_data.py) by introducing support for the EagleChat dataset. 

EagleChat is a high-quality, meticulously curated bilingual (Chinese & English) conversational dataset for instruction fine-tuning. The primary goal of this dataset is to serve as a premium corpus to significantly enhance the comprehensive conversational abilities of Large Language Models, especially models like EAGLE.

We created this unique hybrid dataset by merging three widely-used, high-quality conversational datasets: ShareGPT, UltraChat 200k, and smoltalk-chinese. The data has been uniformly formatted and randomly shuffled. It has been empirically proven that fine-tuning the EAGLE model with EagleChat leads to significant performance improvements.


| Source Dataset | Number of Conversations |
| :------------------------ | :--------------------------------- |
| ShareGPT                  | 120,675                            |
| UltraChat                 | 207,865                            |
| smoltalk-chinese          | 710,564                            |
| **Total**          | **1,039,104**                      |

## Modifications

1. Added Support for EagleChat Dataset: Integrated the EagleChat dataset into the data preparation script. It can now be automatically downloaded from the Hugging Face Hub (zhaode/EagleChat) or loaded directly from a local file path.
2. Enabled Chinese Character Support in Output: Modified the JSON saving parameters (ensure_ascii=False) to ensure that non-ASCII characters, such as Chinese, are correctly serialized and saved in the output .jsonl files.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

N/A. This PR does not affect model-side code (e.g., kernels, model architecture). It is an extension to a data preprocessing script, so accuracy tests are not applicable.

## Benchmark & Profiling

To validate the effectiveness of the newly added `EagleChat` dataset, we conducted a series of benchmarks comparing its performance against models trained on `ShareGPT` and `UltraChat`. The primary goal was to measure the efficiency of speculative decoding, using **Acceptance Length (`acc_length`)** as the key metric. A higher `acc_length` indicates that the draft model's predictions are better aligned with the base model, leading to more efficient generation.

##### Methodology

*   **Base Model:** `Qwen3-4B-Instruct-2507`
*   **Training Datasets:** `EagleChat`, `ShareGPT`, and `UltraChat` were used to fine-tune separate instances of the base model.
*   **Evaluation:** We ran a comprehensive suite of benchmarks including `mtbench`, `gsm8k`, `humaneval`, etc., with varying numbers of draft tokens (`num_draft_tokens`).
*   **Metric:** Average `acc_length`.

##### Results

The results clearly demonstrate that the model fine-tuned on the `EagleChat` dataset consistently outperforms the models trained on `ShareGPT` and `UltraChat` across all tested benchmarks and configurations.

**Visual Comparison (Draft Tokens = 4):**
<img width="4200" height="2400" alt="image" src="https://github.com/user-attachments/assets/65c7aa1d-cb6b-453c-843c-691891df18ad" />

**Visual Comparison (Draft Tokens = 8):**
<img width="4200" height="2400" alt="image" src="https://github.com/user-attachments/assets/ec0d9655-4c20-4416-b775-978fb531ef9b" />

**Detailed Performance Table:**

|                  |   EagleChat |   ShareGPT |   UltraChat |   Best_Baseline |   Improvement |   Improvement (%) |
|:-----------------|------------:|-----------:|------------:|----------------:|--------------:|------------------:|
| ('ceval', 4)     |        1.90 |       1.17 |        1.08 |            1.17 |          0.74 |             63.07 |
| ('ceval', 8)     |        2.03 |       1.17 |        1.08 |            1.17 |          0.86 |             73.38 |
| ('cmmlu', 4)     |        1.90 |       1.17 |        1.08 |            1.17 |          0.73 |             62.20 |
| ('cmmlu', 8)     |        2.02 |       1.18 |        1.08 |            1.18 |          0.84 |             71.65 |
| ('gsm8k', 4)     |        2.19 |       1.89 |        1.77 |            1.89 |          0.30 |             15.89 |
| ('gsm8k', 8)     |        2.38 |       1.93 |        1.81 |            1.93 |          0.45 |             23.35 |
| ('humaneval', 4) |        2.25 |       2.00 |        1.86 |            2.00 |          0.25 |             12.28 |
| ('humaneval', 8) |        2.49 |       2.10 |        1.94 |            2.10 |          0.39 |             18.61 |
| ('math500', 4)   |        2.21 |       1.89 |        1.66 |            1.89 |          0.32 |             17.18 |
| ('math500', 8)   |        2.46 |       1.95 |        1.70 |            1.95 |          0.51 |             26.14 |
| ('mtbench', 4)   |        1.82 |       1.62 |        1.60 |            1.62 |          0.19 |             11.87 |
| ('mtbench', 8)   |        1.90 |       1.65 |        1.61 |            1.65 |          0.25 |             15.05 |

##### Conclusion

Both the quantitative data and the visual charts confirm that training with the `EagleChat` dataset leads to a significant and consistent improvement in speculative decoding efficiency. The higher acceptance length suggests that `EagleChat`'s data quality and structure contribute to a better-aligned draft model, making it a superior choice for this training task.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
