### PR TITLE
feat: add --save-total-limit to auto-cleanup old checkpoints

### DIFF
--- a/specforge/utils.py
+++ b/specforge/utils.py
@@ -188,8 +188,10 @@ def print_args_with_dots(args):
 
 
 def print_on_rank0(message):
-    if dist.get_rank() == 0:
-        logger.info(message)
+    if dist.is_available() and dist.is_initialized() and dist.get_rank() != 0:
+        return
+
+    logger.info(message)
 
 
 def safe_conversations_generator(file_path):

--- a/tests/test_utils/test_print_on_rank0.py
+++ b/tests/test_utils/test_print_on_rank0.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import unittest
+from types import ModuleType
+from unittest import mock
+
+
+def _load_utils_module():
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoTokenizer = object
+    transformers_module.PreTrainedTokenizerFast = object
+
+    transformers_utils_module = ModuleType("transformers.utils")
+    transformers_utils_module.cached_file = mock.Mock(return_value=None)
+
+    sys.modules.pop("specforge.utils", None)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "transformers": transformers_module,
+            "transformers.utils": transformers_utils_module,
+        },
+    ):
+        return importlib.import_module("specforge.utils")
+
+
+utils = _load_utils_module()
+
+
+class TestPrintOnRank0(unittest.TestCase):
+    def test_logs_without_distributed_init(self):
+        with (
+            mock.patch.object(utils, "dist") as mock_dist,
+            mock.patch.object(utils.logger, "info") as mock_info,
+        ):
+            mock_dist.is_available.return_value = False
+
+            utils.print_on_rank0("hello")
+
+        mock_info.assert_called_once_with("hello")
+
+    def test_skips_nonzero_rank(self):
+        with (
+            mock.patch.object(utils, "dist") as mock_dist,
+            mock.patch.object(utils.logger, "info") as mock_info,
+        ):
+            mock_dist.is_available.return_value = True
+            mock_dist.is_initialized.return_value = True
+            mock_dist.get_rank.return_value = 1
+
+            utils.print_on_rank0("hello")
+
+        mock_info.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils/test_print_on_rank0.py
+++ b/tests/test_utils/test_print_on_rank0.py
@@ -7,11 +7,11 @@ from unittest import mock
 
 def _load_utils_module():
     transformers_module = ModuleType("transformers")
-    transformers_module.AutoTokenizer = object
-    transformers_module.PreTrainedTokenizerFast = object
+    setattr(transformers_module, "AutoTokenizer", object)
+    setattr(transformers_module, "PreTrainedTokenizerFast", object)
 
     transformers_utils_module = ModuleType("transformers.utils")
-    transformers_utils_module.cached_file = mock.Mock(return_value=None)
+    setattr(transformers_utils_module, "cached_file", mock.Mock(return_value=None))
 
     sys.modules.pop("specforge.utils", None)
     with mock.patch.dict(


### PR DESCRIPTION
Training scripts save a checkpoint every --save-interval steps with no limit on how many are kept. For long runs (e.g. 500K steps with interval=2000), this produces 250+ checkpoints consuming 1.1TB+ of disk.

This PR adds a --save-total-limit argument to all three training scripts (train_domino, train_dflash, train_eagle3). When set, the oldest checkpoints beyond the limit are automatically removed after each save. Default is None (no cleanup) to preserve backward compatibility.

Changes:
- Add cleanup_checkpoints() utility in specforge/utils.py
- Add --save-total-limit arg to all three training scripts
- Call cleanup_checkpoints() after each periodic save (not after final)
- Add comprehensive unit tests in tests/test_utils/test_checkpoint_cleanup.py

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
