### PR TITLE
feat: reduce Eagle3 training memory spike via all-to-all sharding

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -90,6 +90,12 @@ def parse_args() -> Tuple[ArgumentParser, Namespace]:
         "--is-vlm", action="store_true", help="Whether the target model is a VLM"
     )
     model_group.add_argument(
+        "--shard-target-output",
+        action=argparse.BooleanOptionalAction,
+        help="Whether the target model output is sharded across batch dimension",
+        dest="shard_target_output",
+    )
+    model_group.add_argument(
         "--target-model-backend",
         type=str,
         default="sglang",
@@ -341,6 +347,11 @@ def sanity_check(args: Namespace) -> None:
     args.target_batch_size = args.tp_size * args.batch_size
     if args.attention_backend == "usp":
         sp_sanity_check(args)
+    if args.shard_target_output:
+        if args.target_model_backend != "sglang":
+            raise ValueError("shard_target_output is only supported for sglang backend")
+        if args.is_vlm:
+            raise ValueError("shard_target_output is only supported non vlm model")
 
 
 def sp_sanity_check(args: Namespace) -> None:
@@ -632,13 +643,24 @@ def run_forward(
                     input_ids=data["input_ids"].cuda(),
                     attention_mask=data["attention_mask"].cuda(),
                     loss_mask=data["loss_mask"].cuda(),
+                    shard_returns=args.shard_target_output,
                 )
 
-            input_ids = get_dp_data_shard_from_tp(eagle3_data.input_ids)
-            attention_mask = get_dp_data_shard_from_tp(eagle3_data.attention_mask)
-            loss_mask = get_dp_data_shard_from_tp(eagle3_data.loss_mask)
-            target = get_dp_data_shard_from_tp(eagle3_data.target)
-            hidden_states = get_dp_data_shard_from_tp(eagle3_data.hidden_states)
+            input_ids = get_dp_data_shard_from_tp(
+                eagle3_data.input_ids, args.shard_target_output
+            )
+            attention_mask = get_dp_data_shard_from_tp(
+                eagle3_data.attention_mask, args.shard_target_output
+            )
+            loss_mask = get_dp_data_shard_from_tp(
+                eagle3_data.loss_mask, args.shard_target_output
+            )
+            target = get_dp_data_shard_from_tp(
+                eagle3_data.target, args.shard_target_output
+            )
+            hidden_states = get_dp_data_shard_from_tp(
+                eagle3_data.hidden_states, args.shard_target_output
+            )
         else:
             # we generate the logits using the hidden states loaded from disk
             attention_mask = data["attention_mask"].cuda()
@@ -716,10 +738,14 @@ def record_metrcs(
     tracker.log(logdict, step=global_step)
 
 
-def get_dp_data_shard_from_tp(tensor: torch.Tensor) -> torch.Tensor:
+def get_dp_data_shard_from_tp(
+    tensor: torch.Tensor, sharded: bool = False
+) -> torch.Tensor:
     """
     Get the data shard from the tensor.
     """
+    if sharded:
+        return tensor
     tp_size = dist.get_world_size(get_tp_group())
     tp_rank = dist.get_rank(get_tp_group())
     return tensor.chunk(tp_size, dim=0)[tp_rank]

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -389,9 +389,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         model_worker_batch = batch.get_model_worker_batch()
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
         forward_batch.capture_hidden_mode = CaptureHiddenMode.FULL
-        eagle3_output = self.model_runner.forward(forward_batch)
-        if hasattr(eagle3_output, "logits_output"):
-            eagle3_output = eagle3_output.logits_output
+        eagle3_output = self.model_runner.forward(forward_batch).logits_output
         input_lens = [len(req.origin_input_ids) for req in reqs]
 
         logits = eagle3_output.logits

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -358,12 +358,14 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         capture_aux_hidden_states: bool = True,
         return_last_hidden_states: bool = False,
         return_logits: bool = False,
+        shard_returns: bool = False,
     ):
         # set the logits processor for the model runner
         for name, module in self.model_runner.model.named_modules():
             if isinstance(module, LogitsProcessorForEAGLE3):
                 module.return_last_hidden_states = return_last_hidden_states
                 module.return_logits = return_logits
+                module.shard_returns = shard_returns
 
         cache_params = CacheInitParams(
             disable=False,
@@ -388,39 +390,66 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
         forward_batch.capture_hidden_mode = CaptureHiddenMode.FULL
         eagle3_output = self.model_runner.forward(forward_batch)
-        aux_hidden_states_list = None
+        if hasattr(eagle3_output, "logits_output"):
+            eagle3_output = eagle3_output.logits_output
         input_lens = [len(req.origin_input_ids) for req in reqs]
 
+        logits = eagle3_output.logits
+        aux_hidden_states = eagle3_output.aux_hidden_states
+        last_hidden_states = eagle3_output.last_hidden_states
+
+        if shard_returns:
+            tp_rank = dist.get_rank(get_tp_group())
+            tp_size = dist.get_world_size(get_tp_group())
+            batch_size = len(input_lens) // tp_size
+            valid_indices = list(
+                range(tp_rank * batch_size, (tp_rank + 1) * batch_size)
+            )
+            valid_input_lens = [input_lens[i] for i in valid_indices]
+
         if return_logits:
-            if hasattr(eagle3_output, "logits_output"):
-                raw_logits = eagle3_output.logits_output.logits
+            if shard_returns:
+                logits = _get_sharded_return(
+                    logits,
+                    input_lens,
+                    valid_input_lens,
+                    valid_indices,
+                )
             else:
-                raw_logits = eagle3_output.logits
-            logits = torch.split(raw_logits, input_lens, dim=0)
+                logits = torch.split(logits, input_lens, dim=0)
         else:
             logits = [None] * len(reqs)
 
         if capture_aux_hidden_states:
-            raw_aux_hidden_states = (
-                eagle3_output.logits_output.aux_hidden_states
-            )  # concat hidden shape: (total_tokens, H*3)
-            aux_hidden_states_list = torch.split(
-                raw_aux_hidden_states, input_lens, dim=0
-            )
+            if shard_returns:
+                aux_hidden_states = _get_sharded_return(
+                    aux_hidden_states,
+                    input_lens,
+                    valid_input_lens,
+                    valid_indices,
+                )
+            else:
+                aux_hidden_states = torch.split(aux_hidden_states, input_lens, dim=0)
         else:
-            aux_hidden_states_list = [None] * len(reqs)
+            aux_hidden_states = [None] * len(reqs)
 
         if return_last_hidden_states:
-            last_hidden_states = torch.split(
-                eagle3_output.logits_output.last_hidden_states, input_lens, dim=0
-            )
+            if shard_returns:
+                last_hidden_states = _get_sharded_return(
+                    last_hidden_states,
+                    input_lens,
+                    valid_input_lens,
+                    valid_indices,
+                )
+            else:
+                last_hidden_states = torch.split(last_hidden_states, input_lens, dim=0)
         else:
             last_hidden_states = [None] * len(reqs)
 
         # TODO: can we not clear?
         self.model_runner.req_to_token_pool.clear()
         self.model_runner.token_to_kv_pool_allocator.clear()
-        return logits, aux_hidden_states_list, last_hidden_states
+        return logits, aux_hidden_states, last_hidden_states
 
     def _maybe_prepare_mlp_sync_batch(self, batch: ScheduleBatch):
         if require_mlp_sync(self.model_runner.server_args):
@@ -449,6 +478,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         loss_mask: torch.Tensor,
         return_last_hidden_states: bool = False,
         return_logits: bool = True,
+        shard_returns: bool = False,
     ):
         sampling_params = SamplingParams(temperature=0, max_new_tokens=1, top_k=1)
         reqs, data_cache = [], []
@@ -482,6 +512,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
             capture_aux_hidden_states=True,
             return_last_hidden_states=return_last_hidden_states,
             return_logits=return_logits,
+            shard_returns=shard_returns,
         )
 
         return data_cache, logits_list, aux_hidden_states_list, last_hidden_states_list
@@ -688,6 +719,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         pixel_values: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.Tensor] = None,
         is_vlm: bool = False,
+        shard_returns: bool = False,
     ) -> Eagle3TargetOutput:
         """
         return:
@@ -720,11 +752,13 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
                     loss_mask,
                     return_last_hidden_states=False,
                     return_logits=True,
+                    shard_returns=shard_returns,
                 )
             )
         aux_hidden_states_out = []
         target_out = []
         loss_mask_out = []
+        attention_mask_out = []
         input_ids_out = []
         last_hidden_states_out = []
 
@@ -733,33 +767,32 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
                 data_cache, logits_list, aux_hidden_states_list, last_hidden_states_list
             )
         ):
-            aux_hidden_states_out.append(aux_hidden_states.unsqueeze(0))
-            loss_mask_out.append(data[2])
-            input_ids_out.append(data[0])
+            if aux_hidden_states is not None:
+                aux_hidden_states_out.append(aux_hidden_states.unsqueeze(0))
+                loss_mask_out.append(data[2])
+                attention_mask_out.append(data[1])
+                input_ids_out.append(data[0])
 
             # when generating hidden states for offline training, we don't compute logits and only keep the last_hidden_states
             # when training online, we don't keep the last_hidden_states and only keep the logits
             if logits is not None:
                 target_out.append(logits.unsqueeze(0))
-            else:
-                target_out.append(None)
 
             if last_hidden_states is not None:
                 last_hidden_states_out.append(last_hidden_states.unsqueeze(0))
-            else:
-                last_hidden_states_out.append(None)
 
         aux_hidden_states_out = torch.cat(aux_hidden_states_out, dim=0)
 
         loss_mask_out = torch.cat(loss_mask_out, dim=0)
+        attention_mask_out = torch.cat(attention_mask_out, dim=0)
         input_ids_out = torch.cat(input_ids_out, dim=0)
 
-        if target_out[0] is not None:
+        if target_out:
             target_out = torch.cat(target_out, dim=0)
         else:
             target_out = None
 
-        if last_hidden_states_out[0] is not None:
+        if last_hidden_states_out:
             last_hidden_states_out = torch.cat(last_hidden_states_out, dim=0)
         else:
             last_hidden_states_out = None
@@ -773,7 +806,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
             target=target_out,
             loss_mask=loss_mask_out,
             input_ids=input_ids_out,
-            attention_mask=attention_mask,
+            attention_mask=attention_mask_out,
             last_hidden_states=last_hidden_states_out,
         )
 
@@ -871,3 +904,16 @@ def get_eagle3_target_model(
         )
     else:
         raise ValueError(f"Invalid backend: {backend}")
+
+
+def _get_sharded_return(
+    input_: torch.Tensor,
+    input_lens: list[int],
+    valid_input_lens: list[int],
+    valid_indices: list[int],
+) -> list[Optional[torch.Tensor]]:
+    out: list[Optional[torch.Tensor]] = [None] * len(input_lens)
+    input_scatter = torch.split(input_, valid_input_lens, dim=0)
+    for j, idx in enumerate(valid_indices):
+        out[idx] = input_scatter[j]
+    return out

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
@@ -37,6 +38,8 @@ from specforge.utils import padding
 
 from .sglang_backend import SGLangRunner, wrap_eagle3_logits_processors_in_module
 from .sglang_backend.utils import LogitsProcessorForEAGLE3
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -80,6 +83,7 @@ class Eagle3TargetModel(ABC):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         loss_mask: torch.Tensor,
+        **kwargs,
     ) -> Eagle3TargetOutput:
         """
         Generate the eagle3 data from the target model.
@@ -173,12 +177,16 @@ class HFEagle3TargetModel(Eagle3TargetModel):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         loss_mask: torch.Tensor,
+        **kwargs,
     ) -> Eagle3TargetOutput:
         """
         Optimized HF backend:
         Instead of returning all hidden states (memory heavy), we use forward hooks
         to capture only the specific layers required by Eagle3.
         """
+        if kwargs:
+            logger.debug(f"unused kwargs {list(kwargs.keys())}")
+
         captured_states = {}
         handles = []
 
@@ -718,6 +726,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         image_grid_thw: Optional[torch.Tensor] = None,
         is_vlm: bool = False,
         shard_returns: bool = False,
+        **kwargs,
     ) -> Eagle3TargetOutput:
         """
         return:
@@ -730,6 +739,9 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
                 - pixel_values: (patch_len, patch_width)
                 - image_grid_thw (batch_size, 3)
         """
+        if kwargs:
+            logger.debug(f"unused kwargs {list(kwargs.keys())}")
+
         if is_vlm:
             data_cache, logits_list, aux_hidden_states_list, last_hidden_states_list = (
                 self.extend_vlm(
@@ -841,7 +853,11 @@ class CustomEagle3TargetModel(Eagle3TargetModel):
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
         loss_mask: torch.Tensor,
+        **kwargs,
     ) -> Eagle3TargetOutput:
+        if kwargs:
+            logger.debug(f"unused kwargs {list(kwargs.keys())}")
+
         outputs = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,

--- a/specforge/modeling/target/sglang_backend/utils.py
+++ b/specforge/modeling/target/sglang_backend/utils.py
@@ -3,17 +3,24 @@ This file contains the wrapper for the SGL model.
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Optional, Union, cast
 
 import torch
 import torch.nn as nn
+from sglang.srt.distributed import (
+    GroupCoordinator,
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+)
 from sglang.srt.layers.logits_processor import (
     LogitsMetadata,
     LogitsProcessor,
     LogitsProcessorOutput,
+    fused_softcap,
 )
+from sglang.srt.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils.common import is_npu
 
 
 @dataclass
@@ -33,85 +40,119 @@ def replaced_logits_processor_forward_for_eagle3(
     hidden_states,
     lm_head,
     logits_metadata: Union[LogitsMetadata, ForwardBatch],
-    aux_hidden_states: Optional[List[torch.Tensor]] = None,
+    aux_hidden_states: Optional[list[torch.Tensor]] = None,
     hidden_states_before_norm: Optional[torch.Tensor] = None,
     return_last_hidden_states: bool = False,
     return_logits: bool = False,
+    shard_returns: bool = False,
 ) -> LogitsProcessorOutput:
     """
-    This is a modified forward function for the SGLang's logits processor, adapted from https://github.com/sgl-project/sglang/blob/v0.5.4/python/sglang/srt/layers/logits_processor.py.
+    This is a modified forward function for the SGLang's logits processor, adapted from https://github.com/sgl-project/sglang/blob/v0.5.9/python/sglang/srt/layers/logits_processor.py.
     The modification is to return the logits and aux hidden states instead of the last hidden states.
 
     Updated for sglang 0.5.9:
     - Added hidden_states_before_norm parameter for compatibility
     """
-
     if isinstance(logits_metadata, ForwardBatch):
         logits_metadata = LogitsMetadata.from_forward_batch(logits_metadata)
 
-    # Check if multi-item scoring is enabled via server args (only for prefill-only requests)
-    multi_item_delimiter = get_global_server_args().multi_item_scoring_delimiter
-    if multi_item_delimiter is not None and logits_metadata.is_prefill_only:
+    # Multi-item scoring only for prefill-only requests.
+    if self.multi_item_delimiter is not None and logits_metadata.is_prefill_only:
         return self.compute_logprobs_for_multi_item_scoring(
-            input_ids, hidden_states, lm_head, logits_metadata, multi_item_delimiter
+            input_ids,
+            hidden_states,
+            lm_head,
+            logits_metadata,
+            self.multi_item_delimiter,
         )
 
-    # Get the last hidden states and last logits for the next token prediction
-    if (
-        logits_metadata.forward_mode.is_decode_or_idle()
-        or logits_metadata.forward_mode.is_target_verify()
-        or logits_metadata.forward_mode.is_draft_extend_v2()
-    ):
-        pruned_states = hidden_states
-        if aux_hidden_states is not None:
-            aux_pruned_states = [hidden for hidden in aux_hidden_states]
-        else:
-            aux_pruned_states = None
-        sample_indices = None
-        input_logprob_indices = None
-    else:
+    # Diffusion LLM only.
+    if logits_metadata.forward_mode.is_dllm_extend():
         raise RuntimeError(
             f"The modified logits processor is not supported for this forward mode: {logits_metadata.forward_mode}"
         )
 
+    # Get the last hidden states and last logits for the next token prediction
+    if not (
+        logits_metadata.forward_mode.is_decode_or_idle()
+        or logits_metadata.forward_mode.is_target_verify()
+        or logits_metadata.forward_mode.is_draft_extend_v2()
+    ):
+        raise RuntimeError(
+            f"The modified logits processor is not supported for this forward mode: {logits_metadata.forward_mode}"
+        )
+    (
+        pruned_states,
+        pruned_states_before_norm,
+        aux_pruned_states,
+        sample_indices,
+        _,
+        _,
+    ) = self._get_pruned_states(
+        hidden_states,
+        hidden_states_before_norm,
+        aux_hidden_states,
+        logits_metadata,
+    )
+
+    tp_group: Optional[GroupCoordinator] = None
+    chunk_sizes: list[int] = []
+    if shard_returns:
+        tp_group = get_tp_group()
+        seq_lens = logits_metadata.extend_seq_lens.tolist()
+        if len(seq_lens) != tp_group.world_size:
+            assert len(seq_lens) % tp_group.world_size == 0
+            size = len(seq_lens) // tp_group.world_size
+            chunk_sizes = []
+            for i in range(0, len(seq_lens), size):
+                chunk_sizes.append(sum(seq_lens[i : i + size]))
+        else:
+            chunk_sizes = seq_lens
+
     if return_last_hidden_states:
         last_hidden_states = pruned_states
+        if shard_returns:
+            last_hidden_states = torch.split(last_hidden_states, chunk_sizes, dim=0)[
+                cast(GroupCoordinator, tp_group).rank_in_group
+            ]
     else:
         last_hidden_states = None
 
     if return_logits:
         # Compute logits for both input and sampled tokens.
-        logits = self._get_logits(pruned_states, lm_head, logits_metadata)
+        logits = replaced_logits_processor_get_logits(
+            self,
+            pruned_states,
+            lm_head,
+            logits_metadata,
+            chunk_sizes=chunk_sizes if shard_returns else None,
+        )
     else:
         logits = None
 
-    # get the aux hidden states
-    hidden_states_to_store: Optional[torch.Tensor] = None
-    if logits_metadata.capture_hidden_mode.need_capture():
-        if logits_metadata.capture_hidden_mode.is_full():
-            if aux_hidden_states is not None:
-                aux_hidden_states = torch.cat(aux_hidden_states, dim=-1)
-                hidden_states_to_store = aux_hidden_states
-            else:
-                hidden_states_to_store = hidden_states
-        elif logits_metadata.capture_hidden_mode.is_last():
-            # Get the last token hidden states. If sample_indices is None,
-            # pruned states only contain the last tokens already.
-            if aux_hidden_states is not None:
-                aux_pruned_states = torch.cat(aux_pruned_states, dim=-1)
-                hidden_states_to_store = (
-                    aux_pruned_states[sample_indices]
-                    if sample_indices is not None
-                    else aux_pruned_states
-                )
-            else:
-                hidden_states_to_store = (
-                    pruned_states[sample_indices]
-                    if sample_indices is not None
-                    else pruned_states
-                )
-        else:
-            assert False, "Should never reach"
+    if shard_returns:
+        if aux_hidden_states is not None:
+            aux_hidden_states = [
+                torch.split(hidden, chunk_sizes, dim=0)[
+                    cast(GroupCoordinator, tp_group).rank_in_group
+                ]
+                for hidden in aux_hidden_states
+            ]
+        hidden_states = torch.split(hidden_states, chunk_sizes, dim=0)[
+            cast(GroupCoordinator, tp_group).rank_in_group
+        ]
+
+    hidden_states_to_store = self._get_hidden_states_to_store(
+        hidden_states,
+        hidden_states_before_norm,
+        aux_hidden_states,
+        pruned_states,
+        pruned_states_before_norm,
+        aux_pruned_states,
+        sample_indices,
+        logits_metadata,
+    )
+    del hidden_states
 
     assert (
         not logits_metadata.extend_return_logprob
@@ -124,17 +165,90 @@ def replaced_logits_processor_forward_for_eagle3(
     )
 
 
+def replaced_logits_processor_get_logits(
+    self,
+    hidden_states: torch.Tensor,
+    lm_head: VocabParallelEmbedding,
+    logits_metadata: LogitsMetadata,
+    embedding_bias: Optional[torch.Tensor] = None,
+    chunk_sizes: Optional[list[int]] = None,
+    group: Optional[GroupCoordinator] = None,
+) -> torch.Tensor:
+    """
+    This is a modified forward function for the SGLang's logits processor, adapted from https://github.com/sgl-project/sglang/blob/v0.5.9/python/sglang/srt/layers/logits_processor.py.
+    The modification is to use all_to_all instead of gather to reduce memory footprint.
+    """
+    hidden_states, local_hidden_states = self._gather_dp_attn_hidden_states(
+        hidden_states, logits_metadata
+    )
+
+    logits = self._compute_lm_head(hidden_states, lm_head, embedding_bias)
+
+    if self.logit_scale is not None:
+        logits.mul_(self.logit_scale)
+
+    if self.do_tensor_parallel_all_gather:
+        if chunk_sizes is not None:
+            if self.use_attn_tp_group:
+                raise NotImplementedError(
+                    "'shard_returns' does not support attention tensor parallel"
+                )
+            else:
+                logits = tensor_all_to_all(logits, chunk_sizes, group=group)
+        else:
+            if self.use_attn_tp_group:
+                logits = self._gather_attn_tp_logits(logits)
+            else:
+                logits = tensor_model_parallel_all_gather(logits)
+
+    logits = self._scatter_dp_attn_logits(logits, local_hidden_states, logits_metadata)
+
+    logits = self._copy_logits_to_buffer(logits, logits_metadata)
+
+    if self.final_logit_softcapping:
+        if not is_npu():
+            fused_softcap(logits, self.final_logit_softcapping)
+        else:
+            logits = self.final_logit_softcapping * torch.tanh(
+                logits / self.final_logit_softcapping
+            )
+
+    return logits
+
+
 class LogitsProcessorForEAGLE3(torch.nn.Module):
     def __init__(
         self,
         logits_processor: LogitsProcessor,
         return_last_hidden_states: bool = False,
         return_logits: bool = False,
+        shard_returns: bool = False,
     ):
         super().__init__()
         self.logits_processor = logits_processor
         self.return_last_hidden_states = return_last_hidden_states
         self.return_logits = return_logits
+        self.shard_returns = shard_returns
+
+    @property
+    def shard_returns(self):
+        return self._shard_returns
+
+    @shard_returns.setter
+    def shard_returns(self, v):
+        self._shard_returns = v
+        # NOTE(@cih9088): `shard_returns` does not cover all control path.
+        if self._shard_returns and self.logits_processor.use_attn_tp_group:
+            raise NotImplementedError(
+                "'shard_returns' does not support attention tensor parallel"
+            )
+        if (
+            not self.logits_processor.do_tensor_parallel_all_gather
+            and self._shard_returns
+        ):
+            raise ValueError(
+                "'shard_returns' does nothing if do_tensor_parallel_all_gather is False"
+            )
 
     def forward(
         self,
@@ -142,7 +256,7 @@ class LogitsProcessorForEAGLE3(torch.nn.Module):
         hidden_states,
         lm_head,
         logits_metadata,
-        aux_hidden_states: Optional[torch.Tensor] = None,
+        aux_hidden_states: Optional[list[torch.Tensor]] = None,
         hidden_states_before_norm: Optional[torch.Tensor] = None,
     ) -> LogitsProcessorOutput:
         logits_metadata.forward_mode = ForwardMode.DECODE
@@ -156,6 +270,7 @@ class LogitsProcessorForEAGLE3(torch.nn.Module):
             hidden_states_before_norm,
             self.return_last_hidden_states,
             self.return_logits,
+            self.shard_returns,
         )
         return ret
 
@@ -171,3 +286,26 @@ def wrap_eagle3_logits_processors_in_module(
             wrapped = LogitsProcessorForEAGLE3(submodule, return_full_logits)
             setattr(module, name, wrapped)
             print(f"wrapped {name} with LogitsProcessorForEAGLE3")
+
+
+def tensor_all_to_all(
+    input_: torch.Tensor,
+    chunk_sizes: Optional[list[int]] = None,
+    scatter_dim: int = 0,
+    gather_dim: int = -1,
+    group: Optional[GroupCoordinator] = None,
+):
+    group = group if group is not None else get_tp_group()
+    if chunk_sizes is None:
+        assert input_.shape[scatter_dim] % group.world_size == 0
+        chunk_size = input_.shape[scatter_dim] // group.world_size
+        chunk_sizes = [chunk_size for _ in range(group.world_size)]
+
+    assert group.world_size == len(chunk_sizes), "chunk size must equal to world size"
+
+    scatter_list = list(input_.split(chunk_sizes, dim=scatter_dim))
+    gather_list = [
+        torch.zeros_like(scatter_list[group.rank_in_group]) for _ in scatter_list
+    ]
+    torch.distributed.all_to_all(gather_list, scatter_list, group=group.device_group)
+    return torch.cat(gather_list, dim=gather_dim)

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -1,5 +1,6 @@
 import shutil
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 
 from tests.utils import execute_shell_command
@@ -7,17 +8,30 @@ from tests.utils import execute_shell_command
 CACHE_DIR = Path(__file__).parent.parent.parent.joinpath("cache")
 
 
-def replace_in_script(script_path: Path, pattern: str, replacement: str):
+@contextmanager
+def replace_in_script(script_path: Path, *pattern_replacement_pairs):
+    assert len(pattern_replacement_pairs) % 2 == 0
     with open(script_path, "r") as f:
         script = f.readlines()
-    script = [line.replace(pattern, replacement) for line in script]
+    replaced_script = script
+    for pattern, replacement in zip(
+        pattern_replacement_pairs[::2], pattern_replacement_pairs[1::2]
+    ):
+        replaced_script = [
+            line.replace(pattern, replacement) for line in replaced_script
+        ]
+    with open(script_path, "w") as f:
+        for line in replaced_script:
+            f.write(line)
+
+    yield
+
     with open(script_path, "w") as f:
         for line in script:
             f.write(line)
 
 
 class TestTrainEagle3(unittest.TestCase):
-
     def setUp(self) -> None:
         # prepare data
         data_process = execute_shell_command(
@@ -64,15 +78,14 @@ class TestTrainEagle3(unittest.TestCase):
         script_path = Path(__file__).parent.parent.parent.joinpath(
             "examples", "run_llama3.1_8b_eagle3_online.sh"
         )
-        replace_in_script(
+        with replace_in_script(
             script_path, "--target-model-backend sglang", "--target-model-backend hf"
-        )
-
-        # run training
-        train_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
-        )
-        train_process.wait()
+        ):
+            # run training
+            train_process = execute_shell_command(
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
+            )
+            train_process.wait()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_custom_backend(self):
@@ -80,45 +93,20 @@ class TestTrainEagle3(unittest.TestCase):
         script_path = Path(__file__).parent.parent.parent.joinpath(
             "examples", "run_llama3.1_8b_eagle3_online.sh"
         )
-        replace_in_script(
+        with replace_in_script(
             script_path,
             "--target-model-backend sglang",
             "--target-model-backend custom",
-        )
-
-        # run training
-        train_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
-        )
-        train_process.wait()
+        ):
+            # run training
+            train_process = execute_shell_command(
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
+            )
+            train_process.wait()
         self.assertEqual(train_process.returncode, 0)
 
     def test_offline_train_eagle3(self):
         # remove the hidden states if they exist
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_offline.sh"
-        )
-        replace_in_script(
-            script_path,
-            "meta-llama/Llama-3.1-8B-Instruct",
-            "nreHieW/Llama-3.1-8B-Instruct",
-        )
-        replace_in_script(
-            script_path,
-            "--batch-size 32",
-            "--batch-size 5",
-        )
-        replace_in_script(
-            script_path,
-            "scripts/prepare_hidden_states.py",
-            "scripts/prepare_hidden_states.py --num-samples 10",
-        )
-        replace_in_script(
-            script_path,
-            "$ROOT_DIR/scripts/train_eagle3.py",
-            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
-        )
-
         hidden_states_path = Path(__file__).parent.parent.parent.joinpath(
             "cache", "hidden_states", "sharegpt_train_Llama-3.1-8B-Instruct"
         )
@@ -126,10 +114,24 @@ class TestTrainEagle3(unittest.TestCase):
             # delete the directory
             shutil.rmtree(hidden_states_path)
 
-        training_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
+        script_path = Path(__file__).parent.parent.parent.joinpath(
+            "examples", "run_llama3.1_8b_eagle3_offline.sh"
         )
-        training_process.wait()
+        with replace_in_script(
+            script_path,
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "nreHieW/Llama-3.1-8B-Instruct",
+            "--batch-size 32",
+            "--batch-size 5",
+            "scripts/prepare_hidden_states.py",
+            "scripts/prepare_hidden_states.py --num-samples 10",
+            "$ROOT_DIR/scripts/train_eagle3.py",
+            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
+        ):
+            training_process = execute_shell_command(
+                "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
+            )
+            training_process.wait()
         self.assertEqual(training_process.returncode, 0)
 
 

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -83,7 +83,7 @@ class TestTrainEagle3(unittest.TestCase):
         ):
             # run training
             train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
             )
             train_process.wait()
         self.assertEqual(train_process.returncode, 0)
@@ -100,7 +100,7 @@ class TestTrainEagle3(unittest.TestCase):
         ):
             # run training
             train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
             )
             train_process.wait()
         self.assertEqual(train_process.returncode, 0)

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -83,7 +83,7 @@ class TestTrainEagle3(unittest.TestCase):
         ):
             # run training
             train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
             )
             train_process.wait()
         self.assertEqual(train_process.returncode, 0)
@@ -100,7 +100,7 @@ class TestTrainEagle3(unittest.TestCase):
         ):
             # run training
             train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
             )
             train_process.wait()
         self.assertEqual(train_process.returncode, 0)

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -1,6 +1,5 @@
 import shutil
 import unittest
-from contextlib import contextmanager
 from pathlib import Path
 
 from tests.utils import execute_shell_command
@@ -8,30 +7,17 @@ from tests.utils import execute_shell_command
 CACHE_DIR = Path(__file__).parent.parent.parent.joinpath("cache")
 
 
-@contextmanager
-def replace_in_script(script_path: Path, *pattern_replacement_pairs):
-    assert len(pattern_replacement_pairs) % 2 == 0
+def replace_in_script(script_path: Path, pattern: str, replacement: str):
     with open(script_path, "r") as f:
         script = f.readlines()
-    replaced_script = script
-    for pattern, replacement in zip(
-        pattern_replacement_pairs[::2], pattern_replacement_pairs[1::2]
-    ):
-        replaced_script = [
-            line.replace(pattern, replacement) for line in replaced_script
-        ]
-    with open(script_path, "w") as f:
-        for line in replaced_script:
-            f.write(line)
-
-    yield
-
+    script = [line.replace(pattern, replacement) for line in script]
     with open(script_path, "w") as f:
         for line in script:
             f.write(line)
 
 
 class TestTrainEagle3(unittest.TestCase):
+
     def setUp(self) -> None:
         # prepare data
         data_process = execute_shell_command(
@@ -78,14 +64,15 @@ class TestTrainEagle3(unittest.TestCase):
         script_path = Path(__file__).parent.parent.parent.joinpath(
             "examples", "run_llama3.1_8b_eagle3_online.sh"
         )
-        with replace_in_script(
+        replace_in_script(
             script_path, "--target-model-backend sglang", "--target-model-backend hf"
-        ):
-            # run training
-            train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
-            )
-            train_process.wait()
+        )
+
+        # run training
+        train_process = execute_shell_command(
+            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+        )
+        train_process.wait()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_custom_backend(self):
@@ -93,20 +80,45 @@ class TestTrainEagle3(unittest.TestCase):
         script_path = Path(__file__).parent.parent.parent.joinpath(
             "examples", "run_llama3.1_8b_eagle3_online.sh"
         )
-        with replace_in_script(
+        replace_in_script(
             script_path,
             "--target-model-backend sglang",
             "--target-model-backend custom",
-        ):
-            # run training
-            train_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_online.sh 2 2"
-            )
-            train_process.wait()
+        )
+
+        # run training
+        train_process = execute_shell_command(
+            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+        )
+        train_process.wait()
         self.assertEqual(train_process.returncode, 0)
 
     def test_offline_train_eagle3(self):
         # remove the hidden states if they exist
+        script_path = Path(__file__).parent.parent.parent.joinpath(
+            "examples", "run_llama3.1_8b_eagle3_offline.sh"
+        )
+        replace_in_script(
+            script_path,
+            "meta-llama/Llama-3.1-8B-Instruct",
+            "nreHieW/Llama-3.1-8B-Instruct",
+        )
+        replace_in_script(
+            script_path,
+            "--batch-size 32",
+            "--batch-size 5",
+        )
+        replace_in_script(
+            script_path,
+            "scripts/prepare_hidden_states.py",
+            "scripts/prepare_hidden_states.py --num-samples 10",
+        )
+        replace_in_script(
+            script_path,
+            "$ROOT_DIR/scripts/train_eagle3.py",
+            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
+        )
+
         hidden_states_path = Path(__file__).parent.parent.parent.joinpath(
             "cache", "hidden_states", "sharegpt_train_Llama-3.1-8B-Instruct"
         )
@@ -114,24 +126,10 @@ class TestTrainEagle3(unittest.TestCase):
             # delete the directory
             shutil.rmtree(hidden_states_path)
 
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_offline.sh"
+        training_process = execute_shell_command(
+            "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
         )
-        with replace_in_script(
-            script_path,
-            "meta-llama/Llama-3.1-8B-Instruct",
-            "nreHieW/Llama-3.1-8B-Instruct",
-            "--batch-size 32",
-            "--batch-size 5",
-            "scripts/prepare_hidden_states.py",
-            "scripts/prepare_hidden_states.py --num-samples 10",
-            "$ROOT_DIR/scripts/train_eagle3.py",
-            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
-        ):
-            training_process = execute_shell_command(
-                "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
-            )
-            training_process.wait()
+        training_process.wait()
         self.assertEqual(training_process.returncode, 0)
 
 


### PR DESCRIPTION
## Motivation

Currently, Eagle3 training suffers from memory spikes that make it difficult to increase batch size (as reported in #466).

During Eagle3 training with the SGLang backend under tensor parallelism, the `lm_head` is vocab parallel - each TP rank computes a shard of the logits with shape `(global_batch_size * seq_len, vocab_size // tp_size)`. The current code uses `all_gather` to reconstruct the full logits, resulting in every rank holding `(global_batch_size * seq_len, vocab_size)`. This is already a `tp_size`-fold memory increase, which is very big. The problem compounds in `generate_eagle3_data()`: the gathered logit tensors are concatenated via `torch.cat` (`eagle3_target_model.py:793`), and then `padding()` (`utils.py:41`) performs another `torch.cat` to shift the sequence. Due to `cat` allocating a new full-size copy while the original is still alive, peak memory reaches much higher. With large vocab sizes (e.g. 150K for Qwen3), this makes it difficult to increase batch size.

This PR adds a `--shard-target-output` flag that replaces `all_gather` with `all_to_all`. Instead of gathering the full vocab on every rank, each rank exchanges its vocab shard for a batch shard, ending up with `((global_batch_size // dp_size) * seq_len, vocab_size)` - each rank holds the full vocab but only for its own DP shard of the batch. The same redistribution is applied to `aux_hidden_states` and `last_hidden_states`. Since the base tensor is much smaller (`1/tp_size` of the tensor without sharding), the subsequent `padding`/`cat` operations also operate on smaller tensors, eliminating the memory spike.

There is no alteration of tensor content, just distributed differently - the mathematical result is identical (training run shows identical loss values for 50 steps with sharding on/off).

Note: `--shard-target-output` is currently implemented for SGLang backend only, and is not tested for VLM models.

## Modifications

**`specforge/modeling/target/sglang_backend/utils.py`**
- Added `tensor_all_to_all` helper that redistributes a tensor from vocab-sharded to batch-sharded layout
- Modified `LogitsProcessor.forward` to use `all_to_all` instead of `all_gather` when `chunk_sizes` are provided
- Added `LogitsProcessorForEAGLE3` wrapper with `shard_returns` property to control the sharding behavior
- Modified `replaced_logits_processor_forward_for_eagle3` to return sharded logits, aux hidden states, and last hidden states

**`specforge/modeling/target/eagle3_target_model.py`**
- Added `shard_returns` parameter to `SGLangEagle3TargetModel._extend()` and `generate_eagle3_data()`
- Added `_get_sharded_return()` helper to split and select per-rank batch shards from concatenated outputs

**`scripts/train_eagle3.py`**
- Added `--shard-target-output` CLI flag
- Added `sanity_check` restrictions: sglang backend only, non-VLM only
- Added `get_dp_data_shard_from_tp()` helper that bypasses the standard DP sharding when outputs are already sharded

## Related Issues

Closes #466

## Accuracy Test

Verified on Qwen3-8B with tp_size=8 over 30 training steps. Loss values are the same between baseline (`all_gather`) and `--shard-target-output` (`all_to_all`):

<details>
<summary>Loss comparison (steps 1-30)</summary>

| step | baseline | shard | match |
|------|----------|-------|-------|
| 1 | 10.39 | 10.39 | yes |
| 2 | 10.23 | 10.23 | yes |
| 3 | 9.36 | 9.36 | yes |
| 4 | 9.42 | 9.42 | yes |
| 5 | 9.37 | 9.37 | yes |
| 6 | 7.57 | 7.57 | yes |
| 7 | 2.68 | 2.68 | yes |
| 8 | 2.55 | 2.55 | yes |
| 9 | 2.48 | 2.48 | yes |
| 10 | 8.24 | 8.24 | yes |
| 11 | 2.55 | 2.55 | yes |
| 12 | 2.38 | 2.38 | yes |
| 13 | 2.42 | 2.42 | yes |
| 14 | 4.94 | 4.94 | yes |
| 15 | 2.42 | 2.42 | yes |
| 16 | 2.40 | 2.40 | yes |
| 17 | 6.54 | 6.54 | yes |
| 18 | 4.93 | 4.93 | yes |
| 19 | 4.03 | 4.03 | yes |
| 20 | 2.03 | 2.03 | yes |
| 21 | 2.37 | 2.37 | yes |
| 22 | 2.37 | 2.37 | yes |
| 23 | 5.82 | 5.82 | yes |
| 24 | 5.01 | 5.01 | yes |
| 25 | 2.33 | 2.33 | yes |
| 26 | 2.35 | 2.35 | yes |
| 27 | 2.32 | 2.32 | yes |
| 28 | 2.36 | 2.36 | yes |
| 29 | 3.87 | 3.87 | yes |
| 30 | 5.88 | 5.88 | yes |

</details>

All 30 steps produce identical loss: the `all_to_all` path is mathematically equivalent to `all_gather`.

## Benchmark & Profiling

**Setup:** Qwen3-8B, tp_size=8, batch_size=1 (per DP rank), max_length=4096, 8x H200 GPUs

**Memory snapshot visualization (at rank 0):**

Baseline (`all_gather`) - memory spike from full-vocab materialization:
<img width="1619" height="412" alt="snapshot_baseline" src="https://github.com/user-attachments/assets/20e4743c-9d6f-4c40-80ef-418781ae0f04" />

With `--shard-target-output` (`all_to_all`) - spike gone:
<img width="1573" height="405" alt="snapshot_shard" src="https://github.com/user-attachments/assets/02b41576-a84e-40c7-afa0-21e6f5af7126" />

**Peak memory during training step (observed at rank 0):**

| | baseline (all_gather) | --shard-target-output (all_to_all) | reduction |
|---|---|---|---|
| peak allocated | 60.7 GiB | 16.1 GiB | **-73%** |

The baseline peak (60.7 GiB) reflects the cascading allocations in `generate_eagle3_data()`: `all_gather` materializes the full-vocab logits, then `torch.cat` and `padding()` makes it bigger. With `all_to_all`, the base tensor is `1/tp_size` the size, so the same downstream operations peak at only 16.1 GiB.

cc @cih9088 @Kthyeon

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
