### PR TITLE
Fix script names in training instructions

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -34,7 +34,7 @@ python scripts/prepare_data.py --dataset sharegpt
 
 ```bash
 # train llama3-8B-instruct
-bash ./examples/run_llama3_eagle3.1_8b_online.sh
+bash ./examples/run_llama3.1_8b_eagle3_online.sh
 ```
 
 ## 💨 Offline Training
@@ -49,10 +49,10 @@ Same as above
 
 ```bash
 # train llama3-8B-instruct in an offline manner
-bash ./examples/run_llama3_eagle3.1_8b_offline.sh
+bash ./examples/run_llama3.1_8b_eagle3_offline.sh
 ```
 
-It is important to note that the `run_llama3_eagle3_offline.sh` script consists of two steps:
+It is important to note that the `run_llama3.1_8b_eagle3_offline.sh` script consists of two steps:
 
 1. Generate the hidden states using the `prepare_hidden_states.py` script. This script will generate the hidden states for the test and train datasets and save them to the disk.
 2. Train the model: suppling the `--train-hidden-states-path` argument to the script so that the script will load the hidden states from the disk during training.


### PR DESCRIPTION
Updated script names for training commands in the documentation.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
