### PR TITLE
[Bug] DFlash Training: removed causal constraint from noise mask for bidirectional attention within blocks

### DIFF
--- a/specforge/core/dflash.py
+++ b/specforge/core/dflash.py
@@ -18,8 +18,8 @@ class OnlineDFlashModel(nn.Module):
         draft_model: DFlashDraftModel,
         target_lm_head: nn.Module,
         target_embed_tokens: nn.Module,
+        mask_token_id: int,
         block_size: int = 16,
-        mask_token_id: int = 151666,
     ):
         super().__init__()
         self.draft_model = draft_model


### PR DESCRIPTION
## Motivation

This PR syncs with the latest mask-related fixes from upstream SpecForge.

Key upstream changes:
- `6272687`: Align mask_token_id logic with inference code
- `ca5455e`: Change dflash noise mask to bidirectional (remove causal constraint)

## Modifications

### Mask Logic Alignment
- Updated mask_token_id handling: auto-add `<|MASK|>` special token when tokenizer lacks mask_token_id
- Removed causal constraint from noise mask for bidirectional attention within blocks

## Related Issues

#412 

## Accuracy Test

WIP

## Benchmark & Profiling

WIP

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
