### PR TITLE
feat: add reasoning mode to regenerate data script

### DIFF
--- a/docs/basic_usage/data_preparation.md
+++ b/docs/basic_usage/data_preparation.md
@@ -55,6 +55,8 @@ python scripts/regenerate_train_data.py \
     --output-file-path ./cache/dataset/sharegpt_train_regen.jsonl
 ```
 
+For reasoning models, add `--reasoning save` to store `reasoning_content` in the regenerated dataset. To use a reasoning model with thinking disabled, add `--reasoning disable`, which forwards `chat_template_kwargs.enable_thinking=false` to the SGLang server and does not save `reasoning_content`.
+
 For maximum performance, we recommend to scale the number of GPUs to regenerate the dataset in data parallel mode. To do this, you can simply add more server addresses to the `--server-address` argument, e.g. `--server-address localhost:30000 localhost:30001 localhost:30002 localhost:30003`.
 
 

--- a/scripts/regenerate_train_data.py
+++ b/scripts/regenerate_train_data.py
@@ -27,7 +27,7 @@ python scripts/regenerate_train_data.py \
     --input-file-path /data/jiapingW/pr/SpecForge/cache/dataset/opc_train_first_turn.jsonl \
     --output-file-path ./cache/dataset/opc_train_regen_first_turn.jsonl \
     --resume \
-    --is-reasoning-model
+    --reasoning save
 """
 
 import argparse
@@ -51,9 +51,13 @@ def parse_arguments():
     model_group = parser.add_argument_group("model")
     model_group.add_argument("--model", type=str, required=True)
     model_group.add_argument(
-        "--is-reasoning-model",
-        action="store_true",
-        help="Whether the model is a reasoning model",
+        "--reasoning",
+        choices=["none", "save", "disable"],
+        default="none",
+        help=(
+            "Reasoning mode: 'none' for standard models, 'save' to store "
+            "reasoning_content, or 'disable' to disable thinking via extra_body"
+        ),
     )
     model_group.add_argument(
         "--is-gpt-oss",
@@ -184,6 +188,8 @@ def build_query_kwargs(args, messages, max_tokens=None):
     extra_body = {}
     if args.top_k is not None:
         extra_body["top_k"] = args.top_k
+    if args.reasoning == "disable":
+        extra_body["chat_template_kwargs"] = {"enable_thinking": False}
     if extra_body:
         query_kwargs["extra_body"] = extra_body
     if args.is_gpt_oss:
@@ -230,7 +236,7 @@ def call_sglang(
                 "role": "assistant",
                 "content": response_text,
             }
-            if args.is_reasoning_model:
+            if args.reasoning == "save":
                 resp_msg["reasoning_content"] = resp.choices[
                     0
                 ].message.reasoning_content


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Reasoning models such as Qwen3.5 need explicit control over whether regenerated training data should preserve reasoning content or disable thinking during generation.

## Modifications

  - Replace the old `--is-reasoning-model` flag with `--reasoning {none,save,disable}`.
  - Add `--reasoning save` to preserve `reasoning_content` in regenerated data.
  - Add `--reasoning disable` to pass `chat_template_kwargs.enable_thinking=false` through `extra_body`.
  - Update data preparation docs for reasoning model usage.

## Related Issues

Closes #544.

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

N/A. This is a CLI/data generation behavior change and is not expected to affect runtime performance.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
