### PR TITLE
feat: add support for Qwen3-Coder-480B-A35B-Instruct-FP8 training

### DIFF
--- a/examples/run_qwen3_coder_eagle3_online.sh
+++ b/examples/run_qwen3_coder_eagle3_online.sh
@@ -1,0 +1,33 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+
+# train eagle3 for qwen3-coder
+NUM_GPUS=${1:-8}
+TP_SIZE=${2:-8}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
+
+torchrun \
+    --standalone \
+    --nproc_per_node $NUM_GPUS \
+    $ROOT_DIR/scripts/train_eagle3.py \
+    --target-model-path Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 \
+    --draft-model-config $ROOT_DIR/configs/qwen3-coder-480B-A35B-instruct-eagle3.json \
+    --train-data-path $ROOT_DIR/cache/dataset/opc_regenerated.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
+    --output-dir $ROOT_DIR/outputs/Qwen3-Coder-480B-A35B-Instruct-FP8 \
+    --tp-size $TP_SIZE \
+    --sglang-ep-size 2 \
+    --num-epochs 10 \
+    --batch-size 1 \
+    --learning-rate 1e-5 \
+    --ttt-length 13 \
+    --sglang-mem-fraction-static 0.6 \
+    --max-length 2048 \
+    --chat-template qwen \
+    --target-model-backend sglang \
+    --save-interval 20000 \
+    --eval-interval 20000 \
+    --report-to wandb \
+    --wandb-project specforge-qwen3-480-coder-fp8 \
+    --wandb-name qwen3-coder-480b-a35b-eagle3-tp8-ep2-opc-regen

--- a/specforge/modeling/target/sglang_backend/patch.py
+++ b/specforge/modeling/target/sglang_backend/patch.py
@@ -133,7 +133,6 @@ def initialize_model_parallel(
         torch_compile=torch_compile,
     )
 
-    parallel_state._MOE_TP = parallel_state._TP
     if duplicate_tp_group:
         assert (
             parallel_state._PDMUX_PREFILL_TP_GROUP is None
@@ -176,6 +175,27 @@ def initialize_model_parallel(
         use_custom_allreduce=False,
         group_name="moe_ep",
     )
+
+    assert (
+        parallel_state._MOE_TP is None
+    ), "moe tensor model parallel group is already initialized"
+    if moe_ep_size == 1:
+        parallel_state._MOE_TP = parallel_state._TP
+    else:
+        group_ranks = []
+        for i in range(num_tensor_model_parallel_groups):
+            for j in range(moe_ep_size):
+                st = i * tensor_model_parallel_size + j * moe_tp_size
+                en = i * tensor_model_parallel_size + (j + 1) * moe_tp_size
+                ranks = list(range(st, en))
+                group_ranks.append(ranks)
+        parallel_state._MOE_TP = init_model_parallel_group(
+            group_ranks,
+            parallel_state._WORLD.local_rank,
+            backend,
+            use_custom_allreduce=False,
+            group_name="moe_tp",
+        )
 
     # Build the pipeline model-parallel groups.
     num_pipeline_model_parallel_groups: int = (


### PR DESCRIPTION
## Motivation

This PR adds training support for **Qwen3-Coder-480B-A35B-Instruct-FP8** with expert parallelism (EP) enabled, and fixes an issue in MOE tensor-parallel group initialization when `ep_size > 1`.

---

## Modifications

- Add an example training script for Qwen3-Coder-480B FP8 using EAGLE3 with EP support.
- Fix MOE tensor-parallel group initialization to correctly handle `moe_ep_size > 1`.
      Updated initialize_model_parallel in specforge/modeling/target/sglang_backend/patch.py
      
      Correctly constructs MOE TP groups when expert parallelism is enabled:
      
      Explicitly builds MOE TP groups per EP shard
      
      Avoids incorrectly reusing the global TP group when moe_ep_size > 1
      
      This ensures correct collective behavior and parallel semantics for MoE layers under EP.

---

## Related Issues

N/A

---

## Accuracy Test

This PR does not change model computation or kernels. No accuracy impact is expected.

---

## Benchmark & Profiling

This PR is not intended as a performance optimization and does not include new benchmark results.

---

## Checklist

- [x] Code changes are minimal and backward-compatible
- [ ] Unit tests (not added)
- [ ] Accuracy / benchmark results (not applicable)
