### PR TITLE
fix: prevent draft_model_config being overwritten by config path string.

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -364,7 +364,7 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
 
     draft_model.load_embedding(args.target_model_path, embedding_key=args.embedding_key)
     draft_model.freeze_embedding()
-    draft_model_config = AutoDraftModelConfig.from_file(draft_model_config)
+    draft_model_config = AutoDraftModelConfig.from_file(draft_model_config) if isinstance(draft_model_config, str) else draft_model_config
     return draft_model_config, draft_model
 
 


### PR DESCRIPTION
## Motivation
When providing `--ckpt_dir`, the variable `draft_model_config` could be overwritten with a string path (`config.json`) instead of remaining an `AutoDraftModelConfig` object. This led to an `AttributeError` later in training when accessing attributes such as `draft_model_config.vocab_size`.

The issue breaks the training pipeline and makes it impossible to resume or finetune from an existing checkpoint directory.


## Modifications
Ensured `draft_model_config` always remains an `AutoDraftModelConfig` instance

## Related Issues

## Accuracy Test

## Benchmark & Profiling

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
