### PR TITLE
add  default build_dataset_num_proc value

### DIFF
--- a/examples/run_deepseek_v2_lite_eagle3_online.sh
+++ b/examples/run_deepseek_v2_lite_eagle3_online.sh
@@ -4,6 +4,7 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 # train eagle3 for deepseek-v2-lite
 NUM_GPUS=${1:-8}
 TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -12,6 +13,7 @@ torchrun \
     --target-model-path deepseek-ai/DeepSeek-V2-Lite \
     --draft-model-config $ROOT_DIR/configs/deepseek-v2-lite-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/deepseek-v2-lite-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_gpt_oss_120b_eagle3_online.sh
+++ b/examples/run_gpt_oss_120b_eagle3_online.sh
@@ -4,6 +4,7 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 # train eagle3 for GPT-OSS-120B
 NUM_GPUS=${1:-8}
 TP_SIZE=${2:-8}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -12,6 +13,7 @@ torchrun \
     --target-model-path openai/gpt-oss-120b \
     --draft-model-config $ROOT_DIR/configs/gpt-oss-20B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/perfect-blend-gptoss-20B.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/gpt-oss-20b-eagle3 \
     --tp-size $TP_SIZE \
     --target-model-backend sglang \

--- a/examples/run_gpt_oss_20b_eagle3_online.sh
+++ b/examples/run_gpt_oss_20b_eagle3_online.sh
@@ -4,6 +4,7 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 # train eagle3 for GPT-OSS-20B
 NUM_GPUS=${1:-8}
 TP_SIZE=${2:-2}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -12,6 +13,7 @@ torchrun \
     --target-model-path openai/gpt-oss-20b \
     --draft-model-config $ROOT_DIR/configs/gpt-oss-20B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/perfect-blend-gptoss-20B.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/perfect-blend-gptoss-20b-eagle3 \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_llama3.1_8b_eagle3_offline.sh
+++ b/examples/run_llama3.1_8b_eagle3_offline.sh
@@ -2,6 +2,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$(dirname $SCRIPT_DIR)
 NUM_GPUS=${1:-1}
 TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 # generate hidden states
 torchrun \
@@ -26,6 +27,7 @@ torchrun \
     --draft-model-config $ROOT_DIR/configs/llama3-8B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
     --train-hidden-states-path $ROOT_DIR/cache/hidden_states/sharegpt_train_Llama-3.1-8B-Instruct \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/llama3-8b-eagle3-sharegpt-offline \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_llama3.1_8b_eagle3_online.sh
+++ b/examples/run_llama3.1_8b_eagle3_online.sh
@@ -5,6 +5,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # train eagle3 for llama3.1-8b
 NUM_GPUS=${1:-1}
 TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -13,6 +14,7 @@ torchrun \
     --target-model-path meta-llama/Llama-3.1-8B-Instruct \
     --draft-model-config $ROOT_DIR/configs/llama3-8B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/llama3-8b-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_llama3.3_70b_eagle3_online.sh
+++ b/examples/run_llama3.3_70b_eagle3_online.sh
@@ -4,6 +4,7 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 # train eagle3 for llama3.1-8b
 NUM_GPUS=${1:-8}
 TP_SIZE=${2:-4}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -12,6 +13,7 @@ torchrun \
     --target-model-path meta-llama/Llama-3.3-70B-Instruct \
     --draft-model-config $ROOT_DIR/configs/llama3-70B-ealge3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/llama3.3-70b-eagle3 \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_llama4_scout_eagle3_online.sh
+++ b/examples/run_llama4_scout_eagle3_online.sh
@@ -4,6 +4,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 
 # train eagle3 for llama3.1-8b
 NUM_GPUS=${1:-8}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -12,6 +13,7 @@ torchrun \
     --target-model-path meta-llama/Llama-4-Scout-17B-16E-Instruct \
     --draft-model-config $ROOT_DIR/configs/llama4-scout-17B-16E-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/llama4-scout-17B-16E-eagle3 \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_phi4_eagle3_online.sh
+++ b/examples/run_phi4_eagle3_online.sh
@@ -5,6 +5,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 
 NUM_GPUS=${1:-1}
 TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -13,6 +14,7 @@ torchrun \
     --target-model-path microsoft/phi-4 \
     --draft-model-config $ROOT_DIR/configs/phi4-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/phi4-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_qwen2.5_7b_vl_eagle3_online.sh
+++ b/examples/run_qwen2.5_7b_vl_eagle3_online.sh
@@ -5,6 +5,7 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 
 # support tp1 train eagle3 for qwen2.5-vl-7b-instruct
 NUM_GPUS=${1:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -13,6 +14,7 @@ torchrun \
     --target-model-path Qwen/Qwen2.5-VL-7B-Instruct \
     --draft-model-config $ROOT_DIR/configs/qwen2-5-vl-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/allava4v_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/Qwen2.5-VL-7B-eagle3 \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_qwen3_235b_a22b_eagle3.sh
+++ b/examples/run_qwen3_235b_a22b_eagle3.sh
@@ -5,23 +5,25 @@ ROOT_DIR=$(dirname $SCRIPT_DIR)
 export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 
 # support tp4/tp8 train eagle3 for Qwen3-30B-A3B
-NUM_GPUS=${1:-4}
-TP_SIZE=${2:-4}
+NUM_GPUS=8
+TP_SIZE=4
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
     --nproc_per_node $NUM_GPUS \
     $ROOT_DIR/scripts/train_eagle3.py \
-    --target-model-path Qwen/Qwen3-235B-A22B-Instruct-2507 \
-    --draft-model-config $ROOT_DIR/configs/qwen3-235B-A22B-eagle3.json \
-    --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
-    --output-dir $ROOT_DIR/outputs/qwen3-235b-a22b-instruct-eagle3-sharegpt \
-    --num-epochs 10 \
+    --target-model-path /workdir/huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct-FP8/\
+    --draft-model-config $ROOT_DIR/configs/qwen3-next-80b-a3b-eagle3.json \
+    --train-data-path /workdir/data_qwen80b/qwen3_80b_perfectblend_train_regen.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
+    --output-dir /workdir/qwen3-80b-regen-blend \
+    --num-epochs 2 \
     --batch-size 1 \
     --learning-rate 1e-4 \
     --max-length 4096 \
     --chat-template qwen \
-    --cache-dir $ROOT_DIR/cache \
+    --cache-dir /workdir/cache \
     --embedding-key model.embed_tokens.weight \
     --tp-size $TP_SIZE \
     --target-model-backend sglang

--- a/examples/run_qwen3_30b_a3b_eagle3_online.sh
+++ b/examples/run_qwen3_30b_a3b_eagle3_online.sh
@@ -7,6 +7,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # support tp4/tp8 train eagle3 for Qwen3-30B-A3B
 NUM_GPUS=${1:-4}
 TP_SIZE=${2:-4}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -15,6 +16,7 @@ torchrun \
     --target-model-path Qwen/Qwen3-30B-A3B-Instruct-2507 \
     --draft-model-config $ROOT_DIR/configs/qwen3-30B-A3B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/qwen3-30b-a3b-instruct-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_qwen3_8b_eagle3_online.sh
+++ b/examples/run_qwen3_8b_eagle3_online.sh
@@ -7,6 +7,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # support tp8 train eagle3 for Qwen3-4B/8B/32B up to tp_size = 8
 NUM_GPUS=${1:-1}
 TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -15,6 +16,7 @@ torchrun \
     --target-model-path Qwen/Qwen3-8B \
     --draft-model-config $ROOT_DIR/configs/qwen3-8b-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/qwen3-8b-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \

--- a/examples/run_qwen3_coder_30b_a3b_eagle3_online.sh
+++ b/examples/run_qwen3_coder_30b_a3b_eagle3_online.sh
@@ -10,6 +10,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # GPU Configuration - Use the later 4 GPUs (4,5,6,7)
 export CUDA_VISIBLE_DEVICES=4,5,6,7
 NUM_GPUS=4
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -18,6 +19,7 @@ torchrun \
     --target-model-path Qwen/Qwen3-Coder-30B-A3B-Instruct \
     --draft-model-config $ROOT_DIR/configs/qwen3-coder-30B-A3B-instruct-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/opc_regenerated.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/qwen3-coder-30b-a3b-instruct-eagle3-opc-regen \
     --num-epochs 2 \
     --batch-size 1 \

--- a/examples/run_qwen3_coder_eagle3_offline.sh
+++ b/examples/run_qwen3_coder_eagle3_offline.sh
@@ -5,6 +5,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # train eagle3 for qwen3-coder
 NUM_GPUS=${1:-8}
 TP_SIZE=${2:-8}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -14,6 +15,7 @@ torchrun \
     --draft-model-config $ROOT_DIR/configs/qwen3-coder-480B-A35B-instruct-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/opc.jsonl \
     --train-hidden-states-path $ROOT_DIR/cache/hidden_states \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/Qwen3-Coder-480B-A35B-Instruct \
     --num-epochs 10 \
     --draft-micro-batch-size 1 \

--- a/examples/run_qwq_eagle3_online.sh
+++ b/examples/run_qwq_eagle3_online.sh
@@ -6,6 +6,7 @@ export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 # train eagle3 for qwq-32b
 NUM_GPUS=${1:-4}
 TP_SIZE=${2:-4}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
 torchrun \
     --standalone \
@@ -14,6 +15,7 @@ torchrun \
     --target-model-path Qwen/QwQ-32B \
     --draft-model-config $ROOT_DIR/configs/qwq-32B-eagle3.json \
     --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
     --output-dir $ROOT_DIR/outputs/qwq-32b-eagle3-sharegpt \
     --num-epochs 10 \
     --batch-size 1 \


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
add default value for build_dataset_num_proc

## Modifications

all example scripts

## Accuracy Test

Map (num_proc=64): 14%|█▎ | 192000/1416784 [01:16<07:43, 2640.48 examples/s]
Map (num_proc=8): 3%|▎ | 48000/1416784 [02:13<29:54, 762.88 examples/s]

Based on my test, 64 processes achieved roughly a 4+× speedup over 8 processes.
