### PR TITLE
Reduce peak GPU memory in Eagle3 online target generation by avoiding an extra logits copy

### DIFF
--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -723,10 +723,18 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
                 )
             )
         aux_hidden_states_out = []
-        target_out = []
         loss_mask_out = []
         input_ids_out = []
         last_hidden_states_out = []
+
+        # Pre-allocate target_out to avoid the 2x peak memory from list+cat+padding.
+        # All sequences in a batch share the same padded length (from the DataLoader),
+        # so we can write each sequence's padded logits directly into the output tensor.
+        has_logits = logits_list[0] is not None
+        if has_logits:
+            B = len(logits_list)
+            T, V = logits_list[0].shape[-2], logits_list[0].shape[-1]
+            target_out = torch.empty(B, T, V, device=logits_list[0].device, dtype=logits_list[0].dtype)
 
         for idx, (data, logits, aux_hidden_states, last_hidden_states) in enumerate(
             zip(
@@ -739,10 +747,10 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
 
             # when generating hidden states for offline training, we don't compute logits and only keep the last_hidden_states
             # when training online, we don't keep the last_hidden_states and only keep the logits
-            if logits is not None:
-                target_out.append(logits.unsqueeze(0))
-            else:
-                target_out.append(None)
+            if has_logits:
+                # Write shifted logits directly into pre-allocated tensor (no extra copy)
+                target_out[idx, :-1] = logits[..., 1:, :]
+                target_out[idx, -1] = 0
 
             if last_hidden_states is not None:
                 last_hidden_states_out.append(last_hidden_states.unsqueeze(0))
@@ -754,9 +762,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         loss_mask_out = torch.cat(loss_mask_out, dim=0)
         input_ids_out = torch.cat(input_ids_out, dim=0)
 
-        if target_out[0] is not None:
-            target_out = torch.cat(target_out, dim=0)
-        else:
+        if not has_logits:
             target_out = None
 
         if last_hidden_states_out[0] is not None:
@@ -764,7 +770,6 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         else:
             last_hidden_states_out = None
 
-        target_out = padding(target_out, left=False)
         input_ids_out = padding(input_ids_out, left=False)
         loss_mask_out = loss_mask_out[..., None]
 

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -734,7 +734,9 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         if has_logits:
             B = len(logits_list)
             T, V = logits_list[0].shape[-2], logits_list[0].shape[-1]
-            target_out = torch.empty(B, T, V, device=logits_list[0].device, dtype=logits_list[0].dtype)
+            target_out = torch.empty(
+                B, T, V, device=logits_list[0].device, dtype=logits_list[0].dtype
+            )
 
         for idx, (data, logits, aux_hidden_states, last_hidden_states) in enumerate(
             zip(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

This PR fixes an out-of-memory issue in Eagle3 online training caused by an unnecessary full-tensor copy when shifting target logits.

Previously, `generate_eagle3_data()` accumulated per-sample logits into a list, concatenated them into a `[B, T, V]` tensor, and then called `padding(target_out, left=False)` to shift the logits left and append a zero row at the end. For large vocab models, that final padding step materialized another full `[B, T, V]` allocation and could trigger multi-GB peak memory spikes.

This change pre-allocates the final `target_out` tensor once and writes the shifted logits directly into it:
- `target_out[idx, :-1] = logits[..., 1:, :]`
- `target_out[idx, -1] = 0`

That preserves the original semantics while removing the extra full-size allocation.

**Root Cause**
The old implementation created peak memory pressure in two stages:
1. Concatenate per-sample logits into a full `target_out` tensor.
2. Call `padding(target_out, left=False)`, which internally builds a zero padding tensor and concatenates again, creating another full-sized `[B, T, V]` tensor.

For Eagle3 online training, `V` is the target model vocabulary size, so this copy is extremely expensive. In practice this showed up as OOM during `generate_eagle3_data()` even though steady-state memory usage was otherwise close to fitting.


## Modifications

- Stop collecting `target_out` as a Python list of per-sample logits tensors.
- Detect whether logits are present with `has_logits = logits_list[0] is not None`.
- Pre-allocate `target_out` with shape `[B, T, V]` using the first logits tensor's device and dtype.
- Write the shifted logits directly into the pre-allocated output tensor during the main loop.
- Remove the `padding(target_out, left=False)` call entirely.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
