### PR TITLE
Fix multi-node DP training crash from FlashInfer CUDA IPC handles

### DIFF
--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
@@ -35,6 +37,74 @@ from specforge.utils import padding
 
 from .sglang_backend import SGLangRunner, wrap_eagle3_logits_processors_in_module
 from .sglang_backend.utils import LogitsProcessorForEAGLE3
+
+logger = logging.getLogger(__name__)
+
+
+def _is_multi_node(world_size: int, tp_size: int) -> bool:
+    """Detect whether training spans multiple physical nodes.
+
+    Uses LOCAL_WORLD_SIZE (set by torchrun / torch elastic) to determine
+    how many processes run on the current node and compares to the total
+    world size.  When LOCAL_WORLD_SIZE is not available (e.g. mp.spawn in
+    unit tests), falls back to ``world_size > tp_size``.
+
+    Note: the fallback cannot detect cross-node TP where
+    ``world_size == tp_size`` (e.g. TP=8 across 2×4-GPU nodes).  If your
+    launcher does not set LOCAL_WORLD_SIZE and you use cross-node TP,
+    set ``LOCAL_WORLD_SIZE`` explicitly in your environment.
+    """
+    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", "0"))
+    if local_world_size > 0:
+        return world_size > local_world_size
+    logger.warning(
+        "LOCAL_WORLD_SIZE not set; falling back to world_size > tp_size "
+        "for multi-node detection. This may misclassify single-node DP as "
+        "multi-node, or miss cross-node TP where world_size == tp_size. "
+        "Set LOCAL_WORLD_SIZE in your environment for accurate detection."
+    )
+    return world_size > tp_size
+
+
+def _has_mnnvl_ipc() -> bool:
+    """Check if MNNVL-backed CUDA IPC is available for cross-node GPU memory sharing.
+
+    On GB200 NVL72 racks, all GPUs are connected via NVSwitch. When IMEX
+    (Inter-process Memory Exchange) channels are available, CUDA IPC handles
+    can be shared across nodes via fabric memory, making cross-node
+    custom_all_reduce and FlashInfer allreduce fusion safe.
+
+    Returns True if IMEX channels are present (indicating MNNVL IPC support).
+    """
+    return os.path.isdir("/dev/nvidia-caps-imex-channels")
+
+
+def should_disable_ipc_optimizations(world_size: int, tp_size: int) -> bool:
+    """Determine whether to disable CUDA IPC-based optimizations.
+
+    CUDA IPC-based optimizations (custom_all_reduce, FlashInfer allreduce
+    fusion) assume GPU memory can be shared between processes. This works:
+    - On single-node: always (standard CUDA IPC)
+    - On multi-node with MNNVL: when IMEX channels are available (fabric memory)
+    - On multi-node without MNNVL: never (IPC handles can't cross nodes)
+
+    Returns True if IPC optimizations should be disabled.
+    """
+    multi_node = _is_multi_node(world_size, tp_size)
+    if not multi_node:
+        return False
+    if _has_mnnvl_ipc():
+        logger.info(
+            "Multi-node training detected with MNNVL IPC support "
+            "(IMEX channels available). Keeping IPC optimizations enabled."
+        )
+        return False
+    logger.info(
+        "Multi-node training detected without MNNVL IPC support. "
+        "Disabling custom_all_reduce and FlashInfer allreduce fusion "
+        "to avoid cross-node CUDA IPC failures."
+    )
+    return True
 
 
 @dataclass
@@ -302,12 +372,16 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         **kwargs,
     ) -> "SGLangEagle3TargetModel":
         tp_size = dist.get_world_size(get_tp_group())
+        disable_ipc = should_disable_ipc_optimizations(
+            dist.get_world_size(), tp_size
+        )
         server_args = ServerArgs(
             model_path=pretrained_model_name_or_path,
             trust_remote_code=trust_remote_code,
             dtype=torch_dtype,
             enable_return_hidden_states=True,
             disable_cuda_graph=True,  # we use piecewise cuda graph for prefill instead
+            disable_custom_all_reduce=disable_ipc,
             tp_size=tp_size,
             pp_size=1,
             **kwargs,
@@ -316,6 +390,12 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         tp_rank = dist.get_rank(get_tp_group())
         moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
         model_config = ModelConfig.from_server_args(server_args)
+        if disable_ipc:
+            # Disable FlashInfer allreduce fusion which uses CUDA IPC handles
+            # that cannot cross node boundaries without MNNVL support.
+            # Must be set after ModelConfig.from_server_args() which auto-enables
+            # it for MoE models (e.g. Qwen3MoeForCausalLM) on SM90/SM100 hardware.
+            server_args.enable_flashinfer_allreduce_fusion = False
         model_runner = SGLangRunner(
             model_config=model_config,
             mem_fraction_static=server_args.mem_fraction_static,

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -375,7 +375,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         model_config = ModelConfig.from_server_args(server_args)
         if disable_ipc:
             # Disable FlashInfer allreduce fusion which uses CUDA IPC handles
-            # that cannot cross node boundaries without MNNVL support.
+            # (cudaIpcGetMemHandle) that cannot cross node boundaries.
             # Must be set after ModelConfig.from_server_args() which auto-enables
             # it for MoE models (e.g. Qwen3MoeForCausalLM) on SM90/SM100 hardware.
             server_args.enable_flashinfer_allreduce_fusion = False

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -66,43 +66,26 @@ def _is_multi_node(world_size: int, tp_size: int) -> bool:
     return world_size > tp_size
 
 
-def _has_mnnvl_ipc() -> bool:
-    """Check if MNNVL-backed CUDA IPC is available for cross-node GPU memory sharing.
-
-    On GB200 NVL72 racks, all GPUs are connected via NVSwitch. When IMEX
-    (Inter-process Memory Exchange) channels are available, CUDA IPC handles
-    can be shared across nodes via fabric memory, making cross-node
-    custom_all_reduce and FlashInfer allreduce fusion safe.
-
-    Returns True if IMEX channels are present (indicating MNNVL IPC support).
-    """
-    return os.path.isdir("/dev/nvidia-caps-imex-channels")
-
-
 def should_disable_ipc_optimizations(world_size: int, tp_size: int) -> bool:
     """Determine whether to disable CUDA IPC-based optimizations.
 
     CUDA IPC-based optimizations (custom_all_reduce, FlashInfer allreduce
-    fusion) assume GPU memory can be shared between processes. This works:
-    - On single-node: always (standard CUDA IPC)
-    - On multi-node with MNNVL: when IMEX channels are available (fabric memory)
-    - On multi-node without MNNVL: never (IPC handles can't cross nodes)
+    fusion) use cudaIpcGetMemHandle / cudaIpcOpenMemHandle which rely on
+    POSIX shared memory — they only work between processes on the same node.
 
-    Returns True if IPC optimizations should be disabled.
+    Even on MNNVL-connected racks (GB200 NVL72) with IMEX channels present,
+    FlashInfer's and SGLang's custom IPC code does NOT use the fabric-aware
+    CUDA APIs (cudaMallocFabric / multicast), so cross-node IPC still fails
+    with "CUDART error: invalid resource handle".
+
+    Returns True if IPC optimizations should be disabled (i.e. multi-node).
     """
-    multi_node = _is_multi_node(world_size, tp_size)
-    if not multi_node:
-        return False
-    if _has_mnnvl_ipc():
-        logger.info(
-            "Multi-node training detected with MNNVL IPC support "
-            "(IMEX channels available). Keeping IPC optimizations enabled."
-        )
+    if not _is_multi_node(world_size, tp_size):
         return False
     logger.info(
-        "Multi-node training detected without MNNVL IPC support. "
-        "Disabling custom_all_reduce and FlashInfer allreduce fusion "
-        "to avoid cross-node CUDA IPC failures."
+        "Multi-node training detected. Disabling custom_all_reduce and "
+        "FlashInfer allreduce fusion (CUDA IPC handles cannot cross node "
+        "boundaries)."
     )
     return True
 

--- a/tests/test_modeling/test_target/test_multinode_detection.py
+++ b/tests/test_modeling/test_target/test_multinode_detection.py
@@ -1,0 +1,129 @@
+"""Tests for multi-node topology and IPC optimization detection.
+
+The should_disable_ipc_optimizations gate controls whether CUDA IPC-based
+optimizations (custom_all_reduce, FlashInfer allreduce fusion) are disabled.
+These optimizations use IPC handles that cannot cross node boundaries
+unless MNNVL fabric memory (via IMEX channels) is available.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from specforge.modeling.target.eagle3_target_model import (
+    _has_mnnvl_ipc,
+    _is_multi_node,
+    should_disable_ipc_optimizations,
+)
+
+
+class TestIsMultiNode(unittest.TestCase):
+    """Test the _is_multi_node topology detection."""
+
+    # --- Single-node topologies ---
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    def test_single_node_tp4(self):
+        """1 node, 4 GPUs, TP=4."""
+        self.assertFalse(_is_multi_node(world_size=4, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "8"})
+    def test_single_node_tp4_dp2(self):
+        """1 node, 8 GPUs, TP=4, DP=2: single-node DP."""
+        self.assertFalse(_is_multi_node(world_size=8, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "1"})
+    def test_single_node_tp1(self):
+        """1 node, 1 GPU."""
+        self.assertFalse(_is_multi_node(world_size=1, tp_size=1))
+
+    # --- Multi-node topologies ---
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    def test_multi_node_tp4_dp2(self):
+        """2 nodes, 4 GPUs each, TP=4, DP=2."""
+        self.assertTrue(_is_multi_node(world_size=8, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    def test_multi_node_tp4_dp4(self):
+        """4 nodes, 4 GPUs each, TP=4, DP=4."""
+        self.assertTrue(_is_multi_node(world_size=16, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    def test_multi_node_tp8_across_nodes(self):
+        """2 nodes, 4 GPUs each, TP=8 spanning nodes."""
+        self.assertTrue(_is_multi_node(world_size=8, tp_size=8))
+
+    # --- Fallback (no LOCAL_WORLD_SIZE) ---
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_fallback_single_node(self):
+        os.environ.pop("LOCAL_WORLD_SIZE", None)
+        self.assertFalse(_is_multi_node(world_size=4, tp_size=4))
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_fallback_multi_node(self):
+        os.environ.pop("LOCAL_WORLD_SIZE", None)
+        self.assertTrue(_is_multi_node(world_size=8, tp_size=4))
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_fallback_cross_node_tp_false_negative(self):
+        """Fallback cannot detect cross-node TP where world_size == tp_size."""
+        os.environ.pop("LOCAL_WORLD_SIZE", None)
+        self.assertFalse(_is_multi_node(world_size=8, tp_size=8))
+
+
+class TestShouldDisableIpcOptimizations(unittest.TestCase):
+    """Test the combined multi-node + MNNVL gate."""
+
+    # --- Single-node: never disable ---
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
+    def test_single_node_no_mnnvl(self, _):
+        """Single-node without MNNVL: keep optimizations."""
+        self.assertFalse(should_disable_ipc_optimizations(world_size=4, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "8"})
+    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
+    def test_single_node_dp_no_mnnvl(self, _):
+        """Single-node DP without MNNVL: keep optimizations."""
+        self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=4))
+
+    # --- Multi-node without MNNVL: disable ---
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
+    def test_multi_node_no_mnnvl(self, _):
+        """Multi-node without MNNVL: disable IPC optimizations."""
+        self.assertTrue(should_disable_ipc_optimizations(world_size=8, tp_size=4))
+
+    # --- Multi-node with MNNVL (GB200 NVL72): keep ---
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=True)
+    def test_multi_node_with_mnnvl(self, _):
+        """Multi-node with MNNVL (e.g. GB200 NVL72): keep IPC optimizations."""
+        self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=4))
+
+    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
+    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=True)
+    def test_multi_node_cross_node_tp_with_mnnvl(self, _):
+        """Cross-node TP with MNNVL: keep IPC optimizations."""
+        self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=8))
+
+
+class TestHasMnnvlIpc(unittest.TestCase):
+    """Test IMEX channel detection."""
+
+    @patch("os.path.isdir", return_value=True)
+    def test_imex_present(self, _):
+        self.assertTrue(_has_mnnvl_ipc())
+
+    @patch("os.path.isdir", return_value=False)
+    def test_imex_absent(self, _):
+        self.assertFalse(_has_mnnvl_ipc())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling/test_target/test_multinode_detection.py
+++ b/tests/test_modeling/test_target/test_multinode_detection.py
@@ -2,8 +2,8 @@
 
 The should_disable_ipc_optimizations gate controls whether CUDA IPC-based
 optimizations (custom_all_reduce, FlashInfer allreduce fusion) are disabled.
-These optimizations use IPC handles that cannot cross node boundaries
-unless MNNVL fabric memory (via IMEX channels) is available.
+These optimizations use cudaIpcGetMemHandle / cudaIpcOpenMemHandle which rely
+on POSIX shared memory and only work between processes on the same node.
 """
 
 import os
@@ -11,7 +11,6 @@ import unittest
 from unittest.mock import patch
 
 from specforge.modeling.target.eagle3_target_model import (
-    _has_mnnvl_ipc,
     _is_multi_node,
     should_disable_ipc_optimizations,
 )
@@ -74,55 +73,31 @@ class TestIsMultiNode(unittest.TestCase):
 
 
 class TestShouldDisableIpcOptimizations(unittest.TestCase):
-    """Test the combined multi-node + MNNVL gate."""
+    """Test the multi-node IPC gate."""
 
     # --- Single-node: never disable ---
 
     @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
-    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
-    def test_single_node_no_mnnvl(self, _):
-        """Single-node without MNNVL: keep optimizations."""
+    def test_single_node(self):
+        """Single-node: keep optimizations."""
         self.assertFalse(should_disable_ipc_optimizations(world_size=4, tp_size=4))
 
     @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "8"})
-    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
-    def test_single_node_dp_no_mnnvl(self, _):
-        """Single-node DP without MNNVL: keep optimizations."""
+    def test_single_node_dp(self):
+        """Single-node DP: keep optimizations."""
         self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=4))
 
-    # --- Multi-node without MNNVL: disable ---
+    # --- Multi-node: always disable ---
 
     @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
-    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=False)
-    def test_multi_node_no_mnnvl(self, _):
-        """Multi-node without MNNVL: disable IPC optimizations."""
+    def test_multi_node(self):
+        """Multi-node: disable IPC optimizations."""
         self.assertTrue(should_disable_ipc_optimizations(world_size=8, tp_size=4))
 
-    # --- Multi-node with MNNVL (GB200 NVL72): keep ---
-
     @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
-    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=True)
-    def test_multi_node_with_mnnvl(self, _):
-        """Multi-node with MNNVL (e.g. GB200 NVL72): keep IPC optimizations."""
-        self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=4))
-
-    @patch.dict(os.environ, {"LOCAL_WORLD_SIZE": "4"})
-    @patch("specforge.modeling.target.eagle3_target_model._has_mnnvl_ipc", return_value=True)
-    def test_multi_node_cross_node_tp_with_mnnvl(self, _):
-        """Cross-node TP with MNNVL: keep IPC optimizations."""
-        self.assertFalse(should_disable_ipc_optimizations(world_size=8, tp_size=8))
-
-
-class TestHasMnnvlIpc(unittest.TestCase):
-    """Test IMEX channel detection."""
-
-    @patch("os.path.isdir", return_value=True)
-    def test_imex_present(self, _):
-        self.assertTrue(_has_mnnvl_ipc())
-
-    @patch("os.path.isdir", return_value=False)
-    def test_imex_absent(self, _):
-        self.assertFalse(_has_mnnvl_ipc())
+    def test_multi_node_cross_node_tp(self):
+        """Cross-node TP: disable IPC optimizations."""
+        self.assertTrue(should_disable_ipc_optimizations(world_size=8, tp_size=8))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Gate CUDA IPC-based optimizations (`custom_all_reduce`, `enable_flashinfer_allreduce_fusion`) on multi-node topology detection
- Add `_is_multi_node()` and `should_disable_ipc_optimizations()` helpers with `LOCAL_WORLD_SIZE`-based detection
- Single-node training (including single-node DP) is unaffected

## Problem

When running EAGLE3 training with multi-node data parallelism (e.g. TP=4 per node, DP=2 across 2 nodes), SGLang auto-enables `enable_flashinfer_allreduce_fusion` for MoE models (`Qwen3MoeForCausalLM`) on SM90/SM100 hardware. Both this fusion and `custom_all_reduce` use `cudaIpcGetMemHandle` / `cudaIpcOpenMemHandle`, which rely on POSIX shared memory and only work between processes on the same node.

On multi-node setups this causes:
```
RuntimeError: CUDART error: invalid resource handle
```
at `flashinfer_comm_fusion.py` → `trtllm_create_ipc_workspace_for_all_reduce_fusion`.

This happens even on MNNVL-connected racks (GB200 NVL72) with IMEX channels present, because FlashInfer's IPC code uses the legacy CUDA IPC APIs, not the fabric-aware VMM APIs (`cuMemCreate` + `CU_MEM_HANDLE_TYPE_FABRIC`) that support cross-node sharing.

## Fix

- `_is_multi_node(world_size, tp_size)`: detects multi-node topology using `LOCAL_WORLD_SIZE` (set by torchrun), with fallback to `world_size > tp_size`
- `should_disable_ipc_optimizations(world_size, tp_size)`: returns `True` when multi-node is detected, `False` for single-node (including single-node DP)
- In `SGLangEagle3TargetModel.from_pretrained`: sets `disable_custom_all_reduce` and `enable_flashinfer_allreduce_fusion=False` only when `should_disable_ipc_optimizations()` returns `True`

## Test plan

- [x] 2-node GB200 NVL test (TP=4, DP=2, Qwen3-Coder-480B NVFP4): 50 steps completed successfully with IPC optimizations disabled (SLURM job 443470)
- [x] Confirmed MNNVL bypass does NOT work: keeping IPC enabled on GB200 NVL72 with IMEX channels still crashes with `CUDART error: invalid resource handle` (SLURM job 443253)
- [x] Single-node regression test (TP=4, no DP): 50 steps completed, IPC optimizations correctly kept enabled, DeviceMesh dp=1 tp=4 (SLURM job 446116)

🤖 Generated with [Claude Code](https://claude.com/claude-code)