### PR TITLE
fix: correct vocab_size to 262144 in gemma3-1b-eagle3 configuration

### DIFF
--- a/configs/gemma3-1b-eagle3.json
+++ b/configs/gemma3-1b-eagle3.json
@@ -26,7 +26,7 @@
   "transformers_version": "4.50.0",
   "use_cache": true,
   "use_sliding_window": false,
-  "vocab_size": 262145,
+  "vocab_size": 262144,
   "draft_vocab_size": 32000,
   "target_model_type": "gemma3_text"
 }


### PR DESCRIPTION
## Motivation

Fixed a `vocab_size` mismatch in the `gemma3-1b-eagle3` configuration. The value was incorrectly set to `262145` instead of the correct `262144`, which causes issues during model initialization or weight loading.

## Modifications

- Updated `configs/gemma3-1b-eagle3.json` to change `vocab_size` from `262145` to `262144`.

## Related Issues

N/A

## Accuracy Test

N/A (Configuration fix only)

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.