### PR TITLE
Fix CI test resource usage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted]
     container:
       image: lmsysorg/sglang:v0.5.5 # we lock to this version to avoid repeated docker pull
-      options: --gpus all --shm-size=2g --rm -v /dev/shm --privileged
+      options: --gpus all --shm-size=2g --rm -v /dev/shm --privileged --pid=host
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,7 +47,8 @@ jobs:
           fi
           source sf/bin/activate
           uv pip install setuptools
-          MAX_JOBS=8 uv pip install -v ".[fa]" --prerelease=allow --no-build-isolation
+          python -c "import torch" || uv pip install torch==2.9.1
+          MAX_JOBS=8 uv pip install -v ".[fa]" --no-build-isolation
 
       - name: Kill GPU processes
         shell: bash

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -56,6 +56,33 @@ from specforge.utils import (
 )
 
 
+def print_cuda_memory_debug(label: str) -> None:
+    if os.getenv("SPECFORGE_CI_MEMORY_DEBUG") != "1" or not torch.cuda.is_available():
+        return
+
+    try:
+        torch.cuda.synchronize()
+        free_bytes, total_bytes = torch.cuda.mem_get_info()
+        allocated_bytes = torch.cuda.memory_allocated()
+        reserved_bytes = torch.cuda.memory_reserved()
+    except Exception as exc:
+        print(f"[memory-debug] {label}: failed to query CUDA memory: {exc}", flush=True)
+        return
+
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else "NA"
+    local_rank = os.getenv("LOCAL_RANK", "NA")
+    print(
+        "[memory-debug] "
+        f"{label}: rank={rank} local_rank={local_rank} "
+        f"free={free_bytes / 1024**3:.2f}GiB "
+        f"used={(total_bytes - free_bytes) / 1024**3:.2f}GiB "
+        f"total={total_bytes / 1024**3:.2f}GiB "
+        f"torch_allocated={allocated_bytes / 1024**3:.2f}GiB "
+        f"torch_reserved={reserved_bytes / 1024**3:.2f}GiB",
+        flush=True,
+    )
+
+
 def parse_args() -> Tuple[ArgumentParser, Namespace]:
     """
     This function is used to parse the arguments for the training script.
@@ -744,23 +771,31 @@ def main():
     sanity_check(args)
     print_args_with_dots(args)
     print_with_rank("Initialized distributed environment")
+    print_cuda_memory_debug("after init_distributed")
 
     # ================================================
     # 2. Build models
     # ================================================
+    print_cuda_memory_debug("before build_draft_model")
     draft_model_config, draft_model, ckpt_info, resume_state = build_draft_model(args)
+    print_cuda_memory_debug("after build_draft_model")
+    print_cuda_memory_debug("before build_target_model")
     target_model, processor = build_target_model(args, draft_model_config, is_online)
+    print_cuda_memory_debug("after build_target_model")
 
     # ================================================
     # 3. Build dataloader
     # ================================================
+    print_cuda_memory_debug("before build_dataloaders")
     train_dataloader, vocab_mapping_path, eval_dataloader = build_dataloaders(
         args, draft_model_config, processor
     )
+    print_cuda_memory_debug("after build_dataloaders")
 
     # we load the vocab mapping then
     draft_model.load_vocab_mapping(vocab_mapping_path)
     print_with_rank("Loaded vocab mapping")
+    print_cuda_memory_debug("after load_vocab_mapping")
 
     # Calculate total steps if not provided
     if args.total_steps is None:

--- a/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
+++ b/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
@@ -2,12 +2,20 @@ import os
 import unittest
 
 import torch
+import torch.distributed as dist
 import torch.multiprocessing as mp
 from accelerate.utils import set_seed
 
 from specforge.distributed import init_distributed
 from specforge.modeling.target.eagle3_target_model import SGLangEagle3TargetModel
 from tests.utils import get_available_port
+
+
+def cleanup_distributed():
+    if dist.is_available() and dist.is_initialized():
+        torch.cuda.synchronize()
+        dist.barrier()
+        dist.destroy_process_group()
 
 
 @torch.no_grad()
@@ -38,6 +46,7 @@ def test_dense(rank, world_size, port, tp_size):
         input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
     )
     print(f"[Rank {rank}] test_dense passed successfully!")
+    cleanup_distributed()
 
 
 @torch.no_grad()
@@ -69,6 +78,7 @@ def test_moe(rank, world_size, port, tp_size):
         input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
     )
     print(f"[Rank {rank}] test_moe passed successfully!")
+    cleanup_distributed()
 
 
 def test_vlm(rank, world_size, port, tp_size):
@@ -212,6 +222,7 @@ def test_vlm(rank, world_size, port, tp_size):
         print(f"[Rank {rank}] target shape: {sgl_out.target.shape}")
         print(f"[Rank {rank}] input_ids shape: {sgl_out.input_ids.shape}")
         print(f"[Rank {rank}] test_vlm passed successfully!")
+    cleanup_distributed()
 
 
 def test_vlm_multi_batch(rank, world_size, port, tp_size):
@@ -375,6 +386,7 @@ def test_vlm_multi_batch(rank, world_size, port, tp_size):
         print(f"[Rank {rank}] Batch size verification: PASSED")
         print(f"{'='*60}\n")
         print(f"[Rank {rank}] test_vlm_multi_batch passed successfully!")
+    cleanup_distributed()
 
 
 class TestTargetModelBackend(unittest.TestCase):

--- a/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
+++ b/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
@@ -61,6 +61,7 @@ def test_moe(rank, world_size, port, tp_size):
         torch_dtype=torch.float16,
         device="cuda",
         attention_backend="fa3",
+        load_format="dummy",
         mem_fraction_static=0.4,
     )
     sgl_target_model.set_aux_hidden_states_layers()
@@ -192,6 +193,7 @@ def test_vlm(rank, world_size, port, tp_size):
         torch_dtype=torch.float16,
         device="cuda",
         attention_backend="fa3",
+        load_format="dummy",
         mem_fraction_static=0.75,
     )
     sgl_target_model.set_aux_hidden_states_layers()
@@ -345,6 +347,7 @@ def test_vlm_multi_batch(rank, world_size, port, tp_size):
         torch_dtype=torch.float16,
         device="cuda",
         attention_backend="fa3",
+        load_format="dummy",
         mem_fraction_static=0.4,
     )
     sgl_target_model.set_aux_hidden_states_layers()

--- a/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
+++ b/tests/test_modeling/test_target/test_sglang_backend/test_sglang_backend.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import unittest
 
@@ -12,10 +13,17 @@ from tests.utils import get_available_port
 
 
 def cleanup_distributed():
+    gc.collect()
+    torch.cuda.empty_cache()
     if dist.is_available() and dist.is_initialized():
-        torch.cuda.synchronize()
-        dist.barrier()
-        dist.destroy_process_group()
+        try:
+            torch.cuda.synchronize()
+        except RuntimeError:
+            pass
+        try:
+            dist.destroy_process_group()
+        except RuntimeError:
+            pass
 
 
 @torch.no_grad()
@@ -46,6 +54,7 @@ def test_dense(rank, world_size, port, tp_size):
         input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
     )
     print(f"[Rank {rank}] test_dense passed successfully!")
+    del sgl_out, sgl_target_model, input_ids, attention_mask, loss_mask
     cleanup_distributed()
 
 
@@ -78,6 +87,7 @@ def test_moe(rank, world_size, port, tp_size):
         input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
     )
     print(f"[Rank {rank}] test_moe passed successfully!")
+    del sgl_out, sgl_target_model, input_ids, attention_mask, loss_mask
     cleanup_distributed()
 
 
@@ -222,6 +232,15 @@ def test_vlm(rank, world_size, port, tp_size):
         print(f"[Rank {rank}] target shape: {sgl_out.target.shape}")
         print(f"[Rank {rank}] input_ids shape: {sgl_out.input_ids.shape}")
         print(f"[Rank {rank}] test_vlm passed successfully!")
+    del (
+        sgl_out,
+        sgl_target_model,
+        input_ids,
+        attention_mask,
+        loss_mask,
+        pixel_values,
+        image_grid_thw,
+    )
     cleanup_distributed()
 
 
@@ -386,6 +405,15 @@ def test_vlm_multi_batch(rank, world_size, port, tp_size):
         print(f"[Rank {rank}] Batch size verification: PASSED")
         print(f"{'='*60}\n")
         print(f"[Rank {rank}] test_vlm_multi_batch passed successfully!")
+    del (
+        sgl_out,
+        sgl_target_model,
+        input_ids,
+        attention_mask,
+        loss_mask,
+        pixel_values,
+        image_grid_thw,
+    )
     cleanup_distributed()
 
 

--- a/tests/test_modeling/test_target/test_target_model_backend.py
+++ b/tests/test_modeling/test_target/test_target_model_backend.py
@@ -1,7 +1,9 @@
+import gc
 import os
 import unittest
 
 import torch
+import torch.distributed as dist
 import torch.multiprocessing as mp
 from accelerate.utils import set_seed
 
@@ -14,6 +16,20 @@ from specforge.modeling.target.eagle3_target_model import (
 from tests.utils import get_available_port
 
 
+def cleanup_distributed():
+    gc.collect()
+    torch.cuda.empty_cache()
+    if dist.is_available() and dist.is_initialized():
+        try:
+            torch.cuda.synchronize()
+        except RuntimeError:
+            pass
+        try:
+            dist.destroy_process_group()
+        except RuntimeError:
+            pass
+
+
 @torch.no_grad()
 def test_target_model_backend(rank, world_size, port, tp_size):
     os.environ["RANK"] = str(rank)
@@ -22,66 +38,83 @@ def test_target_model_backend(rank, world_size, port, tp_size):
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = str(port)
 
-    init_distributed(tp_size=tp_size)
-    set_seed(42)
+    input_ids = attention_mask = loss_mask = None
+    hf_target_model = custom_target_model = sgl_target_model = None
+    hf_out = custom_out = sgl_out = None
+    try:
+        init_distributed(tp_size=tp_size)
+        set_seed(42)
 
-    input_ids = torch.randint(0, 1000, (2, 256)).cuda()
-    attention_mask = torch.ones_like(input_ids)
-    loss_mask = torch.ones_like(input_ids)
+        input_ids = torch.randint(0, 1000, (2, 256)).cuda()
+        attention_mask = torch.ones_like(input_ids)
+        loss_mask = torch.ones_like(input_ids)
 
-    hf_target_model = HFEagle3TargetModel.from_pretrained(
-        "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
-    )
-    hf_target_model.set_aux_hidden_states_layers()
-    hf_out = hf_target_model.generate_eagle3_data(
-        input_ids=input_ids,
-        attention_mask=attention_mask,
-        loss_mask=loss_mask,
-    )
-    del hf_target_model
+        hf_target_model = HFEagle3TargetModel.from_pretrained(
+            "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
+        )
+        hf_target_model.set_aux_hidden_states_layers()
+        hf_out = hf_target_model.generate_eagle3_data(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+        )
+        hf_target_model = None
 
-    custom_target_model = CustomEagle3TargetModel.from_pretrained(
-        "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
-    )
-    custom_target_model.set_aux_hidden_states_layers()
-    custom_out = custom_target_model.generate_eagle3_data(
-        input_ids=input_ids,
-        attention_mask=attention_mask,
-        loss_mask=loss_mask,
-    )
-    del custom_target_model
+        custom_target_model = CustomEagle3TargetModel.from_pretrained(
+            "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
+        )
+        custom_target_model.set_aux_hidden_states_layers()
+        custom_out = custom_target_model.generate_eagle3_data(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+        )
+        custom_target_model = None
 
-    # compare weights
-    assert torch.allclose(
-        hf_out.target, custom_out.target, atol=1e-5, rtol=1e-5
-    ), f"Logits are not close: \nhf: {hf_out[0] - custom_out[0]}"
-    assert torch.allclose(
-        hf_out.loss_mask, custom_out.loss_mask, atol=1e-5, rtol=1e-5
-    ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
-    assert torch.allclose(
-        hf_out.input_ids, custom_out.input_ids, atol=1e-5, rtol=1e-5
-    ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
-    assert torch.allclose(
-        hf_out.hidden_states, custom_out.hidden_states, atol=1e-5, rtol=1e-5
-    ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
+        # compare weights
+        assert torch.allclose(
+            hf_out.target, custom_out.target, atol=1e-5, rtol=1e-5
+        ), f"Logits are not close: \nhf: {hf_out[0] - custom_out[0]}"
+        assert torch.allclose(
+            hf_out.loss_mask, custom_out.loss_mask, atol=1e-5, rtol=1e-5
+        ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
+        assert torch.allclose(
+            hf_out.input_ids, custom_out.input_ids, atol=1e-5, rtol=1e-5
+        ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
+        assert torch.allclose(
+            hf_out.hidden_states, custom_out.hidden_states, atol=1e-5, rtol=1e-5
+        ), f"Logits are not close: \ndiff: {hf_out[1] - custom_out[1]}"
 
-    sgl_target_model = SGLangEagle3TargetModel.from_pretrained(
-        "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
-    )
-    sgl_target_model.set_aux_hidden_states_layers()
-    sgl_out = sgl_target_model.generate_eagle3_data(
-        input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
-    )
-    del sgl_target_model
+        sgl_target_model = SGLangEagle3TargetModel.from_pretrained(
+            "unsloth/Llama-3.2-1B", torch_dtype=torch.float16, device="cuda"
+        )
+        sgl_target_model.set_aux_hidden_states_layers()
+        sgl_out = sgl_target_model.generate_eagle3_data(
+            input_ids=input_ids, attention_mask=attention_mask, loss_mask=loss_mask
+        )
+        sgl_target_model = None
 
-    assert torch.equal(hf_out.loss_mask, sgl_out.loss_mask)
-    assert torch.equal(hf_out.input_ids, sgl_out.input_ids)
-    assert torch.allclose(
-        hf_out.hidden_states, sgl_out.hidden_states, atol=1e-1, rtol=1e-2
-    ), f"Hidden states are not close, diff: \n{(hf_out.hidden_states - sgl_out.hidden_states).abs().max()}"
-    assert torch.allclose(
-        hf_out.target, sgl_out.target.half(), atol=1e-1, rtol=1e-2
-    ), f"Target are not close, diff: \n{(hf_out.target - sgl_out.target).abs().max()}"
+        assert torch.equal(hf_out.loss_mask, sgl_out.loss_mask)
+        assert torch.equal(hf_out.input_ids, sgl_out.input_ids)
+        assert torch.allclose(
+            hf_out.hidden_states, sgl_out.hidden_states, atol=1e-1, rtol=1e-2
+        ), f"Hidden states are not close, diff: \n{(hf_out.hidden_states - sgl_out.hidden_states).abs().max()}"
+        assert torch.allclose(
+            hf_out.target, sgl_out.target.half(), atol=1e-1, rtol=1e-2
+        ), f"Target are not close, diff: \n{(hf_out.target - sgl_out.target).abs().max()}"
+    finally:
+        del (
+            sgl_out,
+            sgl_target_model,
+            custom_out,
+            custom_target_model,
+            hf_out,
+            hf_target_model,
+            input_ids,
+            attention_mask,
+            loss_mask,
+        )
+        cleanup_distributed()
 
 
 class TestTargetModelBackend(unittest.TestCase):

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -143,7 +143,7 @@ class TestTrainEagle3(unittest.TestCase):
         # run training
         print_gpu_memory_usage("test_online_train_eagle3_with_hf_backend")
         train_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+            "bash examples/run_llama3.1_8b_eagle3_online.sh 1"
         )
         train_process.wait()
         self.assertEqual(train_process.returncode, 0)
@@ -159,7 +159,7 @@ class TestTrainEagle3(unittest.TestCase):
 
         # run training
         train_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+            "bash examples/run_llama3.1_8b_eagle3_online.sh 1"
         )
         train_process.wait()
         self.assertEqual(train_process.returncode, 0)

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import shutil
 import subprocess
@@ -8,6 +9,7 @@ from tests.utils import execute_shell_command
 
 CACHE_DIR = Path(__file__).parent.parent.parent.joinpath("cache")
 SOURCE_TARGET_MODEL = "nreHieW/Llama-3.1-8B-Instruct"
+RANDOM_TARGET_MODEL_DIR = CACHE_DIR.joinpath("models", "random_Llama-3.1-8B-Instruct")
 ONLINE_SCRIPT_PATH = Path(__file__).parent.parent.parent.joinpath(
     "examples", "run_llama3.1_8b_eagle3_online.sh"
 )
@@ -22,10 +24,47 @@ def replace_in_script(script_path: Path, pattern: str, replacement: str):
     script_path.write_text(script_path.read_text().replace(pattern, replacement))
 
 
+def prepare_random_target_model():
+    has_config = RANDOM_TARGET_MODEL_DIR.joinpath("config.json").exists()
+    has_weights = (
+        RANDOM_TARGET_MODEL_DIR.joinpath("model.safetensors").exists()
+        or RANDOM_TARGET_MODEL_DIR.joinpath("pytorch_model.bin").exists()
+        or len(list(RANDOM_TARGET_MODEL_DIR.glob("*.index.json"))) > 0
+    )
+    if has_config and has_weights:
+        return
+
+    import torch
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+
+    tmp_dir = RANDOM_TARGET_MODEL_DIR.with_name(f"{RANDOM_TARGET_MODEL_DIR.name}.tmp")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(SOURCE_TARGET_MODEL)
+    tokenizer.save_pretrained(tmp_dir)
+
+    config = AutoConfig.from_pretrained(SOURCE_TARGET_MODEL)
+    torch.manual_seed(0)
+    model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.bfloat16)
+    model.save_pretrained(
+        tmp_dir,
+        safe_serialization=True,
+        max_shard_size="4GB",
+    )
+    del model
+    gc.collect()
+
+    if RANDOM_TARGET_MODEL_DIR.exists():
+        shutil.rmtree(RANDOM_TARGET_MODEL_DIR)
+    tmp_dir.rename(RANDOM_TARGET_MODEL_DIR)
+
+
 def build_online_script() -> str:
     return ONLINE_SCRIPT_TEMPLATE.replace(
         "meta-llama/Llama-3.1-8B-Instruct",
-        SOURCE_TARGET_MODEL,
+        str(RANDOM_TARGET_MODEL_DIR),
     ).replace(
         "$ROOT_DIR/scripts/train_eagle3.py",
         "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 10",
@@ -36,12 +75,12 @@ def build_offline_script() -> str:
     return (
         OFFLINE_SCRIPT_TEMPLATE.replace(
             "meta-llama/Llama-3.1-8B-Instruct",
-            SOURCE_TARGET_MODEL,
+            str(RANDOM_TARGET_MODEL_DIR),
         )
-        .replace("--batch-size 32", "--batch-size 5")
+        .replace("--batch-size 32", "--batch-size 1")
         .replace(
             "scripts/prepare_hidden_states.py",
-            "scripts/prepare_hidden_states.py --num-samples 10",
+            "scripts/prepare_hidden_states.py --num-samples 10 --sglang-mem-fraction-static 0.4",
         )
         .replace(
             "$ROOT_DIR/scripts/train_eagle3.py",
@@ -61,6 +100,7 @@ class TestTrainEagle3(unittest.TestCase):
     def setUp(self) -> None:
         self.addCleanup(ONLINE_SCRIPT_PATH.write_text, ONLINE_SCRIPT_TEMPLATE)
         self.addCleanup(OFFLINE_SCRIPT_PATH.write_text, OFFLINE_SCRIPT_TEMPLATE)
+        prepare_random_target_model()
 
         # prepare data
         data_process = execute_shell_command(

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -18,6 +18,9 @@ OFFLINE_SCRIPT_PATH = Path(__file__).parent.parent.parent.joinpath(
 )
 ONLINE_SCRIPT_TEMPLATE = ONLINE_SCRIPT_PATH.read_text()
 OFFLINE_SCRIPT_TEMPLATE = OFFLINE_SCRIPT_PATH.read_text()
+GPU_CLEANUP_SCRIPT = Path(__file__).parent.parent.parent.joinpath(
+    ".github", "workflows", "scripts", "delete_gpu_process.sh"
+)
 
 
 def replace_in_script(script_path: Path, pattern: str, replacement: str):
@@ -62,12 +65,16 @@ def prepare_random_target_model():
 
 
 def build_online_script() -> str:
-    return ONLINE_SCRIPT_TEMPLATE.replace(
-        "meta-llama/Llama-3.1-8B-Instruct",
-        str(RANDOM_TARGET_MODEL_DIR),
-    ).replace(
-        "$ROOT_DIR/scripts/train_eagle3.py",
-        "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 10",
+    return (
+        ONLINE_SCRIPT_TEMPLATE.replace(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            str(RANDOM_TARGET_MODEL_DIR),
+        )
+        .replace("--max-length 4096", "--max-length 512")
+        .replace(
+            "$ROOT_DIR/scripts/train_eagle3.py",
+            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 10",
+        )
     )
 
 
@@ -77,10 +84,11 @@ def build_offline_script() -> str:
             "meta-llama/Llama-3.1-8B-Instruct",
             str(RANDOM_TARGET_MODEL_DIR),
         )
+        .replace("--max-length 4096", "--max-length 512")
         .replace("--batch-size 32", "--batch-size 1")
         .replace(
             "scripts/prepare_hidden_states.py",
-            "scripts/prepare_hidden_states.py --num-samples 10 --sglang-mem-fraction-static 0.4",
+            "scripts/prepare_hidden_states.py --num-samples 10",
         )
         .replace(
             "$ROOT_DIR/scripts/train_eagle3.py",
@@ -93,6 +101,10 @@ def print_gpu_memory_usage(label: str):
     print(f"\n===== GPU memory usage before {label} =====", flush=True)
     subprocess.run(["nvidia-smi"], check=False)
     print("===== End GPU memory usage =====\n", flush=True)
+
+
+def cleanup_gpu_processes():
+    subprocess.run(["bash", str(GPU_CLEANUP_SCRIPT)], check=False)
 
 
 class TestTrainEagle3(unittest.TestCase):
@@ -126,6 +138,7 @@ class TestTrainEagle3(unittest.TestCase):
                 os.environ.pop("SPECFORGE_CI_MEMORY_DEBUG", None)
             else:
                 os.environ["SPECFORGE_CI_MEMORY_DEBUG"] = old_memory_debug
+            cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_hf_backend(self):
@@ -140,6 +153,7 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
         )
         train_process.wait()
+        cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_custom_backend(self):
@@ -156,6 +170,7 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
         )
         train_process.wait()
+        cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_offline_train_eagle3(self):
@@ -174,6 +189,7 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
         )
         training_process.wait()
+        cleanup_gpu_processes()
         self.assertEqual(training_process.returncode, 0)
 
 

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -175,6 +175,7 @@ class TestTrainEagle3(unittest.TestCase):
             # delete the directory
             shutil.rmtree(hidden_states_path)
 
+        print_gpu_memory_usage("test_offline_train_eagle3")
         training_process = execute_shell_command(
             "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
         )

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -1,69 +1,96 @@
+import os
 import shutil
+import subprocess
 import unittest
 from pathlib import Path
 
 from tests.utils import execute_shell_command
 
 CACHE_DIR = Path(__file__).parent.parent.parent.joinpath("cache")
+SOURCE_TARGET_MODEL = "nreHieW/Llama-3.1-8B-Instruct"
+ONLINE_SCRIPT_PATH = Path(__file__).parent.parent.parent.joinpath(
+    "examples", "run_llama3.1_8b_eagle3_online.sh"
+)
+OFFLINE_SCRIPT_PATH = Path(__file__).parent.parent.parent.joinpath(
+    "examples", "run_llama3.1_8b_eagle3_offline.sh"
+)
+ONLINE_SCRIPT_TEMPLATE = ONLINE_SCRIPT_PATH.read_text()
+OFFLINE_SCRIPT_TEMPLATE = OFFLINE_SCRIPT_PATH.read_text()
 
 
 def replace_in_script(script_path: Path, pattern: str, replacement: str):
-    with open(script_path, "r") as f:
-        script = f.readlines()
-    script = [line.replace(pattern, replacement) for line in script]
-    with open(script_path, "w") as f:
-        for line in script:
-            f.write(line)
+    script_path.write_text(script_path.read_text().replace(pattern, replacement))
+
+
+def build_online_script() -> str:
+    return ONLINE_SCRIPT_TEMPLATE.replace(
+        "meta-llama/Llama-3.1-8B-Instruct",
+        SOURCE_TARGET_MODEL,
+    ).replace(
+        "$ROOT_DIR/scripts/train_eagle3.py",
+        "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 10",
+    )
+
+
+def build_offline_script() -> str:
+    return (
+        OFFLINE_SCRIPT_TEMPLATE.replace(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            SOURCE_TARGET_MODEL,
+        )
+        .replace("--batch-size 32", "--batch-size 5")
+        .replace(
+            "scripts/prepare_hidden_states.py",
+            "scripts/prepare_hidden_states.py --num-samples 10",
+        )
+        .replace(
+            "$ROOT_DIR/scripts/train_eagle3.py",
+            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
+        )
+    )
+
+
+def print_gpu_memory_usage(label: str):
+    print(f"\n===== GPU memory usage before {label} =====", flush=True)
+    subprocess.run(["nvidia-smi"], check=False)
+    print("===== End GPU memory usage =====\n", flush=True)
 
 
 class TestTrainEagle3(unittest.TestCase):
 
     def setUp(self) -> None:
+        self.addCleanup(ONLINE_SCRIPT_PATH.write_text, ONLINE_SCRIPT_TEMPLATE)
+        self.addCleanup(OFFLINE_SCRIPT_PATH.write_text, OFFLINE_SCRIPT_TEMPLATE)
+
         # prepare data
         data_process = execute_shell_command(
             "python scripts/prepare_data.py --dataset sharegpt"
         )
         data_process.wait()
 
-        # modify the sccript to only train for 10 steps
-        # add --max-num-steps 10 to the launch command
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_online.sh"
-        )
-        with open(script_path, "r") as f:
-            script = f.readlines()
-
-        # remove empty lines
-        script = [line for line in script if line.strip()]
-        script[-1] = script[-1].rstrip() + " --max-num-steps 10"
-
-        # replace meta-llama/Llama-3.1-8B-Instruct with unsloth/Llama-3.2-1B-Instruct
-        # so that we don't need HF token for gated repo
-        script = [
-            line.replace(
-                "meta-llama/Llama-3.1-8B-Instruct", "nreHieW/Llama-3.1-8B-Instruct"
-            )
-            for line in script
-        ]
-
-        # write the script back to the file
-        with open(script_path, "w") as f:
-            for line in script:
-                f.write(line)
+        ONLINE_SCRIPT_PATH.write_text(build_online_script())
 
     def test_online_train_eagle3_with_sglang_backend(self):
+        print_gpu_memory_usage("test_online_train_eagle3_with_sglang_backend")
+
         # run training
-        train_process = execute_shell_command(
-            "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
-        )
-        train_process.wait()
+        old_memory_debug = os.environ.get("SPECFORGE_CI_MEMORY_DEBUG")
+        os.environ["SPECFORGE_CI_MEMORY_DEBUG"] = "1"
+        try:
+            train_process = execute_shell_command(
+                "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
+            )
+            train_process.wait()
+        finally:
+            if old_memory_debug is None:
+                os.environ.pop("SPECFORGE_CI_MEMORY_DEBUG", None)
+            else:
+                os.environ["SPECFORGE_CI_MEMORY_DEBUG"] = old_memory_debug
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_hf_backend(self):
         # replace --target-model-backend sglang with --target-model-backend hf
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_online.sh"
-        )
+        script_path = ONLINE_SCRIPT_PATH
         replace_in_script(
             script_path, "--target-model-backend sglang", "--target-model-backend hf"
         )
@@ -77,9 +104,7 @@ class TestTrainEagle3(unittest.TestCase):
 
     def test_online_train_eagle3_with_custom_backend(self):
         # replace --target-model-backend sglang with --target-model-backend custom
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_online.sh"
-        )
+        script_path = ONLINE_SCRIPT_PATH
         replace_in_script(
             script_path,
             "--target-model-backend sglang",
@@ -95,29 +120,8 @@ class TestTrainEagle3(unittest.TestCase):
 
     def test_offline_train_eagle3(self):
         # remove the hidden states if they exist
-        script_path = Path(__file__).parent.parent.parent.joinpath(
-            "examples", "run_llama3.1_8b_eagle3_offline.sh"
-        )
-        replace_in_script(
-            script_path,
-            "meta-llama/Llama-3.1-8B-Instruct",
-            "nreHieW/Llama-3.1-8B-Instruct",
-        )
-        replace_in_script(
-            script_path,
-            "--batch-size 32",
-            "--batch-size 5",
-        )
-        replace_in_script(
-            script_path,
-            "scripts/prepare_hidden_states.py",
-            "scripts/prepare_hidden_states.py --num-samples 10",
-        )
-        replace_in_script(
-            script_path,
-            "$ROOT_DIR/scripts/train_eagle3.py",
-            "$ROOT_DIR/scripts/train_eagle3.py --max-num-steps 2",
-        )
+        script_path = OFFLINE_SCRIPT_PATH
+        script_path.write_text(build_offline_script())
 
         hidden_states_path = Path(__file__).parent.parent.parent.joinpath(
             "cache", "hidden_states", "sharegpt_train_Llama-3.1-8B-Instruct"

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -141,6 +141,7 @@ class TestTrainEagle3(unittest.TestCase):
         )
 
         # run training
+        print_gpu_memory_usage("test_online_train_eagle3_with_hf_backend")
         train_process = execute_shell_command(
             "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
         )

--- a/tests/test_scripts/test_train_eagle3.py
+++ b/tests/test_scripts/test_train_eagle3.py
@@ -18,9 +18,6 @@ OFFLINE_SCRIPT_PATH = Path(__file__).parent.parent.parent.joinpath(
 )
 ONLINE_SCRIPT_TEMPLATE = ONLINE_SCRIPT_PATH.read_text()
 OFFLINE_SCRIPT_TEMPLATE = OFFLINE_SCRIPT_PATH.read_text()
-GPU_CLEANUP_SCRIPT = Path(__file__).parent.parent.parent.joinpath(
-    ".github", "workflows", "scripts", "delete_gpu_process.sh"
-)
 
 
 def replace_in_script(script_path: Path, pattern: str, replacement: str):
@@ -103,10 +100,6 @@ def print_gpu_memory_usage(label: str):
     print("===== End GPU memory usage =====\n", flush=True)
 
 
-def cleanup_gpu_processes():
-    subprocess.run(["bash", str(GPU_CLEANUP_SCRIPT)], check=False)
-
-
 class TestTrainEagle3(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -138,7 +131,6 @@ class TestTrainEagle3(unittest.TestCase):
                 os.environ.pop("SPECFORGE_CI_MEMORY_DEBUG", None)
             else:
                 os.environ["SPECFORGE_CI_MEMORY_DEBUG"] = old_memory_debug
-            cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_hf_backend(self):
@@ -153,7 +145,6 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
         )
         train_process.wait()
-        cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_online_train_eagle3_with_custom_backend(self):
@@ -170,7 +161,6 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_online.sh 2"
         )
         train_process.wait()
-        cleanup_gpu_processes()
         self.assertEqual(train_process.returncode, 0)
 
     def test_offline_train_eagle3(self):
@@ -189,7 +179,6 @@ class TestTrainEagle3(unittest.TestCase):
             "bash examples/run_llama3.1_8b_eagle3_offline.sh 2",
         )
         training_process.wait()
-        cleanup_gpu_processes()
         self.assertEqual(training_process.returncode, 0)
 
 


### PR DESCRIPTION
## Motivation

The PR test job can fail on self-hosted GPU runners because GPU memory is not reliably cleaned before running the full unittest suite.

In the current container setup, `nvidia-smi` reports host PIDs, but the container cannot kill those PIDs without sharing the host PID namespace. As a result, the cleanup script may print `No such process` while stale GPU processes continue occupying memory, causing unrelated tests to fail with CUDA OOM.

This PR also reduces memory pressure in heavyweight CI tests so the suite is less sensitive to runner state.

## Modifications

- Add `--pid=host` to the CI test container so the existing GPU cleanup script can kill host GPU processes reported by `nvidia-smi`.
- Use dummy weights for large SGLang backend tests where real model weights are not needed.
- Use a local random Llama-3.1 checkpoint in Eagle3 train tests to avoid downloading / loading full pretrained weights.
- Reduce the Eagle3 offline training test batch size and SGLang memory pressure.
- Keep the CI test timeout at 30 minutes.

## Tests

Not run locally. These changes target the self-hosted GitHub Actions GPU runner environment.