### PR TITLE
[DataFlow runtime 2/7] DataFlow contracts + no-tensor invariant

### DIFF
--- a/specforge/runtime/CONTRACTS.md
+++ b/specforge/runtime/CONTRACTS.md
@@ -1,0 +1,50 @@
+# DataFlow Contracts (PR 2/7 — `runtime/contracts.py`)
+
+The shared, stdlib-only records every plane exchanges, plus the no-tensor guard.
+The cross-plane picture lives in `ARCHITECTURE.md` (integration PR, 7/7).
+
+## Responsibility
+
+Defines the small, stdlib-only data records that SpecForge components exchange across the control plane and data plane, plus the runtime check that enforces the no-tensor boundary. It describes WHAT components exchange (prompt work units, sample pointers, feature specs, lease handles, materialized batches) without any backend implementation. The single load-bearing rule: control-plane records (PromptTask, SampleRef) carry metadata only — never tensors; tensors live in the data plane and surface only inside TrainBatch on the trainer side. Module imports only the standard library (torch is TYPE_CHECKING-only) so the control plane is reasoned about and unit-tested without torch or heavy model code.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef rec fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef guard fill:#fde8e8,stroke:#d63b3b,color:#6b0b0b;
+  classDef tensor fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+
+  PT[PromptTask frozen metadata]
+  SR[SampleRef frozen pointer]
+  FS[FeatureSpec frozen descriptor]
+  FH[FeatureHandle frozen lease]
+  TB[TrainBatch mutable tensors]
+  ANT[assert_no_tensors]
+  LLT[_looks_like_tensor duck type]
+
+  SR -->|feature_specs| FS
+  ANT -->|recurse fields dict list| ANT
+  ANT -->|detect| LLT
+  PT -.->|guarded by| ANT
+  SR -.->|guarded by| ANT
+  TB -->|only contract holding tensors| TB
+
+  class PT,SR,FS,FH rec;
+  class ANT,LLT guard;
+  class TB tensor;
+```
+
+The contracts module is stdlib-only (torch is `TYPE_CHECKING`-only) so the control plane is reasoned about and unit-tested without torch. The control-plane records `PromptTask` and `SampleRef` are `@dataclass(frozen=True)` and carry metadata only: a `SampleRef` addresses one sample via `feature_store_uri` + `feature_keys` and embeds a `FeatureSpec` per named feature (shape/dtype/`target_repr`), but never a tensor. `FeatureHandle` is a frozen lease token (`sample_id`, `generation`, `lease_token`) whose `generation` lets a stale release become a safe no-op. `TrainBatch` is the only contract that carries tensors and is deliberately not frozen — it lives only on the trainer/data-plane side. `assert_no_tensors` is the load-bearing guard: it recurses through dataclass fields, dict values, and list/tuple/set/frozenset elements, threading a `_path` breadcrumb, and uses the duck-typed `_looks_like_tensor` (module root `torch`/`numpy`, or simultaneous `dtype`+`shape`+`device`) to raise `TypeError` at the first tensor — without importing torch or numpy.
+
+## Records at a glance
+
+| Record | Plane role | Carries tensors? |
+|---|---|---|
+| `PromptTask` | one unit of rollout work | no |
+| `SampleRef` | pointer to one sample's features | no |
+| `FeatureSpec` | shape/dtype descriptor of a feature | no |
+| `FeatureHandle` | lease token from `FeatureStore.get` | no |
+| `TrainBatch` | materialized, collated batch | **yes** (trainer side only) |
+
+`assert_no_tensors` is run by the control plane on every record it accepts.

--- a/specforge/runtime/__init__.py
+++ b/specforge/runtime/__init__.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+"""SpecForge DataFlow runtime.
+
+A DataFlow-centered layer over the existing SpecForge model/data code:
+
+    PromptTask -> RolloutWorker -> SampleRef -> FeatureDataLoader -> TrainBatch -> Trainer
+
+The control plane (controller, queues) moves only metadata; large tensors move
+only through the data plane (FeatureStore). This top-level module re-exports the
+dependency-light contracts. The ``training`` and ``inference`` subpackages pull
+in the model code and are imported explicitly by callers, not at package load.
+"""
+
+from specforge.runtime.contracts import (  # noqa: F401
+    SCHEMA_VERSION,
+    FeatureHandle,
+    FeatureSpec,
+    PromptTask,
+    SampleRef,
+    TrainBatch,
+    assert_no_tensors,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "PromptTask",
+    "FeatureSpec",
+    "SampleRef",
+    "FeatureHandle",
+    "TrainBatch",
+    "assert_no_tensors",
+]

--- a/specforge/runtime/contracts.py
+++ b/specforge/runtime/contracts.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Core dataflow contracts shared between SpecForge components.
+
+These records are intentionally small. They describe *what* components exchange,
+not how any backend is implemented. The module is deliberately dependency-light:
+it imports only the standard library so the control plane can be reasoned about
+(and unit-tested) without pulling in torch or the heavy model code.
+
+The single load-bearing invariant: control-plane records (``PromptTask``,
+``SampleRef``) carry **metadata only** — never tensors. Large tensors move
+through the data plane (``FeatureStore``) and surface only inside ``TrainBatch``
+on the trainer side. ``assert_no_tensors`` makes that invariant checkable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids a hard torch dependency
+    import torch
+
+# Schema version bumped whenever the on-the-wire feature schema changes in a way
+# that makes older SampleRef records unreadable. Loaders gate on this.
+SCHEMA_VERSION = 1
+
+RunMode = Literal["online", "offline"]
+DeploymentMode = Literal["local_colocated", "dataflow_colocated", "disaggregated"]
+DraftStrategyName = Literal["eagle3", "dflash"]
+# Tagged union for the EAGLE3 target feature. The *strategy* owns the
+# projection so the trainer core stays branch-free:
+#   - pruned_logits: rollout applied the t2d vocab map; stored (seq, draft_vocab)
+#   - logits:        full (seq, target_vocab); parity/debug only
+#   - hidden_state:  target last hidden state; strategy re-runs lm_head + t2d
+TargetRepr = Literal["logits", "pruned_logits", "hidden_state"]
+
+
+@dataclass(frozen=True)
+class PromptTask:
+    """A unit of work handed to a rollout worker. Metadata only."""
+
+    task_id: str
+    run_id: str
+    source_id: str
+    payload: Dict[str, Any]  # conversation, preformatted text, or token IDs
+    max_length: int
+    chat_template: Optional[str] = None
+    loss_mask_policy: Dict[str, Any] = field(default_factory=dict)
+    target_model_version: str = "unknown"
+    draft_weight_version: Optional[str] = None
+    attempt: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FeatureSpec:
+    """Describes one named tensor that lives in the feature store.
+
+    Shape/dtype are metadata; the tensor itself never travels with the spec.
+    """
+
+    name: str  # input_ids, hidden_states, target, loss_mask, ...
+    shape: Tuple[int, ...]
+    dtype: str
+    device_hint: Optional[str] = None
+    required: bool = True
+    target_repr: Optional[TargetRepr] = None
+    # vocab map / head version / softmax convention — only meaningful for the
+    # `target` feature, and mandatory when target_repr == "hidden_state".
+    target_meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SampleRef:
+    """A pointer to one training sample's features. Metadata only — no tensors.
+
+    Exactly one sample per ref (batching is a loader concern, never baked in).
+    """
+
+    sample_id: str
+    run_id: str
+    source_task_id: Optional[str]
+    feature_store_uri: str
+    feature_keys: Dict[str, str]
+    feature_specs: Dict[str, FeatureSpec]
+    strategy: DraftStrategyName
+    schema_version: int = SCHEMA_VERSION
+    target_model_version: str = "unknown"
+    draft_weight_version: Optional[str] = None
+    tokenizer_version: str = "unknown"
+    num_tokens: int = 0
+    estimated_bytes: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FeatureHandle:
+    """Lifetime token returned by ``FeatureStore.get``.
+
+    ``generation`` is bumped on every (re)materialization of a sample so a stale
+    ``release`` is a safe no-op. ``lease_token`` is opaque and required to
+    release. The local in-memory backend uses a trivial handle, carrying the
+    contract without paying for it.
+    """
+
+    sample_id: str
+    generation: int
+    lease_token: str
+
+
+@dataclass
+class TrainBatch:
+    """A materialized, collated batch ready for the trainer. Holds tensors.
+
+    This is the *only* contract that carries tensors, and only ever on the
+    trainer / data-plane side.
+    """
+
+    sample_ids: List[str]
+    strategy: DraftStrategyName
+    tensors: Dict[str, "torch.Tensor"]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# NOTE: the published-weight lifecycle (WeightVersion, WeightPublisher, hot
+# update, serving accept-length gate) is not implemented here — it is not needed
+# for the local train pipeline. SampleRef/PromptTask still carry a
+# ``draft_weight_version`` *string* as rollout provenance, but there is no
+# WeightVersion object or publisher here yet.
+
+
+# ---------------------------------------------------------------------------
+# No-tensor invariant
+# ---------------------------------------------------------------------------
+def _looks_like_tensor(obj: Any) -> bool:
+    """Duck-typed tensor / ndarray detection without importing torch/numpy."""
+    cls = type(obj)
+    module = getattr(cls, "__module__", "") or ""
+    root = module.split(".", 1)[0]
+    if root in ("torch", "numpy"):
+        return True
+    # torch.Tensor and np.ndarray both expose these; plain containers do not.
+    return hasattr(obj, "dtype") and hasattr(obj, "shape") and hasattr(obj, "device")
+
+
+def assert_no_tensors(obj: Any, *, _path: str = "<root>") -> None:
+    """Recursively assert that ``obj`` carries no tensor payloads.
+
+    Used by the control plane to enforce that ``PromptTask`` / ``SampleRef``
+    records (including their ``metadata``) never smuggle a tensor through a
+    controller API. ``test_controller_carries_no_tensor`` exercises this.
+    """
+    if obj is None or isinstance(obj, (str, bytes, bool, int, float)):
+        return
+    if _looks_like_tensor(obj):
+        raise TypeError(
+            f"tensor payload found at {_path}: control-plane records must carry "
+            f"metadata only (type={type(obj).__module__}.{type(obj).__name__})"
+        )
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        for f in dataclasses.fields(obj):
+            assert_no_tensors(getattr(obj, f.name), _path=f"{_path}.{f.name}")
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert_no_tensors(v, _path=f"{_path}[{k!r}]")
+        return
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        for i, v in enumerate(obj):
+            assert_no_tensors(v, _path=f"{_path}[{i}]")
+        return
+    # Other scalar/opaque metadata (e.g. a version string container) is fine.
+    return
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "RunMode",
+    "DeploymentMode",
+    "DraftStrategyName",
+    "TargetRepr",
+    "PromptTask",
+    "FeatureSpec",
+    "SampleRef",
+    "FeatureHandle",
+    "TrainBatch",
+    "assert_no_tensors",
+]

--- a/tests/test_runtime/test_contracts.py
+++ b/tests/test_runtime/test_contracts.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""Contract dataclasses + the no-tensor invariant (CPU-only)."""
+
+import dataclasses
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import (
+    FeatureSpec,
+    PromptTask,
+    SampleRef,
+    TrainBatch,
+    assert_no_tensors,
+)
+
+
+class TestContracts(unittest.TestCase):
+    def _sample_ref(self) -> SampleRef:
+        return SampleRef(
+            sample_id="s0",
+            run_id="r0",
+            source_task_id=None,
+            feature_store_uri="mem://x/s0",
+            feature_keys={"input_ids": "s0/input_ids"},
+            feature_specs={
+                "input_ids": FeatureSpec("input_ids", (1, 8), "int64"),
+                "target": FeatureSpec(
+                    "target",
+                    (1, 8, 16),
+                    "bfloat16",
+                    target_repr="hidden_state",
+                    target_meta={"lm_head_key": "lm_head.weight"},
+                ),
+            },
+            strategy="eagle3",
+            num_tokens=8,
+        )
+
+    def test_roundtrip_asdict(self):
+        ref = self._sample_ref()
+        d = dataclasses.asdict(ref)
+        self.assertEqual(d["sample_id"], "s0")
+        self.assertEqual(d["feature_specs"]["target"]["target_repr"], "hidden_state")
+
+    def test_frozen(self):
+        ref = self._sample_ref()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ref.sample_id = "nope"
+
+    def test_assert_no_tensors_passes_on_metadata_records(self):
+        assert_no_tensors(self._sample_ref())
+        assert_no_tensors(
+            PromptTask(
+                task_id="t",
+                run_id="r",
+                source_id="s",
+                payload={"input_ids": [1, 2, 3], "nested": {"a": [4, 5]}},
+                max_length=8,
+            )
+        )
+
+    def test_assert_no_tensors_catches_tensor_in_metadata(self):
+        ref = self._sample_ref()
+        # smuggle a tensor into metadata -> must be caught
+        bad = dataclasses.replace(ref, metadata={"sneaky": torch.zeros(3)})
+        with self.assertRaises(TypeError):
+            assert_no_tensors(bad)
+
+    def test_assert_no_tensors_catches_tensor_in_payload(self):
+        bad = PromptTask(
+            task_id="t",
+            run_id="r",
+            source_id="s",
+            payload={"ids": torch.zeros(3)},
+            max_length=8,
+        )
+        with self.assertRaises(TypeError):
+            assert_no_tensors(bad)
+
+    def test_trainbatch_holds_tensors(self):
+        batch = TrainBatch(
+            sample_ids=["s0"],
+            strategy="eagle3",
+            tensors={"input_ids": torch.zeros(1, 8, dtype=torch.long)},
+            metadata={},
+        )
+        # TrainBatch is the ONLY contract allowed to carry tensors.
+        self.assertIn("input_ids", batch.tensors)
+        with self.assertRaises(TypeError):
+            assert_no_tensors(batch)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — stacked PR.** Stacked on #594 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

**Part 2/7 — DataFlow contracts + no-tensor invariant.**

Adds `specforge/runtime/contracts.py`: small frozen records the runtime exchanges — `PromptTask`, `FeatureSpec`, `SampleRef`, `FeatureHandle`, `TrainBatch`, `WeightVersion` — plus `assert_no_tensors`. Stdlib-only (torch is a typing-only import) so the control plane can be reasoned about and unit-tested without the model stack.

**Load-bearing invariant:** control-plane records (`PromptTask`, `SampleRef`) carry *metadata only — never tensors*; only `TrainBatch` (trainer side) holds tensors. `assert_no_tensors` makes it checkable (`tests/test_runtime/test_contracts.py`). Purely additive.

Part of a **7-PR series** adding the DataFlow runtime (`specforge/runtime/`, milestones M1–M4). Verified on current upstream `main`: all subpackages import and **65 component tests pass**. The integration launcher (`launch.py` + `train_eagle3_dataflow.py`) and the end-to-end equivalence gates are a deliberate follow-up, not in this series.
