### PR TITLE
Expose flex_attention kernel options in DFlash and Domino training

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -4,6 +4,7 @@
 
 import argparse
 import functools
+import json
 import logging
 import math
 import os
@@ -66,6 +67,12 @@ def parse_args():
         default="flex_attention",
         choices=["eager", "sdpa", "flex_attention"],
         help="Attention backend for draft model.",
+    )
+    model_group.add_argument(
+        "--flex-kernel-options-json",
+        type=json.loads,
+        default=None,
+        help="JSON dict forwarded as kernel_options when attention-backend=flex_attention.",
     )
     model_group.add_argument(
         "--trust-remote-code", action="store_true", help="Trust remote code"
@@ -375,6 +382,17 @@ def main():
     )
 
     args = parse_args()
+    flex_kernel_options = args.flex_kernel_options_json
+    if flex_kernel_options is not None:
+        if args.attention_backend != "flex_attention":
+            raise ValueError(
+                "--flex-kernel-options-json can only be used when "
+                "--attention-backend is 'flex_attention'."
+            )
+        if not isinstance(flex_kernel_options, dict):
+            raise ValueError(
+                "--flex-kernel-options-json must decode to a JSON object."
+            )
     set_seed(args.seed)
 
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
@@ -460,6 +478,7 @@ def main():
         loss_decay_gamma=args.loss_decay_gamma,
         loss_type=args.loss_type,
         dpace_alpha=args.dpace_alpha,
+        flex_kernel_options=flex_kernel_options,
     )
 
     # Wrap each transformer block as its own FSDP unit so that all-gather /

--- a/scripts/train_domino.py
+++ b/scripts/train_domino.py
@@ -3,6 +3,7 @@
 """Domino Training Script."""
 
 import argparse
+import json
 import logging
 import math
 import os
@@ -63,6 +64,12 @@ def parse_args():
         default="flex_attention",
         choices=["eager", "sdpa", "flex_attention"],
         help="Attention backend for draft model.",
+    )
+    model_group.add_argument(
+        "--flex-kernel-options-json",
+        type=json.loads,
+        default=None,
+        help="JSON dict forwarded as kernel_options when attention-backend=flex_attention.",
     )
     model_group.add_argument(
         "--trust-remote-code", action="store_true", help="Trust remote code"
@@ -444,6 +451,17 @@ def main():
     )
 
     args = parse_args()
+    flex_kernel_options = args.flex_kernel_options_json
+    if flex_kernel_options is not None:
+        if args.attention_backend != "flex_attention":
+            raise ValueError(
+                "--flex-kernel-options-json can only be used when "
+                "--attention-backend is 'flex_attention'."
+            )
+        if not isinstance(flex_kernel_options, dict):
+            raise ValueError(
+                "--flex-kernel-options-json must decode to a JSON object."
+            )
     set_seed(args.seed)
 
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
@@ -528,6 +546,7 @@ def main():
         num_anchors=args.num_anchors,
         loss_decay_gamma=args.loss_decay_gamma,
         shift_label=draft_model.shift_label,
+        flex_kernel_options=flex_kernel_options,
     )
 
     domino_model = FSDP(

--- a/specforge/core/dflash.py
+++ b/specforge/core/dflash.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """DFlash Training Wrapper."""
 
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -117,6 +117,7 @@ class OnlineDFlashModel(nn.Module):
         loss_decay_gamma: Optional[float] = None,
         loss_type: str = "dflash",
         dpace_alpha: float = 0.5,
+        flex_kernel_options: Optional[Dict] = None,
     ):
         super().__init__()
         if loss_type not in _VALID_LOSS_TYPES:
@@ -136,6 +137,7 @@ class OnlineDFlashModel(nn.Module):
         self.loss_decay_gamma = loss_decay_gamma
         self.loss_type = loss_type
         self.dpace_alpha = dpace_alpha
+        self.flex_kernel_options = flex_kernel_options
 
         self._cached_block_mask: Optional[BlockMask] = None
         self._cached_seq_len: Optional[int] = None
@@ -304,11 +306,19 @@ class OnlineDFlashModel(nn.Module):
                 device=device,
             )
 
+        draft_forward_kwargs = {}
+        if (
+            self.attention_backend == "flex_attention"
+            and self.flex_kernel_options is not None
+        ):
+            draft_forward_kwargs["kernel_options"] = self.flex_kernel_options
+
         output_hidden = self.draft_model(
             position_ids=full_position_ids,
             noise_embedding=noise_embedding,
             target_hidden=hidden_states,
             attention_mask=dflash_attn_mask,
+            **draft_forward_kwargs,
         )
 
         logits = self.lm_head(output_hidden)

--- a/specforge/core/domino.py
+++ b/specforge/core/domino.py
@@ -44,6 +44,7 @@ class OnlineDominoModel(nn.Module):
         num_anchors: int = 512,
         loss_decay_gamma: Optional[float] = None,
         shift_label: bool = False,
+        flex_kernel_options: Optional[Dict] = None,
     ):
         super().__init__()
         self.draft_model = draft_model
@@ -55,6 +56,7 @@ class OnlineDominoModel(nn.Module):
         self.num_anchors = num_anchors
         self.loss_decay_gamma = loss_decay_gamma
         self.shift_label = shift_label
+        self.flex_kernel_options = flex_kernel_options
 
         self._cached_block_mask: Optional[BlockMask] = None
         self._cached_seq_len: Optional[int] = None
@@ -332,11 +334,19 @@ class OnlineDominoModel(nn.Module):
                 device=device,
             )
 
+        draft_forward_kwargs = {}
+        if (
+            self.attention_backend == "flex_attention"
+            and self.flex_kernel_options is not None
+        ):
+            draft_forward_kwargs["kernel_options"] = self.flex_kernel_options
+
         output_hidden = self.draft_model(
             position_ids=full_position_ids,
             noise_embedding=noise_embedding,
             target_hidden=hidden_states,
             attention_mask=dflash_attn_mask,
+            **draft_forward_kwargs,
         )
 
         # --- Labels ---


### PR DESCRIPTION
## Summary
- add `--flex-kernel-options-json` to DFlash and Domino training CLIs
- parse the JSON dict in the training entrypoints and forward it to the online wrappers
- pass the resulting dict through to `kernel_options` in the flex attention draft forward path

## Why
On RTX A6000 (sm86), we hit a training failure when using `attention_backend=flex_attention`.

The root cause was not an NCCL error and not a generic CUDA OOM. The failure came from the Triton kernel configuration selected for flex attention during training: the generated configuration could exceed the sm86 shared-memory-per-block opt-in limit.

In practice, this means the default flex attention kernel configuration is not always viable on A6000 for these training paths.

## Local symptom on A6000
A representative workaround on RTX A6000 is to explicitly pass:

`--flex-kernel-options-json '{"num_stages": 2}'`

This reduces the selected kernel aggressiveness enough for the training path to proceed on our A6000 setup.

## Scope
This PR does not hardcode any hardware-specific default.

It only exposes the existing lower-level flex attention `kernel_options` capability through the DFlash and Domino training CLIs, so users can tune it from the command line when needed.

## Example
```bash
python scripts/train_domino.py \
  --attention-backend flex_attention \
  --flex-kernel-options-json '{"num_stages": 2}'
```

The same flag is also available in `scripts/train_dflash.py`.

## Validation
- verified that the CLI accepts a JSON dict and rejects non-dict JSON
- verified the parsed dict is forwarded to the online training wrapper
- this was added specifically to unblock A6000 flex attention training by allowing `num_stages=2` to be passed from the CLI
