### PR TITLE
fix llama3 type rope

### DIFF
--- a/scripts/train_eagle3_offline.py
+++ b/scripts/train_eagle3_offline.py
@@ -241,9 +241,6 @@ def main():
         # Use provided config file
         draft_model_config = AutoDraftModelConfig.from_file(args.draft_model_config)
 
-    if draft_model_config.draft_vocab_size is None:
-        draft_model_config.draft_vocab_size = draft_model_config.vocab_size
-
     if draft_model_last_checkpoint:
         draft_model = (
             AutoEagle3DraftModel.from_pretrained(

--- a/scripts/train_eagle3_online.py
+++ b/scripts/train_eagle3_online.py
@@ -313,9 +313,6 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
         # Use provided config file
         draft_model_config = AutoDraftModelConfig.from_file(args.draft_model_config)
 
-    if draft_model_config.draft_vocab_size is None:
-        draft_model_config.draft_vocab_size = draft_model_config.vocab_size
-
     # detecting last ckpt for draft model
     draft_model_last_checkpoint = None
     if args.resume and os.path.isdir(args.output_dir):

--- a/scripts/train_eagle3_sgl_online.py
+++ b/scripts/train_eagle3_sgl_online.py
@@ -280,10 +280,6 @@ class SglOnlineEagle3Trainer:
         self.draft_model_config = AutoDraftModelConfig.from_file(
             self.args.draft_model_config
         )
-        if self.draft_model_config.draft_vocab_size is None:
-            self.draft_model_config.draft_vocab_size = (
-                self.draft_model_config.vocab_size
-            )
 
         self.draft_model_last_checkpoint = None
         if args.resume and os.path.isdir(args.output_dir):

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -170,4 +170,8 @@ class AutoDraftModelConfig:
         if architecture not in cls._config_mapping:
             raise ValueError(f"Architecture {architecture} not supported")
 
+        # If draft_vocab_size is not in config or is None, set draft_vocab_size to vocab_size
+        if "draft_vocab_size" not in config or config["draft_vocab_size"] is None:
+            config["draft_vocab_size"] = config.get("vocab_size", None)
+
         return cls._config_mapping[architecture].from_dict(config)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The Llama3 type RoPE (Rotary Position Embedding) computation in SpecForge differed from the implementation used in SGLang.
This pull request aligns SpecForge’s RoPE calculation with SGLang’s implementation (see [rotary_embedding.py#L913](https://github.com/moreh-dev/sglang/blob/90401cf7d243da5dcb4f2cef527e2b342ea468b5/python/sglang/srt/layers/rotary_embedding.py#L913)￼).

With this change, SpecForge models can now correctly utilize configurations such as [nvidia/gpt-oss-120b-Eagle3](https://huggingface.co/nvidia/gpt-oss-120b-Eagle3/blob/main/config.json)￼ for training.


## Modifications
- Updated `train_eagle3_offline.py`, `train_eagle3_online.py`, and `train_eagle3_sgl_online.py` to set draft_vocab_size equal to the target model’s vocab size when it is null in the config.
- Modified `llama3_eagle.py` to align Llama3-type RoPE computation with SGLang’s implementation.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
