### PR TITLE
[Fix] preserve image data in preprocess for VLM training on multimodal data

### DIFF
--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -404,7 +404,7 @@ def safe_conversations_generator(file_path):
                             result["tools"] = tools
                     else:
                         result["tools"] = []
-                
+
                 # preserve image - required in preprocess_vlm_conversations for vlm
                 if "image" in row:
                     result["image"] = row["image"]

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -404,6 +404,10 @@ def safe_conversations_generator(file_path):
                             result["tools"] = tools
                     else:
                         result["tools"] = []
+                
+                # preserve image - required in preprocess_vlm_conversations for vlm
+                if "image" in row:
+                    result["image"] = row["image"]
 
                 yield result
 

--- a/tests/test_data/data/vlm_conversation.jsonl
+++ b/tests/test_data/data/vlm_conversation.jsonl
@@ -1,0 +1,2 @@
+
+{"id": 1, "image": "/data/images/test.jpg", "conversations": [{"role": "user", "content": "Describe this image."}, {"role": "assistant", "content": "A cat."}]}

--- a/tests/test_data/test_build_eagle3_dataset.py
+++ b/tests/test_data/test_build_eagle3_dataset.py
@@ -194,6 +194,26 @@ class TestBuildEagle3Dataset(unittest.TestCase):
             assistant_indices = torch.where(loss_mask == 1)[0]
             self.assertTrue(len(assistant_indices) > 0, "No assistant tokens found")
 
+    def test_vlm_image_field_preserved(self):
+        """Regression test - preprocess_vlm_conversations relies on 'image'
+        field being preserved when the dataset is built with build_eagle3_dataset."""
+        data_file = os.path.join(
+            os.path.dirname(__file__), "data", "vlm_conversation.jsonl"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dataset = Dataset.from_generator(
+                generator=safe_conversations_generator,
+                gen_kwargs={"file_path": data_file},
+                cache_dir=tmp_dir,
+                keep_in_memory=True,
+            )
+            self.assertIn(
+                "image",
+                dataset.column_names,
+                "image column missing from dataset — results in KeyError in preprocess_vlm_conversations",
+            )
+            self.assertEqual(dataset[0]["image"], "/data/images/test.jpg")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

When using multimodal conversations in training, `safe_conversations_generator` drops the `image` field when loading and cleaning the data, which leads `preprocess_vlm_conversations` to fail when trying to access the image field in the conversation on this [line](https://github.com/sgl-project/SpecForge/blob/d5fb617f735db85a680876327f8173de0cb57c15/specforge/data/preprocessing.py#L217). For example running this toy script 
```python
import json, os
from datasets import Dataset
from specforge.utils import safe_conversations_generator
from specforge.data.preprocessing import preprocess_vlm_conversations
from specforge.data.template import TEMPLATE_REGISTRY

test_file = "test_vlm_image.jsonl"
with open(test_file, "w") as f:
    f.write(json.dumps({
        "id": 1,
        "image": "/data/images/test.jpg",
        "conversations": [
            {"role": "user", "content": "Describe this image."},
            {"role": "assistant", "content": "A cat."},
        ],
    }) + "\n")

dataset = Dataset.from_generator(
    generator=safe_conversations_generator,
    gen_kwargs={"file_path": test_file},
)

preprocess_vlm_conversations(
    processor=None,
    examples=dataset[:],
    chat_template=TEMPLATE_REGISTRY.get("qwen2-vl"),
    max_length=2048,
)

os.remove(test_file)
```
yields the following:
```
Error: Exit code 1
     /home/ec2-user/qwenvl-eagle/SpecForge/specforge/modeling/draft/llama3_eagle.py:29: UserWarning: flash_attn is not found, falling back to flex_attention. Please install flash_attn if you want to use the
     flash attention backend.
       warnings.warn(
     <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
     <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
     Set TORCH_CUDA_ARCH_LIST to 8.9

     Generating train split: 0 examples [00:00, ? examples/s]
     Generating train split: 1 examples [00:00, 587.85 examples/s]
     Traceback (most recent call last):
       File "/home/ec2-user/qwenvl-eagle/test.py", line 23, in <module>
         preprocess_vlm_conversations(
       File "/home/ec2-user/qwenvl-eagle/SpecForge/specforge/data/preprocessing.py", line 217, in preprocess_vlm_conversations
         for i, image in enumerate(examples["image"]):
                                   ~~~~~~~~^^^^^^^^^
     KeyError: 'image'
```

## Modifications

- Added image field preservation to `safe_conversations_generator`
- Added test (`TestBuildEagle3Dataset.test_vlm_image_field_preserved`) to prevent future regression. If this was failing silently, multimodal quality will likely be hurt.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->
- Related to (#527), which fixes downstream VLM preprocessing issue. This minor patch addresses gap that drops the `image` field separate from the issue.
- May be related to poor accept lengths for VL models cited in (#310) though it would be a silent fail.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
