### PR TITLE
Fix eval dataset race condition in multi-node DP training

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -485,21 +485,31 @@ def build_dataloaders(
     )
     if args.eval_data_path is not None or args.eval_hidden_states_path is not None:
         if args.eval_data_path is not None:
-            eval_dataset = Dataset.from_generator(
-                generator=safe_conversations_generator,
-                gen_kwargs={"file_path": args.eval_data_path},
+            eval_cache_params_string = (
+                f"{args.eval_data_path}-"
+                f"{args.max_length}-"
+                f"{args.chat_template}-"
+                f"{args.target_model_path}-eval"
             )
-            eval_eagle3_dataset = build_eagle3_dataset(
-                eval_dataset,
-                tokenizer,
-                args.chat_template,
-                args.max_length,
-                is_vlm=args.is_vlm,
-                processor=processor,
-                num_proc=args.build_dataset_num_proc,
-                is_preformatted=args.is_preformatted,
-                train_only_last_turn=args.train_only_last_turn,
-            )
+            eval_cache_key = hashlib.md5(eval_cache_params_string.encode()).hexdigest()
+            with rank_0_priority():
+                eval_dataset = Dataset.from_generator(
+                    generator=safe_conversations_generator,
+                    gen_kwargs={"file_path": args.eval_data_path},
+                )
+                eval_eagle3_dataset = build_eagle3_dataset(
+                    eval_dataset,
+                    tokenizer,
+                    args.chat_template,
+                    args.max_length,
+                    cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
+                    cache_key=eval_cache_key,
+                    is_vlm=args.is_vlm,
+                    processor=processor,
+                    num_proc=args.build_dataset_num_proc,
+                    is_preformatted=args.is_preformatted,
+                    train_only_last_turn=args.train_only_last_turn,
+                )
         elif args.eval_hidden_states_path is not None:
             eval_eagle3_dataset = build_offline_eagle3_dataset(
                 args.eval_hidden_states_path,


### PR DESCRIPTION
## Summary

- Wrap eval dataset construction in `rank_0_priority()` so rank 0 builds/caches first
- Add `cache_dir` and `cache_key` parameters to eval dataset building for deterministic caching

## Problem

When running multi-node DP training with an eval dataset, all ranks across all nodes simultaneously spawn multiple worker processes to build the eval dataset. On NFS-backed storage, this creates race conditions where multiple processes write to the same cache files concurrently. On aarch64 (GB200 NVL), this manifests as SIGBUS crashes:

```
Bus error (core dumped)
```

For example, 16 ranks × 8 workers = 128 concurrent processes all hitting NFS at once.

## Fix

- Use the existing `rank_0_priority()` context manager (already used for training data) to let rank 0 build and cache the eval dataset first, then other ranks read from cache
- Pass `cache_dir` and `cache_key` to `build_eagle3_dataset()` for the eval dataset, matching the pattern used for training data

## Test plan

- [ ] Multi-node DP training with eval dataset runs without SIGBUS
- [ ] Eval dataset is correctly cached and reused across ranks
- [ ] Single-node training still works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)