### PR TITLE
feat: Add Ascend npu support.

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -24,3 +24,18 @@ uv pip install -v . --prerelease=allow
 ```bash
 pip install specforge
 ```
+
+- **Install on Ascend NPU**
+
+1. Pull compatible SGLang image for Ascend NPU, currently `quay.io/ascend/sglang:v0.5.9-cann8.5.0-a3` on A3 device, or `quay.io/ascend/sglang:v0.5.9-cann8.5.0-910b` on A2 device.
+2. Install SpecForge.
+
+```bash
+# git clone the source code
+git clone https://github.com/sgl-project/SpecForge.git
+cd SpecForge
+
+# install specforge
+pip install -r requirements-npu.txt
+pip install . --no-deps
+```

--- a/examples/run_llama3.1_8b_eagle3_online_npu.sh
+++ b/examples/run_llama3.1_8b_eagle3_online_npu.sh
@@ -1,0 +1,30 @@
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+# train eagle3 for llama3.1-8b
+NUM_GPUS=${1:-1}
+TP_SIZE=${2:-1}
+BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
+
+# Currently we only train with --max-length 2048 due to OOM issue on 8 * A3(64GB)
+torchrun \
+    --standalone \
+    --nproc_per_node $NUM_GPUS \
+    $ROOT_DIR/scripts/train_eagle3.py \
+    --target-model-path meta-llama/Llama-3.1-8B-Instruct \
+    --draft-model-config $ROOT_DIR/configs/llama3-8B-eagle3.json \
+    --train-data-path $ROOT_DIR/cache/dataset/sharegpt_train.jsonl \
+    --build-dataset-num-proc $BUILD_DATASET_NUM_PROC \
+    --output-dir $ROOT_DIR/outputs/llama3-8b-eagle3-sharegpt \
+    --num-epochs 10 \
+    --batch-size 1 \
+    --tp-size $TP_SIZE \
+    --learning-rate 1e-4 \
+    --max-length 2048 \
+    --chat-template llama3 \
+    --cache-dir $ROOT_DIR/cache \
+    --attention-backend sdpa \
+    --target-model-backend sglang \
+    --log-interval 10 \
+    --sglang-mem-fraction-static 0.3

--- a/examples/run_llama3.1_8b_eagle3_online_npu.sh
+++ b/examples/run_llama3.1_8b_eagle3_online_npu.sh
@@ -7,7 +7,7 @@ NUM_GPUS=${1:-1}
 TP_SIZE=${2:-1}
 BUILD_DATASET_NUM_PROC=${BUILD_DATASET_NUM_PROC:-64}
 
-# Currently we only train with --max-length 2048 due to OOM issue on 8 * A3(64GB)
+# Currently we only train with --max-length 2048 due to OOM issue on A3(64GB)
 torchrun \
     --standalone \
     --nproc_per_node $NUM_GPUS \

--- a/requirements-npu.txt
+++ b/requirements-npu.txt
@@ -1,0 +1,24 @@
+# Use the PyTorch ROCm wheel index (choose the stream that matches your system)
+--extra-index-url https://download.pytorch.org/whl/cpu
+
+pre-commit
+torch==2.8.0+cpu
+torch_npu==2.8.0.post2
+torchaudio==2.8.0
+torchvision==0.23.0
+transformers==4.57.1
+qwen-vl-utils==0.0.11
+datasets
+setuptools
+tqdm
+wandb
+psutil
+numpy
+accelerate
+pydantic
+sglang==0.5.9
+openai-harmony
+ninja
+packaging
+yunchang
+tensorboard

--- a/requirements-npu.txt
+++ b/requirements-npu.txt
@@ -1,4 +1,4 @@
-# Use the PyTorch ROCm wheel index (choose the stream that matches your system)
+# Use the PyTorch CPU wheel index cause torch_npu depends on a CPU version of PyTorch
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 pre-commit

--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -507,7 +507,8 @@ class HiddenStatesGenerator:
                 continue
 
             filtered_batch_gpu = {
-                k: v.to(get_local_device(), non_blocking=True) for k, v in filtered_batch.items()
+                k: v.to(get_local_device(), non_blocking=True)
+                for k, v in filtered_batch.items()
             }
             _, _, aux_hidden_states_list, last_hidden_states_list = self.model.extend(
                 **filtered_batch_gpu,

--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -59,6 +59,9 @@ from specforge.distributed import (
 )
 from specforge.modeling.target import Eagle3TargetModel, get_eagle3_target_model
 from specforge.utils import (
+    empty_cache,
+    get_device_type,
+    get_local_device,
     print_args_with_dots,
     print_with_rank,
     rank_0_priority,
@@ -183,7 +186,7 @@ def build_target_model(
                 ),
             )
             .eval()
-            .cuda()
+            .to(device=get_local_device())
         )
     else:
         target_model_kwargs = SGLangBackendArgs.from_args(args).to_kwargs()
@@ -195,7 +198,7 @@ def build_target_model(
                 if hasattr(model_config, "dtype")
                 else model_config.torch_dtype
             ),
-            device="cuda",
+            device=get_device_type(),
             cache_dir=args.model_download_dir,
             trust_remote_code=args.trust_remote_code,
             **target_model_kwargs,
@@ -463,11 +466,11 @@ class HiddenStatesGenerator:
                     output_path, current_batch_indices
                 )
                 exists_tensor = torch.tensor(
-                    exists_list, dtype=torch.bool, device="cuda"
+                    exists_list, dtype=torch.bool, device=get_local_device()
                 )
             else:
                 exists_tensor = torch.tensor(
-                    [False] * batch_size, dtype=torch.bool, device="cuda"
+                    [False] * batch_size, dtype=torch.bool, device=get_local_device()
                 )
             dist.broadcast(exists_tensor, src=tp_rank_0_global, group=tp_group)
 
@@ -504,7 +507,7 @@ class HiddenStatesGenerator:
                 continue
 
             filtered_batch_gpu = {
-                k: v.cuda(non_blocking=True) for k, v in filtered_batch.items()
+                k: v.to(get_local_device(), non_blocking=True) for k, v in filtered_batch.items()
             }
             _, _, aux_hidden_states_list, last_hidden_states_list = self.model.extend(
                 **filtered_batch_gpu,
@@ -559,7 +562,7 @@ class HiddenStatesGenerator:
             del aux_hidden_states_list, last_hidden_states_list, filtered_batch
 
             if batch_idx % 5 == 0:  # Make GC and cache clearing more frequent
-                torch.cuda.empty_cache()
+                empty_cache()
                 gc.collect()
 
             if self.show_progress:

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -48,6 +48,7 @@ from specforge.tracker import Tracker, create_tracker, get_tracker_class
 from specforge.utils import (
     create_draft_config_from_target,
     current_device,
+    get_device_module,
     get_device_type,
     get_last_checkpoint,
     get_local_device,
@@ -67,7 +68,7 @@ def print_cuda_memory_debug(label: str) -> None:
 
     try:
         synchronize()
-        device_module = torch.get_device_module(device_type)
+        device_module = get_device_module()
         free_bytes, total_bytes = device_module.mem_get_info()
         allocated_bytes = device_module.memory_allocated()
         reserved_bytes = device_module.memory_reserved()

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -47,26 +47,32 @@ from specforge.optimizer import BF16Optimizer
 from specforge.tracker import Tracker, create_tracker, get_tracker_class
 from specforge.utils import (
     create_draft_config_from_target,
+    current_device,
+    get_device_type,
     get_last_checkpoint,
+    get_local_device,
     print_args_with_dots,
     print_on_rank0,
     print_with_rank,
     rank_0_priority,
     safe_conversations_generator,
+    synchronize,
 )
 
 
 def print_cuda_memory_debug(label: str) -> None:
-    if os.getenv("SPECFORGE_CI_MEMORY_DEBUG") != "1" or not torch.cuda.is_available():
+    device_type = get_device_type()
+    if os.getenv("SPECFORGE_CI_MEMORY_DEBUG") != "1" or device_type == "cpu":
         return
 
     try:
-        torch.cuda.synchronize()
-        free_bytes, total_bytes = torch.cuda.mem_get_info()
-        allocated_bytes = torch.cuda.memory_allocated()
-        reserved_bytes = torch.cuda.memory_reserved()
+        synchronize()
+        device_module = torch.get_device_module(device_type)
+        free_bytes, total_bytes = device_module.mem_get_info()
+        allocated_bytes = device_module.memory_allocated()
+        reserved_bytes = device_module.memory_reserved()
     except Exception as exc:
-        print(f"[memory-debug] {label}: failed to query CUDA memory: {exc}", flush=True)
+        print(f"[memory-debug] {label}: failed to query {device_type} memory: {exc}", flush=True)
         return
 
     rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else "NA"
@@ -382,7 +388,7 @@ def build_target_model(
                     torch_dtype=torch.bfloat16,
                 )
                 .eval()
-                .cuda()
+                .to(get_local_device())
             )
         else:
             if args.target_model_backend == "sglang":
@@ -393,7 +399,7 @@ def build_target_model(
                 pretrained_model_name_or_path=args.target_model_path,
                 backend=args.target_model_backend,
                 torch_dtype=torch.bfloat16,
-                device="cuda",
+                device=get_device_type(),
                 cache_dir=args.model_download_dir,
                 **target_model_kwargs,
                 trust_remote_code=args.trust_remote_code,
@@ -521,13 +527,13 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
             draft_model_last_checkpoint,
             attention_backend=args.attention_backend,
             torch_dtype=torch.bfloat16,
-        ).cuda()
+        ).to(get_local_device())
     else:
         draft_model = AutoEagle3DraftModel.from_config(
             draft_model_config,
             attention_backend=args.attention_backend,
             torch_dtype=torch.bfloat16,
-        ).cuda()
+        ).to(get_local_device())
 
     # Load training state (optimizer, scheduler, epoch, step) for true resume
     resume_state = None
@@ -740,11 +746,11 @@ def run_forward(
             metric_losses,
             metric_loss_denoms,
         ) = eagle3_model(
-            input_ids=data["input_ids"].cuda(),
-            attention_mask=data["attention_mask"].cuda(),
-            loss_mask=data["loss_mask"].cuda(),
-            pixel_values=data["pixel_values"].cuda(),
-            image_grid_thw=data["image_grid_thw"].cuda(),
+            input_ids=data["input_ids"].to(get_local_device()),
+            attention_mask=data["attention_mask"].to(get_local_device()),
+            loss_mask=data["loss_mask"].to(get_local_device()),
+            pixel_values=data["pixel_values"].to(get_local_device()),
+            image_grid_thw=data["image_grid_thw"].to(get_local_device()),
         )
     else:
         image_grid_thw = None
@@ -752,27 +758,27 @@ def run_forward(
         if is_online:
             # we generate the eagle3 using the target model in an online fashion
             # Handle VLM data: pixel_values and image_grid_thw are lists
-            # pixel_values = [pv.cuda() for pv in data["pixel_values"]] if args.is_vlm else None
+            # pixel_values = [pv.to(get_local_device()) for pv in data["pixel_values"]] if args.is_vlm else None
             if args.is_vlm:
                 image_grid_thw = (
-                    [thw.cuda().squeeze() for thw in data["image_grid_thw"]]
+                    [thw.to(get_local_device()).squeeze() for thw in data["image_grid_thw"]]
                     if args.is_vlm
                     else None
                 )
-                pixel_values = data["pixel_values"].cuda()
+                pixel_values = data["pixel_values"].to(get_local_device())
                 eagle3_data = target_model.generate_eagle3_data(
-                    input_ids=data["input_ids"].cuda(),
-                    attention_mask=data["attention_mask"].cuda(),
-                    loss_mask=data["loss_mask"].cuda(),
+                    input_ids=data["input_ids"].to(get_local_device()),
+                    attention_mask=data["attention_mask"].to(get_local_device()),
+                    loss_mask=data["loss_mask"].to(get_local_device()),
                     is_vlm=args.is_vlm,
                     pixel_values=pixel_values,
                     image_grid_thw=image_grid_thw,
                 )
             else:
                 eagle3_data = target_model.generate_eagle3_data(
-                    input_ids=data["input_ids"].cuda(),
-                    attention_mask=data["attention_mask"].cuda(),
-                    loss_mask=data["loss_mask"].cuda(),
+                    input_ids=data["input_ids"].to(get_local_device()),
+                    attention_mask=data["attention_mask"].to(get_local_device()),
+                    loss_mask=data["loss_mask"].to(get_local_device()),
                     shard_returns=args.shard_target_output,
                 )
 
@@ -793,19 +799,19 @@ def run_forward(
             )
         else:
             # we generate the logits using the hidden states loaded from disk
-            attention_mask = data["attention_mask"].cuda()
-            hidden_states = data["hidden_state"].cuda()
+            attention_mask = data["attention_mask"].to(get_local_device())
+            hidden_states = data["hidden_state"].to(get_local_device())
             input_ids, target, loss_mask = target_model.preprocess(
                 data["input_ids"], data["target"], data["loss_mask"]
             )
-            input_ids = input_ids.cuda()
-            loss_mask = loss_mask.cuda()
+            input_ids = input_ids.to(get_local_device())
+            loss_mask = loss_mask.to(get_local_device())
             from specforge.core.compact_teacher import build_offline_teacher_inputs
 
             target, offline_compact_kwargs = build_offline_teacher_inputs(
                 compact=args.compact_teacher,
                 target_model=target_model,
-                target_hidden=target.cuda(),
+                target_hidden=target.to(get_local_device()),
                 chunk_size_arg=args.compact_teacher_chunk_size,
             )
             compact_kwargs.update(offline_compact_kwargs)
@@ -824,7 +830,7 @@ def run_forward(
             target=target,
             hidden_states=hidden_states,
             position_ids=(
-                data["position_ids"].cuda() if "position_ids" in data else None
+                data["position_ids"].to(get_local_device()) if "position_ids" in data else None
             ),
             image_grid_thw=image_grid_thw,
             is_vlm=args.is_vlm,
@@ -855,8 +861,8 @@ def run_backward_and_update(
         grad_norm = optimizer.step()
         if dist.is_initialized():
             grad_norm = grad_norm.detach().float()
-            if torch.cuda.is_available():
-                grad_norm = grad_norm.to(torch.cuda.current_device())
+            if get_device_type() != "cpu":
+                grad_norm = grad_norm.to(current_device())
             grad_norm = grad_norm.pow(2)
             dist.all_reduce(grad_norm, op=dist.ReduceOp.SUM)
             grad_norm = grad_norm.sqrt()

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -73,7 +73,10 @@ def print_cuda_memory_debug(label: str) -> None:
         allocated_bytes = device_module.memory_allocated()
         reserved_bytes = device_module.memory_reserved()
     except Exception as exc:
-        print(f"[memory-debug] {label}: failed to query {device_type} memory: {exc}", flush=True)
+        print(
+            f"[memory-debug] {label}: failed to query {device_type} memory: {exc}",
+            flush=True,
+        )
         return
 
     rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else "NA"
@@ -762,7 +765,10 @@ def run_forward(
             # pixel_values = [pv.to(get_local_device()) for pv in data["pixel_values"]] if args.is_vlm else None
             if args.is_vlm:
                 image_grid_thw = (
-                    [thw.to(get_local_device()).squeeze() for thw in data["image_grid_thw"]]
+                    [
+                        thw.to(get_local_device()).squeeze()
+                        for thw in data["image_grid_thw"]
+                    ]
                     if args.is_vlm
                     else None
                 )
@@ -831,7 +837,9 @@ def run_forward(
             target=target,
             hidden_states=hidden_states,
             position_ids=(
-                data["position_ids"].to(get_local_device()) if "position_ids" in data else None
+                data["position_ids"].to(get_local_device())
+                if "position_ids" in data
+                else None
             ),
             image_grid_thw=image_grid_thw,
             is_vlm=args.is_vlm,

--- a/specforge/benchmarks/benchmark_flex_attention.py
+++ b/specforge/benchmarks/benchmark_flex_attention.py
@@ -13,7 +13,13 @@ from specforge.modeling.draft.llama3_eagle import (
     LlamaFlexAttention,
     prepare_decoder_attention_mask,
 )
-from specforge.utils import empty_cache, get_device_module, get_device_type, get_local_device, synchronize
+from specforge.utils import (
+    empty_cache,
+    get_device_module,
+    get_device_type,
+    get_local_device,
+    synchronize,
+)
 
 dynamo.config.recompile_limit = 64
 

--- a/specforge/benchmarks/benchmark_flex_attention.py
+++ b/specforge/benchmarks/benchmark_flex_attention.py
@@ -13,7 +13,7 @@ from specforge.modeling.draft.llama3_eagle import (
     LlamaFlexAttention,
     prepare_decoder_attention_mask,
 )
-from specforge.utils import empty_cache, get_device_type, get_local_device, synchronize
+from specforge.utils import empty_cache, get_device_module, get_device_type, get_local_device, synchronize
 
 dynamo.config.recompile_limit = 64
 
@@ -136,7 +136,7 @@ def benchmark_function(
         # Clear GPU cache
         if get_device_type() != "cpu":
             empty_cache()
-            torch.get_device_module(get_device_type()).reset_peak_memory_stats()
+            get_device_module().reset_peak_memory_stats()
 
         # Warm up runs for this sequence length
         if enable_warmup:
@@ -157,11 +157,11 @@ def benchmark_function(
             # Clear cache again after warmup
             if get_device_type() != "cpu":
                 empty_cache()
-                torch.get_device_module(get_device_type()).reset_peak_memory_stats()
+                get_device_module().reset_peak_memory_stats()
         # Record initial memory
         initial_memory = 0
         if get_device_type() != "cpu":
-            initial_memory = torch.get_device_module(get_device_type()).memory_allocated()
+            initial_memory = get_device_module().memory_allocated()
         hidden_states = [
             torch.randn(
                 BATCH_SIZE,
@@ -188,8 +188,8 @@ def benchmark_function(
         peak_memory = 0
         current_memory = 0
         if get_device_type() != "cpu":
-            peak_memory = torch.get_device_module(get_device_type()).max_memory_allocated()
-            current_memory = torch.get_device_module(get_device_type()).memory_allocated()
+            peak_memory = get_device_module().max_memory_allocated()
+            current_memory = get_device_module().memory_allocated()
         results_per_seq_len.append(
             {
                 "seq_len": seq_len,
@@ -295,7 +295,7 @@ if __name__ == "__main__":
     print("PyTorch version:", torch.__version__)
     device_type = get_device_type()
     if device_type != "cpu":
-        device_module = torch.get_device_module(device_type)
+        device_module = get_device_module()
         print(f"{device_type} available: True")
         print("Device:", device_module.get_device_name())
         print(

--- a/specforge/benchmarks/benchmark_flex_attention.py
+++ b/specforge/benchmarks/benchmark_flex_attention.py
@@ -13,6 +13,7 @@ from specforge.modeling.draft.llama3_eagle import (
     LlamaFlexAttention,
     prepare_decoder_attention_mask,
 )
+from specforge.utils import empty_cache, get_device_type, get_local_device, synchronize
 
 dynamo.config.recompile_limit = 64
 
@@ -40,7 +41,7 @@ def run_attention(
     attention_backend: str = "sdpa",
     enable_profile: bool = False,
 ):
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = get_local_device()
     batch_size = hidden_states_list[0].shape[0]
     # Initialize cache and attention function based on backend
     if attention_backend == "sdpa":
@@ -133,9 +134,9 @@ def benchmark_function(
         print(f"\nTesting sequence length: {seq_len}")
 
         # Clear GPU cache
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.reset_peak_memory_stats()
+        if get_device_type() != "cpu":
+            empty_cache()
+            torch.get_device_module(get_device_type()).reset_peak_memory_stats()
 
         # Warm up runs for this sequence length
         if enable_warmup:
@@ -147,27 +148,27 @@ def benchmark_function(
                         seq_len,
                         HIDDEN_SIZE,
                         requires_grad=True,
-                        device="cuda",
+                        device=get_local_device(),
                         dtype=torch.bfloat16,
                     )
                     for _ in range(TTT_LENGTH)
                 ]
                 run_attention(seq_len, hidden_states, attention_backend)
             # Clear cache again after warmup
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-                torch.cuda.reset_peak_memory_stats()
+            if get_device_type() != "cpu":
+                empty_cache()
+                torch.get_device_module(get_device_type()).reset_peak_memory_stats()
         # Record initial memory
         initial_memory = 0
-        if torch.cuda.is_available():
-            initial_memory = torch.cuda.memory_allocated()
+        if get_device_type() != "cpu":
+            initial_memory = torch.get_device_module(get_device_type()).memory_allocated()
         hidden_states = [
             torch.randn(
                 BATCH_SIZE,
                 seq_len,
                 HIDDEN_SIZE,
                 requires_grad=True,
-                device="cuda",
+                device=get_local_device(),
                 dtype=torch.bfloat16,
             )
             for _ in range(TTT_LENGTH)
@@ -179,16 +180,16 @@ def benchmark_function(
             attention_backend,
             enable_profile and seq_len == seq_lengths[0],
         )
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
+        if get_device_type() != "cpu":
+            synchronize()
         end_time = time.time()
 
         # Record memory usage
         peak_memory = 0
         current_memory = 0
-        if torch.cuda.is_available():
-            peak_memory = torch.cuda.max_memory_allocated()
-            current_memory = torch.cuda.memory_allocated()
+        if get_device_type() != "cpu":
+            peak_memory = torch.get_device_module(get_device_type()).max_memory_allocated()
+            current_memory = torch.get_device_module(get_device_type()).memory_allocated()
         results_per_seq_len.append(
             {
                 "seq_len": seq_len,
@@ -292,16 +293,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     print("PyTorch version:", torch.__version__)
-    if torch.cuda.is_available():
-        print("CUDA available:", torch.cuda.is_available())
-        print("GPU:", torch.cuda.get_device_name())
+    device_type = get_device_type()
+    if device_type != "cpu":
+        device_module = torch.get_device_module(device_type)
+        print(f"{device_type} available: True")
+        print("Device:", device_module.get_device_name())
         print(
-            "GPU memory:",
-            torch.cuda.get_device_properties(0).total_memory / 1024**3,
+            "Device memory:",
+            device_module.get_device_properties(0).total_memory / 1024**3,
             "GB",
         )
     else:
-        print("CUDA not available - running on CPU")
+        print("No accelerator available - running on CPU")
 
     # Define sequence lengths to test
     seq_lengths = [128 * i for i in range(1, 28, 4)]

--- a/specforge/benchmarks/benchmark_loss.py
+++ b/specforge/benchmarks/benchmark_loss.py
@@ -3,7 +3,7 @@ import time
 
 import torch
 
-from specforge.core.loss import LogSoftmaxLoss, _compute_loss
+from specforge.core.loss import log_softmax_loss, _compute_loss
 from specforge.utils import empty_cache, get_device_type, get_local_device, synchronize
 
 TTT_LENGTH = 7
@@ -48,7 +48,7 @@ def benchmark_loss_method(
         for i in range(TTT_LENGTH):
             logits = logits_list[i]
             if loss_method == "triton":
-                loss = LogSoftmaxLoss.apply(logits, target, position_mask)
+                loss = log_softmax_loss(logits, target, position_mask)
             else:
                 loss = _compute_loss(logits, target, position_mask)
             plosses.append(loss)

--- a/specforge/benchmarks/benchmark_loss.py
+++ b/specforge/benchmarks/benchmark_loss.py
@@ -4,7 +4,7 @@ import time
 import torch
 
 from specforge.core.loss import log_softmax_loss, _compute_loss
-from specforge.utils import empty_cache, get_device_type, get_local_device, synchronize
+from specforge.utils import empty_cache, get_device_module, get_device_type, get_local_device, synchronize
 
 TTT_LENGTH = 7
 
@@ -25,7 +25,7 @@ def benchmark_loss_method(
         # Clear GPU cache
         if get_device_type() != "cpu":
             empty_cache()
-            torch.get_device_module(get_device_type()).reset_peak_memory_stats()
+            get_device_module().reset_peak_memory_stats()
 
         # Create tensors outside timing measurement
         target = torch.softmax(
@@ -67,7 +67,7 @@ def benchmark_loss_method(
         total_time = end_time - start_time
         peak_memory = 0
         if get_device_type() != "cpu":
-            peak_memory = torch.get_device_module(get_device_type()).max_memory_allocated()
+            peak_memory = get_device_module().max_memory_allocated()
 
         results.append(
             {
@@ -95,12 +95,11 @@ def main():
     print("PyTorch version:", torch.__version__)
     device_type = get_device_type()
     if device_type != "cpu":
-        device_module = torch.get_device_module(device_type)
         print(f"{device_type} available: True")
-        print("Device:", device_module.get_device_name())
+        print("Device:", get_device_module().get_device_name())
         print(
             "Device memory:",
-            device_module.get_device_properties(0).total_memory / 1024**3,
+            get_device_module().get_device_properties(0).total_memory / 1024**3,
             "GB",
         )
     else:

--- a/specforge/benchmarks/benchmark_loss.py
+++ b/specforge/benchmarks/benchmark_loss.py
@@ -4,6 +4,7 @@ import time
 import torch
 
 from specforge.core.loss import LogSoftmaxLoss, _compute_loss
+from specforge.utils import empty_cache, get_device_type, get_local_device, synchronize
 
 TTT_LENGTH = 7
 
@@ -22,25 +23,25 @@ def benchmark_loss_method(
         print(f"\nTesting config: B={B}, T={T}, V={V}")
 
         # Clear GPU cache
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.reset_peak_memory_stats()
+        if get_device_type() != "cpu":
+            empty_cache()
+            torch.get_device_module(get_device_type()).reset_peak_memory_stats()
 
         # Create tensors outside timing measurement
         target = torch.softmax(
-            torch.randn(B, T, V, device="cuda", dtype=torch.float32), dim=-1
+            torch.randn(B, T, V, device=get_local_device(), dtype=torch.float32), dim=-1
         )
-        position_mask = torch.ones((B, T, 1), dtype=torch.bool, device="cuda")
+        position_mask = torch.ones((B, T, 1), dtype=torch.bool, device=get_local_device())
 
         # Pre-allocate logits tensors for each TTT step
         logits_list = []
         for i in range(TTT_LENGTH):
             logits = torch.randn(
-                B, T, V, device="cuda", requires_grad=True, dtype=torch.float32
+                B, T, V, device=get_local_device(), requires_grad=True, dtype=torch.float32
             )
             logits_list.append(logits)
 
-        torch.cuda.synchronize()  # Ensure all operations are complete
+        synchronize()
         start_time = time.time()
 
         plosses = []
@@ -59,15 +60,14 @@ def benchmark_loss_method(
         )
         ploss.backward()
 
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
+        if get_device_type() != "cpu":
+            synchronize()
 
         end_time = time.time()
         total_time = end_time - start_time
-        # Record memory usage
         peak_memory = 0
-        if torch.cuda.is_available():
-            peak_memory = torch.cuda.max_memory_allocated()
+        if get_device_type() != "cpu":
+            peak_memory = torch.get_device_module(get_device_type()).max_memory_allocated()
 
         results.append(
             {
@@ -93,16 +93,18 @@ def main():
     args = parser.parse_args()
 
     print("PyTorch version:", torch.__version__)
-    if torch.cuda.is_available():
-        print("CUDA available:", torch.cuda.is_available())
-        print("GPU:", torch.cuda.get_device_name())
+    device_type = get_device_type()
+    if device_type != "cpu":
+        device_module = torch.get_device_module(device_type)
+        print(f"{device_type} available: True")
+        print("Device:", device_module.get_device_name())
         print(
-            "GPU memory:",
-            torch.cuda.get_device_properties(0).total_memory / 1024**3,
+            "Device memory:",
+            device_module.get_device_properties(0).total_memory / 1024**3,
             "GB",
         )
     else:
-        print("CUDA not available - running on CPU")
+        print("No accelerator available - running on CPU")
 
     # Define test configurations (B, T, V)
     test_configs = [

--- a/specforge/benchmarks/benchmark_loss.py
+++ b/specforge/benchmarks/benchmark_loss.py
@@ -3,8 +3,14 @@ import time
 
 import torch
 
-from specforge.core.loss import log_softmax_loss, _compute_loss
-from specforge.utils import empty_cache, get_device_module, get_device_type, get_local_device, synchronize
+from specforge.core.loss import _compute_loss, log_softmax_loss
+from specforge.utils import (
+    empty_cache,
+    get_device_module,
+    get_device_type,
+    get_local_device,
+    synchronize,
+)
 
 TTT_LENGTH = 7
 
@@ -31,13 +37,20 @@ def benchmark_loss_method(
         target = torch.softmax(
             torch.randn(B, T, V, device=get_local_device(), dtype=torch.float32), dim=-1
         )
-        position_mask = torch.ones((B, T, 1), dtype=torch.bool, device=get_local_device())
+        position_mask = torch.ones(
+            (B, T, 1), dtype=torch.bool, device=get_local_device()
+        )
 
         # Pre-allocate logits tensors for each TTT step
         logits_list = []
         for i in range(TTT_LENGTH):
             logits = torch.randn(
-                B, T, V, device=get_local_device(), requires_grad=True, dtype=torch.float32
+                B,
+                T,
+                V,
+                device=get_local_device(),
+                requires_grad=True,
+                dtype=torch.float32,
             )
             logits_list.append(logits)
 

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -35,7 +35,7 @@ from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspA
 from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
 from specforge.core.loss import LogSoftmaxLoss
 from specforge.modeling.draft import Eagle3DraftModel
-from specforge.utils import padding
+from specforge.utils import get_compile_backend, padding
 
 
 class Eagle3Model(nn.Module):
@@ -832,7 +832,7 @@ def _compute_target_p_padded(target, t2d, loss_mask, length):
         )
 
 
-@torch.compile(dynamic=None)
+@torch.compile(dynamic=None, backend=get_compile_backend())
 def _compute_target_p(target, t2d, loss_mask):
     target_head = target.float()
     target_token_ids = target_head.argmax(-1)
@@ -849,13 +849,13 @@ def _compute_target_p(target, t2d, loss_mask):
     return target_p, target_p_on_draft, target_token_ids, position_mask
 
 
-@torch.compile(dynamic=None)
+@torch.compile(dynamic=None, backend=get_compile_backend())
 def _compute_metric_acc(logits, target_token_ids, loss_mask, d2t):
     correct, denom = _compute_metric_counts(logits, target_token_ids, loss_mask, d2t)
     return correct / denom
 
 
-@torch.compile(dynamic=None)
+@torch.compile(dynamic=None, backend=get_compile_backend())
 def _compute_metric_counts(logits, target_token_ids, loss_mask, d2t):
     pred_draft_token_ids = logits.argmax(-1)
     pred_target_token_ids = pred_draft_token_ids + d2t[pred_draft_token_ids]

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -33,7 +33,7 @@ from specforge.core.compact_teacher import (
 )
 from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspAdapter
 from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
-from specforge.core.loss import LogSoftmaxLoss
+from specforge.core.loss import log_softmax_loss
 from specforge.modeling.draft import Eagle3DraftModel
 from specforge.utils import get_compile_backend, empty_cache, padding
 
@@ -69,7 +69,7 @@ def _compute_loss_and_acceptance_rate(
         reduce_metrics_fn: Optional distributed reducer for metric numer/denom.
         reduce_loss_fn: Optional distributed reducer for KL loss.
     """
-    kl_loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+    kl_loss = log_softmax_loss(logits, target_p, position_mask)
     if reduce_loss_fn is not None:
         kl_loss = reduce_loss_fn(kl_loss)
 

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -35,7 +35,7 @@ from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspA
 from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
 from specforge.core.loss import log_softmax_loss
 from specforge.modeling.draft import Eagle3DraftModel
-from specforge.utils import get_compile_backend, empty_cache, padding
+from specforge.utils import empty_cache, get_compile_backend, padding
 
 
 class Eagle3Model(nn.Module):

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -35,7 +35,7 @@ from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspA
 from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
 from specforge.core.loss import LogSoftmaxLoss
 from specforge.modeling.draft import Eagle3DraftModel
-from specforge.utils import get_compile_backend, padding
+from specforge.utils import get_compile_backend, empty_cache, padding
 
 
 class Eagle3Model(nn.Module):
@@ -298,7 +298,7 @@ class OnlineEagle3Model(Eagle3Model):
                 length=self.length,
             )
             del target
-        torch.cuda.empty_cache()
+        empty_cache()
 
         # basic info
         batch_size, seq_length, _ = hidden_states.shape

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 
-from specforge.utils import get_compile_backend
+from specforge.utils import get_compile_backend, get_device_type
 
 
 # Reference implementation
@@ -231,7 +231,7 @@ class LogSoftmaxLoss(torch.autograd.Function):
 
 
 if __name__ == "__main__":
-    device = "cuda"
+    device = get_device_type()
     B, T, V = 1, 1024, 16000
     logits = torch.randn(B, T, V, device=device, requires_grad=True)
     logits2 = logits.clone().detach().requires_grad_(True)

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -10,9 +10,11 @@ import torch.nn as nn
 import triton
 import triton.language as tl
 
+from specforge.utils import get_compile_backend
+
 
 # Reference implementation
-@torch.compile(dynamic=None)
+@torch.compile(dynamic=None, backend=get_compile_backend())
 def _compute_loss(logits, target_p, position_mask):
     logits = logits.float()
     out_logp = nn.LogSoftmax(dim=2)(logits)

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -230,6 +230,188 @@ class LogSoftmaxLoss(torch.autograd.Function):
         return logits, None, None
 
 
+def _calculate_settings_npu(n):
+    NPU_MAX_BLOCK_SIZE = 4096
+    BLOCK_SIZE = min(triton.next_power_of_2(n), NPU_MAX_BLOCK_SIZE)
+    return BLOCK_SIZE
+
+
+@triton.jit
+def log_softmax_forward_kernel_npu(
+    logits_ptr,
+    logits_stride,
+    target_ptr,
+    target_stride,
+    position_mask_ptr,
+    position_mask_stride,
+    loss_ptr,
+    loss_stride,
+    m_ptr,
+    d_ptr,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    program_id = tl.program_id(0).to(tl.int64)
+    logits_ptr += program_id * logits_stride
+    target_ptr += program_id * target_stride
+    position_mask_ptr += program_id * position_mask_stride
+    position_mask = tl.load(position_mask_ptr)
+    if position_mask == 0:
+        return
+
+    m = float("-inf")
+    d = 0.0
+    sum_target_logits = 0.0
+    sum_target = 0.0
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        logits_block = tl.load(
+            logits_ptr + offsets, mask=mask, other=float("-inf"), care_padding=False
+        ).cast(tl.float32)
+        target_block = tl.load(
+            target_ptr + offsets, mask=mask, other=0.0, care_padding=False
+        ).cast(tl.float32)
+
+        block_max = tl.max(tl.where(mask, logits_block, float("-inf")))
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(
+            tl.where(mask, tl.exp(logits_block - m_new), 0.0)
+        )
+        m = m_new
+
+        sum_target_logits += tl.sum(tl.where(mask, target_block * logits_block, 0.0))
+        sum_target += tl.sum(tl.where(mask, target_block, 0.0))
+
+    loss = -(sum_target_logits - sum_target * (m + tl.log(d)))
+
+    loss_ptr += program_id * loss_stride
+    m_ptr += program_id
+    d_ptr += program_id
+    tl.store(loss_ptr, loss)
+    tl.store(m_ptr, m.to(tl.float32))
+    tl.store(d_ptr, d.to(tl.float32))
+
+
+@triton.jit
+def log_softmax_backward_kernel_npu(
+    logits_ptr,
+    logits_stride,
+    target_ptr,
+    target_stride,
+    position_mask_ptr,
+    target_grad_sum_ptr,
+    m_ptr,
+    d_ptr,
+    grad_output_scaled,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    program_id = tl.program_id(0).to(tl.int64)
+    logits_ptr += program_id * logits_stride
+    target_ptr += program_id * target_stride
+    position_mask_ptr += program_id
+
+    position_mask = tl.load(position_mask_ptr)
+    if position_mask == 0:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            tl.store(logits_ptr + offsets, 0.0, mask=mask)
+        return
+
+    m_ptr += program_id
+    d_ptr += program_id
+    target_grad_sum_ptr += program_id
+    m = tl.load(m_ptr).to(tl.float32)
+    d = tl.load(d_ptr).to(tl.float32)
+    target_grad_sum = tl.load(target_grad_sum_ptr).to(tl.float32)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        logits_block = tl.load(
+            logits_ptr + offsets, mask=mask, other=0.0, care_padding=False
+        ).cast(tl.float32)
+        target_block = tl.load(
+            target_ptr + offsets, mask=mask, other=0.0, care_padding=False
+        ).cast(tl.float32)
+        softmax_prob = tl.exp(logits_block - m) / d
+        normalized_grad = softmax_prob * target_grad_sum
+        grad_block = -(target_block * grad_output_scaled - normalized_grad)
+        tl.store(logits_ptr + offsets, grad_block.to(tl.float32), mask=mask)
+
+
+class LogSoftmaxLossNPU(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, target, position_mask):
+        B, T, V = logits.shape
+        loss = torch.zeros((B * T, 1), device=logits.device)
+        logits_flat = logits.contiguous().view(B * T, V)
+        target_flat = target.contiguous().view(B * T, V)
+        position_mask_flat = position_mask.contiguous().view(B * T, 1).bool()
+        grid = (B * T,)
+        m = torch.zeros((B * T,), device=logits.device, dtype=torch.float32)
+        d = torch.zeros((B * T,), device=logits.device, dtype=torch.float32)
+        BLOCK_SIZE = _calculate_settings_npu(V)
+        log_softmax_forward_kernel_npu[grid](
+            logits_flat,
+            logits_flat.stride(0),
+            target_flat,
+            target_flat.stride(0),
+            position_mask_flat,
+            position_mask_flat.stride(0),
+            loss,
+            loss.stride(0),
+            m,
+            d,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+        ctx.save_for_backward(logits.detach(), target, position_mask, m, d)
+        return loss.squeeze(1).mean()
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits, target, position_mask, m, d = ctx.saved_tensors
+        B, T, V = logits.shape
+        logits = logits.contiguous().view(B * T, V)
+        target = target.contiguous().view(B * T, V)
+        position_mask = position_mask.contiguous().view(B * T, 1).bool()
+
+        scaling_factor = 1.0 / (B * T)
+        grad_output_scaled = grad_output.item() * scaling_factor
+        target_sum_per_row = target.sum(dim=-1)
+        target_grad_sum_per_row = target_sum_per_row * grad_output_scaled
+
+        grid = (B * T,)
+        BLOCK_SIZE = _calculate_settings_npu(V)
+        log_softmax_backward_kernel_npu[grid](
+            logits,
+            logits.stride(0),
+            target,
+            target.stride(0),
+            position_mask,
+            target_grad_sum_per_row,
+            m,
+            d,
+            grad_output_scaled,
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+        logits = logits.view(B, T, V)
+        return logits, None, None
+
+
+def log_softmax_loss(logits, target, position_mask):
+    if get_device_type() == "npu":
+        return LogSoftmaxLossNPU.apply(logits, target, position_mask)
+    else:
+        return LogSoftmaxLoss.apply(logits, target, position_mask)
+
+
 if __name__ == "__main__":
     device = get_device_type()
     B, T, V = 1, 1024, 16000
@@ -238,7 +420,7 @@ if __name__ == "__main__":
     target = torch.randn(B, T, V, device=device)
     position_mask = torch.randint(0, 2, (B, T, 1), dtype=torch.bool, device=device)
     position_mask = torch.ones((B, T, 1), dtype=torch.bool, device=device)
-    output1 = LogSoftmaxLoss.apply(logits, target, position_mask)
+    output1 = log_softmax_loss(logits, target, position_mask)
     output2 = _compute_loss(logits2, target, position_mask)
     torch.testing.assert_close(output1, output2, rtol=1e-4, atol=1e-4)
     output1.backward()

--- a/specforge/data/parse.py
+++ b/specforge/data/parse.py
@@ -178,19 +178,19 @@ class GeneralParser(Parser):
                         warnings.warn(
                             f"Conversation must start with a 'user' role, but found '{role}'. Conversation truncated."
                         )
-                        break
+                        return None, None
                 else:
                     prev_role = conversation[j - 1]["role"]
                     if role == "tool" and prev_role not in ["assistant", "tool"]:
                         warnings.warn(
                             f"A 'tool' message must follow an 'assistant' or 'tool' message, but was preceded by '{prev_role}'. Conversation truncated."
                         )
-                        break
+                        return None, None
                     if role == "assistant" and prev_role not in ["user", "tool"]:
                         warnings.warn(
                             f"An 'assistant' message must follow a 'user' or 'tool' message, but was preceded by '{prev_role}'. Conversation truncated."
                         )
-                        break
+                        return None, None
                 sentence = self._sanitize_message(sentence)
                 messages.append(sentence)
             try:

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -171,6 +171,9 @@ def preprocess_conversations(
             tool=tool,
             **kwargs_item,
         )
+        if input_ids is None or loss_mask is None:
+            # if parsing failed, skip this conversation
+            continue
         results["input_ids"].append(input_ids[None, :])
         results["loss_mask"].append(loss_mask[None, :])
         results["attention_mask"].append(torch.ones_like(loss_mask)[None, :])

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -5,7 +5,13 @@ import torch
 import torch.distributed as dist
 from yunchang.globals import PROCESS_GROUP, set_seq_parallel_pg
 
-from specforge.utils import print_with_rank
+from specforge.utils import (
+    device_count,
+    get_device_type,
+    get_dist_backend,
+    print_with_rank,
+    set_device,
+)
 
 _DEVICE_MESH = None
 _TP_DEVICE_MESH = None
@@ -72,9 +78,9 @@ def init_distributed(
         timeout(int): Timeout for collective communication in minutes
         tp_size(int): The degree of tensor parallelism
     """
-    dist.init_process_group(backend="nccl", timeout=timedelta(minutes=timeout))
-    local_rank = dist.get_rank() % torch.cuda.device_count()
-    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend=get_dist_backend(), timeout=timedelta(minutes=timeout))
+    local_rank = dist.get_rank() % device_count()
+    set_device(local_rank)
     print_with_rank(f"bind to device {local_rank}")
 
     world_size = dist.get_world_size()
@@ -84,7 +90,7 @@ def init_distributed(
     ), f"world size must be divisible by tp size, now {world_size=}, {(tp_size * dp_size)=} "
 
     device_mesh = dist.device_mesh.init_device_mesh(
-        "cuda", (dp_size, tp_size), mesh_dim_names=("dp", "tp")
+        get_device_type(), (dp_size, tp_size), mesh_dim_names=("dp", "tp")
     )
 
     assert (
@@ -93,7 +99,7 @@ def init_distributed(
 
     draft_dp_size = world_size // (sp_ulysses_size * sp_ring_size)
     draft_device_mesh = dist.device_mesh.init_device_mesh(
-        "cuda",
+        get_device_type(),
         (draft_dp_size, sp_ulysses_size * sp_ring_size),
         mesh_dim_names=("draft_dp", "sp"),
     )
@@ -106,7 +112,7 @@ def init_distributed(
     sp_ulysses_group = PROCESS_GROUP.ULYSSES_PG
     sp_ring_group = PROCESS_GROUP.RING_PG
     # we need to create a 1D submesh
-    tp_device_mesh = dist.DeviceMesh.from_group(tp_group, device_type="cuda")
+    tp_device_mesh = dist.DeviceMesh.from_group(tp_group, device_type=get_device_type())
 
     global _TP_GROUP, _DP_GROUP, _DEVICE_MESH, _TP_DEVICE_MESH, _DP_DEVICE_MESH, _SP_RING_GROUP, _SP_ULYSSES_GROUP, _DRAFT_DP_GROUP, _DRAFT_SP_GROUP
     _DEVICE_MESH = device_mesh
@@ -117,7 +123,7 @@ def init_distributed(
     _DP_GROUP = dp_group
     _DRAFT_DP_GROUP = draft_device_mesh.get_group("draft_dp")
     _DRAFT_SP_GROUP = draft_device_mesh.get_group("sp")
-    _DP_DEVICE_MESH = dist.DeviceMesh.from_group(dp_group, device_type="cuda")
+    _DP_DEVICE_MESH = dist.DeviceMesh.from_group(dp_group, device_type=get_device_type())
 
 
 def destroy_distributed():

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -78,7 +78,9 @@ def init_distributed(
         timeout(int): Timeout for collective communication in minutes
         tp_size(int): The degree of tensor parallelism
     """
-    dist.init_process_group(backend=get_dist_backend(), timeout=timedelta(minutes=timeout))
+    dist.init_process_group(
+        backend=get_dist_backend(), timeout=timedelta(minutes=timeout)
+    )
     local_rank = dist.get_rank() % device_count()
     set_device(local_rank)
     print_with_rank(f"bind to device {local_rank}")
@@ -123,7 +125,9 @@ def init_distributed(
     _DP_GROUP = dp_group
     _DRAFT_DP_GROUP = draft_device_mesh.get_group("draft_dp")
     _DRAFT_SP_GROUP = draft_device_mesh.get_group("sp")
-    _DP_DEVICE_MESH = dist.DeviceMesh.from_group(dp_group, device_type=get_device_type())
+    _DP_DEVICE_MESH = dist.DeviceMesh.from_group(
+        dp_group, device_type=get_device_type()
+    )
 
 
 def destroy_distributed():

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -18,6 +18,8 @@ from transformers import (
     modeling_utils,
 )
 
+from specforge.utils import get_local_device
+
 from .draft.llama3_eagle import LlamaForCausalLMEagle3
 from .target.custom_backend import (
     GptOssForCausalLM,
@@ -28,7 +30,6 @@ from .target.custom_backend import (
     Qwen3ForCausalLM,
     Qwen3MoeForCausalLM,
 )
-from specforge.utils import get_local_device
 
 
 class AutoEagle3DraftModel(AutoModelForCausalLMBase):

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -28,6 +28,7 @@ from .target.custom_backend import (
     Qwen3ForCausalLM,
     Qwen3MoeForCausalLM,
 )
+from specforge.utils import get_local_device
 
 
 class AutoEagle3DraftModel(AutoModelForCausalLMBase):
@@ -125,7 +126,7 @@ class AutoDistributedTargetModel(AutoModelForCausalLMBase):
         if device is not None:
             model = model.to(device)
         else:
-            model = model.cuda()
+            model = model.to(get_local_device())
         return model
 
 

--- a/specforge/modeling/draft/flex_attention.py
+++ b/specforge/modeling/draft/flex_attention.py
@@ -77,7 +77,9 @@ class WrappedCreateBlockMask:
     @torch.compiler.disable(recursive=False)
     def __init__(self):
         if not self._is_create_block_mask_compiled:
-            self._compiled_create_block_mask = torch.compile(create_block_mask, backend=get_compile_backend())
+            self._compiled_create_block_mask = torch.compile(
+                create_block_mask, backend=get_compile_backend()
+            )
             self._is_create_block_mask_compiled = True
 
     def __call__(self):

--- a/specforge/modeling/draft/flex_attention.py
+++ b/specforge/modeling/draft/flex_attention.py
@@ -7,6 +7,8 @@ from torch.nn.attention.flex_attention import (
 )
 from transformers.utils import is_torchdynamo_compiling
 
+from specforge.utils import get_compile_backend
+
 dynamo.config.recompile_limit = 64
 
 
@@ -35,7 +37,7 @@ class WrappedFlexAttention:
             # Enable dynamic shapes to handle different input sizes
             self._compiled_flex_attention = torch.compile(
                 flex_attention,
-                # mode="max-autotune-no-cudagraphs",
+                backend=get_compile_backend(),
             )
             self._is_flex_compiled = True
 
@@ -75,7 +77,7 @@ class WrappedCreateBlockMask:
     @torch.compiler.disable(recursive=False)
     def __init__(self):
         if not self._is_create_block_mask_compiled:
-            self._compiled_create_block_mask = torch.compile(create_block_mask)
+            self._compiled_create_block_mask = torch.compile(create_block_mask, backend=get_compile_backend())
             self._is_create_block_mask_compiled = True
 
     def __call__(self):

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -17,7 +17,7 @@ from specforge.modeling.draft.flex_attention import (
     compile_friendly_flex_attention,
     generate_eagle3_mask,
 )
-from specforge.utils import print_with_rank
+from specforge.utils import get_compile_backend, print_with_rank
 
 from ...distributed import get_sp_ring_group, get_sp_ulysses_group
 from .base import Eagle3DraftModel
@@ -112,7 +112,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
-@torch.compile(dynamic=True)
+@torch.compile(dynamic=True, backend=get_compile_backend())
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
     # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
     cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
@@ -282,7 +282,7 @@ class LlamaRotaryEmbedding(torch.nn.Module):
             "sin_cached", emb.sin()[None, None, :, :].to(dtype), persistent=False
         )
 
-    @torch.compile(dynamic=True)
+    @torch.compile(dynamic=True, backend=get_compile_backend())
     def forward(self, x, seq_len=None):
         # x: [bs, num_attention_heads, seq_len, head_size]
         if seq_len and seq_len > self.max_seq_len_cached:
@@ -1532,7 +1532,7 @@ class LlamaRMSNorm(nn.Module):
         self.weight = nn.Parameter(torch.ones(hidden_size))
         self.variance_epsilon = eps
 
-    @torch.compile(dynamic=True)
+    @torch.compile(dynamic=True, backend=get_compile_backend())
     def forward(self, hidden_states):
         input_dtype = hidden_states.dtype
         hidden_states = hidden_states.to(torch.float32)

--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -18,6 +18,7 @@ from sglang.srt.utils import require_mlp_sync, require_mlp_tp_gather
 from transformers import AutoModelForCausalLM
 
 from specforge.distributed import get_tp_group
+from specforge.utils import current_device
 
 from .sglang_backend import SGLangRunner
 
@@ -98,7 +99,7 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
         model_runner = SGLangRunner(
             model_config=model_config,
             mem_fraction_static=server_args.mem_fraction_static,
-            gpu_id=torch.cuda.current_device(),
+            gpu_id=current_device(),
             tp_rank=dist.get_rank(get_tp_group()),
             tp_size=server_args.tp_size,
             moe_ep_rank=moe_ep_rank,

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -34,7 +34,7 @@ from sglang.srt.utils import require_mlp_sync, require_mlp_tp_gather
 from transformers import AutoModelForCausalLM
 
 from specforge.distributed import get_tp_device_mesh, get_tp_group
-from specforge.utils import padding
+from specforge.utils import current_device, padding
 
 from .sglang_backend import SGLangRunner, wrap_eagle3_logits_processors_in_module
 from .sglang_backend.utils import LogitsProcessorForEAGLE3
@@ -334,7 +334,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         model_runner = SGLangRunner(
             model_config=model_config,
             mem_fraction_static=server_args.mem_fraction_static,
-            gpu_id=torch.cuda.current_device(),
+            gpu_id=current_device(),
             tp_rank=dist.get_rank(get_tp_group()),
             tp_size=server_args.tp_size,
             moe_ep_rank=moe_ep_rank,

--- a/specforge/modeling/target/target_utils.py
+++ b/specforge/modeling/target/target_utils.py
@@ -10,6 +10,8 @@ from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from transformers import AutoConfig
 
+from specforge.utils import get_device_type
+
 
 class TargetEmbeddingsAndHead(nn.Module):
     """
@@ -45,12 +47,13 @@ class TargetEmbeddingsAndHead(nn.Module):
         embed_key: Optional[str] = None,
         lm_head_key: Optional[str] = None,
         cache_dir: Optional[str] = None,
-        device: str = "cuda",
+        device: str = None,
         dtype: torch.dtype = torch.bfloat16,
         trust_remote_code: bool = False,
     ) -> "TargetEmbeddingsAndHead":
 
-        # 1. Load Config
+        if device is None:
+            device = get_device_type()
         config = AutoConfig.from_pretrained(
             model_path, cache_dir=cache_dir, trust_remote_code=trust_remote_code
         )

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -79,11 +79,49 @@ def get_local_device() -> torch.device:
     """Return the local torch.device for the current process rank."""
     device_type = get_device_type()
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    if device_type == "cuda":
-        return torch.device("cuda", local_rank)
-    if device_type == "npu":
-        return torch.device("npu", local_rank)
+    if device_type in ("cuda", "npu"):
+        return torch.device(device_type, local_rank)
     return torch.device("cpu")
+
+
+def get_device_module():
+    """Return the torch device module for the current device type (cuda, npu, etc.)."""
+    return torch.get_device_module(get_device_type())
+
+
+def empty_cache():
+    """Empty the cache for the current accelerator device."""
+    get_device_module().empty_cache()
+
+
+def device_count() -> int:
+    """Return the number of available accelerator devices."""
+    return get_device_module().device_count()
+
+
+def current_device() -> int:
+    """Return the current accelerator device index."""
+    return get_device_module().current_device()
+
+
+def set_device(device_id: int):
+    """Set the current accelerator device."""
+    get_device_module().set_device(device_id)
+
+
+def synchronize():
+    """Synchronize the current accelerator device."""
+    get_device_module().synchronize()
+
+
+def get_dist_backend() -> str:
+    """Return the appropriate distributed backend for the current device type."""
+    device_type = get_device_type()
+    if device_type == "cuda":
+        return "nccl"
+    if device_type == "npu":
+        return "hccl"
+    return "gloo"
 
 
 def print_with_rank(message):

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -12,6 +12,13 @@ from transformers import AutoConfig, PretrainedConfig
 logger = logging.getLogger(__name__)
 
 
+def get_compile_backend() -> str:
+    # now ascend npu can not support inductor for backend,
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return "eager"
+    return "inductor"
+
+
 @contextmanager
 def rank_0_priority():
     rank = dist.get_rank()


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
This PR introduce Ascend NPU support for SpecForge, the majority of the changes replace existing CUDA interfaces with hardware-adaptive options, also includes Ascend NPU installation guides and examples.

Co-author: @mingliangfu  This PR cherry-pick https://github.com/sgl-project/SpecForge/pull/559 changes.

## Modifications

<!-- Describe the changes made in this PR. -->
- Existing CUDA interface: .npu(), to(device="CUDA"), device_count, empty_cache, current_device, set_device, synchronize, etc.
- torch.compile: Currently Ascend NPU cannot use inductor backend, so fallback to the eager backend.
- distributed: Ascend use hccl backend.
- Ascend triton log softmax implement to save the memory: Cause the Ascend triton-ascend cannot use the CUDA triton implement due to UB overflow issue.
- Ascend NPU installation guide: Add `requirements-npu.txt` and `Install on Ascend NPU` section on `installation.md`
- A simple example for llama3.1 online train: Change the `--max-length` and `--sglang-mem-fraction-static` due to OOM issue.
- Directly drop the conversation if not matching the parse rule. Fixes #557 

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->
Fixes #557 

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->
This PR should not introduce any affect on CUDA hardware.

Train with `examples/run_llama3.1_8b_eagle3_online_npu.sh`
Train loss:
<img width="2066" height="1526" alt="image" src="https://github.com/user-attachments/assets/aba39a67-6b52-403f-a86c-f9b6424e8de6" />
llama3.1-8b:
- humaneval output throughput: 72.55
- math500 output throughput: 72.30
llama3.1-8b with eagle3-sharegpt:
- humaneval output throughput: 115.24 ~1.58x accept length: 2.60 
- math500 output throughput: 111.29 ~1.53x accept length: 2.52


## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
