### PR TITLE
per-layer FSDP wrap + prefetch for compute-comm overlap

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -3,6 +3,7 @@
 """DFlash Training Script."""
 
 import argparse
+import functools
 import logging
 import math
 import os
@@ -14,8 +15,10 @@ from typing import Optional, Tuple
 import torch
 import torch.distributed as dist
 from accelerate.utils import set_seed
+from torch.distributed.fsdp import BackwardPrefetch
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import MixedPrecision, ShardingStrategy, StateDictType
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers import AutoConfig, AutoTokenizer
@@ -438,15 +441,38 @@ def main():
         loss_decay_gamma=args.loss_decay_gamma,
     )
 
-    dflash_model = FSDP(
-        dflash_model,
+    # Wrap each transformer block as its own FSDP unit so that all-gather /
+    # reduce-scatter overlap with compute. Without an auto_wrap_policy the
+    # whole model is a single FSDP unit, forcing every collective onto the
+    # critical path with no overlap. The block class is resolved from the
+    # draft model's `_no_split_modules` so this stays architecture-agnostic
+    # rather than hardcoding a specific decoder-layer class.
+    fsdp_kwargs = dict(
         use_orig_params=True,
+        forward_prefetch=True,
+        backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+        limit_all_gathers=True,
         mixed_precision=MixedPrecision(
             param_dtype=torch.bfloat16,
             buffer_dtype=torch.bfloat16,
         ),
         sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
     )
+    block_names = set(getattr(draft_model, "_no_split_modules", None) or [])
+    block_classes = {
+        type(m) for m in dflash_model.modules() if type(m).__name__ in block_names
+    }
+    if block_classes:
+        fsdp_kwargs["auto_wrap_policy"] = functools.partial(
+            transformer_auto_wrap_policy,
+            transformer_layer_cls=block_classes,
+        )
+    else:
+        print_with_rank(
+            "No _no_split_modules on draft model; falling back to single-unit "
+            "FSDP wrap (no compute-comm overlap)."
+        )
+    dflash_model = FSDP(dflash_model, **fsdp_kwargs)
     print_with_rank("Initialized FSDP")
 
     start_epoch = ckpt_info[0]


### PR DESCRIPTION
Wrap each transformer block as its own FSDP unit and enable forward/backward prefetch + limit_all_gathers, so all-gather and reduce-scatter overlap with compute. Previously the whole OnlineDFlashModel was a single FSDP unit, forcing every collective onto the critical path with no overlap.

Measured on a single machine, 8 cards, Qwen3-8B target / 1B draft, batch=1, max_len=3072, HF target backend:
  - per-iter time : 0.99s -> 0.92s  (~7.6% faster)
  - epoch wall     : 20:41 -> 19:15  (~7.4% faster)

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
