### PR TITLE
[Performance] speed up Counting tokens for vocab mapping

### DIFF
--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -532,10 +532,8 @@ def generate_vocab_mapping_file(
 
     # we first count the frequency of effectiev tokens in the dataset
     token_dict = Counter()
-    all_input_ids = dataset["input_ids"]
-    all_loss_mask = dataset["loss_mask"]
     for input_ids, loss_mask in tqdm(
-        zip(all_input_ids, all_loss_mask),
+        zip(dataset["input_ids"], dataset["loss_mask"]),
         total=len(dataset),
         desc="Counting tokens for vocab mapping",
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

VLM datasets use huge storage. When looping through the dataset, it reads image data along with input_ids and loss_mask, leading to unnecessary reading of unused image data. Since HFDataset uses Arrow columnar storage, we can efficiently extract only the required columns (input_ids and loss_mask) for counting tokens during vocab mapping, avoiding the overhead of loading entire rows with image data.

## Modifications

## Related Issues

## Accuracy Test

## Benchmark & Profiling
before: ~31 items/s (disk-speed dependent)
Counting tokens for vocab mapping:   0%|          | 186/468668 [00:07<4:09:50, 31.25it/s]
after: ~2880 items/s (memory-speed dependent)
Counting tokens for vocab mapping:  36%|███▌      | 169259/468668 [00:54<01:43, 2880.52it/s]

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
