### PR TITLE
add resume for dflash training script

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -96,6 +96,7 @@ def parse_args():
     output_group.add_argument("--cache-dir", type=str, default="./cache")
     output_group.add_argument("--log-interval", type=int, default=50)
     output_group.add_argument("--eval-interval", type=int, default=1000)
+    output_group.add_argument("--save-interval", type=int, default=1000)
 
     optimization_group = parser.add_argument_group("optimization")
     optimization_group.add_argument(

--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -143,6 +143,7 @@ def build_models(args) -> Tuple[DFlashTargetModel, DFlashDraftModel]:
     draft_model_last_checkpoint = None
     if args.resume and os.path.isdir(args.output_dir):
         from specforge.utils import get_last_checkpoint
+
         print_on_rank0(args.output_dir)
         draft_model_last_checkpoint = get_last_checkpoint(args.output_dir)
         print_on_rank0(f"Last checkpoint detected: {draft_model_last_checkpoint}")
@@ -150,7 +151,9 @@ def build_models(args) -> Tuple[DFlashTargetModel, DFlashDraftModel]:
     if draft_model_last_checkpoint:
         # Load config from checkpoint
         draft_config = AutoConfig.from_pretrained(draft_model_last_checkpoint)
-        print_on_rank0(f"Loaded draft config from checkpoint: {draft_model_last_checkpoint}")
+        print_on_rank0(
+            f"Loaded draft config from checkpoint: {draft_model_last_checkpoint}"
+        )
 
         # Set attention implementation based on backend
         draft_config._attn_implementation = args.attention_backend
@@ -162,7 +165,9 @@ def build_models(args) -> Tuple[DFlashTargetModel, DFlashDraftModel]:
             config=draft_config,
             torch_dtype=torch.bfloat16,
         ).cuda()
-        print_on_rank0(f"Resumed draft model from checkpoint: {draft_model_last_checkpoint}")
+        print_on_rank0(
+            f"Resumed draft model from checkpoint: {draft_model_last_checkpoint}"
+        )
     else:
         # Build draft model from scratch or provided config
         if args.draft_config_path:
@@ -493,9 +498,7 @@ def main():
                 )
 
         # Save checkpoint after each epoch
-        save_checkpoint(
-            args, epoch, global_step, dflash_model, draft_model, optimizer
-        )
+        save_checkpoint(args, epoch, global_step, dflash_model, draft_model, optimizer)
 
     # Final checkpoint
     save_checkpoint(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

The current dflash saves checkpoint but does not have logic to resume training, dflash tend to have a higher epoch count compared with eagle3, so this will be helpful.

## Modifications

<!-- Describe the changes made in this PR. -->

* change the save checkpoint to be on the epoch resolution since we don't have logic to restore optimizer state
* when loading drafter model, use checkpoint if requested with `--resume` and available

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

NA

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

The loading and training proceeds:

```bash
INFO:specforge.utils:/tmp/tianhaoz/longcat_dflash_training/outputs
INFO:specforge.utils:Last checkpoint detected: /tmp/tianhaoz/longcat_dflash_training/outputs/epoch_4
INFO:specforge.utils:Loaded draft config from checkpoint: /tmp/tianhaoz/longcat_dflash_training/outputs/epoch_4
```

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

This change is unrelated to performance.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
