### PR TITLE
feat: add Qwen3-Coder-Next EAGLE3 draft config

### DIFF
--- a/configs/qwen3-coder-next-eagle3.json
+++ b/configs/qwen3-coder-next-eagle3.json
@@ -1,0 +1,27 @@
+{
+  "architectures": [
+    "LlamaForCausalLMEagle3"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "bos_token_id": 151643,
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 2048,
+  "initializer_range": 0.02,
+  "intermediate_size": 8192,
+  "max_position_embeddings": 4096,
+  "model_type": "llama",
+  "num_attention_heads": 16,
+  "num_hidden_layers": 1,
+  "num_key_value_heads": 4,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000.0,
+  "tie_word_embeddings": false,
+  "torch_dtype": "bfloat16",
+  "use_cache": true,
+  "vocab_size": 151936,
+  "draft_vocab_size": 32000
+}


### PR DESCRIPTION
## Summary

Adds a SpecForge draft model config for training an EAGLE3 speculative decoding draft for **Qwen3-Coder-Next-FP8** (80B MoE, 3B active params, Hybrid GDN+MoE architecture).

### Config: `configs/qwen3-coder-next-eagle3.json`

Key design choices:

- **`hidden_size=2048`** -- matches the target model hidden size (required for EAGLE3 hidden state alignment)
- **`head_dim=128`** -- FlashInfer-compatible (matches target model, avoids kernel dispatch issues)
- **`num_attention_heads=16`, `num_key_value_heads=4`** -- GQA, same ratio as target
- **`intermediate_size=8192`** -- 4x hidden_size, standard for this scale
- **`vocab_size=151936`, `draft_vocab_size=32000`** -- full Qwen3 vocab; draft head uses a frequency-selected 32K subset
- **`bos_token_id=151643`, `eos_token_id=151645`** -- Qwen3 tokenizer

### Architecture note

Qwen3-Coder-Next has 48 layers: 36 GDN (Gated DeltaNet, recurrent) + 12 standard attention layers. EAGLE3 hidden state extraction skips GDN layers and captures only the 12 attention layers. This requires a patched SGLang target backend with `skip_layers` support -- hidden states are generated offline via the SGLang server and passed to SpecForge as a pre-built JSONL dataset.

## Test plan

- [ ] Config is valid JSON
- [ ] Config loads correctly as a SpecForge draft config
