### PR TITLE
  USP Offline Long‑Sequence Refactor: SP Sharded Inputs, Adapter Unification, and Compressed Hidden States

### DIFF
--- a/specforge/core/eagle3_adapters.py
+++ b/specforge/core/eagle3_adapters.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import torch
+import torch.distributed as dist
+import torch.distributed.nn.functional as dist_nn
+
+from specforge.distributed import get_draft_sp_group, get_sp_ulysses_group
+
+
+@dataclass
+class StepState:
+    input_ids: torch.Tensor
+    hidden_states: torch.Tensor
+    position_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    target_p: torch.Tensor
+    position_mask: torch.Tensor
+    loss_mask: torch.Tensor
+
+
+class BackendAdapter:
+    def __init__(self, model: "OnlineEagle3Model"):
+        self.m = model
+
+    def step_view(
+        self,
+        *,
+        idx: int,
+        ttt_length: int,
+        global_input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        target_p_padded: torch.Tensor,
+        position_mask: torch.Tensor,
+        seq_length: int,
+    ) -> StepState:
+        raise NotImplementedError
+
+    def reduce_metrics(
+        self, *, local_correct: torch.Tensor, local_denom: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return local_correct, local_denom
+
+    def reduce_loss(self, loss: torch.Tensor) -> torch.Tensor:
+        return loss
+
+
+class SdpaLikeAdapter(BackendAdapter):
+    def step_view(
+        self,
+        *,
+        idx: int,
+        ttt_length: int,
+        global_input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        target_p_padded: torch.Tensor,
+        position_mask: torch.Tensor,
+        seq_length: int,
+    ) -> StepState:
+        target_p = target_p_padded[:, idx : idx + seq_length, :].contiguous()
+        return StepState(
+            input_ids=global_input_ids,
+            hidden_states=hidden_states,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            target_p=target_p,
+            position_mask=position_mask,
+            loss_mask=loss_mask,
+        )
+
+
+class UspAdapter(BackendAdapter):
+    def __init__(self, model: "OnlineEagle3Model"):
+        super().__init__(model)
+        self.sp_group = get_draft_sp_group()
+        self.sp_world_size = dist.get_world_size(self.sp_group)
+        self.ulysses_pg = get_sp_ulysses_group()
+        self.sp_ulysses_degree = dist.get_world_size(self.ulysses_pg)
+
+    def step_view(
+        self,
+        *,
+        idx: int,
+        ttt_length: int,
+        global_input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        target_p_padded: torch.Tensor,
+        position_mask: torch.Tensor,
+        seq_length: int,
+    ) -> StepState:
+        usp_chunk_size = seq_length - ttt_length
+        if usp_chunk_size <= 0:
+            raise ValueError(
+                f"USP local seq_length ({seq_length}) must be larger than "
+                f"ttt_length ({ttt_length})"
+            )
+        target_p = target_p_padded[:, idx : idx + usp_chunk_size, :]
+        return StepState(
+            input_ids=global_input_ids[:, :usp_chunk_size],
+            hidden_states=hidden_states[:, :usp_chunk_size, :],
+            position_ids=position_ids[:, : usp_chunk_size * self.sp_ulysses_degree],
+            attention_mask=attention_mask[:, :usp_chunk_size],
+            target_p=target_p,
+            position_mask=position_mask[:, :usp_chunk_size, :],
+            loss_mask=loss_mask[:, :usp_chunk_size, :],
+        )
+
+    def reduce_metrics(
+        self, *, local_correct: torch.Tensor, local_denom: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        local_correct = dist_nn.all_reduce(
+            local_correct, op=dist.ReduceOp.SUM, group=self.sp_group
+        )
+        local_denom = dist_nn.all_reduce(
+            local_denom, op=dist.ReduceOp.SUM, group=self.sp_group
+        )
+        return local_correct, local_denom
+
+    def reduce_loss(self, loss: torch.Tensor) -> torch.Tensor:
+        loss = dist_nn.all_reduce(loss, op=dist.ReduceOp.SUM, group=self.sp_group)
+        loss = loss / self.sp_world_size
+        return loss

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -20,6 +20,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gzip
+import io
 import os
 import re
 import warnings
@@ -27,10 +29,13 @@ from collections import Counter
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
+import torch.nn.functional as F
 from tqdm import tqdm
 from transformers import ImageProcessingMixin, PreTrainedTokenizer
 
 from datasets import Dataset as HFDataset
+
+from ..distributed import get_draft_sp_group, get_sp_ring_group
 
 try:
     from qwen_vl_utils import process_vision_info
@@ -432,23 +437,53 @@ def build_eagle3_dataset(
 # Offline Eagle3 Dataset
 # ==============================
 # modified from https://github.com/NickL77/BaldEagle/blob/master/train/modules/data/data.py
-def list_local_files(path, suffixes=[".ckpt"]):
+def list_local_files(path, suffixes=None):
+    if suffixes is None:
+        suffixes = [".ckpt", ".ckpt.gz"]
     datapaths = []
     for root, directories, files in os.walk(path):
         for file in files:
             file_path = os.path.join(root, file)
             datapaths.append(file_path)
-    for suffix in suffixes:
-        datapaths = [f_name for f_name in datapaths if f_name.endswith(suffix)]
+    if suffixes:
+        datapaths = [
+            f_name
+            for f_name in datapaths
+            if any(f_name.endswith(suffix) for suffix in suffixes)
+        ]
     return datapaths
 
 
 class OfflineEagle3Dataset(torch.utils.data.Dataset):
-    def __init__(self, datapath, transform=None, max_len=2048):
+    def __init__(
+        self,
+        datapath,
+        transform=None,
+        max_len=2048,
+        ttt_length=1,
+        use_usp_preprocess=False,
+    ):
+        """
+        Args:
+            datapath: List of file paths.
+            transform: Optional transform to apply.
+            max_len: Maximum sequence length to load.
+            ttt_length: TTT overlap length used in USP preprocessing.
+            use_usp_preprocess: Whether to shard all sequences with USP overlap in preprocessing.
+        """
         self.datapaths = datapath
         self.transform = transform
         self._epoch = 0
         self.max_len = max_len
+        self.ttt_length = ttt_length
+        self.use_usp_preprocess = use_usp_preprocess
+        if use_usp_preprocess:
+            sp_group = get_draft_sp_group()
+            self.sp_rank = torch.distributed.get_rank(sp_group)
+            self.sp_size = torch.distributed.get_world_size(sp_group)
+            ring_group = get_sp_ring_group()
+            self.ring_rank = torch.distributed.get_rank(ring_group)
+            self.sp_ring_size = torch.distributed.get_world_size(ring_group)
 
     @staticmethod
     def process_data(data, max_len, transform=None):
@@ -470,11 +505,98 @@ class OfflineEagle3Dataset(torch.utils.data.Dataset):
             new_data = transform(new_data)
         return new_data
 
+    @staticmethod
+    def process_data_usp(
+        data,
+        max_len,
+        ttt_length=1,
+        transform=None,
+        sp_rank=0,
+        sp_size=1,
+        ring_rank=0,
+        sp_ring_size=1,
+    ):
+        """
+        USP preprocess: shard all sequences by sp_rank and add TTT overlap.
+        Each local sequence length = ceil(max_len / sp_size) + ttt_length.
+        """
+        new_data = {}
+
+        input_ids = data["input_ids"]
+        if input_ids.ndim == 1:
+            input_ids = input_ids.unsqueeze(0)
+
+        global_len = min(max_len, input_ids.shape[1])
+        chunk_size = (global_len + sp_size - 1) // sp_size
+        start = sp_rank * chunk_size
+        local_len = chunk_size + ttt_length
+
+        end = min(start + local_len, global_len)
+
+        def _slice_and_pad(tensor):
+            if tensor.ndim == 1:
+                tensor = tensor.unsqueeze(0)
+            tensor = tensor[:, :global_len]
+            sliced = tensor[:, start : min(end, tensor.shape[1])]
+            valid_len = sliced.shape[1]
+            if valid_len < local_len:
+                pad_len = local_len - valid_len
+                if tensor.ndim == 2:
+                    sliced = F.pad(sliced, (0, pad_len))
+                else:
+                    sliced = F.pad(sliced, (0, 0, 0, pad_len))
+            return sliced.contiguous(), valid_len
+
+        if "aux_hidden_state" not in data or data["aux_hidden_state"] is None:
+            raise KeyError("aux_hidden_state is required for OfflineEagle3Dataset")
+        new_data["hidden_state"], _ = _slice_and_pad(data["aux_hidden_state"])
+        new_data["target"], _ = _slice_and_pad(data["hidden_state"])
+
+        new_data["input_ids"], valid_len = _slice_and_pad(input_ids)
+
+        full_loss_mask = data["loss_mask"]
+        if full_loss_mask.ndim == 1:
+            full_loss_mask = full_loss_mask.unsqueeze(0)
+
+        full_loss_mask = full_loss_mask[:, :global_len].clone()
+        if full_loss_mask.numel() > 0:
+            full_loss_mask[0, -1] = 0
+        new_data["loss_mask"], _ = _slice_and_pad(full_loss_mask)
+
+        local_len = new_data["input_ids"].shape[1]
+        attention_mask = torch.zeros((1, local_len), dtype=torch.long)
+        attention_mask[:, :valid_len] = 1
+        new_data["attention_mask"] = attention_mask
+
+        # Position ids should align with Ulysses all2all-expanded sequence length.
+        # Local seq_len (per sp_rank) = local_len; attention uses (local_len - ttt_length).
+        sp_ulysses_size = max(1, sp_size // sp_ring_size)
+        usp_chunk_size = max(local_len - ttt_length, 0)
+        ring_chunk = usp_chunk_size * sp_ulysses_size
+        ring_start = ring_rank * ring_chunk
+        new_data["position_ids"] = torch.arange(
+            ring_start, ring_start + ring_chunk, dtype=torch.long
+        ).unsqueeze(0)
+
+        if transform:
+            new_data = transform(new_data)
+
+        return new_data
+
     def __len__(self):
         return len(self.datapaths)
 
     def _open_file(self, index):
-        return torch.load(self.datapaths[index], weights_only=False)
+        """
+        Opens the file with memory mapping.
+        This operation is virtually instant and consumes negligible RAM
+        because no data is actually read from disk yet.
+        """
+        data_path = self.datapaths[index]
+        if data_path.endswith(".gz"):
+            with gzip.open(data_path, "rb") as f:
+                return torch.load(io.BytesIO(f.read()), weights_only=False)
+        return torch.load(data_path, weights_only=False, mmap=True)
 
     def __getitem__(self, index):
         try:
@@ -482,7 +604,24 @@ class OfflineEagle3Dataset(torch.utils.data.Dataset):
         except Exception as e:
             print(f"ERROR Failed to load {self.datapaths[index]} with error {e}")
             data = self._open_file(0)
-        return self.process_data(data, self.max_len, self.transform)
+
+        # 2. Read only specific bytes from disk
+        if self.use_usp_preprocess:
+            return self.process_data_usp(
+                data,
+                self.max_len,
+                ttt_length=self.ttt_length,
+                transform=self.transform,
+                sp_rank=self.sp_rank,
+                sp_size=self.sp_size,
+                ring_rank=self.ring_rank,
+                sp_ring_size=self.sp_ring_size,
+            )
+        return self.process_data(
+            data,
+            self.max_len,
+            self.transform,
+        )
 
     def set_epoch(self, epoch):
         self._epoch = epoch
@@ -491,10 +630,15 @@ class OfflineEagle3Dataset(torch.utils.data.Dataset):
 def build_offline_eagle3_dataset(
     hidden_states_path: str,
     max_len: int = 2048,
+    ttt_length: int = 1,
+    use_usp_preprocess: bool = False,
 ) -> torch.utils.data.Dataset:
+
     return OfflineEagle3Dataset(
         list_local_files(hidden_states_path),
         max_len=max_len,
+        ttt_length=ttt_length,
+        use_usp_preprocess=use_usp_preprocess,
     )
 
 
@@ -521,7 +665,7 @@ def generate_vocab_mapping_file(
     Returns:
         The path to the vocab mapping file.
     """
-    # prepare cache direcotory
+    # prepare cache directory
     os.makedirs(cache_dir, exist_ok=True)
     vocab_mapping_path = os.path.join(cache_dir, f"{cache_key}.pt")
 
@@ -529,7 +673,7 @@ def generate_vocab_mapping_file(
         print(f"Loading vocab mapping from the cached file at: {vocab_mapping_path}")
         return vocab_mapping_path
 
-    # we first count the frequency of effectiev tokens in the dataset
+    # we first count the frequency of effective tokens in the dataset
     token_dict = Counter()
     for input_ids, loss_mask in tqdm(
         zip(dataset["input_ids"], dataset["loss_mask"]),

--- a/tests/test_layers/test_decoder.py
+++ b/tests/test_layers/test_decoder.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 
 import torch
@@ -7,6 +8,9 @@ from accelerate.utils import set_seed
 from torch import nn
 from transformers import PretrainedConfig
 from yunchang import EXTRACT_FUNC_DICT
+
+from specforge.core.eagle3_adapters import SdpaLikeAdapter, UspAdapter
+from specforge.data.preprocessing import build_offline_eagle3_dataset
 
 # Project-specific imports
 from specforge.distributed import destroy_distributed, init_distributed
@@ -55,6 +59,19 @@ def setup_env(rank, world_size, port):
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(port)
     torch.cuda.set_device(rank)
+
+
+def dbg(rank, msg):
+    print(f"[rank{rank}] {msg}", flush=True)
+
+
+def wait_for_file(path, timeout_s=60, poll_s=0.1):
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if os.path.exists(path):
+            return True
+        time.sleep(poll_s)
+    return False
 
 
 def run_iterative_pass(
@@ -113,6 +130,7 @@ def run_test_case(rank, world_size, port):
     setup_env(rank, world_size, port)
     device = torch.device(f"cuda:{rank}")
     set_seed(42)
+    dbg(rank, "env setup complete")
 
     # --- Data & Config Preparation ---
     config = get_model_config()
@@ -135,13 +153,34 @@ def run_test_case(rank, world_size, port):
         config.vocab_size, config.hidden_size, config.pad_token_id
     ).to(device)
 
-    # --- Phase 1: Golden Run (SDPA) ---
+    # --- Phase 1: Golden Run (FA) ---
     # Init dist briefly for internal checks, even if running single-device logic
     init_distributed(tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
+    dbg(rank, "init_distributed (FA) done")
 
     sdpa_decoder = (
         LlamaDecoderLayer(config, attention_backend="fa").to(device).to(torch.bfloat16)
     )
+    dbg(rank, "FA decoder created")
+    # Adapter smoke test for FA/SDPA-style path
+    dummy_model = type("Dummy", (), {})()
+    sdpa_adapter = SdpaLikeAdapter(dummy_model)
+    sdpa_target_p = torch.zeros((1, seq_len, 8), device=device, dtype=torch.float32)
+    sdpa_position_mask = torch.ones((1, seq_len, 1), device=device, dtype=torch.float32)
+    sdpa_state = sdpa_adapter.step_view(
+        idx=0,
+        ttt_length=ttt_length,
+        global_input_ids=data_input_ids,
+        attention_mask=attention_mask,
+        loss_mask=torch.ones((1, seq_len, 1), device=device, dtype=torch.float32),
+        position_ids=position_ids,
+        hidden_states=data_hidden_states,
+        target_p_padded=sdpa_target_p,
+        position_mask=sdpa_position_mask,
+        seq_length=seq_len,
+    )
+    assert sdpa_state.input_ids.shape[1] == seq_len
+    assert sdpa_state.hidden_states.shape[1] == seq_len
 
     with torch.no_grad():
         sdpa_output = run_iterative_pass(
@@ -153,11 +192,13 @@ def run_test_case(rank, world_size, port):
             position_ids=position_ids,
             ttt_length=ttt_length,
         )
+    dbg(rank, "FA forward done")
 
     # Save weights for alignment and cleanup SDPA model
     state_dict = sdpa_decoder.state_dict()
     del sdpa_decoder
     destroy_distributed()
+    dbg(rank, "destroy_distributed (FA) done")
 
     # --- Phase 2: Distributed Run (USP) ---
     def subtest_usp(sp_ulysses_degree, sp_ring_degree):
@@ -168,6 +209,89 @@ def run_test_case(rank, world_size, port):
                 sp_ulysses_size=sp_ulysses_degree,
                 sp_ring_size=sp_ring_degree,
             )
+            dbg(
+                rank,
+                f"init_distributed (USP U{sp_ulysses_degree} R{sp_ring_degree}) done",
+            )
+            # Dataset + adapter smoke test (USP path)
+            tmp_dir = "./tmp/usp_dataset_shared"
+            try:
+                if rank == 0:
+                    os.makedirs(tmp_dir, exist_ok=True)
+                    sample = {
+                        "input_ids": data_input_ids[0].cpu(),
+                        "loss_mask": torch.ones_like(data_input_ids[0].cpu()),
+                        "hidden_state": data_hidden_states[0].cpu().unsqueeze(0),
+                        "aux_hidden_state": data_hidden_states[0].cpu().unsqueeze(0),
+                    }
+                    torch.save(sample, os.path.join(tmp_dir, "data_0.ckpt"))
+                    dbg(rank, "wrote sample ckpt")
+                    ready_flag = os.path.join(tmp_dir, "ready.flag")
+                    with open(ready_flag, "w", encoding="utf-8") as f:
+                        f.write("ready\n")
+                if rank != 0:
+                    ready_flag = os.path.join(tmp_dir, "ready.flag")
+                    assert wait_for_file(
+                        ready_flag, timeout_s=60
+                    ), "timeout waiting for ready flag"
+                dbg(rank, "dataset sync done")
+                assert os.path.exists(
+                    os.path.join(tmp_dir, "data_0.ckpt")
+                ), f"Expected sample not found at {tmp_dir}"
+                dbg(rank, "sample exists")
+
+                ds = build_offline_eagle3_dataset(
+                    tmp_dir,
+                    max_len=seq_len,
+                    ttt_length=ttt_length,
+                    use_usp_preprocess=True,
+                )
+                dbg(rank, "dataset built")
+                item = ds[0]
+                dbg(rank, "dataset item loaded")
+                assert "position_ids" in item
+
+                dummy_model = type("Dummy", (), {})()
+                adapter = UspAdapter(dummy_model)
+                local_seq_len = item["input_ids"].shape[1]
+                target_p_padded = torch.zeros(
+                    (1, local_seq_len, 8), device=device, dtype=torch.float32
+                )
+                position_mask = torch.ones(
+                    (1, local_seq_len, 1), device=device, dtype=torch.float32
+                )
+                state = adapter.step_view(
+                    idx=0,
+                    ttt_length=ttt_length,
+                    global_input_ids=item["input_ids"].to(device),
+                    attention_mask=item["attention_mask"].to(device),
+                    loss_mask=item["loss_mask"].to(device).unsqueeze(-1),
+                    position_ids=item["position_ids"].to(device),
+                    hidden_states=item["hidden_state"].to(device),
+                    target_p_padded=target_p_padded,
+                    position_mask=position_mask,
+                    seq_length=local_seq_len,
+                )
+                assert state.input_ids.shape[1] == local_seq_len - ttt_length
+                assert state.hidden_states.shape[1] == local_seq_len - ttt_length
+                dbg(rank, "adapter step_view ok")
+            finally:
+                if rank == 0:
+                    done_flag = os.path.join(tmp_dir, "done.flag")
+                    assert wait_for_file(
+                        done_flag, timeout_s=60
+                    ), "timeout waiting for done flag"
+                    try:
+                        for root, _, files in os.walk(tmp_dir):
+                            for name in files:
+                                os.remove(os.path.join(root, name))
+                        os.rmdir(tmp_dir)
+                    except OSError:
+                        pass
+                else:
+                    done_flag = os.path.join(tmp_dir, "done.flag")
+                    with open(done_flag, "w", encoding="utf-8") as f:
+                        f.write("done\n")
 
             # Init USP model and load golden weights
             usp_decoder = (
@@ -176,6 +300,7 @@ def run_test_case(rank, world_size, port):
                 .to(torch.bfloat16)
             )
             usp_decoder.load_state_dict(state_dict)
+            dbg(rank, "USP decoder loaded")
 
             # Shard data (Split Input)
             extract_func = EXTRACT_FUNC_DICT["basic"]
@@ -203,24 +328,41 @@ def run_test_case(rank, world_size, port):
                 .detach()
                 .clone()
             )
+            dbg(rank, "USP local inputs prepared")
+            total_degree = sp_ring_degree * sp_ulysses_degree
+            chunk_size = sdpa_output.shape[1] // total_degree
+            start_idx = (rank % total_degree) * chunk_size
+            local_len = local_input_ids.shape[1]
+            local_position_ids = (
+                torch.arange(start_idx, start_idx + local_len, device=device)
+                .unsqueeze(0)
+                .long()
+            )
+            local_attention_mask = torch.tril(
+                torch.ones(local_len, local_len, device=device)
+            ).view(1, 1, local_len, local_len)
 
             # Run USP forward
+            if sp_ring_degree > 1:
+                usp_attention_mask = local_attention_mask
+                usp_position_ids = local_position_ids
+            else:
+                usp_attention_mask = attention_mask
+                usp_position_ids = position_ids
             with torch.no_grad():
                 usp_output = run_iterative_pass(
                     decoder_layer=usp_decoder,
                     embed_tokens=embed_tokens,
                     input_ids=local_input_ids,
                     hidden_states=local_hidden_states,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
+                    attention_mask=usp_attention_mask,
+                    position_ids=usp_position_ids,
                     ttt_length=ttt_length,
                 )
+            dbg(rank, "USP forward done")
 
             # Verify results
             # Slice the golden output to match the current rank's chunk
-            total_degree = sp_ring_degree * sp_ulysses_degree
-            chunk_size = sdpa_output.shape[1] // total_degree
-            start_idx = (rank % total_degree) * chunk_size
             end_idx = start_idx + chunk_size
 
             golden_chunk = sdpa_output[:, start_idx:end_idx, :]
@@ -229,9 +371,11 @@ def run_test_case(rank, world_size, port):
                 f"[Rank {rank}] USP (U{sp_ulysses_degree}R{sp_ring_degree}) mismatch!\n"
                 f"Max Diff: {(usp_output - golden_chunk).abs().max().item()}"
             )
+            dbg(rank, "USP output verified")
 
         finally:
             destroy_distributed()
+            dbg(rank, "destroy_distributed (USP) done")
 
     # Case 1: Hybrid (Ulysses=2, Ring=1)
     subtest_usp(sp_ulysses_degree=2, sp_ring_degree=1)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
 - For long sequences, storing full hidden states and targets on GPU is too memory‑heavy. We need to shard along sequence‑parallel (SP) at input time so memory scales with SP degree.
 - USP/sequence‑parallel paths diverged between offline and online training, which made loss/metric computation and position_ids handling fragile; therefore we introduced adapters to unify backend-specific step views and distributed
  loss/metric reductions, keeping position_ids handling consistent.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
With these changes, 8 GPUs can now support training on sequences up to 128K length.


## Modifications
  1. Add specforge/core/eagle3_adapters.py to abstract SDPA/USP step views and distributed loss/metric reductions.
  2. Offline dataset reads hidden states via mmap and only loads the local shard needed by the current SP rank.
  3. Remove long‑sequence support in online mode (target models are too large for VRAM). Long‑sequence online needs a redesign. In the near term, we’ll focus on offline mode and add compression to mitigate disk usage.
  4. prepare_hidden_states.py adds --compress to gzip hidden states, reducing storage by ~20%.
<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test
**split input**
<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->
<img width="1134" height="836" alt="image" src="https://github.com/user-attachments/assets/9852d868-f400-4b44-8727-c7103ebf9778" />
<img width="1120" height="827" alt="image" src="https://github.com/user-attachments/assets/fe4e4a10-c2ea-45a3-8f86-60cf54cfe10d" />

## Benchmark & Profiling

**Compression is accuracy-neutral**: 
- accept length stays the same for compressed vs. uncompressed runs (1.93 vs. 1.93).
- training throughput is slightly lower due to decompression overhead: time/step increases from 0.45s to 0.47s (~4% slower).


| setting | accept length | time/step (s) | disk usage |
|--------|---------------|---------------|------------|
| gzip (compressed) | 1.93 | 0.47 | 659G |
| uncompressed | 1.93 | 0.45 | 822G |

**SP-sharded inputs**:
 accept length unchanged




<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
