### PR TITLE
feat: compact draft-vocab teacher for offline EAGLE-3 training (default off)

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -83,10 +83,8 @@ def print_cuda_memory_debug(label: str) -> None:
     )
 
 
-def parse_args() -> Tuple[ArgumentParser, Namespace]:
-    """
-    This function is used to parse the arguments for the training script.
-    """
+def build_parser() -> ArgumentParser:
+    """Build the training argument parser (import-safe seam for tests)."""
     parser = argparse.ArgumentParser(description="Train Eagle3 with online data")
 
     # add model-related arguments
@@ -233,6 +231,25 @@ def parse_args() -> Tuple[ArgumentParser, Namespace]:
     optimization_group.add_argument("--sp-ulysses-size", type=int, default=1)
     optimization_group.add_argument("--sp-ring-size", type=int, default=1)
     optimization_group.add_argument(
+        "--compact-teacher",
+        action="store_true",
+        help=(
+            "Offline only: compute the EAGLE-3 teacher distribution from target "
+            "hidden states via a draft-vocab-sliced head plus a streaming "
+            "logsumexp/argmax, avoiding the full-vocab [B, S, vocab] fp32 logits. "
+            "Default off; training behavior is unchanged when off."
+        ),
+    )
+    optimization_group.add_argument(
+        "--compact-teacher-chunk-size",
+        type=int,
+        default=None,
+        help=(
+            "Vocabulary chunk size for the compact-teacher streaming reduction. "
+            "Defaults to compact_teacher.DEFAULT_VOCAB_CHUNK_SIZE when unset."
+        ),
+    )
+    optimization_group.add_argument(
         "--attention-backend",
         type=str,
         default="flex_attention",
@@ -282,8 +299,40 @@ def parse_args() -> Tuple[ArgumentParser, Namespace]:
     tracker_group = parser.add_argument_group("tracker")
     TrackerArgs.add_args(tracker_group)
 
+    return parser
+
+
+def parse_args() -> Tuple[ArgumentParser, Namespace]:
+    """Parse CLI arguments for the training script."""
+    parser = build_parser()
     args = parser.parse_args()
     return parser, args
+
+
+def validate_compact_teacher_args(
+    args: Namespace,
+    is_online: bool,
+    target_model,
+    draft_model,
+    draft_model_config,
+) -> None:
+    """Validate compact-teacher settings before training (offline exact mode)."""
+    from specforge.core.compact_teacher import (
+        validate_compact_teacher_enabled,
+        validate_vocab_mapping_consistency,
+    )
+
+    target_head_weight = getattr(getattr(target_model, "fc", None), "weight", None)
+    validate_compact_teacher_enabled(
+        is_online=is_online,
+        is_vlm=args.is_vlm,
+        draft_vocab_size=draft_model_config.draft_vocab_size,
+        vocab_size=draft_model_config.vocab_size,
+        t2d=draft_model.t2d,
+        target_head_weight=target_head_weight,
+        chunk_size=args.compact_teacher_chunk_size,
+    )
+    validate_vocab_mapping_consistency(draft_model.t2d, draft_model.d2t)
 
 
 def build_tracker(args: Namespace, parser: ArgumentParser) -> Tracker:
@@ -613,6 +662,21 @@ def build_dataloaders(
     )
 
 
+def filter_draft_state_dict(model_state_dict: dict) -> dict:
+    """Keep only draft-model weights for the serving checkpoint (drop embeddings).
+
+    Embeddings are intentionally excluded (SGLang loads them from the target); the
+    target ``TargetHead`` is never part of the wrapped draft model, so no teacher state
+    can leak. The compact-teacher flag adds no new draft-model state, so its export is
+    identical to the full path.
+    """
+    return {
+        k.replace("draft_model.", ""): v
+        for k, v in model_state_dict.items()
+        if "draft_model." in k and "embed" not in k.lower()
+    }
+
+
 def save_checkpoints(
     args: Namespace,
     epoch: int,
@@ -633,11 +697,7 @@ def save_checkpoints(
             "args": args,
         }
         state_to_save.update(optimizer.state_dict())
-        draft_model_state_dict = {
-            k.replace("draft_model.", ""): v
-            for k, v in model_state_dict.items()
-            if "draft_model." in k and "embed" not in k.lower()
-        }
+        draft_model_state_dict = filter_draft_state_dict(model_state_dict)
 
         if dist.get_rank() == 0:
             torch.save(
@@ -688,6 +748,7 @@ def run_forward(
         )
     else:
         image_grid_thw = None
+        compact_kwargs = {}
         if is_online:
             # we generate the eagle3 using the target model in an online fashion
             # Handle VLM data: pixel_values and image_grid_thw are lists
@@ -738,10 +799,16 @@ def run_forward(
                 data["input_ids"], data["target"], data["loss_mask"]
             )
             input_ids = input_ids.cuda()
-            target = target_model(
-                target.cuda()
-            )  # The `data['target']` value occupies a large amount of GPU memory, with a shape of [seqlen, vocab_size]. It needs to be processed before being loaded into the GPU.
             loss_mask = loss_mask.cuda()
+            from specforge.core.compact_teacher import build_offline_teacher_inputs
+
+            target, offline_compact_kwargs = build_offline_teacher_inputs(
+                compact=args.compact_teacher,
+                target_model=target_model,
+                target_hidden=target.cuda(),
+                chunk_size_arg=args.compact_teacher_chunk_size,
+            )
+            compact_kwargs.update(offline_compact_kwargs)
         (
             plosses,
             acceptance_rates,
@@ -761,6 +828,7 @@ def run_forward(
             ),
             image_grid_thw=image_grid_thw,
             is_vlm=args.is_vlm,
+            **compact_kwargs,
         )
     return (
         plosses,
@@ -956,6 +1024,12 @@ def main():
     draft_model.load_vocab_mapping(vocab_mapping_path)
     print_with_rank("Loaded vocab mapping")
     print_cuda_memory_debug("after load_vocab_mapping")
+
+    if args.compact_teacher:
+        validate_compact_teacher_args(
+            args, is_online, target_model, draft_model, draft_model_config
+        )
+        print_with_rank("Validated compact-teacher configuration (offline exact mode)")
 
     # Calculate total steps if not provided
     if args.total_steps is None:

--- a/specforge/core/compact_teacher.py
+++ b/specforge/core/compact_teacher.py
@@ -1,0 +1,277 @@
+# coding=utf-8
+# Licensed under the Apache License, Version 2.0 (the "License").
+"""Compact (draft-vocabulary) teacher distribution for EAGLE-3 training.
+
+Reproduces the teacher quantities of ``specforge.core.eagle3._compute_target_p`` from
+the target's last hidden states and ``lm_head`` weight without materializing the full
+``[B, S, vocab_size]`` fp32 logits: the draft-vocab logits come from a ``t2d``-sliced
+head, and the full-vocab ``logsumexp``/``argmax`` from a streaming reduction over
+vocabulary chunks.
+
+Scope: offline training only. The teacher uses the full (unsharded, rank-replicated)
+target ``lm_head`` weight, so the computation is a pure function of
+``(hidden, weight, t2d)`` with no cross-rank/tensor-parallel sharding of the teacher
+head; every rank computes identical teacher tensors from identical inputs. Online
+compact training is not supported in this release.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+DEFAULT_VOCAB_CHUNK_SIZE = 32768
+
+
+def validate_compact_teacher_config(
+    *,
+    draft_vocab_size: int,
+    vocab_size: int,
+    t2d: torch.Tensor,
+) -> None:
+    """Validate the draft/vocab sizes and the ``t2d`` mask, or raise ValueError."""
+    if draft_vocab_size >= vocab_size:
+        raise ValueError(
+            "compact teacher requires draft_vocab_size < vocab_size; got "
+            f"draft_vocab_size={draft_vocab_size}, vocab_size={vocab_size}."
+        )
+    if t2d is None:
+        raise ValueError(
+            "compact teacher requires a loaded t2d vocab mapping; got None."
+        )
+    if t2d.dtype != torch.bool:
+        raise ValueError(f"t2d must be a bool tensor, got dtype {t2d.dtype}.")
+    if t2d.dim() != 1 or t2d.shape[0] != vocab_size:
+        raise ValueError(
+            f"t2d must have shape [vocab_size]={[vocab_size]}, got {list(t2d.shape)}."
+        )
+    selected = int(t2d.sum().item())
+    if selected != draft_vocab_size:
+        raise ValueError(
+            f"t2d selects {selected} tokens but draft_vocab_size={draft_vocab_size}."
+        )
+
+
+@torch.no_grad()
+def tiled_logsumexp_argmax(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Full-vocabulary fp32 ``logsumexp`` (``[..., 1]``) and ``argmax`` (``[...]``).
+
+    Streams over vocabulary chunks without allocating ``[..., vocab_size]``. Chunk
+    logits are upcast to fp32 to match ``target.float()``; ties resolve to the lowest
+    index like ``torch.argmax``.
+    """
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive, got {chunk_size}.")
+
+    vocab_size = weight.shape[0]
+    lead_shape = hidden.shape[:-1]
+    device = hidden.device
+
+    neg_inf = float("-inf")
+    running_max = torch.full(
+        (*lead_shape, 1), neg_inf, dtype=torch.float32, device=device
+    )
+    running_sumexp = torch.zeros((*lead_shape, 1), dtype=torch.float32, device=device)
+    running_argval = torch.full(lead_shape, neg_inf, dtype=torch.float32, device=device)
+    running_argmax = torch.zeros(lead_shape, dtype=torch.long, device=device)
+
+    for start in range(0, vocab_size, chunk_size):
+        end = min(start + chunk_size, vocab_size)
+        chunk_logits = F.linear(hidden, weight[start:end]).float()
+
+        chunk_max = chunk_logits.max(dim=-1, keepdim=True).values
+        new_max = torch.maximum(running_max, chunk_max)
+        running_sumexp = running_sumexp * torch.exp(running_max - new_max) + torch.exp(
+            chunk_logits - new_max
+        ).sum(dim=-1, keepdim=True)
+        running_max = new_max
+
+        # Ascending scan + strict-greater update keeps the lowest global index on ties.
+        chunk_val, chunk_idx = chunk_logits.max(dim=-1)
+        chunk_idx = chunk_idx + start
+        take = chunk_val > running_argval
+        running_argmax = torch.where(take, chunk_idx, running_argmax)
+        running_argval = torch.where(take, chunk_val, running_argval)
+
+    log_z = running_max + torch.log(running_sumexp)
+    return log_z, running_argmax
+
+
+@torch.no_grad()
+def compute_target_from_hidden(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    t2d: torch.Tensor,
+    loss_mask: torch.Tensor,
+    *,
+    chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compact-teacher equivalent of ``_compute_target_p``, computed from hidden states.
+
+    Returns detached ``(target_p, target_p_on_draft, target_token_ids, position_mask)``
+    matching the full-vocab path within fp tolerance, without a ``[B, S, vocab]`` fp32
+    tensor.
+    """
+    if t2d.dtype != torch.bool:
+        raise ValueError(f"t2d must be a bool mask, got dtype {t2d.dtype}.")
+    if t2d.shape[0] != lm_head_weight.shape[0]:
+        raise ValueError(
+            f"t2d length {t2d.shape[0]} must equal vocab_size {lm_head_weight.shape[0]}."
+        )
+    if hidden.shape[-1] != lm_head_weight.shape[1]:
+        raise ValueError(
+            f"hidden size {hidden.shape[-1]} must equal lm_head hidden size "
+            f"{lm_head_weight.shape[1]}."
+        )
+
+    # weight[t2d] keeps the same row order as (full_logits)[..., t2d] column slicing.
+    draft_logits = F.linear(hidden, lm_head_weight[t2d]).float()
+    target_p = torch.softmax(draft_logits, dim=-1)
+
+    log_z, target_token_ids = tiled_logsumexp_argmax(
+        hidden, lm_head_weight, chunk_size=chunk_size
+    )
+    target_p_on_draft = torch.exp(draft_logits - log_z)
+
+    target_mask = t2d[target_token_ids][..., None].int()
+    position_mask = target_mask * loss_mask
+
+    return (
+        target_p.detach(),
+        target_p_on_draft.detach(),
+        target_token_ids.detach(),
+        position_mask,
+    )
+
+
+@torch.no_grad()
+def compute_target_p_padded_from_hidden(
+    hidden: torch.Tensor,
+    lm_head_weight: torch.Tensor,
+    t2d: torch.Tensor,
+    loss_mask: torch.Tensor,
+    length: int,
+    *,
+    chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Compact-teacher equivalent of ``_compute_target_p_padded`` (same pad constants)."""
+    (
+        target_p,
+        target_p_on_draft,
+        target_token_ids,
+        position_mask,
+    ) = compute_target_from_hidden(
+        hidden, lm_head_weight, t2d, loss_mask, chunk_size=chunk_size
+    )
+
+    assert target_p.dim() == 3
+    target_p_padded = F.pad(
+        target_p, pad=(0, 0, 0, length), mode="constant", value=1 / target_p.shape[-1]
+    )
+    target_p_on_draft_padded = F.pad(
+        target_p_on_draft, pad=(0, 0, 0, length), mode="constant", value=0.0
+    )
+    target_token_ids_padded = F.pad(
+        target_token_ids, pad=(0, length), mode="constant", value=0
+    )
+
+    return (
+        target_p_padded,
+        target_p_on_draft_padded,
+        target_token_ids_padded,
+        position_mask,
+    )
+
+
+def build_offline_teacher_inputs(
+    *,
+    compact: bool,
+    target_model,
+    target_hidden: torch.Tensor,
+    chunk_size_arg: Optional[int],
+):
+    """Decide the offline teacher inputs for ``run_forward``.
+
+    ``compact=False`` returns ``(target_model(target_hidden), {})`` (full logits, legacy).
+    ``compact=True`` returns ``(None, {...})`` from ``target_model.fc.weight`` without
+    calling ``target_model.forward``.
+    """
+    if not compact:
+        return target_model(target_hidden), {}
+    chunk_size = (
+        chunk_size_arg if chunk_size_arg is not None else DEFAULT_VOCAB_CHUNK_SIZE
+    )
+    return None, {
+        "target_hidden_for_compact": target_hidden,
+        "target_head_weight": target_model.fc.weight,
+        "compact_teacher_chunk_size": chunk_size,
+    }
+
+
+def validate_vocab_mapping_consistency(t2d: torch.Tensor, d2t: torch.Tensor) -> None:
+    """Require the ascending ids selected by ``t2d`` to equal ``d2t + arange``."""
+    selected = torch.nonzero(t2d.bool(), as_tuple=False).flatten()
+    if selected.numel() != d2t.numel():
+        raise ValueError(
+            f"t2d selects {selected.numel()} tokens but d2t has {d2t.numel()} entries."
+        )
+    expected = d2t.to(device=selected.device, dtype=selected.dtype) + torch.arange(
+        d2t.numel(), device=selected.device, dtype=selected.dtype
+    )
+    if not torch.equal(selected, expected):
+        raise ValueError(
+            "t2d/d2t mapping is inconsistent: nonzero(t2d) must equal "
+            "d2t + arange(draft_vocab_size)."
+        )
+
+
+def validate_compact_teacher_enabled(
+    *,
+    is_online: bool,
+    is_vlm: bool,
+    draft_vocab_size: int,
+    vocab_size: int,
+    t2d: torch.Tensor,
+    target_head_weight: torch.Tensor,
+    chunk_size: Optional[int] = None,
+) -> None:
+    """Validate that the compact teacher path may be enabled, or raise ValueError.
+
+    Hidden-size compatibility of ``target_head_weight`` is enforced at runtime by
+    ``compute_target_from_hidden``.
+    """
+    if is_online:
+        raise ValueError(
+            "compact teacher supports offline training only; disable --compact-teacher "
+            "or train offline."
+        )
+    if is_vlm:
+        raise ValueError(
+            "compact teacher does not support VLM training yet; disable --compact-teacher."
+        )
+    if target_head_weight is None:
+        raise ValueError(
+            "compact teacher (offline) requires a TargetHead lm_head weight (fc.weight)."
+        )
+    if target_head_weight.dim() != 2:
+        raise ValueError(
+            "target_head_weight must be 2-D [vocab_size, hidden_size], got shape "
+            f"{list(target_head_weight.shape)}."
+        )
+    if target_head_weight.shape[0] != vocab_size:
+        raise ValueError(
+            f"target_head_weight has {target_head_weight.shape[0]} rows but vocab_size "
+            f"is {vocab_size}."
+        )
+    if chunk_size is not None and chunk_size <= 0:
+        raise ValueError(
+            f"--compact-teacher-chunk-size must be a positive integer, got {chunk_size}."
+        )
+    validate_compact_teacher_config(
+        draft_vocab_size=draft_vocab_size, vocab_size=vocab_size, t2d=t2d
+    )

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -27,6 +27,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.cache_utils import DynamicCache
 
+from specforge.core.compact_teacher import (
+    DEFAULT_VOCAB_CHUNK_SIZE,
+    compute_target_p_padded_from_hidden,
+)
 from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspAdapter
 from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
 from specforge.core.loss import LogSoftmaxLoss
@@ -239,6 +243,9 @@ class OnlineEagle3Model(Eagle3Model):
         position_ids: Optional[torch.Tensor] = None,
         image_grid_thw: Optional[torch.Tensor] = None,
         is_vlm: bool = False,
+        target_hidden_for_compact: Optional[torch.Tensor] = None,
+        target_head_weight: Optional[torch.Tensor] = None,
+        compact_teacher_chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
         **kwargs,
     ) -> Tuple[
         List[torch.Tensor],
@@ -258,20 +265,39 @@ class OnlineEagle3Model(Eagle3Model):
             loss_mask: (batch, seq_len)
             past_key_values: We dont use this past_key_values in eagle3, but keep it for compatibility. We control kvcache by cache_hidden.
             position_ids: (batch, seq_len)
+            target_hidden_for_compact, target_head_weight, compact_teacher_chunk_size:
+                when the first two are given, the padded teacher is built from hidden
+                states in draft-vocab space and ``target`` is ignored.
         """
         # Step 1: handle vocab size
-        (
-            target_p_padded,
-            target_p_on_draft_padded,
-            target_token_ids_padded,
-            position_mask,
-        ) = _compute_target_p_padded(
-            target=target,
-            t2d=self.draft_model.t2d,
-            loss_mask=loss_mask,
-            length=self.length,
-        )
-        del target
+        if target_hidden_for_compact is not None:
+            (
+                target_p_padded,
+                target_p_on_draft_padded,
+                target_token_ids_padded,
+                position_mask,
+            ) = compute_target_p_padded_from_hidden(
+                hidden=target_hidden_for_compact,
+                lm_head_weight=target_head_weight,
+                t2d=self.draft_model.t2d,
+                loss_mask=loss_mask,
+                length=self.length,
+                chunk_size=compact_teacher_chunk_size,
+            )
+            del target_hidden_for_compact
+        else:
+            (
+                target_p_padded,
+                target_p_on_draft_padded,
+                target_token_ids_padded,
+                position_mask,
+            ) = _compute_target_p_padded(
+                target=target,
+                t2d=self.draft_model.t2d,
+                loss_mask=loss_mask,
+                length=self.length,
+            )
+            del target
         torch.cuda.empty_cache()
 
         # basic info

--- a/tests/test_scripts/test_compact_teacher_integration.py
+++ b/tests/test_scripts/test_compact_teacher_integration.py
@@ -1,0 +1,225 @@
+"""Integration tests for the offline compact-teacher path in scripts/train_eagle3.py.
+
+Exercises the real ``build_parser``, ``run_forward``, and
+``validate_compact_teacher_args`` with lightweight doubles. Self-skips if torch or the
+training script cannot be imported here (e.g. an sglang version skew); see
+BL-20260613-specforge-import-isolation.
+"""
+
+import importlib.util
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+try:
+    import torch
+
+    _HAS_TORCH = True
+except Exception as exc:  # pragma: no cover - environment dependent
+    torch = None
+    _HAS_TORCH = False
+    _TORCH_ERROR = exc
+
+
+def _load_train_module():
+    spec = importlib.util.spec_from_file_location(
+        "train_eagle3_under_test", ROOT / "scripts" / "train_eagle3.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+if _HAS_TORCH:
+    try:
+        train_mod = _load_train_module()
+        IMPORT_ERROR = None
+    except Exception as exc:  # pragma: no cover - environment dependent
+        train_mod = None
+        IMPORT_ERROR = exc
+else:
+    train_mod = None
+    IMPORT_ERROR = _TORCH_ERROR
+
+_SKIP = train_mod is None
+_SKIP_MSG = f"train_eagle3 import unavailable: {IMPORT_ERROR}"
+_HAS_CUDA = bool(_HAS_TORCH and torch.cuda.is_available())
+
+
+if _HAS_TORCH:
+
+    class _TargetHeadDouble(torch.nn.Module):
+        def __init__(self, hidden_size, vocab_size):
+            super().__init__()
+            self.fc = torch.nn.Linear(hidden_size, vocab_size, bias=False)
+            self.forward_calls = 0
+
+        def preprocess(self, input_ids, target, loss_mask):
+            return input_ids, target, loss_mask[..., None]
+
+        def forward(self, x):
+            self.forward_calls += 1
+            return self.fc(x)
+
+    class _RecordingEagle3Model:
+        def __init__(self):
+            self.kwargs = None
+
+        def __call__(self, **kwargs):
+            self.kwargs = kwargs
+            dummy = [torch.tensor(0.0)]
+            return (dummy, dummy, dummy, dummy, dummy, dummy, dummy)
+
+    def _mapping(vocab=64, draft=16):
+        sel = torch.sort(
+            torch.randperm(vocab, generator=torch.Generator().manual_seed(0))[:draft]
+        ).values
+        t2d = torch.zeros(vocab, dtype=torch.bool)
+        t2d[sel] = True
+        d2t = sel - torch.arange(draft)
+        return t2d, d2t
+
+
+@unittest.skipIf(_SKIP, _SKIP_MSG)
+class TestBuildParser(unittest.TestCase):
+    def _base_args(self):
+        return [
+            "--target-model-path",
+            "m",
+            "--train-data-path",
+            "d",
+            "--output-dir",
+            "o",
+        ]
+
+    def test_compact_teacher_defaults_off(self):
+        args = train_mod.build_parser().parse_args(self._base_args())
+        self.assertFalse(args.compact_teacher)
+        self.assertIsNone(args.compact_teacher_chunk_size)
+
+    def test_compact_teacher_flags_parse(self):
+        args = train_mod.build_parser().parse_args(
+            self._base_args()
+            + ["--compact-teacher", "--compact-teacher-chunk-size", "8"]
+        )
+        self.assertTrue(args.compact_teacher)
+        self.assertEqual(args.compact_teacher_chunk_size, 8)
+
+
+@unittest.skipIf(_SKIP, _SKIP_MSG)
+class TestValidateCompactTeacherArgs(unittest.TestCase):
+    def _config(self, vocab=64, draft=16):
+        t2d, d2t = _mapping(vocab, draft)
+        return types.SimpleNamespace(
+            args=types.SimpleNamespace(is_vlm=False, compact_teacher_chunk_size=128),
+            target_model=_TargetHeadDouble(8, vocab),
+            draft_model=types.SimpleNamespace(t2d=t2d, d2t=d2t),
+            cfg=types.SimpleNamespace(vocab_size=vocab, draft_vocab_size=draft),
+        )
+
+    def _validate(self, c, is_online=False):
+        train_mod.validate_compact_teacher_args(
+            c.args, is_online, c.target_model, c.draft_model, c.cfg
+        )
+
+    def test_accepts_valid_offline(self):
+        self._validate(self._config())
+
+    def test_rejects_online(self):
+        with self.assertRaises(ValueError):
+            self._validate(self._config(), is_online=True)
+
+    def test_rejects_vlm(self):
+        c = self._config()
+        c.args.is_vlm = True
+        with self.assertRaises(ValueError):
+            self._validate(c)
+
+    def test_rejects_nonpositive_chunk(self):
+        c = self._config()
+        c.args.compact_teacher_chunk_size = 0
+        with self.assertRaises(ValueError):
+            self._validate(c)
+
+    def test_rejects_bad_mapping(self):
+        c = self._config()
+        c.draft_model.d2t = c.draft_model.d2t.clone()
+        c.draft_model.d2t[0] = c.draft_model.d2t[0] + 1
+        with self.assertRaises(ValueError):
+            self._validate(c)
+
+
+@unittest.skipIf(_SKIP, _SKIP_MSG)
+@unittest.skipUnless(_HAS_CUDA, "CUDA required for run_forward smoke")
+class TestOfflineRunForwardSmoke(unittest.TestCase):
+    def _data(self):
+        return {
+            "input_ids": torch.zeros(1, 4, dtype=torch.long),
+            "target": torch.randn(1, 4, 8),
+            "loss_mask": torch.ones(1, 4, dtype=torch.int),
+            "attention_mask": torch.ones(1, 4, dtype=torch.int),
+            "hidden_state": torch.randn(1, 4, 8),
+        }
+
+    def _args(self, compact):
+        return types.SimpleNamespace(
+            is_vlm=False,
+            target_model_backend="hf",
+            compact_teacher=compact,
+            compact_teacher_chunk_size=None,
+            shard_target_output=False,
+        )
+
+    def test_compact_skips_target_forward(self):
+        target_model = _TargetHeadDouble(8, 32).cuda()
+        eagle3_model = _RecordingEagle3Model()
+        train_mod.run_forward(
+            self._args(compact=True), eagle3_model, self._data(), target_model, False
+        )
+        self.assertEqual(target_model.forward_calls, 0)
+        kw = eagle3_model.kwargs
+        self.assertIsNone(kw["target"])
+        self.assertIn("target_hidden_for_compact", kw)
+        self.assertIs(kw["target_head_weight"], target_model.fc.weight)
+        from specforge.core.compact_teacher import DEFAULT_VOCAB_CHUNK_SIZE
+
+        self.assertEqual(kw["compact_teacher_chunk_size"], DEFAULT_VOCAB_CHUNK_SIZE)
+
+    def test_legacy_calls_target_forward(self):
+        target_model = _TargetHeadDouble(8, 32).cuda()
+        eagle3_model = _RecordingEagle3Model()
+        train_mod.run_forward(
+            self._args(compact=False), eagle3_model, self._data(), target_model, False
+        )
+        self.assertEqual(target_model.forward_calls, 1)
+        kw = eagle3_model.kwargs
+        self.assertEqual(tuple(kw["target"].shape), (1, 4, 32))
+        self.assertNotIn("target_hidden_for_compact", kw)
+
+
+@unittest.skipIf(_SKIP, _SKIP_MSG)
+class TestExportFilter(unittest.TestCase):
+    def test_keeps_draft_drops_embed_and_teacher(self):
+        state_dict = {
+            "draft_model.lm_head.weight": 1,
+            "draft_model.t2d": 2,
+            "draft_model.d2t": 3,
+            "draft_model.midlayer.norm.weight": 4,
+            "draft_model.embed_tokens.weight": 5,
+            "target_model.fc.weight": 6,
+            "verifier_lm_head.weight": 7,
+        }
+        out = train_mod.filter_draft_state_dict(state_dict)
+        self.assertIn("lm_head.weight", out)
+        self.assertIn("t2d", out)
+        self.assertIn("d2t", out)
+        self.assertNotIn("embed_tokens.weight", out)  # embeddings excluded by design
+        self.assertFalse(any("fc" in k for k in out))  # no target head leaks
+        self.assertFalse(any(k.startswith("target_model") for k in out))
+        self.assertTrue(all("draft_model." not in k for k in out))  # prefix stripped
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_utils/test_compact_teacher.py
+++ b/tests/test_utils/test_compact_teacher.py
@@ -1,0 +1,693 @@
+"""CPU-friendly equivalence tests for the compact (draft-vocab) teacher path.
+
+These compare ``specforge.core.compact_teacher`` against a plain reimplementation of
+``specforge.core.eagle3._compute_target_p`` (the same math, without ``torch.compile``)
+and, best-effort, against the real compiled function. They are CPU-friendly toy
+tests; GPU-only checks (memory, tensor-parallel, export) live elsewhere.
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from specforge.core.compact_teacher import (
+    DEFAULT_VOCAB_CHUNK_SIZE,
+    build_offline_teacher_inputs,
+    compute_target_from_hidden,
+    compute_target_p_padded_from_hidden,
+    tiled_logsumexp_argmax,
+    validate_compact_teacher_config,
+    validate_compact_teacher_enabled,
+    validate_vocab_mapping_consistency,
+)
+from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
+
+
+def _reference_target_p(target, t2d, loss_mask):
+    """Plain mirror of ``specforge.core.eagle3._compute_target_p`` (no torch.compile)."""
+    target_head = target.float()
+    target_token_ids = target_head.argmax(-1)
+    target_mask = t2d[target_token_ids][..., None].int()
+    position_mask = target_mask * loss_mask
+    draft_target_head = target_head[..., t2d]
+    target_p = torch.softmax(draft_target_head, dim=2)
+    target_logsumexp = torch.logsumexp(target_head, dim=-1, keepdim=True)
+    target_p_on_draft = torch.exp(draft_target_head - target_logsumexp)
+    return target_p, target_p_on_draft, target_token_ids, position_mask
+
+
+def _reference_target_p_padded(target, t2d, loss_mask, length):
+    """Plain mirror of ``specforge.core.eagle3._compute_target_p_padded``."""
+    target_p, target_p_on_draft, target_token_ids, position_mask = _reference_target_p(
+        target, t2d, loss_mask
+    )
+    target_p_padded = torch.nn.functional.pad(
+        target_p, (0, 0, 0, length), value=1 / target_p.shape[-1]
+    )
+    target_p_on_draft_padded = torch.nn.functional.pad(
+        target_p_on_draft, (0, 0, 0, length), value=0.0
+    )
+    target_token_ids_padded = torch.nn.functional.pad(
+        target_token_ids, (0, length), value=0
+    )
+    return (
+        target_p_padded,
+        target_p_on_draft_padded,
+        target_token_ids_padded,
+        position_mask,
+    )
+
+
+def _make_sorted_t2d(vocab_size, draft_vocab_size, generator):
+    """Boolean draft-membership mask in ascending id order (as the real pipeline)."""
+    perm = torch.randperm(vocab_size, generator=generator)
+    selected = torch.sort(perm[:draft_vocab_size]).values
+    t2d = torch.zeros(vocab_size, dtype=torch.bool)
+    t2d[selected] = True
+    return t2d
+
+
+class _TargetHeadDouble(torch.nn.Module):
+    """TargetHead stand-in with `.fc.weight` and a call-counting `forward`."""
+
+    def __init__(self, weight):
+        super().__init__()
+        self.fc = torch.nn.Linear(weight.shape[1], weight.shape[0], bias=False)
+        with torch.no_grad():
+            self.fc.weight.copy_(weight)
+        self.forward_calls = 0
+
+    def forward(self, x):
+        self.forward_calls += 1
+        return self.fc(x)
+
+
+class TestCompactTeacherEquivalence(unittest.TestCase):
+    def setUp(self):
+        self.gen = torch.Generator().manual_seed(0)
+        self.batch, self.seq, self.hidden = 2, 3, 8
+        self.vocab, self.draft_vocab = 64, 16
+
+    def _make_inputs(self, dtype):
+        hidden = torch.randn(self.batch, self.seq, self.hidden, generator=self.gen).to(
+            dtype
+        )
+        weight = torch.randn(self.vocab, self.hidden, generator=self.gen).to(dtype)
+        t2d = _make_sorted_t2d(self.vocab, self.draft_vocab, self.gen)
+        loss_mask = torch.randint(
+            0, 2, (self.batch, self.seq, 1), generator=self.gen
+        ).int()
+        return hidden, weight, t2d, loss_mask
+
+    def test_matches_reference_bf16(self):
+        # bf16 head logits then fp32 reduction, matching target.float() semantics.
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.bfloat16)
+        full_logits = torch.nn.functional.linear(hidden, weight)  # [B,S,V] bf16
+
+        ref = _reference_target_p(full_logits, t2d, loss_mask)
+        got = compute_target_from_hidden(
+            hidden,
+            weight,
+            t2d,
+            loss_mask,
+            chunk_size=7,  # small chunk -> exercises tiling
+        )
+
+        torch.testing.assert_close(got[0], ref[0], rtol=1e-4, atol=1e-5)  # target_p
+        torch.testing.assert_close(
+            got[1], ref[1], rtol=1e-4, atol=1e-5
+        )  # target_p_on_draft
+        self.assertTrue(torch.equal(got[2], ref[2]))  # target_token_ids (exact)
+        self.assertTrue(torch.equal(got[3], ref[3]))  # position_mask (exact)
+
+    def test_chunk_size_independence(self):
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.float32)
+        full = compute_target_from_hidden(
+            hidden, weight, t2d, loss_mask, chunk_size=self.vocab
+        )
+        tiled = compute_target_from_hidden(hidden, weight, t2d, loss_mask, chunk_size=5)
+        for a, b in zip(full, tiled):
+            torch.testing.assert_close(a.float(), b.float(), rtol=1e-5, atol=1e-6)
+
+    def test_argmax_lowest_index_on_ties_across_chunks(self):
+        # Two identical, maximal vocab rows in different chunks -> lowest index wins.
+        hidden = torch.ones(1, 1, 4, dtype=torch.float32)
+        weight = torch.zeros(8, 4, dtype=torch.float32)
+        weight[1] = 10.0  # chunk 0 (chunk_size=3)
+        weight[5] = 10.0  # chunk 1 -> identical maximal logit
+        t2d = torch.zeros(8, dtype=torch.bool)
+        t2d[[1, 5]] = True
+        loss_mask = torch.ones(1, 1, 1, dtype=torch.int)
+
+        logz, argmax_id = tiled_logsumexp_argmax(hidden, weight, chunk_size=3)
+        full_argmax = torch.nn.functional.linear(hidden, weight).argmax(-1)
+        self.assertEqual(int(argmax_id.item()), 1)
+        self.assertTrue(torch.equal(argmax_id, full_argmax))
+        # logZ finite and matches one-shot logsumexp
+        ref_logz = torch.logsumexp(
+            torch.nn.functional.linear(hidden, weight).float(), dim=-1, keepdim=True
+        )
+        torch.testing.assert_close(logz, ref_logz, rtol=1e-5, atol=1e-6)
+
+    def test_outputs_are_detached(self):
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.float32)
+        hidden.requires_grad_(True)
+        weight.requires_grad_(True)
+        got = compute_target_from_hidden(hidden, weight, t2d, loss_mask, chunk_size=9)
+        for tensor in got:
+            self.assertFalse(tensor.requires_grad)
+
+    def test_padded_path_compatible(self):
+        # The compact outputs must pad exactly like _compute_target_p_padded expects.
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.float32)
+        target_p, target_p_on_draft, token_ids, _ = compute_target_from_hidden(
+            hidden, weight, t2d, loss_mask, chunk_size=11
+        )
+        length = 4
+        padded_p = torch.nn.functional.pad(
+            target_p, (0, 0, 0, length), value=1 / target_p.shape[-1]
+        )
+        padded_on_draft = torch.nn.functional.pad(
+            target_p_on_draft, (0, 0, 0, length), value=0.0
+        )
+        padded_ids = torch.nn.functional.pad(token_ids, (0, length), value=0)
+        # Pad regions carry the documented constants; data region is unchanged.
+        self.assertTrue(torch.all(padded_p[:, self.seq :, :] == 1 / self.draft_vocab))
+        self.assertTrue(torch.all(padded_on_draft[:, self.seq :, :] == 0.0))
+        self.assertTrue(torch.all(padded_ids[:, self.seq :] == 0))
+        torch.testing.assert_close(padded_p[:, : self.seq, :], target_p)
+
+    def test_padded_from_hidden_matches_reference(self):
+        # The wired offline path uses compute_target_p_padded_from_hidden; it must
+        # match padding the reference _compute_target_p outputs.
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.bfloat16)
+        full_logits = torch.nn.functional.linear(hidden, weight)
+        length = 5
+        ref = _reference_target_p_padded(full_logits, t2d, loss_mask, length)
+        got = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, length, chunk_size=7
+        )
+        torch.testing.assert_close(got[0], ref[0], rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(got[1], ref[1], rtol=1e-4, atol=1e-5)
+        self.assertTrue(torch.equal(got[2], ref[2]))
+        self.assertTrue(torch.equal(got[3], ref[3]))
+        self.assertTrue(torch.all(got[0][:, self.seq :, :] == 1 / self.draft_vocab))
+        self.assertTrue(torch.all(got[1][:, self.seq :, :] == 0.0))
+        self.assertTrue(torch.all(got[2][:, self.seq :] == 0))
+
+    def test_compute_target_from_hidden_input_validation(self):
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.float32)
+        with self.assertRaises(ValueError):  # non-bool t2d
+            compute_target_from_hidden(hidden, weight, t2d.int(), loss_mask)
+        with self.assertRaises(ValueError):  # t2d length != vocab
+            compute_target_from_hidden(hidden, weight, t2d[:-1], loss_mask)
+        with self.assertRaises(ValueError):  # hidden size != lm_head hidden
+            compute_target_from_hidden(hidden[..., :-1], weight, t2d, loss_mask)
+
+    def test_multistep_ttt_slice_shift_equivalence(self):
+        # Run both teacher sources through the real SdpaLikeAdapter.step_view + padding
+        # shift for ttt_length>1 and assert per-step equality.
+        try:
+            from specforge.core.eagle3_adapters import SdpaLikeAdapter
+            from specforge.utils import padding
+        except Exception as exc:  # pragma: no cover - import/env dependent
+            self.skipTest(f"adapter/padding import unavailable: {exc}")
+
+        gen = torch.Generator().manual_seed(3)
+        batch, seq, hidden_size, vocab, draft = 2, 6, 16, 96, 24
+        hidden = torch.randn(batch, seq, hidden_size, generator=gen).bfloat16()
+        weight = torch.randn(vocab, hidden_size, generator=gen).bfloat16()
+        t2d = _make_sorted_t2d(vocab, draft, gen)
+        loss_mask = torch.randint(0, 2, (batch, seq, 1), generator=gen).int()
+        full_logits = torch.nn.functional.linear(hidden, weight)
+        ttt_length = 3
+        ref = _reference_target_p_padded(full_logits, t2d, loss_mask, ttt_length)
+        got = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, ttt_length, chunk_size=7
+        )
+
+        adapter = SdpaLikeAdapter(model=None)  # step_view does not use the model
+        pm_ref, pm_got = ref[3], got[3]
+        lm_ref, lm_got = loss_mask.clone(), loss_mask.clone()
+        gi = torch.zeros(batch, seq, dtype=torch.long)
+        for idx in range(ttt_length):
+            common = dict(
+                idx=idx,
+                ttt_length=ttt_length,
+                global_input_ids=gi,
+                attention_mask=None,
+                position_ids=None,
+                hidden_states=hidden,
+                seq_length=seq,
+            )
+            s_ref = adapter.step_view(
+                loss_mask=lm_ref,
+                target_p_padded=ref[0],
+                target_p_on_draft_padded=ref[1],
+                target_token_ids_padded=ref[2],
+                position_mask=pm_ref,
+                **common,
+            )
+            s_got = adapter.step_view(
+                loss_mask=lm_got,
+                target_p_padded=got[0],
+                target_p_on_draft_padded=got[1],
+                target_token_ids_padded=got[2],
+                position_mask=pm_got,
+                **common,
+            )
+            torch.testing.assert_close(
+                s_got.target_p, s_ref.target_p, rtol=1e-4, atol=1e-5
+            )
+            torch.testing.assert_close(
+                s_got.target_p_on_draft, s_ref.target_p_on_draft, rtol=1e-4, atol=1e-5
+            )
+            self.assertTrue(torch.equal(s_got.target_token_ids, s_ref.target_token_ids))
+            self.assertTrue(torch.equal(s_got.position_mask, s_ref.position_mask))
+            self.assertTrue(torch.equal(s_got.loss_mask, s_ref.loss_mask))
+            if idx != ttt_length - 1:
+                pm_ref = padding(pm_ref, left=False)
+                pm_got = padding(pm_got, left=False)
+                lm_ref = padding(lm_ref, left=False)
+                lm_got = padding(lm_got, left=False)
+
+    def test_wrong_tiling_is_detected(self):
+        # A naive per-chunk logsumexp sum is wrong and must differ from the correct one.
+        gen = torch.Generator().manual_seed(5)
+        hidden = torch.randn(1, 1, 8, generator=gen)
+        weight = torch.randn(40, 8, generator=gen)
+        correct_logz, _ = tiled_logsumexp_argmax(hidden, weight, chunk_size=10)
+        ref = torch.logsumexp(
+            torch.nn.functional.linear(hidden, weight).float(), dim=-1, keepdim=True
+        )
+        torch.testing.assert_close(correct_logz, ref, rtol=1e-5, atol=1e-6)
+        broken = torch.stack(
+            [
+                torch.logsumexp(
+                    torch.nn.functional.linear(hidden, weight[s : s + 10]).float(),
+                    dim=-1,
+                    keepdim=True,
+                )
+                for s in range(0, 40, 10)
+            ]
+        ).sum(0)
+        self.assertFalse(torch.allclose(broken, ref, rtol=1e-3, atol=1e-3))
+
+    def test_matches_real_compute_target_p_best_effort(self):
+        # Tie the equivalence to the real (compiled) function when importable.
+        try:
+            from specforge.core.eagle3 import _compute_target_p
+        except Exception as exc:  # pragma: no cover - import/env dependent
+            self.skipTest(f"could not import _compute_target_p: {exc}")
+
+        hidden, weight, t2d, loss_mask = self._make_inputs(torch.float32)
+        full_logits = torch.nn.functional.linear(hidden, weight)
+        try:
+            ref = _compute_target_p(target=full_logits, t2d=t2d, loss_mask=loss_mask)
+        except Exception as exc:  # pragma: no cover - torch.compile env dependent
+            self.skipTest(f"_compute_target_p (compiled) failed in this env: {exc}")
+
+        got = compute_target_from_hidden(hidden, weight, t2d, loss_mask, chunk_size=7)
+        torch.testing.assert_close(got[0], ref[0], rtol=1e-4, atol=1e-5)
+        torch.testing.assert_close(got[1], ref[1], rtol=1e-4, atol=1e-5)
+        self.assertTrue(torch.equal(got[2], ref[2]))
+        self.assertTrue(torch.equal(got[3], ref[3]))
+
+
+class TestCompactTeacherValidation(unittest.TestCase):
+    def test_rejects_equal_vocab_sizes(self):
+        t2d = torch.ones(32, dtype=torch.bool)
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_config(draft_vocab_size=32, vocab_size=32, t2d=t2d)
+
+    def test_rejects_missing_mapping(self):
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_config(
+                draft_vocab_size=16, vocab_size=64, t2d=None
+            )
+
+    def test_rejects_wrong_dtype(self):
+        t2d = torch.zeros(64, dtype=torch.int64)
+        t2d[:16] = 1
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_config(draft_vocab_size=16, vocab_size=64, t2d=t2d)
+
+    def test_rejects_mismatched_selection_count(self):
+        t2d = torch.zeros(64, dtype=torch.bool)
+        t2d[:10] = True  # 10 selected != draft_vocab_size 16
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_config(draft_vocab_size=16, vocab_size=64, t2d=t2d)
+
+    def test_accepts_valid_config(self):
+        t2d = torch.zeros(64, dtype=torch.bool)
+        t2d[:16] = True
+        validate_compact_teacher_config(draft_vocab_size=16, vocab_size=64, t2d=t2d)
+
+
+class TestCompactTeacherEnabledValidation(unittest.TestCase):
+    def _t2d(self):
+        t = torch.zeros(64, dtype=torch.bool)
+        t[:16] = True
+        return t
+
+    def _weight(self):
+        return torch.zeros(64, 8)
+
+    def test_rejects_online(self):
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_enabled(
+                is_online=True,
+                is_vlm=False,
+                draft_vocab_size=16,
+                vocab_size=64,
+                t2d=self._t2d(),
+                target_head_weight=self._weight(),
+            )
+
+    def test_rejects_vlm(self):
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_enabled(
+                is_online=False,
+                is_vlm=True,
+                draft_vocab_size=16,
+                vocab_size=64,
+                t2d=self._t2d(),
+                target_head_weight=self._weight(),
+            )
+
+    def test_rejects_missing_head_weight(self):
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_enabled(
+                is_online=False,
+                is_vlm=False,
+                draft_vocab_size=16,
+                vocab_size=64,
+                t2d=self._t2d(),
+                target_head_weight=None,
+            )
+
+    def test_rejects_equal_vocab(self):
+        t = torch.ones(32, dtype=torch.bool)
+        with self.assertRaises(ValueError):
+            validate_compact_teacher_enabled(
+                is_online=False,
+                is_vlm=False,
+                draft_vocab_size=32,
+                vocab_size=32,
+                t2d=t,
+                target_head_weight=torch.zeros(32, 8),
+            )
+
+    def test_rejects_bad_head_shape(self):
+        with self.assertRaises(ValueError):  # wrong row count
+            validate_compact_teacher_enabled(
+                is_online=False,
+                is_vlm=False,
+                draft_vocab_size=16,
+                vocab_size=64,
+                t2d=self._t2d(),
+                target_head_weight=torch.zeros(32, 8),
+            )
+        with self.assertRaises(ValueError):  # not 2-D
+            validate_compact_teacher_enabled(
+                is_online=False,
+                is_vlm=False,
+                draft_vocab_size=16,
+                vocab_size=64,
+                t2d=self._t2d(),
+                target_head_weight=torch.zeros(64),
+            )
+
+    def test_rejects_nonpositive_chunk_size(self):
+        for bad in (0, -1):
+            with self.assertRaises(ValueError):
+                validate_compact_teacher_enabled(
+                    is_online=False,
+                    is_vlm=False,
+                    draft_vocab_size=16,
+                    vocab_size=64,
+                    t2d=self._t2d(),
+                    target_head_weight=self._weight(),
+                    chunk_size=bad,
+                )
+
+    def test_accepts_valid_offline(self):
+        validate_compact_teacher_enabled(
+            is_online=False,
+            is_vlm=False,
+            draft_vocab_size=16,
+            vocab_size=64,
+            t2d=self._t2d(),
+            target_head_weight=self._weight(),
+            chunk_size=128,
+        )
+
+
+class TestVocabMappingConsistency(unittest.TestCase):
+    def _consistent(self, vocab=64, draft=16):
+        gen = torch.Generator().manual_seed(0)
+        t2d = _make_sorted_t2d(vocab, draft, gen)
+        selected = torch.nonzero(t2d).flatten()
+        d2t = selected - torch.arange(draft)
+        return t2d, d2t
+
+    def test_accepts_consistent(self):
+        t2d, d2t = self._consistent()
+        validate_vocab_mapping_consistency(t2d, d2t)
+
+    def test_rejects_wrong_order(self):
+        t2d, d2t = self._consistent()
+        d2t_bad = d2t.clone()
+        d2t_bad[0] = d2t_bad[0] + 1  # breaks selected == d2t + arange deterministically
+        with self.assertRaises(ValueError):
+            validate_vocab_mapping_consistency(t2d, d2t_bad)
+
+    def test_rejects_count_mismatch(self):
+        t2d = torch.zeros(64, dtype=torch.bool)
+        t2d[:16] = True
+        with self.assertRaises(ValueError):
+            validate_vocab_mapping_consistency(t2d, torch.zeros(10, dtype=torch.long))
+
+
+class TestCompactTeacherMemory(unittest.TestCase):
+    @unittest.skipUnless(
+        torch.cuda.is_available(), "CUDA required for memory regression"
+    )
+    def test_peak_memory_drop_vs_full_path(self):
+        # Route both branches through build_offline_teacher_inputs (the run_forward seam).
+        dev = "cuda"
+        batch, seq, hidden_size, vocab, draft = 1, 2048, 4096, 128256, 32000
+        length = 7
+        hidden = torch.randn(batch, seq, hidden_size, device=dev, dtype=torch.bfloat16)
+        weight = torch.randn(vocab, hidden_size, device=dev, dtype=torch.bfloat16)
+        double = _TargetHeadDouble(weight).to(device=dev, dtype=torch.bfloat16)
+        sel = torch.sort(torch.randperm(vocab, device=dev)[:draft]).values
+        t2d = torch.zeros(vocab, dtype=torch.bool, device=dev)
+        t2d[sel] = True
+        loss_mask = torch.randint(0, 2, (batch, seq, 1), device=dev).int()
+
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+        base = torch.cuda.memory_allocated()
+        full_logits, kw_full = build_offline_teacher_inputs(
+            compact=False,
+            target_model=double,
+            target_hidden=hidden,
+            chunk_size_arg=None,
+        )
+        full_out = _reference_target_p_padded(full_logits, t2d, loss_mask, length)
+        torch.cuda.synchronize()
+        full_peak = torch.cuda.max_memory_allocated() - base
+        self.assertEqual(kw_full, {})
+        self.assertEqual(double.forward_calls, 1)
+        del full_logits, full_out
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
+        double.forward_calls = 0
+        linear_out_dims = []
+        orig_linear = torch.nn.functional.linear
+
+        def _record_linear(inp, weight, *a, **k):
+            out = orig_linear(inp, weight, *a, **k)
+            linear_out_dims.append(out.shape[-1])
+            return out
+
+        torch.cuda.reset_peak_memory_stats()
+        base2 = torch.cuda.memory_allocated()
+        target_c, kw = build_offline_teacher_inputs(
+            compact=True,
+            target_model=double,
+            target_hidden=hidden,
+            chunk_size_arg=32768,
+        )
+        self.assertIsNone(target_c)
+        self.assertEqual(double.forward_calls, 0)  # no full-vocab logits produced
+        with mock.patch("torch.nn.functional.linear", _record_linear):
+            compact_out = compute_target_p_padded_from_hidden(
+                hidden,
+                kw["target_head_weight"],
+                t2d,
+                loss_mask,
+                length,
+                chunk_size=kw["compact_teacher_chunk_size"],
+            )
+        torch.cuda.synchronize()
+        compact_peak = torch.cuda.max_memory_allocated() - base2
+        del compact_out
+        self.assertTrue(linear_out_dims)
+        self.assertNotIn(vocab, linear_out_dims)  # no [.., vocab] projection in compact
+
+        fp32_full_cast = batch * seq * vocab * 4
+        drop = full_peak - compact_peak
+        print(
+            f"\n[memory] full_peak={full_peak/1e9:.3f}GB compact_peak={compact_peak/1e9:.3f}GB "
+            f"drop={drop/1e9:.3f}GB fp32_cast={fp32_full_cast/1e9:.3f}GB"
+        )
+        self.assertLess(compact_peak, full_peak)
+        self.assertGreaterEqual(drop, fp32_full_cast - 64 * 1024 * 1024)
+
+
+class TestBuildOfflineTeacherInputs(unittest.TestCase):
+    def setUp(self):
+        gen = torch.Generator().manual_seed(0)
+        self.hidden = torch.randn(2, 3, 8, generator=gen)
+        self.weight = torch.randn(64, 8, generator=gen)
+
+    def test_legacy_calls_forward_returns_full_logits(self):
+        double = _TargetHeadDouble(self.weight)
+        target, kw = build_offline_teacher_inputs(
+            compact=False,
+            target_model=double,
+            target_hidden=self.hidden,
+            chunk_size_arg=None,
+        )
+        self.assertEqual(double.forward_calls, 1)
+        self.assertEqual(kw, {})
+        self.assertEqual(tuple(target.shape), (2, 3, 64))
+
+    def test_compact_skips_forward_returns_kwargs(self):
+        double = _TargetHeadDouble(self.weight)
+        target, kw = build_offline_teacher_inputs(
+            compact=True,
+            target_model=double,
+            target_hidden=self.hidden,
+            chunk_size_arg=None,
+        )
+        self.assertEqual(double.forward_calls, 0)
+        self.assertIsNone(target)
+        self.assertIs(kw["target_head_weight"], double.fc.weight)
+        self.assertTrue(torch.equal(kw["target_hidden_for_compact"], self.hidden))
+        self.assertEqual(kw["compact_teacher_chunk_size"], DEFAULT_VOCAB_CHUNK_SIZE)
+
+    def test_compact_resolves_explicit_chunk(self):
+        double = _TargetHeadDouble(self.weight)
+        _, kw = build_offline_teacher_inputs(
+            compact=True,
+            target_model=double,
+            target_hidden=self.hidden,
+            chunk_size_arg=64,
+        )
+        self.assertEqual(kw["compact_teacher_chunk_size"], 64)
+
+
+def _kl_loss(logits, target_p, position_mask):
+    logp = torch.log_softmax(logits.float(), dim=-1)
+    return -(position_mask * (target_p * logp)).sum(-1).mean()
+
+
+def _acc_and_loss(logits, target_p, target_p_on_draft, position_mask, lk_loss_type):
+    kl = _kl_loss(logits, target_p, position_mask)
+    acc, log_acc = compute_acceptance_rate(
+        logits=logits, target_probs=target_p_on_draft, position_mask=position_mask
+    )
+    if lk_loss_type is None:
+        return acc, kl
+    loss = compute_lk_loss(
+        kl_loss=kl,
+        acceptance_rate=acc,
+        log_acceptance_rate=log_acc,
+        lk_loss_type=lk_loss_type,
+        kl_scale=1.0,
+        kl_decay=1.0,
+    )
+    return acc, loss
+
+
+class TestAcceptanceEquivalence(unittest.TestCase):
+    def test_acceptance_and_loss_match_full(self):
+        gen = torch.Generator().manual_seed(2)
+        batch, seq, hidden_size, vocab, draft = 2, 4, 16, 80, 20
+        hidden = torch.randn(batch, seq, hidden_size, generator=gen).bfloat16()
+        weight = torch.randn(vocab, hidden_size, generator=gen).bfloat16()
+        t2d = _make_sorted_t2d(vocab, draft, gen)
+        loss_mask = torch.randint(0, 2, (batch, seq, 1), generator=gen).int()
+        full = _reference_target_p(
+            torch.nn.functional.linear(hidden, weight), t2d, loss_mask
+        )
+        comp = compute_target_from_hidden(hidden, weight, t2d, loss_mask, chunk_size=7)
+        logits = torch.randn(batch, seq, draft, generator=gen)
+        for lk in (None, "alpha", "lambda"):
+            acc_full, loss_full = _acc_and_loss(logits, full[0], full[1], full[3], lk)
+            acc_comp, loss_comp = _acc_and_loss(logits, comp[0], comp[1], comp[3], lk)
+            torch.testing.assert_close(acc_comp, acc_full, rtol=1e-4, atol=1e-5)
+            torch.testing.assert_close(loss_comp, loss_full, rtol=1e-4, atol=1e-5)
+
+    def test_approximate_diverges_with_out_of_draft_mass(self):
+        vocab, draft = 8, 3
+        t2d = torch.zeros(vocab, dtype=torch.bool)
+        t2d[[0, 1, 2]] = True
+        full_logits = torch.zeros(1, 1, vocab)
+        full_logits[0, 0, 7] = 10.0  # dominant token is outside the draft vocab
+        loss_mask = torch.ones(1, 1, 1, dtype=torch.int)
+        _, exact_on_draft, _, _ = _reference_target_p(full_logits, t2d, loss_mask)
+        approx_on_draft = torch.softmax(full_logits[..., t2d], dim=-1)
+        self.assertLess(float(exact_on_draft.sum()), 0.5)
+        self.assertAlmostEqual(float(approx_on_draft.sum()), 1.0, places=4)
+        logits = torch.zeros(1, 1, draft)
+        acc_exact, _ = compute_acceptance_rate(
+            logits=logits, target_probs=exact_on_draft, position_mask=loss_mask
+        )
+        acc_approx, _ = compute_acceptance_rate(
+            logits=logits, target_probs=approx_on_draft, position_mask=loss_mask
+        )
+        self.assertGreater(float(acc_approx), float(acc_exact) + 1e-3)
+
+
+class TestCompactTeacherRankReplication(unittest.TestCase):
+    def test_deterministic_pure_function(self):
+        # The offline teacher uses the full, rank-replicated TargetHead.fc, so it is a
+        # pure function of (hidden, weight, t2d): every TP rank gets identical outputs.
+        gen = torch.Generator().manual_seed(11)
+        hidden = torch.randn(2, 4, 16, generator=gen)
+        weight = torch.randn(70, 16, generator=gen)
+        t2d = _make_sorted_t2d(70, 18, gen)
+        loss_mask = torch.randint(0, 2, (2, 4, 1), generator=gen).int()
+        a = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, 3, chunk_size=7
+        )
+        b = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, 3, chunk_size=7
+        )
+        for x, y in zip(a, b):
+            self.assertTrue(torch.equal(x, y))
+
+    def test_chunk_size_invariant(self):
+        gen = torch.Generator().manual_seed(12)
+        hidden = torch.randn(1, 3, 16, generator=gen)
+        weight = torch.randn(70, 16, generator=gen)
+        t2d = _make_sorted_t2d(70, 18, gen)
+        loss_mask = torch.ones(1, 3, 1, dtype=torch.int)
+        full = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, 2, chunk_size=70
+        )
+        tiled = compute_target_p_padded_from_hidden(
+            hidden, weight, t2d, loss_mask, 2, chunk_size=9
+        )
+        for x, y in zip(full, tiled):
+            torch.testing.assert_close(x.float(), y.float(), rtol=1e-5, atol=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

In offline EAGLE-3 training, `specforge/core/eagle3.py::_compute_target_p` builds the teacher distribution by materializing the **full-vocabulary** target logits and casting them to fp32 (`target_head = target.float()` → a `[B, S, vocab_size]` fp32 tensor, e.g. ~1.05 GB at `B=1, S=2048, V=128256`, larger for Gemma-class vocabularies), on top of the bf16 full-vocab logits.

The draft model already predicts over a reduced draft vocabulary (`t2d`/`d2t`). The teacher only needs the draft-vocab probabilities plus a full-vocab `logsumexp`/`argmax`, which can be produced **without** ever materializing the full-vocab fp32 logit tensor.

This PR adds a **default-off** `--compact-teacher` path for offline training that does exactly that, **numerically exact-equivalent** to the current path. With the flag off, training behavior and logged metrics are unchanged.

## Modifications

- `specforge/core/compact_teacher.py` (new): `compute_target_from_hidden` / `compute_target_p_padded_from_hidden` produce `(target_p, target_p_on_draft, target_token_ids, position_mask)` from the target hidden states + `lm_head` weight via a `t2d`-sliced head and a tiled fp32 `logsumexp`/`argmax` reduction (no `[B,S,vocab]` fp32 tensor). Plus validation helpers (`validate_compact_teacher_enabled`, `validate_vocab_mapping_consistency`) and the `build_offline_teacher_inputs` seam.
- `specforge/core/eagle3.py`: `OnlineEagle3Model.forward` accepts optional `target_hidden_for_compact` / `target_head_weight` / `compact_teacher_chunk_size`; when present it builds the padded teacher from hidden states and skips the full-logits path (which is otherwise untouched).
- `scripts/train_eagle3.py`: `--compact-teacher` / `--compact-teacher-chunk-size` flags (default off); offline `run_forward` delegates to `build_offline_teacher_inputs` (skips `TargetHead.forward` in compact mode); `validate_compact_teacher_args` enforces offline-only / non-VLM / valid head-shape / chunk-size / `t2d`-`d2t` consistency before training; `build_parser` / `filter_draft_state_dict` extracted as testable seams.
- Tests: `tests/test_utils/test_compact_teacher.py` and `tests/test_scripts/test_compact_teacher_integration.py`.

## Related Issues

Closes #580

## Accuracy Test

Compact-mode teacher quantities are **numerically exact-equivalent** to the existing path:

- `compute_target_from_hidden` / `compute_target_p_padded_from_hidden` match the real `_compute_target_p` / `_compute_target_p_padded` (extracted from `eagle3.py`) on **CPU and CUDA** for `target_p`, `target_p_on_draft` (within rtol=1e-4/atol=1e-5) and exact equality for `target_token_ids` / `position_mask`, including bf16→fp32 behavior and `torch.argmax` lowest-index ties across chunk boundaries.
- Acceptance-rate and KL/LK loss are equal between compact and full teacher for `lk_loss_type` `None`/`alpha`/`lambda`; a renormalized "approximate" teacher is shown to diverge when out-of-draft mass is nonzero.
- Offline `run_forward` smoke (with a `TargetHead` double) proves compact mode never calls `TargetHead.forward` while the flag-off path still does.

A full end-to-end accuracy-eval run is a follow-up; the above covers the teacher computation that this PR changes.

## Benchmark & Profiling

Isolated teacher-building segment on one H100, Llama3-8B dimensions (`B=1, S=2048, H=4096, V=128256, D=32000`), via `reset_peak_memory_stats()` + `synchronize()`:

| path | peak |
|------|------|
| full-vocab (current) | 3.186 GB |
| compact | 1.330 GB |
| **drop** | **1.856 GB** (≥ eliminated fp32 `[B,S,V]` cast = 1.051 GB) |

A patched-`F.linear` detector also asserts no compact-mode projection output has final dim == `vocab_size`. This is a teacher-segment micro-benchmark; a full end-to-end training throughput/acceptance-length comparison is a follow-up.

## Checklist

- [x] Code formatted with `black` + `isort` (pre-commit profile).
- [x] Unit + integration tests added.
- [x] Docstrings added for the new module/functions.
- [ ] Full end-to-end throughput/latency + accuracy-eval (teacher-segment micro-benchmark + numerical equivalence provided; full training run is a follow-up).

## Notes / follow-ups (out of scope here)

Online path (avoiding `outputs.logits` allocation in the HF/custom/SGLang target wrappers); opt-in experiments (draft `lm_head` init-from-verifier + freeze with an optimizer-resume guard, an approximate/renormalized objective mode, and a comparison harness/report). These can be tracked as follow-up issues.
