### PR TITLE
[Bug Fix] fix the drifting of target ids in DFlash model

### DIFF
--- a/specforge/core/dflash.py
+++ b/specforge/core/dflash.py
@@ -222,7 +222,7 @@ class OnlineDFlashModel(nn.Module):
 
         logits = self.lm_head(output_hidden)
 
-        # --- Labels: same-position prediction (position k predicts token anchor+k) ---
+        # --- Labels: same-position prediction (position k predicts token anchor+k+1) ---
         label_offsets = torch.arange(1, self.block_size + 1, device=device).view(1, 1, -1)
         label_indices = anchor_positions.unsqueeze(-1) + label_offsets
         valid_label_mask = label_indices < seq_len


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<img width="1070" height="688" alt="2a026680935d4f9fb6bb5c5eb5092bfe" src="https://github.com/user-attachments/assets/1b102854-b085-4cd6-bb40-a03e65dfdebb" />

If the length of fused target context feature is n, the block should predict the (n+2), (n+3)...(n+block_size+1) th tokens instead of 
 (n+1), (n+2)...(n+block_size) th tokens.


## Modifications



## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
