### PR TITLE
fix: EAGLE-3 training compatibility with multimodal-wrapped targets and large vocabs

### DIFF
--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -28,7 +28,7 @@ import torch.nn.functional as F
 from transformers.cache_utils import DynamicCache
 
 from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspAdapter
-from specforge.core.loss import LogSoftmaxLoss
+from specforge.core.loss import LogSoftmaxLoss, _compute_loss
 from specforge.modeling.draft import Eagle3DraftModel
 from specforge.utils import padding
 
@@ -92,7 +92,12 @@ class OnlineEagle3Model(Eagle3Model):
             )
             acc = local_correct / local_denom
 
-        loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+        try:
+            loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+        except RuntimeError:
+            # Fused Triton kernel has a block-size ceiling (131072); fall back
+            # to the @torch.compile reference for large-vocab models.
+            loss = _compute_loss(logits, target_p, position_mask)
         loss = adapter.reduce_loss(loss)
         return acc, loss
 
@@ -553,7 +558,12 @@ class QwenVLOnlineEagle3Model(Eagle3Model):
                 )
 
             # Step 5.6: calculate loss, in-place modifies logits!
-            loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+            try:
+                loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+            except RuntimeError:
+                # Fused Triton kernel has a block-size ceiling (131072); fall
+                # back to the @torch.compile reference for large-vocab models.
+                loss = _compute_loss(logits, target_p, position_mask)
             plosses.append(loss)
 
             if not is_last:

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -349,7 +349,14 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
     def set_aux_hidden_states_layers(
         self, aux_hidden_states_layers: Optional[List[int]] = None
     ) -> None:
-        self.model_runner.model.set_eagle3_layers_to_capture(aux_hidden_states_layers)
+        # Some target models (e.g., Kimi-K2.5) load via a multimodal wrapper
+        # that delegates to a text backbone at .language_model.  The EAGLE-3
+        # helper set_eagle3_layers_to_capture is defined on the text backbone,
+        # not the outer wrapper.
+        inner = getattr(
+            self.model_runner.model, "language_model", self.model_runner.model
+        )
+        inner.set_eagle3_layers_to_capture(aux_hidden_states_layers)
 
     @torch.no_grad
     def _extend(

--- a/specforge/modeling/target/sglang_backend/utils.py
+++ b/specforge/modeling/target/sglang_backend/utils.py
@@ -164,10 +164,27 @@ def wrap_eagle3_logits_processors_in_module(
     module: nn.Module, return_full_logits: bool = False
 ):
     """
-    This function will wrap the SGLang's original logits processor with the modified one for EAGLE3.
+    Wrap SGLang's original logits processors with the EAGLE3 variant.
+
+    Fixes:
+      1. Iterate over a materialized list so mutations to _modules do not
+         corrupt the iterator returned by named_modules().
+      2. Use module.set_submodule(dotted_name, wrapped) so nested
+         LogitsProcessors (e.g. language_model.logits_processor) are actually
+         replaced in their parent module, instead of creating a literal
+         dotted-name attribute on the root module.
     """
-    for name, submodule in module.named_modules():
-        if isinstance(submodule, LogitsProcessor):
-            wrapped = LogitsProcessorForEAGLE3(submodule, return_full_logits)
-            setattr(module, name, wrapped)
-            print(f"wrapped {name} with LogitsProcessorForEAGLE3")
+    to_wrap = [
+        (name, submodule)
+        for name, submodule in list(module.named_modules())
+        if isinstance(submodule, LogitsProcessor)
+    ]
+    for name, submodule in to_wrap:
+        wrapped = LogitsProcessorForEAGLE3(submodule, return_full_logits)
+        if name == "":
+            print(
+                "warning: root module is a LogitsProcessor; cannot replace in-place"
+            )
+            continue
+        module.set_submodule(name, wrapped)
+        print(f"wrapped {name} with LogitsProcessorForEAGLE3")


### PR DESCRIPTION
## Summary
Three bugs that block EAGLE-3 offline training (`prepare_hidden_states.py` + `train_eagle3.py`) on multimodal-wrapped target models (e.g., Kimi-K2.5) and/or large-vocab targets (vocab > 131072).

Discovered while fine-tuning `lightseekorg/kimi-k2.5-eagle3` on 8×H200 via SpecForge offline mode.

## Bugs fixed

### 1. `wrap_eagle3_logits_processors_in_module` iteration mutation + wrong targeting
- **File**: `specforge/modeling/target/sglang_backend/utils.py`
- **Symptoms**: `RuntimeError: dictionary changed size during iteration` on any model with nested `LogitsProcessor` submodules (e.g., `KimiK25ForConditionalGeneration.language_model.logits_processor`). Even if only the iteration bug is fixed, `setattr(root, dotted_name, wrapped)` silently creates a wrong attribute instead of navigating into the nested module — hidden-state capture produces junk data.
- **Fix**: materialize `list(module.named_modules())` + use `module.set_submodule(name, wrapped)` for correct dotted-path navigation.

### 2. `SGLangEagle3TargetModel.set_aux_hidden_states_layers` missing MM wrapper delegation
- **File**: `specforge/modeling/target/eagle3_target_model.py`
- **Symptoms**: `AttributeError: 'KimiK25ForConditionalGeneration' object has no attribute 'set_eagle3_layers_to_capture'` because the method is on the text backbone (`.language_model`), not the outer wrapper.
- **Fix**: `getattr(model, "language_model", model)` probe before calling.

### 3. `LogSoftmaxLoss` Triton block size ceiling blocks vocab > 131072
- **File**: `specforge/core/loss.py` + `specforge/core/eagle3.py`
- **Symptoms**: `RuntimeError: Cannot launch Triton kernel since n = 163840 exceeds the recommended Triton blocksize = 131072` at the first training step.
- **Fix**: graceful fallback from fused `LogSoftmaxLoss.apply` to `@torch.compile` reference `_compute_loss` when vocab exceeds the Triton ceiling. No performance regression for models that fit.

## Test plan
- [x] Verified on Kimi-K2.5 (vocab 163840, multimodal wrapper) with 8×H200, SpecForge offline mode
- [x] `prepare_hidden_states.py` runs to completion (1947 samples, all output files validated)
- [x] `train_eagle3.py` trains for 244 steps without crash, loss descends 0.46→0.26
- [x] No regression on non-wrapped models (Llama-3 path unchanged — `getattr` falls through, `set_submodule` works on flat models, `LogSoftmaxLoss` still used for vocab ≤ 131072)