### PR TITLE
fix qwen3-8b-eagle3 max_position_embeddings

### DIFF
--- a/configs/qwen3-8b-eagle3.json
+++ b/configs/qwen3-8b-eagle3.json
@@ -11,7 +11,7 @@
   "hidden_size": 4096,
   "initializer_range": 0.02,
   "intermediate_size": 12288,
-  "max_position_embeddings": 2048,
+  "max_position_embeddings": 40960,
   "max_window_layers": 36,
   "model_type": "llama",
   "num_attention_heads": 32,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
I found that the [official Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B/blob/main/config.json#L14) config should be 40960, but [this file](https://github.com/sgl-project/SpecForge/blob/main/configs/qwen3-8b-eagle3.json#L14C3-L14C28) lists it as 2048. Setting "max_position_embeddings" to 2048 results in an extremely low average acceptance length when testing the model with SpecForge/benchmarks after training.For this reason, I changed "max_position_embeddings" in qwen3-8b-eagle.json to the official 40960.
## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->
https://github.com/sgl-project/SpecForge/issues/249

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->
This change will not affect the training accuracy, but it will affect the average acceptance length during testing. Below is a comparison of the average acceptance length before and after modifying "max_position_embeddings".
```
python3 -m sglang.launch_server \
    --model /target/model/path \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path /draft/model \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --mem-fraction-static 0.75 \
    --cuda-graph-max-bs 32 \
    --tp 8 \
    --trust-remote-code \
    --host 0.0.0.0 \
    --port 30000 \
    --dtype bfloat16
```
| max_position_embeddings | 2048 | 40960 |
|---------|---------|---------|
| AcceptLength | 1.296 | 2.738 |

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
