### PR TITLE
fix(dflash): remove incorrect padding shift and fix cross-block data leak

### DIFF
--- a/examples/run_qwen3_8b_dflash_online.sh
+++ b/examples/run_qwen3_8b_dflash_online.sh
@@ -13,6 +13,8 @@ torchrun \
     --nproc_per_node $NUM_GPUS \
     $ROOT_DIR/scripts/train_dflash.py \
     --target-model-path Qwen/Qwen3-8B \
+    --target-model-backend sglang \
+    --sglang-mem-fraction-static 0.2 \
     --draft-config-path $ROOT_DIR/configs/qwen3-8b-dflash.json \
     --train-data-path $ROOT_DIR/cache/dataset/perfectblend_qwen3-8b_regen.jsonl \
     --output-dir $ROOT_DIR/outputs/qwen3-8b-perfectblend \

--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -44,7 +44,7 @@ def parse_args():
     model_group.add_argument(
         "--target-model-backend",
         type=str,
-        default="hf",
+        default="sglang",
         choices=["sglang", "hf"],
         help="Backend for target model: 'sglang' (service) or 'hf' (local)",
     )

--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -18,7 +18,6 @@ from sglang.srt.utils import require_mlp_sync, require_mlp_tp_gather
 from transformers import AutoModelForCausalLM
 
 from specforge.distributed import get_tp_group
-from specforge.utils import padding
 
 from .sglang_backend import SGLangRunner
 
@@ -234,10 +233,6 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
         input_ids = torch.cat([d[0] for d in data_cache], dim=0)
         attention_mask = torch.cat([d[1] for d in data_cache], dim=0)
         loss_mask = torch.cat([d[2] for d in data_cache], dim=0)
-
-        # Padding might be needed if batching varied lengths (but usually fixed length training)
-        hidden_states = padding(hidden_states, left=False)
-        input_ids = padding(input_ids, left=False)
 
         return DFlashTargetOutput(
             hidden_states=hidden_states,


### PR DESCRIPTION
## Motivation

Fix two bugs in DFlash training identified in #470 and #471.

## Modifications

### 1. Remove incorrect padding (shift) in SGLang backend (Related: #471)

The `padding()` function in `dflash_target_model.py` is a left-shift operation inherited from Eagle3, where it aligns `hidden_states[t]` with `token[t+1]` for next-token prediction. However, DFlash uses **same-position prediction** (`logits[j]` → `token[j]`), so this shift is incorrect and causes a 1-position misalignment between `input_ids`/`hidden_states` (shifted) and `loss_mask`/`attention_mask` (not shifted).

**Fix**: Remove the `padding()` calls entirely. The HF backend was already correct (no shift).

### 2. Fix cross-block data leak in random-anchor mode (Related: #470)

When `num-anchors` is large, anchor spacing drops below `block_size`, causing blocks to overlap. The old attention mask used **block-id comparison** (`k_ctx < q_b`) to determine context visibility, which allowed a later block to see target hidden states from overlapping positions — a data leak that never occurs during inference.

**Fix**: Change context visibility from block-id comparison to **original position comparison** (`orig_pos[kv] < anchor_pos[query_block]`), ensuring each block can only attend to context strictly before its anchor position, regardless of overlap.

## Related Issues

Fixes #470
Fixes #471

## Checklist

- [x] Format your code according to the [[Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit)](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [[Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci)](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [[Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci)](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [[Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html)](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [[Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html)](https://docs.sglang.ai/references/accuracy_evaluation.html).