### PR TITLE
fix: handle empty/invalid conversations to prevent IndexError in data parsing

### DIFF
--- a/specforge/data/parse.py
+++ b/specforge/data/parse.py
@@ -80,6 +80,12 @@ class GeneralParser(Parser):
         if not preformatted:
             messages = []
 
+            if not conversation:
+                warnings.warn(
+                    "Empty conversation encountered, skipping."
+                )
+                return None
+
             if conversation[0]["role"] == "system":
                 warnings.warn(
                     f"The first message is from system, we will use the system prompt from the data and ignore the system prompt from the template"
@@ -120,6 +126,14 @@ class GeneralParser(Parser):
                         warnings.warn(f"Failed to parse tool_calls JSON: {tool_calls}")
                         break
                 messages.append(sentence)
+
+            # Skip conversations with no user/assistant turns (only system prompt)
+            has_non_system = any(m["role"] != "system" for m in messages)
+            if not has_non_system:
+                warnings.warn(
+                    "Conversation has no user/assistant turns after validation, skipping."
+                )
+                return None
 
             try:
                 conversation = self.apply_chat_template(messages, **kwargs)

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -163,13 +163,17 @@ def preprocess_conversations(
         if not source:
             # if the source is None, skip it
             continue
-        input_ids, loss_mask = parser.parse(
+        result = parser.parse(
             source,
             max_length,
             preformatted=is_preformatted,
             train_only_last_turn=train_only_last_turn,
             **kwargs_item,
         )
+        if result is None:
+            # parser returned None for invalid/empty conversations
+            continue
+        input_ids, loss_mask = result
         results["input_ids"].append(input_ids[None, :])
         results["loss_mask"].append(loss_mask[None, :])
         results["attention_mask"].append(torch.ones_like(loss_mask)[None, :])


### PR DESCRIPTION
## Summary
- Fixes #368 — `IndexError: list index out of range` when training EAGLE3 with datasets containing empty or malformed conversations

## Root Cause

Two crash paths in `GeneralParser.parse()` (`specforge/data/parse.py`):

**Path 1 — Empty conversation list:**
```python
# line 83: conversation is [] → IndexError
if conversation[0]["role"] == "system":
```

**Path 2 — Conversation starts with non-"user" role:**
```python
# After removing system prompt, if first message isn't "user":
for j, sentence in enumerate(conversation):
    if j == 0:
        if role != "user":
            break  # ← messages = [system_prompt_only]

# Then:
self.apply_chat_template(messages)  # ← messages has no user/assistant turns
# → transformers internally does conversation[0] on empty/invalid input → IndexError
```

This commonly happens with ShareGPT datasets that have entries starting with `"assistant"` role, or entries that are empty after filtering.

## Fix

1. **`parse.py`**: `GeneralParser.parse()` now returns `None` for:
   - Empty conversation input (`[]`)
   - Conversations with no user/assistant turns after validation (only system prompt remains)

2. **`preprocessing.py`**: `preprocess_conversations()` checks for `None` return and skips the entry with `continue`, matching the existing `if not source: continue` pattern.

## Test plan
- [ ] Train with ShareGPT dataset containing entries that start with assistant role — should skip gracefully with a warning instead of crashing
- [ ] Train with clean dataset — no behavior change
- [ ] Verify skipped conversations produce a warning message in logs