### PR TITLE
Fix per-rank training state resume

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -36,7 +36,12 @@ from specforge.modeling.target.dflash_target_model import (
 from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
 from specforge.optimizer import BF16Optimizer
 from specforge.tracker import create_tracker
-from specforge.utils import get_last_checkpoint, print_on_rank0, print_with_rank
+from specforge.utils import (
+    get_last_checkpoint,
+    get_training_state_path,
+    print_on_rank0,
+    print_with_rank,
+)
 
 
 def parse_args():
@@ -306,17 +311,17 @@ def save_checkpoint(args, epoch, step, dflash_model, draft_model, optimizer):
             if "draft_model." in k
         }
 
-        if dist.get_rank() == 0:
-            torch.save(
-                {
-                    "epoch": epoch,
-                    "global_step": step,
-                    "args": args,
-                    **optimizer.state_dict(),
-                },
-                os.path.join(save_dir, "training_state.pt"),
-            )
+        torch.save(
+            {
+                "epoch": epoch,
+                "global_step": step,
+                "args": args,
+                **optimizer.state_dict(),
+            },
+            get_training_state_path(save_dir),
+        )
 
+        if dist.get_rank() == 0:
             draft_model.save_pretrained(save_dir, state_dict=draft_state_dict)
 
             modeling_src = os.path.join(
@@ -406,17 +411,14 @@ def main():
         del loaded_model
         print("Loaded draft model weights from checkpoint")
 
-        training_state_path = os.path.join(
-            draft_model_last_checkpoint, "training_state.pt"
+        training_state_path = get_training_state_path(draft_model_last_checkpoint)
+        resume_state = torch.load(
+            training_state_path, map_location="cpu", weights_only=False
         )
-        if os.path.exists(training_state_path):
-            resume_state = torch.load(
-                training_state_path, map_location="cpu", weights_only=False
-            )
-            print(
-                f"Will resume from epoch {resume_state['epoch']}, "
-                f"step {resume_state['global_step']}"
-            )
+        print(
+            f"Will resume from epoch {resume_state['epoch']}, "
+            f"step {resume_state['global_step']}"
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(args.target_model_path)
 

--- a/scripts/train_domino.py
+++ b/scripts/train_domino.py
@@ -33,7 +33,12 @@ from specforge.modeling.target.dflash_target_model import (
 from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
 from specforge.optimizer import BF16Optimizer
 from specforge.tracker import create_tracker
-from specforge.utils import get_last_checkpoint, print_on_rank0, print_with_rank
+from specforge.utils import (
+    get_last_checkpoint,
+    get_training_state_path,
+    print_on_rank0,
+    print_with_rank,
+)
 
 
 def parse_args():
@@ -324,17 +329,17 @@ def save_checkpoint(args, epoch, step, domino_model, draft_model, optimizer):
             if "draft_model." in k
         }
 
-        if dist.get_rank() == 0:
-            torch.save(
-                {
-                    "epoch": epoch,
-                    "global_step": step,
-                    "args": args,
-                    **optimizer.state_dict(),
-                },
-                os.path.join(save_dir, "training_state.pt"),
-            )
+        torch.save(
+            {
+                "epoch": epoch,
+                "global_step": step,
+                "args": args,
+                **optimizer.state_dict(),
+            },
+            get_training_state_path(save_dir),
+        )
 
+        if dist.get_rank() == 0:
             draft_model.save_pretrained(save_dir, state_dict=draft_state_dict)
 
             modeling_src = os.path.join(
@@ -475,17 +480,14 @@ def main():
         del loaded_model
         print("Loaded draft model weights from checkpoint")
 
-        training_state_path = os.path.join(
-            draft_model_last_checkpoint, "training_state.pt"
+        training_state_path = get_training_state_path(draft_model_last_checkpoint)
+        resume_state = torch.load(
+            training_state_path, map_location="cpu", weights_only=False
         )
-        if os.path.exists(training_state_path):
-            resume_state = torch.load(
-                training_state_path, map_location="cpu", weights_only=False
-            )
-            print(
-                f"Will resume from epoch {resume_state['epoch']}, "
-                f"step {resume_state['global_step']}"
-            )
+        print(
+            f"Will resume from epoch {resume_state['epoch']}, "
+            f"step {resume_state['global_step']}"
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(args.target_model_path)
 
@@ -553,7 +555,7 @@ def main():
     )
 
     if resume_state is not None:
-        optimizer.scheduler.load_state_dict(resume_state["scheduler_state_dict"])
+        optimizer.load_state_dict(resume_state)
         start_epoch = resume_state["epoch"]
         global_step = resume_state["global_step"]
         del resume_state

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -48,6 +48,7 @@ from specforge.tracker import Tracker, create_tracker, get_tracker_class
 from specforge.utils import (
     create_draft_config_from_target,
     get_last_checkpoint,
+    get_training_state_path,
     print_args_with_dots,
     print_on_rank0,
     print_with_rank,
@@ -532,17 +533,14 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
     # Load training state (optimizer, scheduler, epoch, step) for true resume
     resume_state = None
     if is_resume_checkpoint and draft_model_last_checkpoint:
-        training_state_path = os.path.join(
-            draft_model_last_checkpoint, "training_state.pt"
+        training_state_path = get_training_state_path(draft_model_last_checkpoint)
+        resume_state = torch.load(
+            training_state_path, map_location="cpu", weights_only=False
         )
-        if os.path.exists(training_state_path):
-            resume_state = torch.load(
-                training_state_path, map_location="cpu", weights_only=False
-            )
-            print_on_rank0(
-                f"Loaded training state from {training_state_path}: "
-                f"epoch={resume_state['epoch']}, step={resume_state['global_step']}"
-            )
+        print_on_rank0(
+            f"Loaded training state from {training_state_path}: "
+            f"epoch={resume_state['epoch']}, step={resume_state['global_step']}"
+        )
 
     draft_model.load_embedding(args.target_model_path, embedding_key=args.embedding_key)
     draft_model.freeze_embedding()
@@ -699,13 +697,10 @@ def save_checkpoints(
         state_to_save.update(optimizer.state_dict())
         draft_model_state_dict = filter_draft_state_dict(model_state_dict)
 
+        torch.save(state_to_save, get_training_state_path(epoch_output_dir))
         if dist.get_rank() == 0:
-            torch.save(
-                state_to_save,
-                os.path.join(epoch_output_dir, "training_state.pt"),
-            )
             print_on_rank0(
-                f"Saved full training state to {epoch_output_dir}/training_state.pt"
+                f"Saved full training state to {epoch_output_dir}/training_state_rank_*.pt"
             )
             eagle3_model.draft_model.save_pretrained(
                 epoch_output_dir,

--- a/specforge/optimizer.py
+++ b/specforge/optimizer.py
@@ -63,6 +63,7 @@ class BF16Optimizer:
         return {
             "optimizer_state_dict": self.optimizer.state_dict(),
             "scheduler_state_dict": self.scheduler.state_dict(),
+            "lr": self.get_learning_rate(),
         }
 
     def get_learning_rate(self):

--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -118,6 +118,11 @@ def get_last_checkpoint(folder, prefix="epoch"):
     return os.path.join(folder, last_checkpoint), (epoch, step)
 
 
+def get_training_state_path(checkpoint_dir):
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    return os.path.join(checkpoint_dir, f"training_state_rank_{rank}.pt")
+
+
 def generate_draft_model_config(
     target_model_path: str, template_config_path: str = None, cache_dir: str = None
 ):


### PR DESCRIPTION
## Summary

Fix resume behavior by saving and loading optimizer/scheduler training state per rank.

## Changes

- Save training state as `training_state_rank_{rank}.pt`
- Load the matching per-rank state on resume
- Stop using the shared `training_state.pt`
- Restore full optimizer state for Domino resume
- Include current `lr` in optimizer state

## Validation

- `python -m py_compile specforge/optimizer.py specforge/utils.py scripts/train_eagle3.py scripts/train_dflash.py scripts/train_domino.py`
- `git diff --check`

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
