### PR TITLE
dLLM (DFlash) Online Training in SpecForge

### DIFF
--- a/configs/qwen3-8b-dflash.json
+++ b/configs/qwen3-8b-dflash.json
@@ -1,0 +1,41 @@
+{
+  "architectures": [
+    "DFlashDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "modeling_dflash.DFlashDraftModel"
+  },
+  "block_size": 16,
+  "bos_token_id": 151643,
+  "dtype": "bfloat16",
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 4096,
+  "initializer_range": 0.02,
+  "intermediate_size": 12288,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "max_position_embeddings": 40960,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 36,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/examples/run_qwen3_8b_dflash_online.sh
+++ b/examples/run_qwen3_8b_dflash_online.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+export SPECFORGE_DATA_NUM_PROC=32
+NUM_GPUS=${1:-1}
+
+torchrun \
+    --standalone \
+    --nproc_per_node $NUM_GPUS \
+    $ROOT_DIR/scripts/train_dflash.py \
+    --target-model-path Qwen/Qwen3-8B \
+    --draft-config-path $ROOT_DIR/configs/qwen3-8b-dflash.json \
+    --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --output-dir $ROOT_DIR/outputs/qwen3-8b-dflash-sharegpt \
+    --num-epochs 20 \
+    --batch-size 4 \
+    --learning-rate 1e-4 \
+    --max-length 2048 \
+    --chat-template qwen \
+    --log-interval 50 \
+    --save-interval 1000 \
+    --report-to wandb \
+    --wandb-project specforge-qwen3-8b-dflash \
+    --wandb-name qwen3-8b-dflash-sharegpt

--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+# coding=utf-8
+"""DFlash Training Script."""
+
+import argparse
+import logging
+import math
+import os
+import shutil
+import time
+import warnings
+from typing import Optional, Tuple
+
+import torch
+import torch.distributed as dist
+from accelerate.utils import set_seed
+from datasets import load_dataset
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, ShardingStrategy, StateDictType
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from transformers import AutoConfig, AutoTokenizer
+
+from specforge.args import SGLangBackendArgs, TrackerArgs
+from specforge.core.dflash import OnlineDFlashModel
+from specforge.data import build_eagle3_dataset, prepare_dp_dataloaders
+from specforge.distributed import destroy_distributed, get_dp_group, init_distributed
+from specforge.modeling.draft.dflash import DFlashDraftModel
+from specforge.modeling.target.dflash_target_model import (
+    DFlashTargetModel,
+    get_dflash_target_model,
+)
+from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
+from specforge.optimizer import BF16Optimizer
+from specforge.tracker import create_tracker
+from specforge.utils import print_on_rank0, print_with_rank
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train DFlash Draft Model")
+
+    model_group = parser.add_argument_group("model")
+    model_group.add_argument("--target-model-path", type=str, required=True)
+    model_group.add_argument(
+        "--target-model-backend",
+        type=str,
+        default="hf",
+        choices=["sglang", "hf"],
+        help="Backend for target model: 'sglang' (service) or 'hf' (local)",
+    )
+    model_group.add_argument("--draft-config-path", type=str, default=None)
+    model_group.add_argument("--block-size", type=int, default=16)
+    model_group.add_argument("--num-draft-layers", type=int, default=1)
+    model_group.add_argument(
+        "--mask-token-id",
+        type=int,
+        default=None,
+        help="MASK token ID. If not provided, auto-detect from tokenizer.",
+    )
+
+    dataset_group = parser.add_argument_group("dataset")
+    dataset_group.add_argument("--train-data-path", type=str, required=True)
+    dataset_group.add_argument("--eval-data-path", type=str, default=None)
+    dataset_group.add_argument("--chat-template", type=str, default="qwen")
+    dataset_group.add_argument("--is-preformatted", action="store_true")
+    dataset_group.add_argument("--dataloader-num-workers", type=int, default=8)
+    dataset_group.add_argument(
+        "--build-dataset-num-proc",
+        type=int,
+        default=int(os.environ.get("SPECFORGE_DATA_NUM_PROC", 8)),
+    )
+
+    training_group = parser.add_argument_group("training")
+    training_group.add_argument("--num-epochs", type=int, default=3)
+    training_group.add_argument("--batch-size", type=int, default=1)
+    training_group.add_argument("--learning-rate", type=float, default=1e-4)
+    training_group.add_argument("--max-length", type=int, default=2048)
+    training_group.add_argument("--warmup-ratio", type=float, default=0.01)
+    training_group.add_argument("--max-grad-norm", type=float, default=1.0)
+    training_group.add_argument("--accumulation-steps", type=int, default=1)
+    training_group.add_argument("--seed", type=int, default=42)
+    training_group.add_argument("--resume", action="store_true")
+
+    output_group = parser.add_argument_group("output")
+    output_group.add_argument("--output-dir", type=str, required=True)
+    output_group.add_argument("--cache-dir", type=str, default="./cache")
+    output_group.add_argument("--log-interval", type=int, default=50)
+    output_group.add_argument("--eval-interval", type=int, default=1000)
+    output_group.add_argument("--save-interval", type=int, default=1000)
+
+    tracker_group = parser.add_argument_group("tracker")
+    TrackerArgs.add_args(tracker_group)
+
+    dist_group = parser.add_argument_group("distributed")
+    dist_group.add_argument("--dist-timeout", type=int, default=30)
+
+    # SGLang specific args
+    sglang_group = parser.add_argument_group("sglang backend")
+    SGLangBackendArgs.add_args(sglang_group)
+
+    return parser.parse_args()
+
+
+def build_models(args) -> Tuple[DFlashTargetModel, DFlashDraftModel]:
+    """Build target model (backend wrapper) and draft model."""
+    print_on_rank0(
+        f"Loading target model from {args.target_model_path} using {args.target_model_backend} backend"
+    )
+
+    # 1. Build Target Model Wrapper
+    target_model_kwargs = {}
+    if args.target_model_backend == "sglang":
+        target_model_kwargs = SGLangBackendArgs.from_args(args).to_kwargs()
+
+    target_model = get_dflash_target_model(
+        pretrained_model_name_or_path=args.target_model_path,
+        backend=args.target_model_backend,
+        torch_dtype=torch.bfloat16,
+        device="cuda" if args.target_model_backend == "hf" else None,
+        **target_model_kwargs,
+    )
+
+    # 2. Build Draft Model
+    if args.draft_config_path:
+        draft_config = AutoConfig.from_pretrained(args.draft_config_path)
+        print_on_rank0(f"Loaded draft config from {args.draft_config_path}")
+    else:
+        # Load config from HF (needed for structure info even if backend is sglang)
+        target_config = AutoConfig.from_pretrained(args.target_model_path)
+        draft_config = AutoConfig.from_pretrained(args.target_model_path)
+        draft_config.num_hidden_layers = args.num_draft_layers
+        draft_config.block_size = args.block_size
+        draft_config.num_target_layers = target_config.num_hidden_layers
+        print_on_rank0("Auto-generated draft config from target model")
+
+    draft_model = DFlashDraftModel(draft_config).cuda().to(torch.bfloat16)
+
+    # Set capture layers for target model based on draft model config
+    target_model.set_capture_layers(draft_model.target_layer_ids)
+
+    print_on_rank0(
+        f"Draft config: block_size={draft_config.block_size}, "
+        f"num_hidden_layers={draft_config.num_hidden_layers}, "
+        f"num_target_layers={draft_config.num_target_layers}"
+    )
+    print_on_rank0(
+        f"Draft model parameters: {sum(p.numel() for p in draft_model.parameters()):,}"
+    )
+
+    return target_model, draft_model
+
+
+def build_dataloader(args, tokenizer) -> Tuple[DataLoader, Optional[DataLoader]]:
+    """Build train and eval dataloaders."""
+    import hashlib
+
+    # convert to dataloader
+    cache_params_string = (
+        f"{args.train_data_path}-"
+        f"{args.max_length}-"
+        f"{args.chat_template}-"
+        f"{args.target_model_path}"
+    )
+    cache_key = hashlib.md5(cache_params_string.encode()).hexdigest()
+
+    train_dataset = load_dataset("json", data_files=args.train_data_path)["train"]
+    train_eagle3_dataset = build_eagle3_dataset(
+        dataset=train_dataset,
+        tokenizer=tokenizer,
+        chat_template=args.chat_template,
+        max_length=args.max_length,
+        is_preformatted=args.is_preformatted,
+        cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
+        cache_key=cache_key,
+        num_proc=args.build_dataset_num_proc,
+    )
+
+    # Filter out samples with too few loss tokens (DFlash requires >= 2 * block_size)
+    min_loss_tokens = 2 * args.block_size
+    original_size = len(train_eagle3_dataset)
+    train_eagle3_dataset = train_eagle3_dataset.filter(
+        lambda x: x["loss_mask"].sum() >= min_loss_tokens
+    )
+    print_on_rank0(
+        f"Filtered train dataset: {original_size} -> {len(train_eagle3_dataset)} samples"
+    )
+
+    train_dataloader = prepare_dp_dataloaders(
+        train_eagle3_dataset,
+        args.batch_size,
+        num_workers=args.dataloader_num_workers,
+        shuffle=True,
+        process_group=get_dp_group(),
+    )
+
+    eval_dataloader = None
+    if args.eval_data_path:
+        eval_dataset = load_dataset("json", data_files=args.eval_data_path)["train"]
+        eval_eagle3_dataset = build_eagle3_dataset(
+            dataset=eval_dataset,
+            tokenizer=tokenizer,
+            chat_template=args.chat_template,
+            max_length=args.max_length,
+            is_preformatted=args.is_preformatted,
+        )
+        eval_dataloader = prepare_dp_dataloaders(
+            eval_eagle3_dataset,
+            args.batch_size,
+            num_workers=args.dataloader_num_workers,
+            shuffle=False,
+            process_group=get_dp_group(),
+        )
+
+    return train_dataloader, eval_dataloader
+
+
+def save_checkpoint(args, epoch, step, dflash_model, draft_model, optimizer):
+    """Save checkpoint."""
+    save_dir = os.path.join(args.output_dir, f"epoch_{epoch}_step_{step}")
+    if dist.get_rank() == 0:
+        os.makedirs(save_dir, exist_ok=True)
+    dist.barrier()
+
+    with FSDP.state_dict_type(dflash_model, StateDictType.FULL_STATE_DICT):
+        state_dict = dflash_model.state_dict()
+        draft_state_dict = {
+            k.replace("draft_model.", ""): v
+            for k, v in state_dict.items()
+            if "draft_model." in k
+        }
+
+        if dist.get_rank() == 0:
+            torch.save(
+                {
+                    "epoch": epoch,
+                    "global_step": step,
+                    "args": args,
+                    **optimizer.state_dict(),
+                },
+                os.path.join(save_dir, "training_state.pt"),
+            )
+
+            draft_model.save_pretrained(save_dir, state_dict=draft_state_dict)
+
+            # Copy modeling_dflash.py for inference compatibility
+            modeling_src = os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "specforge",
+                "modeling",
+                "draft",
+                "dflash.py",
+            )
+            modeling_dst = os.path.join(save_dir, "modeling_dflash.py")
+            if os.path.exists(modeling_src):
+                shutil.copy(modeling_src, modeling_dst)
+
+            print_on_rank0(f"Saved checkpoint to {save_dir}")
+
+    dist.barrier()
+
+
+def record_metrics(
+    args,
+    loss: float,
+    accuracy: float,
+    global_step: int,
+    tracker,
+    optimizer,
+    train_dataloader=None,
+    mode: str = "train",
+) -> None:
+    logdict = {}
+
+    if mode == "train" and optimizer is not None:
+        logdict["train/lr"] = optimizer.get_learning_rate()
+
+    logdict[f"{mode}/loss"] = loss
+    logdict[f"{mode}/accuracy"] = accuracy
+
+    print_on_rank0(
+        f"{mode.capitalize()} - Step {global_step} [{global_step}/{args.num_epochs * len(train_dataloader) // args.accumulation_steps}?], Loss: {loss:.4f}, Acc: {accuracy:.4f}"
+    )
+
+    tracker.log(logdict, step=global_step)
+
+
+def main():
+    # Configure logging to ensure we see INFO logs
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO,
+    )
+    # Force the root logger to INFO as well, just in case
+    logging.getLogger().setLevel(logging.INFO)
+
+    # Filter annoying FSDP warnings
+    warnings.filterwarnings(
+        "ignore",
+        "The .grad attribute of a Tensor that is not a leaf Tensor is being accessed",
+    )
+
+    args = parse_args()
+    set_seed(args.seed)
+
+    init_distributed(timeout=args.dist_timeout)
+    print_with_rank("Initialized distributed")
+
+    target_model, draft_model = build_models(args)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.target_model_path)
+    train_dataloader, eval_dataloader = build_dataloader(args, tokenizer)
+
+    # Get mask_token_id
+    if args.mask_token_id is not None:
+        mask_token_id = args.mask_token_id
+    elif hasattr(tokenizer, "mask_token_id") and tokenizer.mask_token_id is not None:
+        mask_token_id = tokenizer.mask_token_id
+    elif hasattr(tokenizer, "pad_token_id") and tokenizer.pad_token_id is not None:
+        mask_token_id = tokenizer.pad_token_id
+    else:
+        mask_token_id = tokenizer.eos_token_id
+    print_on_rank0(f"Using mask_token_id: {mask_token_id}")
+
+    steps_per_epoch = math.ceil(len(train_dataloader) / args.accumulation_steps)
+    total_steps = args.num_epochs * steps_per_epoch
+    print_on_rank0(f"Total training steps: {total_steps}")
+
+    # Note: We need embedding layer for DFlash wrapper.
+    # For SGLang backend, we can't easily get the embedding layer object.
+    # We use TargetEmbeddingsAndHead to efficiently load only needed weights.
+    print_on_rank0("Loading target embeddings and head efficiently...")
+    target_components = TargetEmbeddingsAndHead.from_pretrained(
+        args.target_model_path,
+        embed_key="model.embed_tokens.weight",  # Adjust if Qwen/Llama differs
+        lm_head_key="lm_head.weight",
+        device="cuda",
+    )
+
+    dflash_model = OnlineDFlashModel(
+        draft_model=draft_model,
+        target_lm_head=target_components.lm_head,
+        target_embed_tokens=target_components.embed_tokens,
+        block_size=draft_model.block_size,
+        mask_token_id=mask_token_id,
+    )
+
+    dflash_model = FSDP(
+        dflash_model,
+        use_orig_params=True,
+        mixed_precision=MixedPrecision(
+            param_dtype=torch.bfloat16,
+            buffer_dtype=torch.bfloat16,
+        ),
+        sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
+    )
+    print_with_rank("Initialized FSDP")
+
+    optimizer = BF16Optimizer(
+        draft_model,
+        lr=args.learning_rate,
+        max_grad_norm=args.max_grad_norm,
+        warmup_ratio=args.warmup_ratio,
+        total_steps=total_steps,
+    )
+
+    print_on_rank0(f"Initializing tracker (report_to={args.report_to})...")
+    tracker = create_tracker(args, args.output_dir)
+    print_on_rank0("Tracker initialized successfully.")
+
+    global_step = 0
+    last_time = time.time()
+
+    for epoch in range(args.num_epochs):
+        train_dataloader.sampler.set_epoch(epoch)
+        draft_model.train()
+
+        if dist.get_rank() == 0:
+            progress_bar = tqdm(
+                train_dataloader, desc=f"Training Epoch {epoch}", leave=True
+            )
+        else:
+            progress_bar = train_dataloader
+
+        for data in progress_bar:
+            global_step += 1
+
+            input_ids = data["input_ids"].cuda()
+            attention_mask = data["attention_mask"].cuda()
+            loss_mask = data["loss_mask"].cuda()
+
+            # Generate context from Target Model (SGLang or HF)
+            # This calls the backend to get hidden states
+            target_output = target_model.generate_dflash_data(
+                input_ids, attention_mask, loss_mask
+            )
+            hidden_states = target_output.hidden_states.cuda()  # Ensure on GPU
+
+            # Forward pass (Parallel Training)
+            loss, accuracy = dflash_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                hidden_states=hidden_states,
+                loss_mask=loss_mask,
+            )
+
+            (loss / args.accumulation_steps).backward()
+
+            if global_step % args.accumulation_steps == 0:
+                optimizer.step()
+
+            if global_step % args.log_interval == 0:
+                loss_log = loss.clone()
+                acc_log = accuracy.clone()
+                dist.all_reduce(loss_log)
+                dist.all_reduce(acc_log)
+                loss_log = loss_log / dist.get_world_size()
+                acc_log = acc_log / dist.get_world_size()
+
+                record_metrics(
+                    args,
+                    loss_log.item(),
+                    acc_log.item(),
+                    global_step,
+                    tracker,
+                    optimizer,
+                    train_dataloader,
+                    mode="train",
+                )
+
+            if dist.get_rank() == 0:
+                elapsed = time.time() - last_time
+                last_time = time.time()
+                progress_bar.set_postfix(
+                    {
+                        "loss": f"{loss.item():.4f}",
+                        "acc": f"{accuracy.item():.4f}",
+                    }
+                )
+
+            if global_step % args.save_interval == 0:
+                save_checkpoint(
+                    args, epoch, global_step, dflash_model, draft_model, optimizer
+                )
+
+    save_checkpoint(
+        args, args.num_epochs, global_step, dflash_model, draft_model, optimizer
+    )
+
+    tracker.close()
+    destroy_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/core/__init__.py
+++ b/specforge/core/__init__.py
@@ -1,3 +1,9 @@
+from .dflash import OnlineDFlashModel, create_dflash_loss_mask
 from .eagle3 import OnlineEagle3Model, QwenVLOnlineEagle3Model
 
-__all__ = ["OnlineEagle3Model", "QwenVLOnlineEagle3Model"]
+__all__ = [
+    "OnlineDFlashModel",
+    "create_dflash_loss_mask",
+    "OnlineEagle3Model",
+    "QwenVLOnlineEagle3Model",
+]

--- a/specforge/core/dflash.py
+++ b/specforge/core/dflash.py
@@ -1,0 +1,242 @@
+# coding=utf-8
+"""DFlash Training Wrapper."""
+
+from typing import Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from specforge.modeling.draft.dflash import DFlashDraftModel
+
+
+class OnlineDFlashModel(nn.Module):
+    """DFlash online training wrapper with block-wise CE loss."""
+
+    def __init__(
+        self,
+        draft_model: DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        block_size: int = 16,
+        mask_token_id: int = 151666,
+    ):
+        super().__init__()
+        self.draft_model = draft_model
+        self.lm_head = target_lm_head
+        self.embed_tokens = target_embed_tokens
+        self.block_size = block_size
+        self.mask_token_id = mask_token_id
+
+    def prepare_noise_input(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Prepare noise input: first token of each block is real, rest are MASK."""
+        # input_ids: [bsz, seq_len]
+        seq_len = input_ids.shape[1]
+        device = input_ids.device
+
+        positions = torch.arange(seq_len, device=device)
+        is_block_start = (positions % self.block_size) == 0
+
+        noise_input_ids = torch.full_like(input_ids, self.mask_token_id)
+        noise_input_ids[:, is_block_start] = input_ids[:, is_block_start]
+
+        return noise_input_ids
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Parallel Block-wise training forward pass.
+
+        Uses a global attention mask to process all blocks in parallel without
+        modifying the underlying modeling code.
+        """
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        # Truncate to multiple of block_size
+        n_blocks = seq_len // self.block_size
+        effective_len = n_blocks * self.block_size
+        input_ids = input_ids[:, :effective_len]
+        # hidden_states here is the RAW target hidden states (before projection)
+        hidden_states = hidden_states[:, :effective_len, :]
+        loss_mask = loss_mask[:, :effective_len]
+        # Original attention mask is typically just 1s for valid tokens
+        attention_mask = attention_mask[:, :effective_len]
+
+        # 2. Prepare Inputs
+        noise_input_ids = self.prepare_noise_input(input_ids)
+        noise_embedding = self.embed_tokens(noise_input_ids)
+
+        # 3. Construct Parallel Training Position IDs
+        # We need Position IDs for K which has length 2*L (Context + Noise)
+        # Context part: 0..L-1
+        # Noise part:   0..L-1
+        # This ensures that Noise at pos i uses the same RoPE embedding as Context at pos i
+        pos_seq = torch.arange(effective_len, device=device)
+        # shape: [1, 2*L] -> [bsz, 2*L]
+        position_ids = torch.cat([pos_seq, pos_seq], dim=0).unsqueeze(0).expand(bsz, -1)
+
+        # 4. Construct Parallel Attention Mask
+        # The modeling code will internally concat K = [K_ctx, K_noise]
+        # So K has length 2*L. Q has length L (from Noise).
+        # We need a mask of shape [L, 2*L]
+        dflash_attn_mask = self._create_parallel_attention_mask(effective_len, device)
+        dflash_attn_mask = dflash_attn_mask.to(dtype=hidden_states.dtype)
+        # Expand to batch size: [bsz, 1, L, 2*L]
+        # Note: transformers usually expects [bsz, 1, Q, K]
+        dflash_attn_mask = (
+            dflash_attn_mask.unsqueeze(0).unsqueeze(0).expand(bsz, -1, -1, -1)
+        )
+
+        # 5. Parallel Forward Pass
+        # efficient: one single forward pass for the whole sequence
+        hidden = self.draft_model(
+            position_ids=position_ids,  # [bsz, 2*L] (used for RoPE)
+            noise_embedding=noise_embedding,  # [bsz, L, H] (Query source)
+            target_hidden=hidden_states,  # [bsz, L, H] (Context source)
+            attention_mask=dflash_attn_mask,  # [bsz, 1, L, 2*L]
+        )
+
+        # 6. Compute Loss
+        # Create mask for valid loss positions (skip block 0, skip block starts)
+        dflash_loss_mask_base = create_dflash_loss_mask(
+            effective_len, self.block_size, device
+        )
+        combined_mask = loss_mask * dflash_loss_mask_base.unsqueeze(0)
+
+        # hidden[i] predicts input_ids[i] (based on DFlash design where noise[i] is input to predict target[i])
+        # However, check design:
+        # "hidden[i] predicts token[i] (directly corresponding), not token[i+1]"
+        # "noise_input[i] is MASK, we want to predict input_ids[i]"
+        # So logits at index i should be compared to labels at index i.
+
+        logits = self.lm_head(hidden)
+
+        # Calculate Loss
+        # Flatten
+        logits_flat = logits.reshape(-1, logits.size(-1))
+        labels_flat = input_ids.reshape(-1)
+        mask_flat = combined_mask.reshape(-1)
+
+        # Optimization: only compute CE on valid tokens
+        active_indices = mask_flat > 0.5
+        active_logits = logits_flat[active_indices]
+        active_labels = labels_flat[active_indices]
+
+        loss = F.cross_entropy(active_logits, active_labels)
+
+        with torch.no_grad():
+            preds = active_logits.argmax(dim=-1)
+            correct = (preds == active_labels).float().sum()
+            total = active_labels.numel()
+            accuracy = correct / total
+
+        return loss, accuracy
+
+    def _create_parallel_attention_mask(
+        self, seq_len: int, device: torch.device
+    ) -> torch.Tensor:
+        """
+        Creates the [L, 2L] mask for parallel training.
+        Rows: Query (Noise) indices 0..L-1
+        Cols: Key indices 0..2L-1 (First L are Context, Next L are Noise)
+
+        Logic for Query at index i (belonging to block B = i // block_size):
+        1. Can see Context (Cols 0..L-1):
+           - Can see context of PREVIOUS blocks.
+           - Range: [0, B * block_size)
+        2. Can see Noise (Cols L..2L-1):
+           - Can see noise of CURRENT block up to self.
+           - Range: [L + B * block_size, L + i]
+           - (Inclusive of i because causal mask usually allows seeing self)
+        """
+        # Block indices for each position [0, 0, ..., 1, 1, ...]
+        indices = torch.arange(seq_len, device=device)
+        block_ids = indices // self.block_size
+
+        # 1. Context Mask (L x L) - Left half of K
+        # Q[i] can see K_ctx[j] if Block(Q[i]) > Block(K_ctx[j])
+        # Actually, Block(Q[i]) can see Context of all previous blocks.
+        # It implies Block(K_ctx[j]) < Block(Q[i])
+        # Wait, strictly: Block B needs context from 0..(B*16).
+        # So it sees all K_ctx where index < B * 16.
+        # Which is equivalent to block_ids[j] < block_ids[i].
+
+        # Broadcast logic
+        # shape [L, 1]
+        q_block_ids = block_ids.unsqueeze(1)
+        # shape [1, L]
+        k_block_ids = block_ids.unsqueeze(0)
+
+        # Mask: 1 if K's block is strictly less than Q's block
+        # This gives access to all PREVIOUS blocks' context.
+        ctx_mask = k_block_ids < q_block_ids
+
+        # 2. Noise Mask (L x L) - Right half of K
+        # Standard Causal Mask WITHIN the same block.
+        # Q[i] can see K_noise[j] if:
+        #   a) Same Block: Block(Q[i]) == Block(K_noise[j])
+        #   b) Causal: j <= i
+        # Different blocks cannot see each other's noise.
+
+        same_block = q_block_ids == k_block_ids
+        causal = indices.unsqueeze(0) >= indices.unsqueeze(1)  # j <= i
+
+        noise_mask = same_block & causal
+
+        # Combine [Ctx_Mask, Noise_Mask]
+        # Shape [L, 2L]
+        # We need float mask for attention: 0.0 for allow, -inf for mask
+        # Transformers usually handles boolean masks by converting them,
+        # but explicit MinValue is safer if passing to generic attention.
+        # However, most HF models accept boolean [batch, 1, Q, K].
+
+        full_mask_bool = torch.cat([ctx_mask, noise_mask], dim=1)
+
+        # Check standard HF format: usually 1 for keep, 0 for mask, or boolean.
+        # Qwen3 implementation likely uses typical attention_mask handling.
+        # Let's return boolean for now, the model wrapper usually handles conversion
+        # or we check Qwen3DFlashAttention source usage.
+        # Looking at Qwen3DFlashAttention: `attn_output = attn_fn(..., attention_mask, ...)`
+        # If using SDPA, it expects boolean or float mask.
+        # If we look at `modeling_qwen3.py` (standard), it usually employs `_prepare_4d_causal_attention_mask`.
+        # But here we pass it explicitly.
+        # To be safe with `eager_attention_forward` and `SDPA`, we typically want:
+        # 0.0 for unmasked, -inf for masked.
+
+        dtype = (
+            torch.bfloat16
+        )  # or get from device/model, but we return a tensor builder
+        # We will cast later or return boolean and let logic handle it?
+        # Safe bet: Return typical extended attention mask format: 0.0 for keep, min_dtype for remove.
+
+        # But wait, Qwen3DFlashAttention passes attention_mask directly to attn_fn.
+        # If attn_fn is SDPA, it handles boolean.
+        # Let's return a float mask: 0.0 for True, -inf for False.
+
+        full_mask = torch.zeros_like(full_mask_bool, dtype=torch.float32)
+        full_mask.masked_fill_(~full_mask_bool, torch.finfo(torch.float32).min)
+
+        return full_mask
+
+
+def create_dflash_loss_mask(
+    seq_len: int, block_size: int, device: torch.device
+) -> torch.Tensor:
+    """
+    Create DFlash-specific loss mask.
+    Excludes Block 0 and first position of each block.
+    """
+    positions = torch.arange(seq_len, device=device)
+    block_ids = positions // block_size
+
+    is_block_0 = block_ids == 0
+    is_block_start = (positions % block_size) == 0
+
+    valid_mask = ~is_block_0 & ~is_block_start
+    return valid_mask.float()

--- a/specforge/modeling/draft/__init__.py
+++ b/specforge/modeling/draft/__init__.py
@@ -1,4 +1,17 @@
 from .base import Eagle3DraftModel
+from .dflash import (
+    DFlashDraftModel,
+    build_target_layer_ids,
+    extract_context_feature,
+    sample,
+)
 from .llama3_eagle import LlamaForCausalLMEagle3
 
-__all__ = ["Eagle3DraftModel", "LlamaForCausalLMEagle3"]
+__all__ = [
+    "Eagle3DraftModel",
+    "DFlashDraftModel",
+    "LlamaForCausalLMEagle3",
+    "build_target_layer_ids",
+    "extract_context_feature",
+    "sample",
+]

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -1,0 +1,378 @@
+from typing import Callable, Optional
+
+import torch
+from torch import nn
+from transformers import DynamicCache
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.models.qwen3.modeling_qwen3 import (
+    ALL_ATTENTION_FUNCTIONS,
+    FlashAttentionKwargs,
+    GradientCheckpointingLayer,
+    Qwen3Config,
+    Qwen3MLP,
+    Qwen3PreTrainedModel,
+    Qwen3RMSNorm,
+    Qwen3RotaryEmbedding,
+    eager_attention_forward,
+    rotate_half,
+)
+from typing_extensions import Tuple, Unpack
+
+
+def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
+    if temperature < 1e-5:
+        return torch.argmax(logits, dim=-1)
+    bsz, seq_len, vocab_size = logits.shape
+    logits = logits.view(-1, vocab_size)
+    logits = logits / temperature
+    probs = torch.softmax(logits, dim=-1)
+    return torch.multinomial(probs, num_samples=1).view(bsz, seq_len)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_len = q.size(-2)
+    q_embed = (q * cos[..., -q_len:, :]) + (rotate_half(q) * sin[..., -q_len:, :])
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen3DFlashAttention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_groups = (
+            config.num_attention_heads // config.num_key_value_heads
+        )
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = False
+        self.q_proj = nn.Linear(
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.sliding_window = (
+            config.sliding_window
+            if config.layer_types[layer_idx] == "sliding_attention"
+            else None
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        target_hidden: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        bsz, q_len = hidden_states.shape[:-1]
+        ctx_len = target_hidden.shape[1]
+        q = self.q_proj(hidden_states)
+        q = q.view(bsz, q_len, -1, self.head_dim)
+        q = self.q_norm(q).transpose(1, 2)
+        k_ctx = self.k_proj(target_hidden)
+        k_noise = self.k_proj(hidden_states)
+        v_ctx = self.v_proj(target_hidden)
+        v_noise = self.v_proj(hidden_states)
+        k = torch.cat([k_ctx, k_noise], dim=1).view(
+            bsz, ctx_len + q_len, -1, self.head_dim
+        )
+        v = torch.cat([v_ctx, v_noise], dim=1).view(
+            bsz, ctx_len + q_len, -1, self.head_dim
+        )
+        k = self.k_norm(k).transpose(1, 2)
+        v = v.transpose(1, 2)
+        cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb(q, k, cos, sin)
+        if past_key_values is not None:
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
+        attn_fn: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attn_fn = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attn_output, attn_weights = attn_fn(
+            self,
+            q,
+            k,
+            v,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+        attn_output = attn_output.reshape(bsz, q_len, -1)
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Qwen3DFlashAttention(config=config, layer_idx=layer_idx)
+        self.mlp = Qwen3MLP(config)
+        self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        target_hidden: Optional[torch.Tensor] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_value: Optional[Cache] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # necessary, but kept here for BC
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> Tuple[
+        torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]
+    ]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            target_hidden=target_hidden,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_value,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )[0]
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+def build_target_layer_ids(num_target_layers: int, num_draft_layers: int):
+    if num_draft_layers == 1:
+        return [(num_target_layers // 2)]
+    start = 1
+    end = num_target_layers - 3
+    span = end - start
+    target_layer_ids = [
+        int(round(start + (i * span) / (num_draft_layers - 1)))
+        for i in range(num_draft_layers)
+    ]
+    return target_layer_ids
+
+
+def extract_context_feature(
+    hidden_states: list[torch.Tensor],
+    layer_ids: Optional[list[int]],
+) -> torch.Tensor:
+    offset = 1
+    selected_states = []
+    for layer_id in layer_ids:
+        selected_states.append(hidden_states[layer_id + offset])
+    target_hidden = torch.cat(selected_states, dim=-1)
+    return target_hidden
+
+
+class DFlashDraftModel(Qwen3PreTrainedModel):
+    config_class = Qwen3Config
+    _no_split_modules = ["Qwen3DFlashDecoderLayer"]
+
+    def __init__(self, config) -> None:
+        super().__init__(config)
+        self.config = config
+        self.layers = nn.ModuleList(
+            [
+                Qwen3DFlashDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.target_layer_ids = build_target_layer_ids(
+            config.num_target_layers, config.num_hidden_layers
+        )
+        self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen3RotaryEmbedding(config)
+        self.fc = nn.Linear(
+            len(self.target_layer_ids) * config.hidden_size,
+            config.hidden_size,
+            bias=False,
+        )
+        self.hidden_norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.block_size = config.block_size
+        self.post_init()
+
+    def forward(
+        self,
+        position_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        noise_embedding: Optional[torch.Tensor] = None,
+        target_hidden: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        hidden_states = noise_embedding
+        target_hidden = self.hidden_norm(self.fc(target_hidden))
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                target_hidden=target_hidden,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_values,
+                use_cache=use_cache,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+        return self.norm(hidden_states)
+
+    @torch.inference_mode()
+    def spec_generate(
+        self,
+        target: nn.Module,
+        input_ids: torch.LongTensor,
+        mask_token_id: int,
+        max_new_tokens: int,
+        stop_token_ids: list[int],
+        temperature: float,
+    ):
+        self.eval()
+        target.eval()
+        num_input_tokens = input_ids.shape[1]
+        max_length = num_input_tokens + max_new_tokens
+
+        block_size = self.block_size
+        output_ids = torch.full(
+            (1, max_length + block_size),
+            mask_token_id,
+            dtype=torch.long,
+            device=target.device,
+        )
+        position_ids = torch.arange(
+            output_ids.shape[1], device=target.device
+        ).unsqueeze(0)
+
+        past_key_values_target = DynamicCache()
+        past_key_values_draft = DynamicCache()
+
+        # Prefill stage
+        output = target(
+            input_ids,
+            position_ids=position_ids[:, :num_input_tokens],
+            past_key_values=past_key_values_target,
+            use_cache=True,
+            logits_to_keep=1,
+            output_hidden_states=True,
+        )
+
+        output_ids[:, :num_input_tokens] = input_ids
+        output_ids[:, num_input_tokens : num_input_tokens + 1] = sample(
+            output.logits, temperature
+        )
+        target_hidden = extract_context_feature(
+            output.hidden_states, self.target_layer_ids
+        )
+
+        # Decode stage
+        acceptance_lengths = []
+        start = input_ids.shape[1]
+        while start < max_length:
+            block_output_ids = output_ids[:, start : start + block_size].clone()
+            block_position_ids = position_ids[:, start : start + block_size]
+            noise_embedding = target.model.embed_tokens(block_output_ids)
+            draft_logits = target.lm_head(
+                self(
+                    target_hidden=target_hidden,
+                    noise_embedding=noise_embedding,
+                    position_ids=position_ids[
+                        :, past_key_values_draft.get_seq_length() : start + block_size
+                    ],
+                    past_key_values=past_key_values_draft,
+                    use_cache=True,
+                    is_causal=False,
+                )[:, -block_size + 1 :, :]
+            )
+            past_key_values_draft.crop(start)
+            block_output_ids[:, 1:] = sample(draft_logits)
+
+            output = target(
+                block_output_ids,
+                position_ids=block_position_ids,
+                past_key_values=past_key_values_target,
+                use_cache=True,
+                output_hidden_states=True,
+            )
+
+            posterior = sample(output.logits, temperature)
+            acceptance_length = (
+                (block_output_ids[:, 1:] == posterior[:, :-1])
+                .cumprod(dim=1)
+                .sum(dim=1)[0]
+                .item()
+            )
+            output_ids[:, start : start + acceptance_length + 1] = block_output_ids[
+                :, : acceptance_length + 1
+            ]
+            output_ids[:, start + acceptance_length + 1] = posterior[
+                :, acceptance_length
+            ]
+            start += acceptance_length + 1
+            past_key_values_target.crop(start)
+            target_hidden = extract_context_feature(
+                output.hidden_states, self.target_layer_ids
+            )[:, : acceptance_length + 1, :]
+            acceptance_lengths.append(acceptance_length + 1)
+            if stop_token_ids is not None and any(
+                stop_token_id in output_ids[:, num_input_tokens:]
+                for stop_token_id in stop_token_ids
+            ):
+                break
+        output_ids = output_ids[:, :max_length]
+        output_ids = output_ids[:, output_ids[0] != mask_token_id]
+        if stop_token_ids is not None:
+            stop_token_ids = torch.tensor(stop_token_ids, device=output_ids.device)
+            stop_token_indices = torch.isin(
+                output_ids[0][num_input_tokens:], stop_token_ids
+            ).nonzero(as_tuple=True)[0]
+            if stop_token_indices.numel() > 0:
+                output_ids = output_ids[
+                    :, : num_input_tokens + stop_token_indices[0] + 1
+                ]
+
+        return output_ids

--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -1,0 +1,342 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils import require_mlp_sync, require_mlp_tp_gather
+from transformers import AutoModelForCausalLM
+
+from specforge.distributed import get_tp_group
+from specforge.utils import padding
+
+from .sglang_backend import SGLangRunner
+
+
+@dataclass
+class DFlashTargetOutput:
+    hidden_states: torch.Tensor  # [batch, seq_len, hidden_size]
+    input_ids: torch.Tensor  # [batch, seq_len]
+    attention_mask: torch.Tensor  # [batch, seq_len]
+    loss_mask: torch.Tensor  # [batch, seq_len]
+
+
+class DFlashTargetModel(ABC):
+    """
+    Abstract base class for DFlash target model backend.
+    """
+
+    def __init__(self):
+        self.capture_layer_ids = None
+
+    @classmethod
+    @abstractmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        torch_dtype: torch.dtype = None,
+        device: str = None,
+        cache_dir: Optional[str] = None,
+        **kwargs,
+    ) -> "DFlashTargetModel":
+        """Initialize the target model backend."""
+
+    @abstractmethod
+    def generate_dflash_data(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> DFlashTargetOutput:
+        """Generate context hidden states for DFlash training."""
+
+    def set_capture_layers(self, layer_ids: List[int]) -> None:
+        """Set which layers' hidden states to capture."""
+        self.capture_layer_ids = layer_ids
+
+
+class SGLangDFlashTargetModel(DFlashTargetModel):
+    def __init__(self, model_runner: SGLangRunner):
+        super().__init__()
+        self.model_runner = model_runner
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        torch_dtype: torch.dtype = None,
+        device: str = None,
+        cache_dir: Optional[str] = None,
+        trust_remote_code: bool = False,
+        **kwargs,
+    ) -> "SGLangDFlashTargetModel":
+        tp_size = dist.get_world_size(get_tp_group())
+        server_args = ServerArgs(
+            model_path=pretrained_model_name_or_path,
+            trust_remote_code=trust_remote_code,
+            dtype=torch_dtype,
+            enable_return_hidden_states=True,  # Critical for DFlash
+            disable_cuda_graph=True,
+            tp_size=tp_size,
+            pp_size=1,
+            **kwargs,
+        )
+
+        tp_rank = dist.get_rank(get_tp_group())
+        moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
+        model_config = ModelConfig.from_server_args(server_args)
+
+        model_runner = SGLangRunner(
+            model_config=model_config,
+            mem_fraction_static=server_args.mem_fraction_static,
+            gpu_id=torch.cuda.current_device(),
+            tp_rank=dist.get_rank(get_tp_group()),
+            tp_size=server_args.tp_size,
+            moe_ep_rank=moe_ep_rank,
+            moe_ep_size=server_args.ep_size,
+            pp_rank=0,
+            pp_size=1,
+            server_args=server_args,
+            nccl_port=None,
+        )
+        return cls(model_runner)
+
+    def set_capture_layers(self, layer_ids: List[int]) -> None:
+        super().set_capture_layers(layer_ids)
+        # Note: We need to ensure SGLang supports custom capture layers.
+        # Eagle3 implementation uses `set_eagle3_layers_to_capture`.
+        # For DFlash, we might need to rely on `output_hidden_states=True` returning all layers
+        # and then filtering, OR implementing `set_custom_layers_to_capture` in SGLang patch.
+        # Assuming we can use the same mechanism or general mechanism if available.
+        # If SGLang doesn't support selective capture easily, we might get all and select later.
+        # But for memory efficiency, selective capture is better.
+
+        # Checking Eagle3 implementation again: it calls `model.set_eagle3_layers_to_capture`.
+        # This implies SGLang model wrapper has this method patched.
+        # We will try to use a similar approach or assume we get full hidden states.
+
+        # For now, let's assume we capture what's needed.
+        if hasattr(self.model_runner.model, "set_eagle3_layers_to_capture"):
+            self.model_runner.model.set_eagle3_layers_to_capture(layer_ids)
+
+    @torch.no_grad
+    def _extend(self, reqs):
+        # Similar to Eagle3 _extend but simplified for just hidden states
+        cache_params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=self.model_runner.req_to_token_pool,
+            token_to_kv_pool_allocator=self.model_runner.token_to_kv_pool_allocator,
+            page_size=self.model_runner.server_args.page_size,
+        )
+        tree_cache = RadixCache(cache_params)
+
+        batch = ScheduleBatch.init_new(
+            reqs=reqs,
+            req_to_token_pool=self.model_runner.req_to_token_pool,
+            token_to_kv_pool_allocator=self.model_runner.token_to_kv_pool_allocator,
+            tree_cache=tree_cache,
+            model_config=self.model_runner.model_config,
+            enable_overlap=False,
+            spec_algorithm=SpeculativeAlgorithm.NONE,
+        )
+        batch.prepare_for_extend()
+
+        if require_mlp_sync(self.model_runner.server_args):
+            Scheduler.prepare_mlp_sync_batch_raw(
+                batch,
+                dp_size=self.model_runner.server_args.dp_size,
+                attn_tp_size=1,
+                tp_group=self.model_runner.tp_group,
+                get_idle_batch=None,
+                disable_cuda_graph=self.model_runner.server_args.disable_cuda_graph,
+                spec_algorithm=SpeculativeAlgorithm.NONE,
+                speculative_num_draft_tokens=None,
+                require_mlp_tp_gather=require_mlp_tp_gather(
+                    self.model_runner.server_args
+                ),
+                disable_overlap_schedule=self.model_runner.server_args.disable_overlap_schedule,
+                offload_tags=set(),
+            )
+
+        model_worker_batch = batch.get_model_worker_batch()
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
+        forward_batch.capture_hidden_mode = CaptureHiddenMode.FULL
+
+        output, _ = self.model_runner.forward(forward_batch)
+
+        # Eagle3 output has aux_hidden_states.
+        # We need to check what SGLang returns. Typically it returns 'hidden_states' or 'aux_hidden_states'.
+        # Assuming it aligns with Eagle3 patch.
+
+        input_lens = [len(req.origin_input_ids) for req in reqs]
+
+        # Split per request
+        if (
+            hasattr(output, "aux_hidden_states")
+            and output.aux_hidden_states is not None
+        ):
+            hidden_states_list = torch.split(
+                output.aux_hidden_states, input_lens, dim=0
+            )
+        elif hasattr(output, "hidden_states") and output.hidden_states is not None:
+            hidden_states_list = torch.split(output.hidden_states, input_lens, dim=0)
+        else:
+            raise ValueError("SGLang output does not contain hidden states.")
+
+        self.model_runner.req_to_token_pool.clear()
+        self.model_runner.token_to_kv_pool_allocator.clear()
+
+        return hidden_states_list
+
+    @torch.no_grad()
+    def generate_dflash_data(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> DFlashTargetOutput:
+        sampling_params = SamplingParams(temperature=0, max_new_tokens=1)
+        reqs, data_cache = [], []
+
+        if isinstance(input_ids, torch.Tensor):
+            input_ids_list = torch.split(input_ids, 1, dim=0)
+            attn_mask_list = torch.split(attention_mask, 1, dim=0)
+            loss_mask_list = torch.split(loss_mask, 1, dim=0)
+
+        for idx, (curr_ids, curr_attn, curr_loss) in enumerate(
+            zip(input_ids_list, attn_mask_list, loss_mask_list)
+        ):
+            req = Req(
+                rid=str(idx),
+                origin_input_text="",
+                origin_input_ids=curr_ids.view(-1).tolist(),
+                sampling_params=sampling_params,
+            )
+            req.fill_ids = req.origin_input_ids
+            req.extend_input_len = len(req.fill_ids) - len(req.prefix_indices)
+            data_cache.append((curr_ids, curr_attn, curr_loss))
+            reqs.append(req)
+
+        hidden_states_list = self._extend(reqs)
+
+        # Stack back to batch
+        hidden_states = torch.cat([h.unsqueeze(0) for h in hidden_states_list], dim=0)
+        input_ids = torch.cat([d[0] for d in data_cache], dim=0)
+        attention_mask = torch.cat([d[1] for d in data_cache], dim=0)
+        loss_mask = torch.cat([d[2] for d in data_cache], dim=0)
+
+        # Padding might be needed if batching varied lengths (but usually fixed length training)
+        hidden_states = padding(hidden_states, left=False)
+        input_ids = padding(input_ids, left=False)
+
+        return DFlashTargetOutput(
+            hidden_states=hidden_states,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+        )
+
+
+class HFDFlashTargetModel(DFlashTargetModel):
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        torch_dtype: torch.dtype = None,
+        device: str = None,
+        cache_dir: Optional[str] = None,
+        **kwargs,
+    ) -> "HFDFlashTargetModel":
+
+        target_model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path,
+            torch_dtype=torch_dtype,
+            cache_dir=cache_dir,
+            output_hidden_states=True,
+            trust_remote_code=True,
+            **kwargs,
+        ).eval()
+
+        if device:
+            target_model = target_model.to(device)
+
+        return cls(target_model)
+
+    @torch.no_grad()
+    def generate_dflash_data(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> DFlashTargetOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            use_cache=False,
+        )
+
+        # Extract selected layers
+        # outputs.hidden_states is a tuple of (L+1) tensors
+        # Indices in self.capture_layer_ids correspond to 0-based index of transformer layers.
+        # outputs.hidden_states[0] is embedding output (usually).
+        # Typically hidden_states[i+1] is output of layer i.
+
+        offset = 1
+        selected = []
+        if self.capture_layer_ids is not None:
+            for idx in self.capture_layer_ids:
+                selected.append(outputs.hidden_states[idx + offset])
+            hidden_states = torch.cat(selected, dim=-1)
+        else:
+            # Fallback if no layers specified (maybe return last?)
+            hidden_states = outputs.hidden_states[-1]
+
+        return DFlashTargetOutput(
+            hidden_states=hidden_states,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+        )
+
+
+def get_dflash_target_model(
+    pretrained_model_name_or_path: str,
+    backend: str = "sglang",
+    torch_dtype: torch.dtype = None,
+    device: str = None,
+    cache_dir: Optional[str] = None,
+    **kwargs,
+) -> DFlashTargetModel:
+    if backend == "sglang":
+        return SGLangDFlashTargetModel.from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            torch_dtype=torch_dtype,
+            device=device,
+            cache_dir=cache_dir,
+            **kwargs,
+        )
+    elif backend == "hf":
+        return HFDFlashTargetModel.from_pretrained(
+            pretrained_model_name_or_path=pretrained_model_name_or_path,
+            torch_dtype=torch_dtype,
+            device=device,
+            cache_dir=cache_dir,
+            **kwargs,
+        )
+    else:
+        raise ValueError(f"Invalid backend: {backend}")

--- a/specforge/modeling/target/target_utils.py
+++ b/specforge/modeling/target/target_utils.py
@@ -1,0 +1,131 @@
+import glob
+import json
+import os
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+from transformers import AutoConfig
+
+
+class TargetEmbeddingsAndHead(nn.Module):
+    """
+    Efficiently loads only the embedding layer and lm_head from a pretrained model.
+    Avoids loading the full model into memory.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id
+        )
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_path: str,
+        embed_key: str = "model.embed_tokens.weight",
+        lm_head_key: str = "lm_head.weight",
+        cache_dir: Optional[str] = None,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> "TargetEmbeddingsAndHead":
+
+        # 1. Load Config
+        config = AutoConfig.from_pretrained(model_path, cache_dir=cache_dir)
+        instance = cls(config)
+
+        # 2. Resolve Model Path (Handle Hub)
+        local_model_path = model_path
+        if not os.path.exists(local_model_path):
+            try:
+                local_model_path = snapshot_download(
+                    repo_id=model_path, cache_dir=cache_dir
+                )
+            except:
+                pass  # Maybe it's a local path that looks like a repo ID but doesn't exist?
+
+        # 3. Load Weights Efficiently
+        instance._load_weights(local_model_path, embed_key, lm_head_key)
+
+        # 4. Move to Device & Freeze
+        instance.to(device=device, dtype=dtype)
+        instance.eval()
+        instance.requires_grad_(False)
+
+        return instance
+
+    def _load_weights(self, model_path: str, embed_key: str, lm_head_key: str):
+        # Locate index.json
+        index_files = glob.glob(os.path.join(model_path, "*.index.json"))
+
+        weight_map = {}
+        if index_files:
+            # Sharded Checkpoint
+            with open(index_files[0], "r") as f:
+                index = json.load(f)
+
+            # Find which file contains our keys
+            weight_map = index.get("weight_map", {})
+            files_to_load = {}
+
+            if embed_key in weight_map:
+                files_to_load[embed_key] = weight_map[embed_key]
+            else:
+                # Fallback: sometimes keys are prefixed differently?
+                print(
+                    f"Warning: {embed_key} not found in weight_map. Keys available: {list(weight_map.keys())[:5]}..."
+                )
+
+            if lm_head_key in weight_map:
+                files_to_load[lm_head_key] = weight_map[lm_head_key]
+
+            # Load specific files
+            for key, filename in files_to_load.items():
+                file_path = os.path.join(model_path, filename)
+                self._load_key_from_file(file_path, key)
+
+        else:
+            # Non-sharded Checkpoint (single file)
+            # Try finding .safetensors or .bin
+            safetensors = glob.glob(os.path.join(model_path, "*.safetensors"))
+            bins = glob.glob(os.path.join(model_path, "*.bin"))
+
+            target_file = None
+            if safetensors:
+                target_file = safetensors[0]
+            elif bins:
+                target_file = bins[0]
+
+            if target_file:
+                self._load_key_from_file(target_file, embed_key)
+                self._load_key_from_file(target_file, lm_head_key)
+            else:
+                raise FileNotFoundError(f"No checkpoint file found in {model_path}")
+
+    def _load_key_from_file(self, file_path: str, key: str):
+        tensor = None
+        if file_path.endswith(".safetensors"):
+            with safe_open(file_path, framework="pt") as f:
+                if key in f.keys():
+                    tensor = f.get_tensor(key)
+        else:
+            # torch.load loads full dict, less efficient but works
+            state_dict = torch.load(file_path, map_location="cpu")
+            if key in state_dict:
+                tensor = state_dict[key]
+                del state_dict  # Free immediately
+
+        if tensor is not None:
+            if key.endswith("embed_tokens.weight"):
+                self.embed_tokens.weight.data.copy_(tensor)
+                print(f"Loaded embedding weights from {file_path}")
+            elif key.endswith("lm_head.weight"):
+                self.lm_head.weight.data.copy_(tensor)
+                print(f"Loaded lm_head weights from {file_path}")
+        else:
+            print(f"Warning: Key {key} not found in {file_path}")


### PR DESCRIPTION
## 1. Objective

Implement DFlash (Block-wise Parallel Decoding) architecture in SpecForge framework, enabling **Online** Draft Model training with SGLang backend support.

- **Input**: Target Model inference via SGLang/HuggingFace to obtain Context Hidden States
- **Output**: Train Draft Model to predict tokens in parallel blocks
- **Mode**: Online training with real-time Target Model inference

## 2. Architecture Overview

### 2.1 Module Structure

| Component | Path | Responsibility |
|-----------|------|----------------|
| **Draft Model** | `specforge/modeling/draft/dflash.py` | `DFlashDraftModel` with Hybrid Attention (Query from Noise, K/V from Context + Noise) |
| **Target Backend** | `specforge/modeling/target/dflash_target_model.py` | SGLang/HF backend wrapper for Target Model inference |
| **Weight Loader** | `specforge/modeling/target/target_utils.py` | Efficient embedding & lm_head loading without full model instantiation |
| **Training Core** | `specforge/core/dflash.py` | `OnlineDFlashModel` wrapper with mask generation and loss computation |
| **Script** | `scripts/train_dflash.py` | Training entry point with backend selection |

### 2.2 Data Flow (Online Pipeline)

```
Raw Text → Tokenizer → Input IDs
                          ↓
         Target Model (SGLang/HF Backend)
                          ↓
              Context Hidden States
                          ↓
┌─────────────────────────┴─────────────────────────┐
↓                                                   ↓
Context Stream (H_ctx)                    Noise Stream (E_noise)
[Target Hidden States]                    [Block-start: real, others: MASK]
        ↓                                           ↓
        └──────────────── Hybrid Attention ─────────┘
                     Q: Noise | K/V: [Context, Noise]
                          ↓
                  Draft Hidden States
                          ↓
                Target LM Head (Frozen)
                          ↓
                Draft Logits → CE Loss ← Labels
```

## 3. Core Design

### 3.1 Global Masked Parallel Training

Process entire sequence in **single forward pass** using carefully constructed attention mask.

| Aspect | Design |
|--------|--------|
| **Tensor Layout** | Query: `[B, L, D]`, Key/Value: `[B, 2L, D]` (Context L + Noise L) |
| **Attention Mask** | `[L, 2L]` controlling visibility between positions |
| **Position IDs** | `[0..L-1, 0..L-1]` ensuring RoPE alignment |

### 3.2 Attention Mask Logic

For Query at position `i` in Block `B = i // block_size`:

| Region | Visibility Rule |
|--------|-----------------|
| **Context** (cols 0..L-1) | See all positions where `block_id < B` |
| **Noise** (cols L..2L-1) | See same block positions where `j <= i` (causal) |

### 3.3 Loss Calculation

- **Excluded**: Block 0 (no preceding context) + Block anchor tokens (known inputs)
- **Included**: All other positions predict their corresponding token IDs
- **Method**: Masked Cross-Entropy Loss

## 4. Files Changed

```
configs/qwen3-8b-dflash.json              # DFlash configuration
examples/run_qwen3_8b_dflash_online.sh    # Example training script
scripts/train_dflash.py                   # Training entry point
specforge/core/dflash.py                  # OnlineDFlashModel wrapper
specforge/modeling/draft/dflash.py        # DFlashDraftModel architecture
specforge/modeling/target/dflash_target_model.py  # SGLang/HF backend
specforge/modeling/target/target_utils.py # Efficient weight loader
```

## 5. Usage

```bash
python scripts/prepare_data.py --dataset sharegpt

bash examples/run_qwen3_8b_dflash_online.sh
```

## 6. References

- DFlash: [https://github.com/z-lab/dflash](https://github.com/z-lab/dflash)

