### PR TITLE
Add D-PACE loss option to DFlash training

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,3 +7,11 @@ bash examples/<script-name>.sh [NUM_GPUS] [TP_SIZE]
 ```
 
 We use the ShareGPT dataset for all the examples for now, but you can replace it with more robust datasets such as perfectblend, magpie-qwen2.5-pro-1m-v0.1, etc.
+
+## D-PACE
+
+DFlash training also supports the D-PACE loss (Dynamic Position-Aware Cross-Entropy). Add `--loss-type dpace` (optionally `--dpace-alpha`, default 0.5) to any `scripts/train_dflash.py` command. `--loss-decay-gamma` is DFlash-only and is ignored by D-PACE variants. Ablation variants are available via `--loss-type dpace-cumulative-confidence-only` and `--loss-type dpace-continuation-value-only`. A ready-to-run example:
+
+```bash
+NUM_GPUS=8 DPACE_ALPHA=0.5 bash examples/run_qwen3_8b_dpace_online.sh
+```

--- a/examples/run_qwen3_8b_dpace_online.sh
+++ b/examples/run_qwen3_8b_dpace_online.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+
+NUM_GPUS=${NUM_GPUS:-${1:-8}}
+ATTENTION_BACKEND=${ATTENTION_BACKEND:-${2:-flex_attention}}
+TARGET_MODEL_PATH=${TARGET_MODEL_PATH:-Qwen/Qwen3-8B}
+DRAFT_CONFIG_PATH=${DRAFT_CONFIG_PATH:-$ROOT_DIR/configs/qwen3-8b-dflash.json}
+TRAIN_DATA_PATH=${TRAIN_DATA_PATH:-$ROOT_DIR/cache/dataset/perfectblend_qwen3-8b_regen.jsonl}
+OUTPUT_DIR=${OUTPUT_DIR:-$ROOT_DIR/outputs/qwen3-8b-dpace}
+CACHE_DIR=${CACHE_DIR:-$ROOT_DIR/cache}
+DPACE_ALPHA=${DPACE_ALPHA:-0.5}
+
+export TORCHINDUCTOR_CACHE_DIR=${TORCHINDUCTOR_CACHE_DIR:-$ROOT_DIR/cache/compiled_kernels}
+export SPECFORGE_DATA_NUM_PROC=${SPECFORGE_DATA_NUM_PROC:-32}
+export PYTHONPATH="$ROOT_DIR:${PYTHONPATH:-}"
+
+torchrun \
+    --standalone \
+    --nproc_per_node "$NUM_GPUS" \
+    "$ROOT_DIR/scripts/train_dflash.py" \
+    --target-model-path "$TARGET_MODEL_PATH" \
+    --target-model-backend sglang \
+    --draft-config-path "$DRAFT_CONFIG_PATH" \
+    --train-data-path "$TRAIN_DATA_PATH" \
+    --output-dir "$OUTPUT_DIR" \
+    --cache-dir "$CACHE_DIR" \
+    --num-epochs 6 \
+    --batch-size 4 \
+    --learning-rate 6e-4 \
+    --warmup-ratio 0.04 \
+    --max-grad-norm 1.0 \
+    --max-length 3072 \
+    --chat-template qwen \
+    --attention-backend "$ATTENTION_BACKEND" \
+    --block-size 16 \
+    --num-draft-layers 1 \
+    --num-anchors 512 \
+    --loss-type dpace \
+    --dpace-alpha "$DPACE_ALPHA" \
+    --log-interval 50 \
+    --save-interval 1000 \
+    --report-to wandb \
+    --wandb-project "${WANDB_PROJECT:-dpace-qwen3-8b}" \
+    --wandb-name "${WANDB_NAME:-qwen3-8b-dpace}"

--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -81,7 +81,26 @@ def parse_args():
         type=float,
         default=None,
         help="Gamma for exponential loss decay weighting (paper Eq.4). "
-        "Suggested: 7 for block_size=16, 5 for 10, 4 for 8. None disables.",
+        "Suggested: 7 for block_size=16, 5 for 10, 4 for 8. None disables. "
+        "Only applies when --loss-type dflash.",
+    )
+    model_group.add_argument(
+        "--loss-type",
+        type=str,
+        default="dflash",
+        choices=[
+            "dflash",
+            "dpace",
+            "dpace-cumulative-confidence-only",
+            "dpace-continuation-value-only",
+        ],
+        help=("Loss variant. Use dpace for Dynamic Position-Aware Cross-Entropy."),
+    )
+    model_group.add_argument(
+        "--dpace-alpha",
+        type=float,
+        default=0.5,
+        help="Smoothing alpha for D-PACE position weights.",
     )
     model_group.add_argument(
         "--embedding-key",
@@ -439,6 +458,8 @@ def main():
         attention_backend=args.attention_backend,
         num_anchors=args.num_anchors,
         loss_decay_gamma=args.loss_decay_gamma,
+        loss_type=args.loss_type,
+        dpace_alpha=args.dpace_alpha,
     )
 
     # Wrap each transformer block as its own FSDP unit so that all-gather /

--- a/specforge/core/dflash.py
+++ b/specforge/core/dflash.py
@@ -19,6 +19,15 @@ except ImportError:
     create_block_mask = None
 
 
+_VALID_LOSS_TYPES = {
+    "dflash",
+    "dpace",
+    "dpace-cumulative-confidence-only",
+    "dpace-continuation-value-only",
+}
+_DPACE_LOSS_TYPES = _VALID_LOSS_TYPES - {"dflash"}
+
+
 def create_dflash_sdpa_mask(anchor_positions, block_keep_mask, S, block_size, device):
     B, N = anchor_positions.shape
     Q_LEN = N * block_size
@@ -94,7 +103,7 @@ def create_dflash_block_mask(
 
 
 class OnlineDFlashModel(nn.Module):
-    """DFlash online training wrapper with block-wise CE loss."""
+    """DFlash online training wrapper with DFlash and D-PACE losses."""
 
     def __init__(
         self,
@@ -106,8 +115,17 @@ class OnlineDFlashModel(nn.Module):
         attention_backend: str = "flex_attention",
         num_anchors: int = 512,
         loss_decay_gamma: Optional[float] = None,
+        loss_type: str = "dflash",
+        dpace_alpha: float = 0.5,
     ):
         super().__init__()
+        if loss_type not in _VALID_LOSS_TYPES:
+            raise ValueError(
+                f"loss_type={loss_type!r}; must be one of {sorted(_VALID_LOSS_TYPES)}"
+            )
+        if not 0.0 <= dpace_alpha <= 1.0:
+            raise ValueError(f"dpace_alpha must be in [0, 1], got {dpace_alpha}")
+
         self.draft_model = draft_model
         self.lm_head = target_lm_head
         self.embed_tokens = target_embed_tokens
@@ -116,6 +134,8 @@ class OnlineDFlashModel(nn.Module):
         self.attention_backend = attention_backend
         self.num_anchors = num_anchors
         self.loss_decay_gamma = loss_decay_gamma
+        self.loss_type = loss_type
+        self.dpace_alpha = dpace_alpha
 
         self._cached_block_mask: Optional[BlockMask] = None
         self._cached_seq_len: Optional[int] = None
@@ -211,6 +231,38 @@ class OnlineDFlashModel(nn.Module):
 
         return self.embed_tokens(noise_ids)
 
+    def _dpace_weight(
+        self,
+        prob: torch.Tensor,
+        binary_mask: torch.Tensor,
+        binary_mask_b: torch.Tensor,
+        loss_type: str,
+    ) -> torch.Tensor:
+        """Compute detached D-PACE position weights.
+
+        ``prob`` is the draft probability on the target token at each draft
+        position. Invalid positions are treated as multiplicative no-ops inside
+        prefix products and excluded from suffix sums; the caller still
+        multiplies the returned weights by ``binary_mask`` before reduction.
+        """
+        smooth = (1.0 - self.dpace_alpha) * prob + self.dpace_alpha
+        smooth = torch.where(binary_mask_b, smooth, torch.ones_like(smooth))
+        prefix = torch.cumprod(smooth, dim=-1)
+
+        if loss_type == "dpace-cumulative-confidence-only":
+            return prefix
+
+        suffix = torch.flip(
+            torch.cumsum(torch.flip(prefix * binary_mask, dims=[-1]), dim=-1),
+            dims=[-1],
+        )
+
+        if loss_type == "dpace":
+            return suffix
+        if loss_type == "dpace-continuation-value-only":
+            return suffix / prefix.clamp_min(torch.finfo(prefix.dtype).tiny)
+        raise ValueError(f"unknown D-PACE loss_type {loss_type!r}")
+
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -291,22 +343,39 @@ class OnlineDFlashModel(nn.Module):
 
         binary_eval_mask = weight_mask.view(-1)
 
-        # --- Loss decay: exp(-(k-1)/γ) so k=1 (1st prediction) gets weight 1.0 ---
-        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
-            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
-            decay_weights = torch.exp(
-                -(k - 1).clamp(min=0).float() / self.loss_decay_gamma
-            )
-            weight_mask = weight_mask * decay_weights
-
         # --- Cross entropy ---
         flat_logits = logits.view(-1, logits.size(-1))
         flat_targets = target_ids.view(-1)
-        flat_weights = weight_mask.view(-1)
 
         loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
-        valid_token_count = flat_weights.sum() + 1e-6
-        loss = (loss_per_token * flat_weights).sum() / valid_token_count
+
+        if self.loss_type == "dflash":
+            # Preserve the existing DFlash weighted-mean behavior.
+            loss_weights = weight_mask
+            if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+                k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+                decay_weights = torch.exp(
+                    -(k - 1).clamp(min=0).float() / self.loss_decay_gamma
+                )
+                loss_weights = loss_weights * decay_weights
+
+            flat_weights = loss_weights.view(-1)
+            valid_token_count = flat_weights.sum() + 1e-6
+            loss = (loss_per_token * flat_weights).sum() / valid_token_count
+        elif self.loss_type in _DPACE_LOSS_TYPES:
+            neg_log_q = loss_per_token.view_as(target_ids)
+            with torch.no_grad():
+                q = torch.exp(-neg_log_q)
+                dpace_weights = self._dpace_weight(
+                    q,
+                    weight_mask,
+                    weight_mask > 0,
+                    self.loss_type,
+                )
+            loss_weights = weight_mask * dpace_weights
+            loss = (neg_log_q * loss_weights).sum() / float(bsz)
+        else:
+            raise ValueError(f"unknown loss_type {self.loss_type!r}")
 
         # --- Accuracy ---
         with torch.no_grad():

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -1,0 +1,329 @@
+# coding=utf-8
+"""Formula-level tests for DFlash/D-PACE loss behavior.
+
+The tests load ``specforge/core/dflash.py`` directly with a lightweight draft
+model stub so they can run on CPU without importing the full modeling stack.
+They still exercise ``OnlineDFlashModel.forward``: anchor sampling, draft
+output, and LM head output are made deterministic.
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+REPO = Path(__file__).resolve().parents[2]
+
+_stub_dflash_draft = types.ModuleType("specforge.modeling.draft.dflash")
+
+
+class _DFlashDraftStub(nn.Module):
+    pass
+
+
+_stub_dflash_draft.DFlashDraftModel = _DFlashDraftStub
+
+_spec = importlib.util.spec_from_file_location(
+    "specforge.core.dflash", REPO / "specforge" / "core" / "dflash.py"
+)
+_dflash_module = importlib.util.module_from_spec(_spec)
+
+_pkg_specforge = types.ModuleType("specforge")
+_pkg_specforge.__path__ = [str(REPO / "specforge")]
+_pkg_core = types.ModuleType("specforge.core")
+_pkg_core.__path__ = [str(REPO / "specforge" / "core")]
+_pkg_modeling = types.ModuleType("specforge.modeling")
+_pkg_modeling.__path__ = [str(REPO / "specforge" / "modeling")]
+_pkg_draft = types.ModuleType("specforge.modeling.draft")
+_pkg_draft.__path__ = [str(REPO / "specforge" / "modeling" / "draft")]
+
+with patch.dict(
+    sys.modules,
+    {
+        "specforge": _pkg_specforge,
+        "specforge.core": _pkg_core,
+        "specforge.core.dflash": _dflash_module,
+        "specforge.modeling": _pkg_modeling,
+        "specforge.modeling.draft": _pkg_draft,
+        "specforge.modeling.draft.dflash": _stub_dflash_draft,
+    },
+):
+    _spec.loader.exec_module(_dflash_module)
+OnlineDFlashModel = _dflash_module.OnlineDFlashModel
+
+
+class _FixedDraft(nn.Module):
+    def __init__(self, hidden_size: int):
+        super().__init__()
+        self.hidden_size = hidden_size
+
+    def forward(self, position_ids, noise_embedding, target_hidden, attention_mask):
+        bsz, draft_len = noise_embedding.shape[:2]
+        return torch.zeros(
+            bsz,
+            draft_len,
+            self.hidden_size,
+            dtype=noise_embedding.dtype,
+            device=noise_embedding.device,
+        )
+
+
+class _FixedHead(nn.Module):
+    def __init__(self, logits: torch.Tensor):
+        super().__init__()
+        self.register_buffer("fixed_logits", logits)
+
+    def forward(self, hidden_states):
+        return self.fixed_logits.to(device=hidden_states.device)
+
+
+def _fixed_noise_embed(self, input_ids, anchor_positions, block_keep_mask):
+    bsz, n_blocks = anchor_positions.shape
+    return torch.zeros(
+        bsz,
+        n_blocks * self.block_size,
+        self.embed_tokens.embedding_dim,
+        dtype=torch.double,
+        device=input_ids.device,
+    )
+
+
+def _fixed_anchor_sampler(anchors, keep_mask):
+    def _sample(self, seq_len, loss_mask, device):
+        return anchors.to(device), keep_mask.to(device)
+
+    return _sample
+
+
+def _make_model(logits, anchors, keep_mask, **kwargs):
+    bsz, n_blocks, block_size, vocab_size = logits.shape
+    model = OnlineDFlashModel(
+        draft_model=_FixedDraft(hidden_size=4),
+        target_lm_head=_FixedHead(
+            logits.reshape(bsz, n_blocks * block_size, vocab_size)
+        ),
+        target_embed_tokens=nn.Embedding(vocab_size, 4).double(),
+        mask_token_id=0,
+        block_size=block_size,
+        attention_backend="sdpa",
+        num_anchors=n_blocks,
+        **kwargs,
+    ).double()
+    model._sample_anchor_positions = types.MethodType(
+        _fixed_anchor_sampler(anchors, keep_mask), model
+    )
+    model._create_noise_embed = types.MethodType(_fixed_noise_embed, model)
+    return model
+
+
+def _sample_tensors():
+    torch.manual_seed(123)
+    bsz, n_blocks, block_size, vocab_size = 2, 2, 5, 13
+    seq_len = 9
+    logits = torch.randn(bsz, n_blocks, block_size, vocab_size, dtype=torch.double)
+    input_ids = torch.tensor(
+        [
+            [1, 4, 2, 8, 3, 7, 5, 6, 9],
+            [2, 5, 1, 4, 7, 3, 8, 10, 11],
+        ],
+        dtype=torch.long,
+    )
+    loss_mask = torch.ones(bsz, seq_len, dtype=torch.double)
+    loss_mask[0, 7] = 0.0
+    loss_mask[1, 6] = 0.0
+    anchors = torch.tensor([[0, 3], [1, 4]], dtype=torch.long)
+    keep_mask = torch.tensor([[True, True], [True, False]])
+    hidden_states = torch.zeros(bsz, seq_len, 4, dtype=torch.double)
+    return logits, input_ids, loss_mask, hidden_states, anchors, keep_mask
+
+
+def _targets_and_mask(input_ids, loss_mask, anchors, keep_mask, block_size):
+    bsz, seq_len = input_ids.shape
+    n_blocks = anchors.shape[1]
+    offsets = torch.arange(block_size).view(1, 1, -1)
+    label_indices = anchors.unsqueeze(-1) + offsets
+    safe_indices = label_indices.clamp(max=seq_len - 1)
+    targets = torch.gather(
+        input_ids.unsqueeze(1).expand(-1, n_blocks, -1),
+        2,
+        safe_indices,
+    )
+    binary_mask = keep_mask.unsqueeze(-1).expand(-1, -1, block_size).double()
+    binary_mask = binary_mask * (label_indices < seq_len).double()
+    binary_mask = binary_mask * (offsets > 0).double()
+    gathered_loss_mask = torch.gather(
+        loss_mask.unsqueeze(1).expand(-1, n_blocks, -1),
+        2,
+        safe_indices,
+    )
+    binary_mask = binary_mask * gathered_loss_mask
+    return targets, binary_mask
+
+
+def _neg_log_q(logits, targets):
+    return F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)),
+        targets.reshape(-1),
+        reduction="none",
+    ).view_as(targets)
+
+
+def _naive_dpace_weight(prob, binary_mask, alpha, loss_type):
+    smooth = (1.0 - alpha) * prob + alpha
+    smooth = torch.where(binary_mask > 0, smooth, torch.ones_like(smooth))
+    prefix = torch.cumprod(smooth, dim=-1)
+    if loss_type == "dpace-cumulative-confidence-only":
+        return prefix
+    suffix = torch.flip(
+        torch.cumsum(torch.flip(prefix * binary_mask, dims=[-1]), dim=-1),
+        dims=[-1],
+    )
+    if loss_type == "dpace":
+        return suffix
+    if loss_type == "dpace-continuation-value-only":
+        return suffix / prefix.clamp_min(torch.finfo(prefix.dtype).tiny)
+    raise ValueError(loss_type)
+
+
+def _naive_dflash_loss(neg_log_q, binary_mask, gamma):
+    weight = binary_mask
+    if gamma is not None and gamma > 0:
+        block_size = neg_log_q.shape[-1]
+        positions = torch.arange(block_size, dtype=neg_log_q.dtype).view(1, 1, -1)
+        decay = torch.exp(-(positions - 1).clamp(min=0) / gamma)
+        weight = weight * decay
+    return (neg_log_q * weight).sum() / (weight.sum() + 1e-6)
+
+
+class TestDFlashLosses(unittest.TestCase):
+    def setUp(self):
+        (
+            self.logits,
+            self.input_ids,
+            self.loss_mask,
+            self.hidden_states,
+            self.anchors,
+            self.keep_mask,
+        ) = _sample_tensors()
+        self.targets, self.binary_mask = _targets_and_mask(
+            self.input_ids,
+            self.loss_mask,
+            self.anchors,
+            self.keep_mask,
+            self.logits.shape[2],
+        )
+        self.neg_log_q = _neg_log_q(self.logits, self.targets)
+        self.q = torch.exp(-self.neg_log_q)
+
+    def _forward_loss(self, **kwargs):
+        model = _make_model(self.logits, self.anchors, self.keep_mask, **kwargs)
+        loss, accuracy = model(
+            input_ids=self.input_ids,
+            hidden_states=self.hidden_states,
+            loss_mask=self.loss_mask,
+        )
+        self.assertTrue(torch.isfinite(loss))
+        self.assertTrue(torch.isfinite(accuracy))
+        return loss
+
+    def test_dflash_default_matches_existing_weighted_mean(self):
+        got = self._forward_loss()
+        want = _naive_dflash_loss(self.neg_log_q, self.binary_mask, gamma=None)
+        torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
+
+    def test_dflash_decay_gamma_is_preserved(self):
+        gamma = 7.0
+        got = self._forward_loss(loss_type="dflash", loss_decay_gamma=gamma)
+        want = _naive_dflash_loss(self.neg_log_q, self.binary_mask, gamma=gamma)
+        torch.testing.assert_close(got, want, rtol=0, atol=1e-8)
+
+    def test_dpace_full_matches_naive_reference(self):
+        alpha = 0.5
+        got = self._forward_loss(loss_type="dpace", dpace_alpha=alpha)
+        weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
+        want = (self.neg_log_q * weight * self.binary_mask).sum() / float(
+            self.input_ids.shape[0]
+        )
+        torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
+
+    def test_cumulative_confidence_ablation_matches_naive_reference(self):
+        alpha = 0.5
+        got = self._forward_loss(
+            loss_type="dpace-cumulative-confidence-only", dpace_alpha=alpha
+        )
+        weight = _naive_dpace_weight(
+            self.q,
+            self.binary_mask,
+            alpha,
+            "dpace-cumulative-confidence-only",
+        )
+        want = (self.neg_log_q * weight * self.binary_mask).sum() / float(
+            self.input_ids.shape[0]
+        )
+        torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
+
+    def test_continuation_value_ablation_matches_naive_reference(self):
+        alpha = 0.5
+        got = self._forward_loss(
+            loss_type="dpace-continuation-value-only", dpace_alpha=alpha
+        )
+        weight = _naive_dpace_weight(
+            self.q,
+            self.binary_mask,
+            alpha,
+            "dpace-continuation-value-only",
+        )
+        want = (self.neg_log_q * weight * self.binary_mask).sum() / float(
+            self.input_ids.shape[0]
+        )
+        torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
+
+    def test_dpace_loss_reduces_by_batch_size(self):
+        alpha = 0.5
+        got = self._forward_loss(loss_type="dpace", dpace_alpha=alpha)
+        weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
+        weighted_sum = (self.neg_log_q * weight * self.binary_mask).sum()
+        token_count_loss = weighted_sum / ((weight * self.binary_mask).sum() + 1e-6)
+        batch_loss = weighted_sum / float(self.input_ids.shape[0])
+        torch.testing.assert_close(got, batch_loss, rtol=0, atol=1e-10)
+        self.assertFalse(torch.allclose(got, token_count_loss))
+
+    def test_alpha_changes_dpace_loss(self):
+        low_alpha = self._forward_loss(loss_type="dpace", dpace_alpha=0.1)
+        high_alpha = self._forward_loss(loss_type="dpace", dpace_alpha=0.9)
+        self.assertNotAlmostEqual(low_alpha.item(), high_alpha.item(), places=8)
+
+    def test_invalid_loss_type_rejected(self):
+        with self.assertRaisesRegex(ValueError, "loss_type"):
+            _make_model(
+                self.logits,
+                self.anchors,
+                self.keep_mask,
+                loss_type="topk_mask",
+            )
+
+    def test_invalid_dpace_alpha_rejected(self):
+        with self.assertRaisesRegex(ValueError, "dpace_alpha"):
+            _make_model(
+                self.logits,
+                self.anchors,
+                self.keep_mask,
+                loss_type="dpace",
+                dpace_alpha=1.5,
+            )
+
+    def test_dflash_draft_stub_does_not_leak_to_sys_modules(self):
+        self.assertIsNot(
+            sys.modules.get("specforge.modeling.draft.dflash"),
+            _stub_dflash_draft,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds [D-PACE](https://arxiv.org/pdf/2605.18810) as an optional training objective for DFlash in SpecForge.

The goal is to make it easy to compare the original DFlash loss against the D-PACE loss proposed in *D-PACE: Dynamic Position-Aware Cross-Entropy for Parallel Speculative Drafting* without changing the drafter architecture or inference pipeline.

### What changed

Added a new training argument:

```bash
--loss-type
```

Supported values:

```text
dflash
dpace
dpace-cumulative-confidence-only
dpace-continuation-value-only
```

Added:

```bash
--dpace-alpha
```

for confidence smoothing.

Extended `OnlineDFlashModel` with:

```python
loss_type
dpace_alpha
```

The existing DFlash behavior remains the default:

```bash
--loss-type dflash
```

so existing training workflows are unchanged.

The D-PACE implementation computes detached position weights from:

- cumulative confidence
- continuation value

and applies them to the per-position cross-entropy loss.

Also included:

- `examples/run_qwen3_8b_dpace_online.sh`
- README updates
- CPU-only unit tests

### Motivation

DFlash uses a fixed position-dependent weighting schedule.

D-PACE replaces this with adaptive per-sample position weights derived from the drafter's current confidence estimates.

The intuition is that training signal should focus more on positions that currently limit accepted draft length rather than following a fixed position schedule throughout training.

This PR exposes that alternative objective while preserving the existing DFlash objective as the default path.

### Validation

#### Unit tests

```bash
python -m pytest tests/test_utils/test_dflash_losses.py -q
```

Result:

```text
9 passed
```

Coverage includes:

- DFlash compatibility
- D-PACE equivalence against naive references
- cumulative-confidence-only ablation
- continuation-value-only ablation
- batch reduction behavior
- alpha sensitivity
- argument validation

#### Loss-path benchmark

Synthetic forward + backward benchmark on H200 GPUs.

| loss_type                        | mean step time (ms) | relative to dflash |
| -------------------------------- | ------------------- | ------------------ |
| dflash                           | 3.794               | baseline           |
| dpace                            | 3.838               | +1.16%             |
| dpace-cumulative-confidence-only | 3.784               | -0.26%             |
| dpace-continuation-value-only    | 3.816               | +0.58%             |

Observed overhead of the D-PACE loss path is small and consistent with the paper's claim that the objective introduces only modest training-time cost.

#### Surrogate sanity check

For a synthetic acceptance-length simulation:

```text
Pearson correlation  = 0.990
Spearman correlation = 0.988
```

The confidence-prefix surrogate closely tracks simulated emitted/accepted length and preserves sample ranking, which is the intended signal used by D-PACE for adaptive weighting.