### PR TITLE
[Feature]: add --train-only-last-turn option

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -109,6 +109,12 @@ def parse_args() -> Tuple[ArgumentParser, Namespace]:
         action="store_true",
         help="Whether the input data is preformatted text with the chat template already applied to the conversation messages.",
     )
+    dataset_group.add_argument(
+        "--train-only-last-turn",
+        action="store_true",
+        help="If set, only the last assistant turn in each conversation contributes to the loss. "
+        "Useful for thinking models where conversation history may lack thought processes.",
+    )
     dataset_group.add_argument("--build-dataset-num-proc", type=int, default=8)
     dataset_group.add_argument(
         "--dataloader-num-workers",
@@ -422,6 +428,7 @@ def build_dataloaders(
             is_preformatted=args.is_preformatted,
             processor=processor,
             num_proc=args.build_dataset_num_proc,
+            train_only_last_turn=args.train_only_last_turn,
         )
         vocab_mapping_path = generate_vocab_mapping_file(
             dataset=train_eagle3_dataset,
@@ -462,6 +469,7 @@ def build_dataloaders(
                 processor=processor,
                 num_proc=args.build_dataset_num_proc,
                 is_preformatted=args.is_preformatted,
+                train_only_last_turn=args.train_only_last_turn,
             )
         elif args.eval_hidden_states_path is not None:
             eval_eagle3_dataset = build_offline_eagle3_dataset(


### PR DESCRIPTION
## Motivation

This PR introduces the `--train-only-last-turn` flag to focus training on the final assistant turn in a conversation. 

In practical deployments, the pattern of conversation history often diverges significantly from the target output mode:
1. **Missing Thinking Process**: Conversation history typically contains only the final answer of previous turns, whereas the current target generation requires the draft model to mimic the thinking process (`<think>...</think>`).
2. **Dynamic Context Manipulation**: Agents often modify system prompts or use sliding windows (truncating the last N turns) during serving. 
3. **Distribution Mismatch**: Training on all historical assistant turns forces the draft model to learn from context that doesn't accurately represent the generation state at inference time.

Focusing loss only on the last turn ensures the draft model learns the most relevant generation dynamics, improving the acceptance rate for speculative decoding.

## Modifications

- **`specforge/data/parse.py`**: 
    - Added `train_only_last_turn` parameter to `GeneralParser`, `HarmonyParser`, and `ThinkingParser`.
    - Implemented logic to filter assistant turn matches, keeping only the last one when the flag is enabled.
- **`specforge/data/preprocessing.py`**:
    - Updated `preprocess_conversations` and `build_eagle3_dataset` to accept and propagate the `train_only_last_turn` argument.
- **`scripts/train_eagle3.py`**:
    - Added `--train-only-last-turn` to the dataset argument group.
    - Passed the argument to the dataset builder for both training and evaluation dataloaders.

## Related Issues

## Accuracy Test

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.