### PR TITLE
add datapaths sort to ensure deterministic order across ranks

### DIFF
--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -451,6 +451,7 @@ def list_local_files(path, suffixes=None):
             for f_name in datapaths
             if any(f_name.endswith(suffix) for suffix in suffixes)
         ]
+    datapaths.sort()  # Sort to ensure deterministic order across ranks
     return datapaths
 
 


### PR DESCRIPTION
# Fix: Sort data files to resolve SeqAllToAll shape mismatch in distributed training

## Summary
This PR enforces a deterministic order for file loading in `specforge/data/preprocessing.py` to fix a critical bug in distributed training.

## Problem
The `list_local_files` function previously used `os.walk` without sorting the results. In distributed environments, `os.walk` does not guarantee a consistent traversal order across different nodes or ranks.

## Impact
In **Sequence Parallel (USP)** mode, this non-deterministic behavior caused ranks within the same parallel group to load different data files for the same batch index.

* **Observation:** Rank 0 loaded File A (len: 3503) while Rank 1 loaded File B (len: 3925).
* **Result:** This length mismatch triggered deadlocks (NCCL Watchdog Timeout) or shape mismatch errors during the `SeqAllToAll` communication in the Attention layer, as ranks expected consistent sequence lengths.

## Solution
Applied `.sort()` to the file paths returned by `list_local_files`. This guarantees that all ranks process data in a synchronized order regardless of the environment.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)