### PR TITLE
fix draft config loading

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -352,7 +352,9 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
     draft_model_last_checkpoint = None
     if args.ckpt_dir is not None:
         if os.path.isdir(args.ckpt_dir):
-            draft_model_config = os.path.join(args.ckpt_dir, "config.json")
+            draft_model_config = AutoDraftModelConfig.from_file(
+                os.path.join(args.ckpt_dir, "config.json")
+            )
             draft_model_last_checkpoint = args.ckpt_dir
             print_on_rank0(f"Finetuning from base model: {draft_model_last_checkpoint}")
         else:


### PR DESCRIPTION

## Motivation

Root Cause
In the build_draft_model() function at line 350, when --ckpt-dir is provided, the code incorrectly assigns a string path to draft_model_config instead of loading the config object:

Line 350 (before fix)
draft_model_config = os.path.join(args.ckpt_dir, "config.json")  # This is a string!
This causes the error later at line 414 when trying to access draft_model_config.vocab_size.
Solution
Replace line 350 with proper config loading:

Fixed code
draft_model_config = AutoDraftModelConfig.from_file(
    os.path.join(args.ckpt_dir, "config.json")
)

## Modifications

scripts/train_eagle3.py





## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
