### PR TITLE
feat: add GLM-4.7-Flash EAGLE3 training support

### DIFF
--- a/configs/glm4-flash-eagle3.json
+++ b/configs/glm4-flash-eagle3.json
@@ -1,0 +1,26 @@
+{
+  "architectures": [
+    "LlamaForCausalLMEagle3"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151329,
+  "eos_token_id": 151336,
+  "head_dim": 102,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 8192,
+  "max_position_embeddings": 4096,
+  "model_type": "llama",
+  "num_attention_heads": 20,
+  "num_hidden_layers": 1,
+  "num_key_value_heads": 4,
+  "rms_norm_eps": 1e-05,
+  "rope_theta": 1000000,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "use_cache": true,
+  "vocab_size": 154880,
+  "draft_vocab_size": 32000
+}

--- a/examples/run_glm4_flash_eagle3_debug.sh
+++ b/examples/run_glm4_flash_eagle3_debug.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# GLM-4.7-Flash EAGLE3 Debug Training Script
+# Quick test run with verbose logging
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+
+# Load wandb API key from persistent storage
+if [ -f /gustavo/.wandb_key ]; then
+    export WANDB_API_KEY=$(cat /gustavo/.wandb_key)
+fi
+
+NUM_GPUS=1
+TP_SIZE=1
+BUILD_DATASET_NUM_PROC=64
+
+echo "========================================"
+echo "GLM-4.7-Flash EAGLE3 DEBUG Training"
+echo "========================================"
+echo "NUM_GPUS: $NUM_GPUS"
+echo "TP_SIZE: $TP_SIZE"
+echo "Testing with 1 epoch, verbose logging"
+echo "Using single GPU for debugging"
+echo "Loss debugging ENABLED"
+echo "========================================"
+
+torchrun \
+    --standalone \
+    --nproc_per_node $NUM_GPUS \
+    $ROOT_DIR/scripts/train_eagle3.py \
+    --target-model-path zai-org/GLM-4.7-Flash \
+    --trust-remote-code \
+    --draft-model-config $ROOT_DIR/configs/glm4-flash-eagle3.json \
+    --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
+    --output-dir $ROOT_DIR/outputs/glm4-flash-eagle3-debug \
+    --num-epochs 1 \
+    --batch-size 1 \
+    --learning-rate 1e-4 \
+    --max-length 512 \
+    --chat-template glm4 \
+    --cache-dir $ROOT_DIR/cache \
+    --embedding-key model.embed_tokens.weight \
+    --tp-size $TP_SIZE \
+    --target-model-backend sglang \
+    --sglang-mem-fraction-static 0.75 \
+    --log-interval 10 \
+    --save-interval 500 \
+    --eval-interval 500 \
+    --verbose \
+    --debug-loss \
+    --report-to wandb \
+    --wandb-project baby-shark-glm-eagle3 \
+    --wandb-name glm4-flash-eagle3-debug-$(date +%Y%m%d-%H%M%S)

--- a/examples/run_glm4_flash_eagle3_online.sh
+++ b/examples/run_glm4_flash_eagle3_online.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# GLM-4.7-Flash EAGLE3 Training Script
+# Usage: ./examples/run_glm4_flash_eagle3_online.sh [NUM_GPUS] [TP_SIZE]
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+
+# Load wandb API key from persistent storage
+if [ -f /gustavo/.wandb_key ]; then
+    export WANDB_API_KEY=$(cat /gustavo/.wandb_key)
+fi
+
+NUM_GPUS=${1:-1}
+TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
+
+echo "========================================"
+echo "GLM-4.7-Flash EAGLE3 Training"
+echo "========================================"
+echo "NUM_GPUS: $NUM_GPUS"
+echo "TP_SIZE: $TP_SIZE"
+echo "BUILD_DATASET_NUM_PROC: $BUILD_DATASET_NUM_PROC"
+echo "========================================"
+
+torchrun \
+    --standalone \
+    --nproc_per_node $NUM_GPUS \
+    $ROOT_DIR/scripts/train_eagle3.py \
+    --target-model-path zai-org/GLM-4.7-Flash \
+    --trust-remote-code \
+    --draft-model-config $ROOT_DIR/configs/glm4-flash-eagle3.json \
+    --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
+    --output-dir $ROOT_DIR/outputs/glm4-flash-eagle3-sharegpt \
+    --num-epochs 10 \
+    --batch-size 1 \
+    --learning-rate 1e-4 \
+    --max-length 4096 \
+    --chat-template glm4 \
+    --cache-dir $ROOT_DIR/cache \
+    --embedding-key model.embed_tokens.weight \
+    --tp-size $TP_SIZE \
+    --target-model-backend sglang \
+    --sglang-mem-fraction-static 0.4

--- a/scripts/mix_datasets.py
+++ b/scripts/mix_datasets.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Mix multiple datasets according to specified ratios."""
+import json
+import random
+from pathlib import Path
+from typing import List, Tuple
+
+def load_jsonl(path: str) -> List[dict]:
+    """Load JSONL file."""
+    data = []
+    with open(path, 'r') as f:
+        for line in f:
+            data.append(json.loads(line))
+    return data
+
+def mix_datasets(
+    datasets: List[Tuple[str, float]],  # [(path, ratio)]
+    output_path: str,
+    total_samples: int = None,
+    seed: int = 42
+):
+    """Mix datasets according to ratios."""
+    random.seed(seed)
+
+    # Load all datasets
+    all_data = []
+    for path, ratio in datasets:
+        data = load_jsonl(path)
+        print(f"Loaded {len(data)} samples from {path}")
+
+        if total_samples:
+            # Sample according to ratio
+            n_samples = int(total_samples * ratio)
+            sampled = random.sample(data, min(n_samples, len(data)))
+        else:
+            # Use all data weighted by ratio
+            sampled = random.sample(data, int(len(data) * ratio / sum(r for _, r in datasets)))
+
+        all_data.extend(sampled)
+        print(f"Added {len(sampled)} samples ({ratio*100:.1f}%)")
+
+    # Shuffle combined dataset
+    random.shuffle(all_data)
+
+    # Normalize IDs to strings (fix type mismatch between datasets)
+    for i, item in enumerate(all_data):
+        item['id'] = str(item.get('id', i))
+
+    # Save mixed dataset
+    with open(output_path, 'w') as f:
+        for item in all_data:
+            f.write(json.dumps(item) + '\n')
+
+    print(f"\nSaved {len(all_data)} mixed samples to {output_path}")
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=str, required=True)
+    parser.add_argument("--total-samples", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    # Mix for Experiment J: 45% ShareGPT, 35% UltraChat, 20% PerfectBlend
+    base_dir = Path(__file__).parent.parent / "cache" / "dataset"
+    datasets = [
+        (str(base_dir / "sharegpt_train.jsonl"), 0.45),
+        (str(base_dir / "ultrachat_train.jsonl"), 0.35),
+        (str(base_dir / "perfectblend_train.jsonl"), 0.20),
+    ]
+
+    mix_datasets(
+        datasets=datasets,
+        output_path=args.output,
+        total_samples=args.total_samples,
+        seed=args.seed
+    )

--- a/specforge/data/parse.py
+++ b/specforge/data/parse.py
@@ -121,6 +121,12 @@ class GeneralParser(Parser):
                         break
                 messages.append(sentence)
 
+            # Check if we have any actual content to train on (not just system prompt)
+            has_assistant = any(m["role"] == "assistant" for m in messages)
+            if not has_assistant:
+                # No assistant response to train on - skip this sample
+                return None
+
             try:
                 conversation = self.apply_chat_template(messages, **kwargs)
             except (ValueError, TypeError):

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -84,9 +84,14 @@ def _apply_loss_mask_from_chat_template(
     )
 
     # Find spans of assistant responses using regex
+    # Match assistant header with OR without end_of_turn_token prefix
+    # (first response often lacks the prefix)
     assistant_pattern = (
-        re.escape(assistant_message_separator)
-        + r"(.*?)(?="
+        r"(?:"
+        + re.escape(assistant_message_separator)
+        + "|"
+        + re.escape(chat_template.assistant_header)
+        + r")(.*?)(?="
         + re.escape(user_message_separator)
         + "|$)"
     )
@@ -163,13 +168,17 @@ def preprocess_conversations(
         if not source:
             # if the source is None, skip it
             continue
-        input_ids, loss_mask = parser.parse(
+        result = parser.parse(
             source,
             max_length,
             preformatted=is_preformatted,
             train_only_last_turn=train_only_last_turn,
             **kwargs_item,
         )
+        if result is None:
+            # Skip invalid conversations (e.g., no assistant response)
+            continue
+        input_ids, loss_mask = result
         results["input_ids"].append(input_ids[None, :])
         results["loss_mask"].append(loss_mask[None, :])
         results["attention_mask"].append(torch.ones_like(loss_mask)[None, :])

--- a/specforge/data/template.py
+++ b/specforge/data/template.py
@@ -308,3 +308,13 @@ TEMPLATE_REGISTRY.register(
         end_of_turn_token="</longcat_s>",
     ),
 )
+
+TEMPLATE_REGISTRY.register(
+    name="glm4",
+    template=ChatTemplate(
+        assistant_header="<|assistant|></think>",
+        user_header="<|user|>",
+        system_prompt="",  # GLM tokenizer handles system prompts natively - don't duplicate
+        end_of_turn_token="<|endoftext|>",
+    ),
+)

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -6,7 +6,6 @@ import torch
 from transformers import AutoConfig
 from transformers import AutoModelForCausalLM as AutoModelForCausalLMBase
 from transformers import (
-    Glm4MoeLiteConfig,
     GptOssConfig,
     Llama4Config,
     Llama4TextConfig,
@@ -19,8 +18,16 @@ from transformers import (
     modeling_utils,
 )
 
+try:
+    from transformers import Glm4MoeLiteConfig
+    _GLM4_CONFIG_AVAILABLE = True
+except ImportError:
+    Glm4MoeLiteConfig = None
+    _GLM4_CONFIG_AVAILABLE = False
+
 from .draft.llama3_eagle import LlamaForCausalLMEagle3
 from .target.custom_backend import (
+    _GLM4_AVAILABLE,
     Glm4MoeLiteForCausalLM,
     GptOssForCausalLM,
     Llama4ForCausalLM,
@@ -88,7 +95,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
 class AutoDistributedTargetModel(AutoModelForCausalLMBase):
     # the model mapping is currently hardcoded, we should support lazy model mapping via registry
     _model_mapping = {
-        Glm4MoeLiteConfig: [Glm4MoeLiteForCausalLM],
+        **({Glm4MoeLiteConfig: [Glm4MoeLiteForCausalLM]} if _GLM4_CONFIG_AVAILABLE and _GLM4_AVAILABLE else {}),
         Llama4TextConfig: [Llama4ForCausalLM],
         Qwen3MoeConfig: [Qwen3MoeForCausalLM],
         Qwen2Config: [Qwen2ForCausalLM],

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -6,6 +6,7 @@ import torch
 from transformers import AutoConfig
 from transformers import AutoModelForCausalLM as AutoModelForCausalLMBase
 from transformers import (
+    Glm4MoeLiteConfig,
     GptOssConfig,
     Llama4Config,
     Llama4TextConfig,
@@ -20,6 +21,7 @@ from transformers import (
 
 from .draft.llama3_eagle import LlamaForCausalLMEagle3
 from .target.custom_backend import (
+    Glm4MoeLiteForCausalLM,
     GptOssForCausalLM,
     Llama4ForCausalLM,
     LlamaForCausalLM,
@@ -86,6 +88,7 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
 class AutoDistributedTargetModel(AutoModelForCausalLMBase):
     # the model mapping is currently hardcoded, we should support lazy model mapping via registry
     _model_mapping = {
+        Glm4MoeLiteConfig: [Glm4MoeLiteForCausalLM],
         Llama4TextConfig: [Llama4ForCausalLM],
         Qwen3MoeConfig: [Qwen3MoeForCausalLM],
         Qwen2Config: [Qwen2ForCausalLM],
@@ -171,5 +174,9 @@ class AutoDraftModelConfig:
         # If draft_vocab_size is not in config or is None, set draft_vocab_size to vocab_size
         if "draft_vocab_size" not in config or config["draft_vocab_size"] is None:
             config["draft_vocab_size"] = config.get("vocab_size", None)
+
+        # Ensure rope_scaling is None if not explicitly set, to avoid "default" type errors
+        if "rope_scaling" not in config:
+            config["rope_scaling"] = None
 
         return cls._config_mapping[architecture].from_dict(config)

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -556,7 +556,14 @@ class LlamaAttention(nn.Module):
             scaling_type = rope_get("rope_type", rope_get("type"))
             scaling_factor = rope_get("factor")
 
-            if scaling_type == "linear":
+            if scaling_type == "default" or scaling_type is None:
+                # Handle "default" rope_type as standard RoPE (no scaling)
+                self.rotary_emb = LlamaRotaryEmbedding(
+                    self.head_dim,
+                    max_position_embeddings=self.max_position_embeddings,
+                    base=getattr(self.config, "rope_theta", 10000),
+                )
+            elif scaling_type == "linear":
                 if scaling_factor is None:
                     raise ValueError(
                         "Linear RoPE scaling requires 'factor' in rope_scaling config."

--- a/specforge/modeling/target/custom_backend/__init__.py
+++ b/specforge/modeling/target/custom_backend/__init__.py
@@ -1,4 +1,10 @@
-from .glm4_moe_lite import Glm4MoeLiteForCausalLM
+try:
+    from .glm4_moe_lite import Glm4MoeLiteForCausalLM
+    _GLM4_AVAILABLE = True
+except ImportError:
+    Glm4MoeLiteForCausalLM = None
+    _GLM4_AVAILABLE = False
+
 from .gpt_oss import GptOssForCausalLM
 from .llama import LlamaForCausalLM
 from .llama4 import Llama4ForCausalLM

--- a/specforge/modeling/target/custom_backend/__init__.py
+++ b/specforge/modeling/target/custom_backend/__init__.py
@@ -1,3 +1,4 @@
+from .glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .gpt_oss import GptOssForCausalLM
 from .llama import LlamaForCausalLM
 from .llama4 import Llama4ForCausalLM
@@ -7,6 +8,7 @@ from .qwen3 import Qwen3ForCausalLM
 from .qwen3_moe import Qwen3MoeForCausalLM
 
 __all__ = [
+    "Glm4MoeLiteForCausalLM",
     "GptOssForCausalLM",
     "LlamaForCausalLM",
     "Llama4ForCausalLM",

--- a/specforge/modeling/target/custom_backend/glm4_moe_lite.py
+++ b/specforge/modeling/target/custom_backend/glm4_moe_lite.py
@@ -1,0 +1,663 @@
+# coding=utf-8
+# Copyright 2025 GLM Team and HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SpecForge-compatible GLM-4.7-Flash MoE Lite model with tensor parallelism support."""
+
+import math
+from typing import Callable, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import Glm4MoeLiteConfig
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.generation import GenerationMixin
+from transformers.integrations import use_experts_implementation, use_kernel_func_from_hub
+from transformers.masking_utils import create_causal_mask
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+from transformers.utils.generic import maybe_autocast
+
+from specforge.distributed import get_tp_group
+from specforge.layers import (
+    ColumnParallelLinear,
+    ParallelLMHead,
+    RowParallelLinear,
+    VocabParallelEmbedding,
+)
+
+logger = logging.get_logger(__name__)
+
+
+class Glm4MoeLiteRotaryEmbedding(nn.Module):
+    """Rotary Position Embedding for GLM-4 MoE Lite."""
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: Glm4MoeLiteConfig, device=None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+        self.config = config
+
+        self.rope_type = self.config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, device)
+
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: Glm4MoeLiteConfig | None = None,
+        device: Optional["torch.device"] = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        base = config.rope_parameters["rope_theta"]
+        partial_rotary_factor = config.rope_parameters.get("partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * partial_rotary_factor)
+        attention_factor = 1.0
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(self, x, position_ids):
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_interleave(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies interleaved Rotary Position Embedding (GLM-4 style)."""
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+
+    b, h, s, d = q.shape
+    q = q.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+
+    b, h, s, d = k.shape
+    k = k.view(b, h, s, d // 2, 2).transpose(4, 3).reshape(b, h, s, d)
+
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """Repeat key/value tensors for GQA."""
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs: Unpack[TransformersKwargs],
+):
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
+
+
+def yarn_get_mscale(scale=1, mscale=1):
+    if scale <= 1:
+        return 1.0
+    return 0.1 * mscale * math.log(scale) + 1.0
+
+
+class Glm4MoeLiteRMSNorm(nn.Module):
+    """RMS Normalization layer."""
+
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class Glm4MoeLiteAttention(nn.Module):
+    """
+    Multi-head Latent Attention (MLA) with LoRA-compressed KV projections.
+    Adapted for tensor parallelism with SpecForge.
+    """
+
+    def __init__(self, config: Glm4MoeLiteConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.attention_dropout = config.attention_dropout
+
+        # TP support
+        self.tp_group = get_tp_group()
+        self.tp_size = dist.get_world_size(self.tp_group) if self.tp_group is not None else 1
+        self.tp_rank = dist.get_rank(self.tp_group) if self.tp_group is not None else 0
+
+        # Head distribution
+        self.total_num_heads = config.num_attention_heads
+        self.num_heads = self.total_num_heads // self.tp_size
+
+        # MLA parameters
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.qk_head_dim = config.qk_head_dim
+
+        self.is_causal = True
+
+        # Q projection with LoRA
+        if self.q_lora_rank is None:
+            self.q_proj = ColumnParallelLinear(
+                config.hidden_size,
+                self.total_num_heads * self.qk_head_dim,
+                bias=False,
+            )
+        else:
+            self.q_a_proj = nn.Linear(config.hidden_size, config.q_lora_rank, bias=config.attention_bias)
+            self.q_a_layernorm = Glm4MoeLiteRMSNorm(config.q_lora_rank)
+            self.q_b_proj = ColumnParallelLinear(
+                config.q_lora_rank,
+                self.total_num_heads * self.qk_head_dim,
+                bias=False,
+            )
+
+        # KV projection with compressed MLA
+        self.kv_a_proj_with_mqa = nn.Linear(
+            config.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=config.attention_bias,
+        )
+        self.kv_a_layernorm = Glm4MoeLiteRMSNorm(self.kv_lora_rank)
+        self.kv_b_proj = ColumnParallelLinear(
+            self.kv_lora_rank,
+            self.total_num_heads * (self.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+        )
+
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.v_head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
+        )
+
+        self.scaling = self.qk_head_dim ** (-0.5)
+        if self.config.rope_parameters.get("rope_type", "default") != "default":
+            mscale_all_dim = self.config.rope_parameters.get("mscale_all_dim", 0)
+            scaling_factor = self.config.rope_parameters["factor"]
+            if mscale_all_dim:
+                mscale = yarn_get_mscale(scaling_factor, mscale_all_dim)
+                self.scaling = self.scaling * mscale * mscale
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        past_key_value: Cache | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        batch_size, seq_length = hidden_states.shape[:-1]
+
+        # Query projection with MLA
+        if self.q_lora_rank is None:
+            q_states = self.q_proj(hidden_states)
+        else:
+            q_states = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
+        q_states = q_states.view(batch_size, seq_length, self.num_heads, self.qk_head_dim).transpose(1, 2)
+
+        # KV projection with MLA compression
+        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+        compressed_kv, k_pe = torch.split(compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
+        k_pe = k_pe.view(batch_size, seq_length, 1, self.qk_rope_head_dim).transpose(1, 2)
+        kv_states = self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
+        kv_states = kv_states.view(
+            batch_size, seq_length, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+        ).transpose(1, 2)
+        k_nope, v_states = torch.split(kv_states, [self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+        # Split query into RoPE and non-RoPE parts
+        q_nope, q_pe = torch.split(q_states, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        # Apply RoPE to position-encoded components
+        cos, sin = position_embeddings
+        q_pe, k_pe = apply_rotary_pos_emb_interleave(q_pe, k_pe, cos, sin)
+
+        # Combine RoPE and non-RoPE parts
+        query_states = torch.cat([q_nope, q_pe], dim=-1)
+        key_states = torch.cat([k_nope, k_pe.expand(-1, self.num_heads, -1, -1)], dim=-1)
+
+        # Update KV cache
+        if past_key_value is not None:
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            key_states, v_states = past_key_value.update(
+                key_states, v_states, self.layer_idx, cache_kwargs
+            )
+
+        # Attention computation
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            v_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(batch_size, seq_length, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+
+        # All-reduce for TP
+        if self.tp_group is not None:
+            dist.all_reduce(attn_output, op=dist.ReduceOp.SUM, group=self.tp_group)
+
+        return attn_output, attn_weights
+
+
+class Glm4MoeLiteMLP(nn.Module):
+    """Dense feed-forward network."""
+
+    def __init__(self, config, intermediate_size=None):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = intermediate_size if intermediate_size is not None else config.intermediate_size
+
+        self.gate_proj = ColumnParallelLinear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = ColumnParallelLinear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = RowParallelLinear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        gate = self.act_fn(self.gate_proj(x))
+        up = self.up_proj(x)
+        down = self.down_proj(gate * up)
+        return down
+
+
+class Glm4MoeLiteTopkRouter(nn.Module):
+    """Top-k router for MoE."""
+
+    def __init__(self, config: Glm4MoeLiteConfig):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty((config.n_routed_experts, config.hidden_size)))
+        self.e_score_correction_bias = nn.Parameter(torch.zeros(config.n_routed_experts))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        logits = F.linear(hidden_states.float(), self.weight.float(), None)
+        return logits
+
+
+@use_experts_implementation
+class Glm4MoeLiteNaiveMoe(nn.Module):
+    """Naive MoE implementation with expert weights as 3D tensors."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_local_experts
+        self.hidden_dim = config.hidden_size
+        self.intermediate_dim = config.moe_intermediate_size
+        self.gate_up_proj = nn.Parameter(torch.empty(self.num_experts, 2 * self.intermediate_dim, self.hidden_dim))
+        self.down_proj = nn.Parameter(torch.empty(self.num_experts, self.hidden_dim, self.intermediate_dim))
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        final_hidden_states = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = torch.nn.functional.one_hot(top_k_index, num_classes=self.num_experts)
+            expert_mask = expert_mask.permute(2, 1, 0)
+            expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+        for expert_idx in expert_hit:
+            expert_idx = expert_idx[0]
+            if expert_idx == self.num_experts:
+                continue
+            top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+            current_state = hidden_states[token_idx]
+            gate, up = nn.functional.linear(current_state, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
+            current_hidden_states = self.act_fn(gate) * up
+            current_hidden_states = nn.functional.linear(current_hidden_states, self.down_proj[expert_idx])
+            current_hidden_states = current_hidden_states * top_k_weights[token_idx, top_k_pos, None]
+            final_hidden_states.index_add_(0, token_idx, current_hidden_states.to(final_hidden_states.dtype))
+
+        return final_hidden_states
+
+
+class Glm4MoeLiteMoE(nn.Module):
+    """Mixed expert module with shared experts."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.experts = Glm4MoeLiteNaiveMoe(config)
+        self.gate = Glm4MoeLiteTopkRouter(config)
+        self.shared_experts = Glm4MoeLiteMLP(
+            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
+        )
+        self.n_routed_experts = config.n_routed_experts
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.norm_topk_prob = config.norm_topk_prob
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.top_k = config.num_experts_per_tok
+
+    def route_tokens_to_experts(self, router_logits):
+        router_logits = router_logits.sigmoid()
+        router_logits_for_choice = router_logits + self.gate.e_score_correction_bias
+        group_scores = (
+            router_logits_for_choice.view(-1, self.n_group, self.n_routed_experts // self.n_group)
+            .topk(2, dim=-1)[0]
+            .sum(dim=-1)
+        )
+        group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
+        group_mask = torch.zeros_like(group_scores)
+        group_mask.scatter_(1, group_idx, 1)
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(-1, self.n_group, self.n_routed_experts // self.n_group)
+            .reshape(-1, self.n_routed_experts)
+        )
+        scores_for_choice = router_logits_for_choice.masked_fill(~score_mask.bool(), 0.0)
+        topk_indices = torch.topk(scores_for_choice, k=self.top_k, dim=-1, sorted=False)[1]
+        topk_weights = router_logits.gather(1, topk_indices)
+        if self.norm_topk_prob:
+            denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
+            topk_weights /= denominator
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_indices, topk_weights
+
+    def forward(self, hidden_states):
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        router_logits = self.gate(hidden_states)
+        topk_indices, topk_weights = self.route_tokens_to_experts(router_logits)
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        hidden_states = self.experts(hidden_states, topk_indices, topk_weights).view(*orig_shape)
+        hidden_states = hidden_states + self.shared_experts(residuals)
+        return hidden_states
+
+
+class Glm4MoeLiteDecoderLayer(GradientCheckpointingLayer):
+    """GLM-4 MoE Lite decoder layer with optional sparse MoE."""
+
+    def __init__(self, config: Glm4MoeLiteConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Glm4MoeLiteAttention(config, layer_idx)
+
+        if config.mlp_layer_types[layer_idx] == "sparse":
+            self.mlp = Glm4MoeLiteMoE(config)
+        else:
+            self.mlp = Glm4MoeLiteMLP(config)
+
+        self.input_layernorm = Glm4MoeLiteRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.post_attention_layernorm = Glm4MoeLiteRMSNorm(config.hidden_size, config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_value: Cache | None = None,
+        cache_position: torch.LongTensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        # Self Attention
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Glm4MoeLitePreTrainedModel(PreTrainedModel):
+    config_class = Glm4MoeLiteConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Glm4MoeLiteDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+
+
+class Glm4MoeLiteModel(Glm4MoeLitePreTrainedModel):
+    """GLM-4 MoE Lite base model."""
+
+    def __init__(self, config: Glm4MoeLiteConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = VocabParallelEmbedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Glm4MoeLiteDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Glm4MoeLiteRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Glm4MoeLiteRotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        causal_mask = self._update_causal_mask(
+            attention_mask, inputs_embeds, cache_position, past_key_values, **kwargs
+        )
+
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_embeddings=position_embeddings,
+                position_ids=position_ids,
+                past_key_value=past_key_values,
+                cache_position=cache_position,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+        )
+
+    def _update_causal_mask(
+        self,
+        attention_mask: torch.Tensor,
+        input_tensor: torch.Tensor,
+        cache_position: torch.Tensor,
+        past_key_values: Cache,
+        **kwargs,
+    ):
+        if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and 0.0 in attention_mask:
+                return attention_mask
+            return None
+
+        dtype, device = input_tensor.dtype, input_tensor.device
+        sequence_length = input_tensor.shape[1]
+        if past_key_values is not None:
+            target_length = past_key_values.get_max_cache_shape()
+        else:
+            target_length = attention_mask.shape[-1] if attention_mask is not None else sequence_length
+
+        causal_mask = create_causal_mask(
+            sequence_length, target_length, dtype=dtype, device=device, cache_position=cache_position
+        )
+
+        if attention_mask is not None:
+            causal_mask = causal_mask.masked_fill(attention_mask[:, None, None, :] == 0, float("-inf"))
+
+        return causal_mask
+
+
+class Glm4MoeLiteForCausalLM(Glm4MoeLitePreTrainedModel, GenerationMixin):
+    """GLM-4 MoE Lite for causal language modeling with TP support."""
+
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = Glm4MoeLiteModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = ParallelLMHead(config.hidden_size, config.vocab_size, bias=False)
+
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> CausalLMOutputWithPast:
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        logits = self.lm_head(hidden_states, gather_output=True)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+        )
+
+
+__all__ = ["Glm4MoeLitePreTrainedModel", "Glm4MoeLiteModel", "Glm4MoeLiteForCausalLM"]


### PR DESCRIPTION
## Summary

Adds EAGLE3 speculative decoding training support for the GLM-4.7-Flash MoE model.

### Changes

- **`specforge/modeling/target/custom_backend/glm4_moe_lite.py`** — New target model backend for GLM-4.7-Flash: MLA attention, MoE expert dispatch, tensor parallelism, RoPE fix for null `rope_type`
- **`configs/glm4-flash-eagle3.json`** — Draft model config (`LlamaForCausalLMEagle3`, hidden_size=2048, head_dim=128, draft_vocab_size=32000)
- **`specforge/data/template.py`** — GLM-4 chat template
- **`specforge/data/parse.py`** — Skip invalid conversations in data parser
- **`specforge/modeling/auto.py`** + **`specforge/modeling/target/custom_backend/__init__.py`** — Register backend with optional import guard (graceful fallback when GLM-4.7 transformers fork is not installed)
- **`scripts/mix_datasets.py`** — Dataset mixing utility
- **`examples/run_glm4_flash_eagle3_*.sh`** — Training example scripts

## Test plan

- [ ] `python -c "from specforge.modeling.auto import AutoTargetModel"` works without GLM transformers fork (no ImportError)
- [ ] `python -c "from specforge.modeling.auto import AutoTargetModel"` with GLM fork — `Glm4MoeLiteForCausalLM` registers correctly
- [ ] Smoke-test data gen: `bash examples/run_glm4_flash_eagle3_debug.sh`