### PR TITLE
[DataFlow runtime 3/7] Data plane: FeatureStore, queue, offline reader, loader

### DIFF
--- a/specforge/runtime/data_plane/DESIGN.md
+++ b/specforge/runtime/data_plane/DESIGN.md
@@ -1,0 +1,209 @@
+# Data Plane Design (PR 3/7 — `runtime/data_plane`)
+
+This is the design note for the **data plane**: the large-tensor storage and
+transfer boundary, plus the two metadata-only iteration sources that feed it and
+the loader that turns references into training batches.
+
+It is one slice of the larger DataFlow refactor. The end-to-end motivation and
+staged plan live in `docs/dataflow_centered_scaleout_refactor_plan.md` on the
+`refactor/specforge-redesign` branch; the shared records this layer exchanges are
+defined in [`runtime/contracts.py`](../contracts.py).
+
+## The one load-bearing invariant
+
+There are **two planes**, and they never mix:
+
+- **Control plane** moves only `SampleRef` — *metadata, never tensors*
+  (`assert_no_tensors` enforces this structurally).
+- **Data plane** (`FeatureStore`) is the *only* component that holds tensors.
+
+Everything below is a consequence of keeping those two separate.
+
+## Online vs offline: where they diverge, where they converge
+
+```mermaid
+flowchart TD
+    subgraph produce["① produce — online / offline diverge"]
+        direction LR
+        subgraph online["online (rollout)"]
+            direction TB
+            O1["rollout worker<br/><i>computes features on GPU</i>"]
+            O2["FeatureStore · mem://<br/><i>tensors in RAM, freed on release</i>"]
+            O3["SampleRefQueue<br/><i>ref stream, consume-once</i>"]
+            O1 --> O2 --> O3
+        end
+        subgraph offline["offline (precomputed)"]
+            direction TB
+            F1["prepare_hidden_states.py<br/><i>earlier job, writes to disk</i>"]
+            F2[".ckpt files on disk<br/><i>tensors already on disk</i>"]
+            F3["OfflineManifestReader<br/><i>scan → refs (file://)</i>"]
+            F1 --> F2 --> F3
+        end
+    end
+
+    SR["SampleRef<br/><i>metadata only · no tensors</i>"]
+    O3 -->|control flow| SR
+    F3 -->|control flow| SR
+
+    SR --> DL["FeatureDataLoader<br/><i>get → clone → collate</i>"]
+    DL --> TB["TrainBatch<br/><i>the only tensor-carrying contract</i>"]
+    TB --> TR["Trainer<br/><i>draft model training</i>"]
+
+    O2 -.->|fetch tensors| DL
+    F2 -.->|fetch tensors| DL
+
+    classDef data fill:#E1F5EE,stroke:#0F6E56,color:#085041;
+    classDef control fill:#EEEDFE,stroke:#534AB7,color:#3C3489;
+    classDef compute fill:#F1EFE8,stroke:#5F5E5A,color:#444441;
+    class O2,F2,TB data;
+    class O3,F3,SR control;
+    class O1,F1,DL,TR compute;
+```
+
+Legend: teal = **data plane** (carries tensors) · purple = **control plane**
+(metadata only) · gray = compute. Solid = control flow · dashed = tensor fetch.
+
+Read it in three bands:
+
+1. **Produce (diverge).** This is the *only* place the two modes differ — and
+   they differ on both planes at once:
+   - *Data plane:* online's `rollout_worker` computes tensors on the GPU and
+     `put()`s them into `FeatureStore` as `mem://` (RAM). Offline's tensors were
+     written to disk **earlier** by `prepare_hidden_states.py`; nobody re-writes
+     them — the reader just points at the existing `.ckpt` files.
+   - *Control plane:* online refs flow through `SampleRefQueue` (a consume-once
+     stream); offline refs are produced by `OfflineManifestReader` scanning files
+     (`file://`).
+
+2. **Converge.** Both control-plane paths meet at `SampleRef` — a metadata-only
+   contract. From here down, **no code branches on online vs offline.**
+
+3. **Consume (shared).** `FeatureDataLoader → TrainBatch → Trainer` is one code
+   path for both modes.
+
+### The subtle part: control flow converges, tensors do not
+
+Notice the dashed arrows **bypass** `SampleRef` and go straight into the loader.
+Only the *control flow* (refs) actually merges. The *tensors* are fetched
+separately by the loader via `store.get(ref)`, which **re-routes by URI**:
+
+| ref URI    | source              | populates `_mem`? |
+|------------|---------------------|-------------------|
+| `mem://`   | `_mem` (RAM)        | yes (online only) |
+| `file://`  | disk file (mmap)    | no                |
+
+So the loader and trainer share one API and one code path, but the physical data
+source stays split until the very last moment, behind `FeatureStore.get`.
+
+## Components
+
+All four live in this folder; each carries no knowledge of the model.
+
+### `FeatureStore` / `LocalFeatureStore` — [`feature_store.py`](feature_store.py)
+
+The data plane's storage and transfer boundary. `FeatureStore` is the abstract
+contract; `LocalFeatureStore` is the only backend today (shared-memory and
+Mooncake/RDMA backends slot in behind the same API later).
+
+`LocalFeatureStore` serves both ref flavours transparently:
+
+- `mem://<store_id>/<sample_id>` — produced by `put()` (online rollout), held in
+  RAM on the hot path, with an opt-in disk/mmap `dump_dir` that doubles as the
+  capture/replay tap.
+- `file://<abs_path>` — produced by `OfflineManifestReader`; `get()` lazily loads
+  the named keys out of the existing file. No tensor copy, no `_mem` residency.
+
+Why RAM for the online hot path (not disk): online samples are computed fresh,
+consumed once, and require freshness — there is no reuse to amortize a disk
+round-trip, and disk bandwidth would bottleneck rollout. Offline samples are the
+opposite (computed once, reused every epoch), which is exactly why offline lives
+on disk.
+
+### `SampleRefQueue` — [`sample_ref_queue.py`](sample_ref_queue.py)
+
+A **metadata-only** queue with lease / ack / fail semantics (carries no
+tensors). In-process today, but the lease contract is present so a durable queue
+(visibility timeout, replay) can be swapped in without touching callers.
+`put` is idempotent on `sample_id` (at-least-once delivery); `fail(retryable=…)`
+either requeues or drops.
+
+### `OfflineManifestReader` — [`offline_reader.py`](offline_reader.py)
+
+Walks a directory of precomputed `.ckpt` files and emits one metadata-only
+`SampleRef` per file, referencing each file in place via a `file://` URI. It is
+the offline **ref producer** — it never `put()`s tensors. (Its online counterpart
+is `rollout_worker`, not the queue.)
+
+### `FeatureDataLoader` — [`feature_dataloader.py`](feature_dataloader.py)
+
+The bridge from `SampleRef` to `TrainBatch`, and the one place the online/offline
+difference is erased. Two iteration modes:
+
+- `queue` — online stream, consume-once, owns ack/fail of the queue.
+- `refs` — offline fixed set, re-iterable across epochs.
+
+For each ref it materializes (`store.get` → clone-on-fetch → `store.release`),
+applies an **injected** `per_sample_transform`, validates batch homogeneity,
+collates via an **injected** `collate_fn`, and emits a `TrainBatch`. Because
+transform and collate are injected, the loader carries no model knowledge and is
+unit-testable on CPU.
+
+What is explicitly **not** the loader's job: model semantics (injected), physical
+tensor free (the store's job — see below), and how samples are produced.
+
+## Lifecycle and memory semantics
+
+The store has five lifetime ops:
+
+| op          | who calls it                          | effect on `_mem`            |
+|-------------|---------------------------------------|-----------------------------|
+| `put`       | `rollout_worker` (online only)        | adds the sample             |
+| `get`       | `FeatureDataLoader`                   | none (hands out a lease)    |
+| `release`   | `FeatureDataLoader` after fetch       | frees on the last lease     |
+| `abort`     | `rollout_worker` / terminal drop      | evicts (or debug-retains)   |
+| `gc`        | controller/orchestrator on a timer    | force-frees abandoned bytes |
+
+### Consume-once free (the design point worth remembering)
+
+`mem://` samples are **consume-once**. The store owns the tensors, and physical
+free is the *store's* responsibility — the consumer never needs to know the
+backend's memory policy. `release()` therefore frees the sample's tensors once
+the **last lease on the current generation** drops (reference-counted). `file://`
+samples never enter `_mem`, so release is a harmless no-op for them and offline
+ref sets stay re-iterable across epochs.
+
+Generation is a **global monotonic counter**: a re-`put` of the same `sample_id`
+always gets a strictly higher generation, so a stale handle released after the
+re-put is a safe no-op and can never alias freshly stored data. This is what lets
+`release()` drop the `_generation` entry too, bounding metadata growth.
+
+> **History / rationale.** An earlier version made `release()` free only the
+> *lease*, leaving tensors in `_mem` until `abort()`. But on the online success
+> path nothing calls `abort()` (it is only reached on a failed `put`), so a
+> `put → get → release` loop over unique `sample_id`s grew `_mem` without bound —
+> an OOM on long online runs. Offline was unaffected (it uses `file://`, never
+> `_mem`). The fix moves physical free into `release()` as above; see the
+> `test_release_*` and `test_online_put_get_release_loop_is_bounded` tests.
+
+### Backpressure guard
+
+`LocalFeatureStore(max_resident_bytes=…)` (opt-in, default unbounded) makes
+`put()` raise a descriptive `MemoryError` once residency would exceed the budget
+— a defined failure instead of a silent OOM when the consumer falls behind.
+Residency is observable via `health()`.
+
+## Tests
+
+CPU-only, in [`tests/test_runtime/`](../../../tests/test_runtime):
+
+- `test_feature_store.py` — atomic put, get/handle, idempotent + stale-safe
+  release, **consume-once free**, refcounted multi-lease, **bounded online
+  loop**, `max_resident_bytes`, abort, disk dump, `file://` mode.
+- `test_sample_ref_queue.py` — lease / ack / fail / depth, idempotent put.
+- `test_feature_dataloader.py` — queue and refs modes, drop_last, batch
+  homogeneity validation, offline re-iteration across epochs.
+
+```bash
+# heavy model imports are stubbed on CPU; runs without a GPU or model download
+python -m unittest discover -s tests/test_runtime
+```

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+"""Data plane: large-tensor storage, transfer, and materialization."""
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.feature_store import (
+    FeatureStore,
+    LocalFeatureStore,
+    load_feature_file,
+    spec_from_tensor,
+)
+from specforge.runtime.data_plane.offline_reader import (
+    OfflineManifestReader,
+    list_feature_files,
+)
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+__all__ = [
+    "FeatureStore",
+    "LocalFeatureStore",
+    "load_feature_file",
+    "spec_from_tensor",
+    "SampleRefQueue",
+    "FeatureDataLoader",
+    "OfflineManifestReader",
+    "list_feature_files",
+]

--- a/specforge/runtime/data_plane/feature_dataloader.py
+++ b/specforge/runtime/data_plane/feature_dataloader.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""FeatureDataLoader: ``SampleRef`` + ``FeatureStore`` -> ``TrainBatch``.
+
+The loader is the one place the online/offline difference is erased: it leases
+refs from a queue, fetches their tensors from the store, normalizes each sample
+(an injectable ``per_sample_transform``), collates a batch (an injectable
+``collate_fn``), and emits a ``TrainBatch``. Because both transform and collate
+are injected, the loader carries no model knowledge and is unit-testable on CPU;
+the offline-EAGLE3 run injects the existing ``OfflineEagle3Dataset.process_data``
+and ``DataCollatorWithPadding`` so the result is bit-identical to today's path.
+
+clone-on-fetch is the default: the loader clones tensors out of the store and
+releases the store handle immediately, so prefetch can never race a release.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import SampleRef, TrainBatch
+from specforge.runtime.data_plane.feature_store import FeatureStore
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+PerSampleTransform = Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
+CollateFn = Callable[[List[Dict[str, torch.Tensor]]], Dict[str, Any]]
+
+
+def _default_collate(features: List[Dict[str, torch.Tensor]]) -> Dict[str, Any]:
+    """Trivial stack collate (used only when no collate_fn is injected)."""
+    keys = features[0].keys()
+    return {k: torch.stack([f[k] for f in features], dim=0) for k in keys}
+
+
+class FeatureDataLoader:
+    def __init__(
+        self,
+        store: FeatureStore,
+        queue: Optional[SampleRefQueue] = None,
+        *,
+        refs: Optional[List[SampleRef]] = None,
+        batch_size: int = 1,
+        collate_fn: Optional[CollateFn] = None,
+        per_sample_transform: Optional[PerSampleTransform] = None,
+        device: "torch.device | str" = "cpu",
+        clone_on_fetch: bool = True,
+        drop_last: bool = True,
+        strategy: str = "eagle3",
+        ack: bool = True,
+    ) -> None:
+        # Two iteration modes, reflecting that online and offline differ in
+        # *iteration* even though they converge at SampleRef:
+        #   - queue: a consume-once stream (online rollout produces over time)
+        #   - refs:  a fixed set, re-iterable across epochs (offline manifest)
+        if (queue is None) == (refs is None):
+            raise ValueError(
+                "provide exactly one of `queue` (stream) or `refs` (re-iterable)"
+            )
+        self.store = store
+        self.queue = queue
+        self._refs = list(refs) if refs is not None else None
+        self.batch_size = batch_size
+        self.collate_fn = collate_fn or _default_collate
+        self.per_sample_transform = per_sample_transform
+        self.device = device
+        self.clone_on_fetch = clone_on_fetch
+        self.drop_last = drop_last
+        self.strategy = strategy
+        self.ack = ack
+
+    def _validate_refs(self, refs: List[SampleRef]) -> None:
+        strategies = {ref.strategy for ref in refs}
+        if strategies != {self.strategy}:
+            raise ValueError(
+                f"loader strategy={self.strategy!r} received refs with "
+                f"strategies={sorted(strategies)}"
+            )
+
+        schema_versions = {ref.schema_version for ref in refs}
+        if len(schema_versions) != 1:
+            raise ValueError(
+                f"mixed schema versions in batch: {sorted(schema_versions)}"
+            )
+
+        target_reprs = {ref.metadata.get("target_repr") for ref in refs}
+        if len(target_reprs) != 1:
+            raise ValueError(
+                f"mixed target_repr values in batch: {sorted(map(repr, target_reprs))}"
+            )
+
+        spec_sets = [set(ref.feature_specs) for ref in refs if ref.feature_specs]
+        if spec_sets and any(spec_set != spec_sets[0] for spec_set in spec_sets[1:]):
+            raise ValueError(f"mixed feature spec names in batch: {spec_sets}")
+
+        if not spec_sets:
+            return
+        first_specs = next(ref.feature_specs for ref in refs if ref.feature_specs)
+        for ref in refs:
+            if not ref.feature_specs:
+                continue
+            for name, spec in ref.feature_specs.items():
+                expected = first_specs[name]
+                if spec.dtype != expected.dtype or len(spec.shape) != len(
+                    expected.shape
+                ):
+                    raise ValueError(
+                        f"incompatible feature spec for sample {ref.sample_id}, "
+                        f"feature {name!r}: {spec} vs {expected}"
+                    )
+
+    def _materialize(self, ref: SampleRef) -> Dict[str, torch.Tensor]:
+        tensors, handle = self.store.get(ref, device=self.device)
+        if self.clone_on_fetch:
+            tensors = {k: v.clone() for k, v in tensors.items()}
+        self.store.release(handle, reason="loaded")
+        if self.per_sample_transform is not None:
+            tensors = self.per_sample_transform(tensors)
+        return tensors
+
+    def _make_batch(self, refs: List[SampleRef]) -> TrainBatch:
+        self._validate_refs(refs)
+        per_sample = [self._materialize(r) for r in refs]
+        batch_tensors = self.collate_fn(per_sample)
+        non_tensors = [
+            name
+            for name, value in batch_tensors.items()
+            if not isinstance(value, torch.Tensor)
+        ]
+        if non_tensors:
+            raise TypeError(f"collate_fn returned non-tensors for {non_tensors}")
+        return TrainBatch(
+            sample_ids=[r.sample_id for r in refs],
+            strategy=self.strategy,
+            tensors=batch_tensors,
+            metadata={
+                "target_repr": refs[0].metadata.get("target_repr"),
+                "ttt_length": refs[0].metadata.get("ttt_length"),
+            },
+        )
+
+    def __iter__(self) -> Iterator[TrainBatch]:
+        if self._refs is not None:
+            yield from self._iter_refs()
+        else:
+            yield from self._iter_queue()
+
+    def _iter_refs(self) -> Iterator[TrainBatch]:
+        # Offline: a fixed ref set, re-iterable every epoch. Acking (durable
+        # marker) is the trainer's job via its ack callback, not the loader's.
+        for start in range(0, len(self._refs), self.batch_size):
+            chunk = self._refs[start : start + self.batch_size]
+            if self.drop_last and len(chunk) < self.batch_size:
+                break
+            yield self._make_batch(chunk)
+
+    def _iter_queue(self) -> Iterator[TrainBatch]:
+        while True:
+            refs = self.queue.get(self.batch_size, timeout_s=0.0)
+            if not refs:
+                return
+            if self.drop_last and len(refs) < self.batch_size:
+                # Incomplete trailing batch: fail-retryable so it is not lost,
+                # then stop (mirrors DataLoader(drop_last=True) per epoch pass).
+                self.queue.fail(refs, reason="drop_last", retryable=True)
+                return
+            try:
+                batch = self._make_batch(refs)
+            except Exception as exc:
+                self.queue.fail(refs, reason=f"materialize:{exc}", retryable=False)
+                raise
+            yield batch
+            if self.ack:
+                self.queue.ack(refs)
+
+    def set_epoch(self, epoch: int) -> None:
+        # hook for per-epoch shuffling of the offline ref set (no-op for now)
+        self._epoch = epoch
+
+    def close(self) -> None:
+        pass
+
+
+__all__ = ["FeatureDataLoader", "PerSampleTransform", "CollateFn"]

--- a/specforge/runtime/data_plane/feature_store.py
+++ b/specforge/runtime/data_plane/feature_store.py
@@ -1,0 +1,391 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""FeatureStore: the data plane's large-tensor storage and transfer boundary.
+
+``FeatureStore`` is the abstract contract; ``LocalFeatureStore`` is the local
+implementation. The local backend keeps features in memory on the hot path,
+with an *optional* disk/mmap debug dump that doubles as the capture/replay tap.
+It also supports a read-only "existing file" mode so the
+``OfflineManifestReader`` can reference precomputed ``.ckpt`` files without
+copying them.
+
+Other backends (shared memory, Mooncake/RDMA) slot in behind the same API; the
+lease/generation/clone-on-fetch primitives are carried here so the in-memory
+backend pays nothing for them but the contract is already exercised.
+
+This is the *minimal core*: relative to the first cut it adds exactly three
+correctness fixes and nothing else.
+
+* **generation-in-URI**: ``mem://`` refs carry their generation in the URI, and
+  ``get()`` rejects a ref whose generation no longer matches the resident
+  sample. This closes the at-least-once redelivery hole where a stale ref could
+  silently alias a freshly re-put sample.
+* **atomic lease registration**: for ``mem://``, the resident read and the lease
+  registration happen under one lock, so a concurrent ``abort`` can never slip
+  between "I read the tensors" and "I registered my borrow".
+* **best-effort dump**: an optional debug dump failure no longer aborts an
+  otherwise successful in-memory publish (mem is authoritative, disk is a tap).
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import gzip
+import io
+import itertools
+import logging
+import os
+import threading
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, quote, urlparse
+
+import torch
+
+from specforge.runtime.contracts import (
+    SCHEMA_VERSION,
+    FeatureHandle,
+    FeatureSpec,
+    SampleRef,
+)
+
+logger = logging.getLogger(__name__)
+
+_DTYPE_BYTES = {  # best-effort; falls back to element_size() for real tensors
+    "float32": 4,
+    "float16": 2,
+    "bfloat16": 2,
+    "int64": 8,
+    "int32": 4,
+    "int16": 2,
+    "uint8": 1,
+    "bool": 1,
+}
+
+_GENERATION_QUERY_KEY = "generation"
+
+
+def _dtype_str(t: torch.Tensor) -> str:
+    return str(t.dtype).replace("torch.", "")
+
+
+def spec_from_tensor(name: str, t: torch.Tensor, **kw: Any) -> FeatureSpec:
+    return FeatureSpec(name=name, shape=tuple(t.shape), dtype=_dtype_str(t), **kw)
+
+
+def _make_mem_uri(store_id: str, sample_id: str, generation: int) -> str:
+    return (
+        f"mem://{store_id}/{quote(sample_id, safe='')}"
+        f"?{_GENERATION_QUERY_KEY}={generation}"
+    )
+
+
+def _mem_uri_generation(uri: str) -> Optional[int]:
+    """Extract the generation a ``mem://`` ref was minted for, if present."""
+    values = parse_qs(urlparse(uri).query).get(_GENERATION_QUERY_KEY)
+    return int(values[0]) if values else None
+
+
+class FeatureStore(abc.ABC):
+    """Stores and serves large feature tensors. Carries no scheduling state."""
+
+    @abc.abstractmethod
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef: ...
+
+    @abc.abstractmethod
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]: ...
+
+    @abc.abstractmethod
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None: ...
+
+    @abc.abstractmethod
+    def abort(self, sample_id: str, *, reason: str) -> None: ...
+
+    def estimate_bytes(self, specs: Dict[str, FeatureSpec]) -> int:
+        total = 0
+        for spec in specs.values():
+            n = 1
+            for d in spec.shape:
+                n *= int(d)
+            total += n * _DTYPE_BYTES.get(spec.dtype, 4)
+        return total
+
+    @abc.abstractmethod
+    def health(self) -> Dict[str, Any]: ...
+
+
+def load_feature_file(path: str) -> Dict[str, torch.Tensor]:
+    """Load a SpecForge offline feature file (mirrors OfflineEagle3Dataset)."""
+    if path.endswith(".gz"):
+        with gzip.open(path, "rb") as f:
+            return torch.load(io.BytesIO(f.read()), weights_only=False)
+    return torch.load(path, weights_only=False, mmap=True)
+
+
+class LocalFeatureStore(FeatureStore):
+    """In-memory feature store with optional disk dump and read-only file mode.
+
+    Two ref flavours are served transparently so the loader/trainer path is
+    identical online vs offline:
+
+    * ``mem://<store_id>/<sample_id>?generation=<n>`` — produced by :meth:`put`
+      (online rollout).
+    * ``file://<abs_path>`` — produced by ``OfflineManifestReader``; :meth:`get`
+      lazily loads the named keys out of the existing file.
+    """
+
+    def __init__(
+        self,
+        store_id: Optional[str] = None,
+        *,
+        dump_dir: Optional[str] = None,
+        clone_on_get: bool = False,
+        max_resident_bytes: Optional[int] = None,
+    ) -> None:
+        self.store_id = store_id or uuid.uuid4().hex[:8]
+        self.dump_dir = dump_dir
+        # When True the store itself clones on get(); normally the *loader* owns
+        # the clone policy (clone-on-fetch default lives there), so this is off.
+        self.clone_on_get = clone_on_get
+        # Optional cap on mem:// residency. None = unbounded. When set, put()
+        # raises loudly once exceeded — a defined failure instead of silent OOM.
+        self.max_resident_bytes = max_resident_bytes
+        self._mem: Dict[str, Dict[str, torch.Tensor]] = {}
+        self._generation: Dict[str, int] = {}
+        self._active_leases: Dict[str, FeatureHandle] = {}
+        self._lock = threading.RLock()
+        self._counter = itertools.count()
+        # Global monotonic generation: a re-put never reuses a prior generation,
+        # so a stale handle can never alias freshly stored data. This lets
+        # release() drop the _generation entry too (bounding metadata growth).
+        self._gen_counter = itertools.count(1)
+        if dump_dir:
+            os.makedirs(dump_dir, exist_ok=True)
+
+    def _resident_bytes_locked(self) -> int:
+        return sum(
+            t.numel() * t.element_size()
+            for feats in self._mem.values()
+            for t in feats.values()
+        )
+
+    # -- write -------------------------------------------------------------
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef:
+        if not tensors:
+            raise ValueError("put requires at least one tensor")
+        # Atomic from the controller's view: materialize fully, *then* return a
+        # ref. The over-budget check raises *before* the entry is committed, so
+        # there is nothing to roll back on that path.
+        staged = {k: v for k, v in tensors.items()}
+        specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
+        # Stamp the target feature's representation + vocab-map version onto its
+        # spec so the trainer-side mapping is version-gated. For pruned_logits the
+        # token-to-draft (t2d) map is applied at rollout, so the version must travel
+        # with the feature.
+        target_repr = metadata.get("target_repr")
+        target_name = metadata.get("target_feature_name", "target")
+        if target_repr and target_name in specs:
+            vmv = metadata.get("vocab_map_version")
+            specs[target_name] = dataclasses.replace(
+                specs[target_name],
+                target_repr=target_repr,
+                target_meta={"vocab_map_version": vmv} if vmv else {},
+            )
+        num_tokens = int(metadata.get("num_tokens", 0))
+        staged_bytes = sum(t.numel() * t.element_size() for t in staged.values())
+        with self._lock:
+            if self.max_resident_bytes is not None:
+                projected = self._resident_bytes_locked() + staged_bytes
+                if projected > self.max_resident_bytes:
+                    raise MemoryError(
+                        f"feature store {self.store_id} over budget: "
+                        f"{projected} > {self.max_resident_bytes} bytes "
+                        f"(resident_samples={len(self._mem)}); consumer is behind"
+                    )
+            gen = next(self._gen_counter)
+            self._generation[sample_id] = gen
+            self._mem[sample_id] = staged
+        # Best-effort capture/replay tap. mem is authoritative; a dump failure
+        # must not undo a successful in-memory publish, so it is logged, not
+        # raised.
+        if self.dump_dir:
+            try:
+                self._dump(sample_id, staged)
+            except Exception:  # pragma: no cover - disk is a debug side channel
+                logger.warning(
+                    "feature dump failed for sample %s in store %s; "
+                    "mem publish kept",
+                    sample_id,
+                    self.store_id,
+                    exc_info=True,
+                )
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=str(metadata.get("run_id", "unknown")),
+            source_task_id=metadata.get("source_task_id"),
+            feature_store_uri=_make_mem_uri(self.store_id, sample_id, gen),
+            feature_keys={k: f"{sample_id}/{k}" for k in staged},
+            feature_specs=specs,
+            strategy=metadata.get("strategy", "eagle3"),
+            schema_version=int(metadata.get("schema_version", SCHEMA_VERSION)),
+            target_model_version=str(metadata.get("target_model_version", "unknown")),
+            draft_weight_version=metadata.get("draft_weight_version"),
+            tokenizer_version=str(metadata.get("tokenizer_version", "unknown")),
+            num_tokens=num_tokens,
+            estimated_bytes=staged_bytes,
+            metadata={k: v for k, v in metadata.items() if k not in ("num_tokens",)},
+        )
+
+    def _dump(self, sample_id: str, tensors: Dict[str, torch.Tensor]) -> None:
+        path = os.path.join(self.dump_dir, f"{sample_id}.ckpt")
+        tmp = path + ".tmp"
+        torch.save({k: v.detach().cpu() for k, v in tensors.items()}, tmp)
+        os.replace(tmp, path)  # atomic publish
+
+    # -- read --------------------------------------------------------------
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        uri = sample_ref.feature_store_uri
+        wanted = names or list(sample_ref.feature_keys.keys())
+        if uri.startswith("file://"):
+            tensors = self._get_from_file(uri[len("file://") :], sample_ref, wanted)
+            handle = self._register_file_lease(sample_ref)
+        else:
+            tensors, handle = self._get_from_mem(sample_ref, wanted)
+        # Materialization (device move / clone) can fail or OOM. It happens
+        # *after* the lease exists, so on failure we drop the lease before
+        # propagating — no leaked borrow.
+        try:
+            if str(device) != "cpu":
+                tensors = {k: v.to(device) for k, v in tensors.items()}
+            if self.clone_on_get:
+                tensors = {k: v.clone() for k, v in tensors.items()}
+        except Exception:
+            self.release(handle, reason="materialization_failed")
+            raise
+        return tensors, handle
+
+    def _get_from_mem(
+        self, ref: SampleRef, wanted: List[str]
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        # The resident read and the lease registration share one lock so a
+        # concurrent abort() cannot reclaim the sample between them.
+        expected_generation = _mem_uri_generation(ref.feature_store_uri)
+        with self._lock:
+            if ref.sample_id not in self._mem:
+                raise KeyError(f"sample {ref.sample_id} not in store {self.store_id}")
+            gen = self._generation.get(ref.sample_id, 0)
+            if expected_generation is not None and gen != expected_generation:
+                raise KeyError(
+                    f"sample {ref.sample_id} generation {expected_generation} "
+                    f"is not resident in store {self.store_id} (current={gen})"
+                )
+            stored = self._mem[ref.sample_id]
+            missing = [n for n in wanted if n not in stored]
+            if missing:
+                raise KeyError(f"sample {ref.sample_id} missing features {missing}")
+            handle = FeatureHandle(
+                sample_id=ref.sample_id,
+                generation=gen,
+                lease_token=f"{ref.sample_id}:{gen}:{next(self._counter)}",
+            )
+            self._active_leases[handle.lease_token] = handle
+            out = {n: stored[n] for n in wanted}
+        return out, handle
+
+    def _register_file_lease(self, ref: SampleRef) -> FeatureHandle:
+        handle = FeatureHandle(
+            sample_id=ref.sample_id,
+            generation=0,
+            lease_token=f"{ref.sample_id}:0:{next(self._counter)}",
+        )
+        with self._lock:
+            self._active_leases[handle.lease_token] = handle
+        return handle
+
+    def _get_from_file(
+        self, path: str, ref: SampleRef, wanted: List[str]
+    ) -> Dict[str, torch.Tensor]:
+        raw = load_feature_file(path)
+        out = {}
+        for n in wanted:
+            # feature_keys may remap a logical name -> a raw file key.
+            raw_key = ref.feature_keys.get(n, n)
+            raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
+            if raw_key not in raw:
+                raise KeyError(f"{path} missing key {raw_key!r} for feature {n!r}")
+            out[n] = raw[raw_key]
+        return out
+
+    # -- lifetime ----------------------------------------------------------
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
+        # mem:// samples are consume-once: when the LAST lease on the current
+        # generation is released, free the tensors. This is what bounds online
+        # residency — release() owns physical free here, so the consumer never
+        # needs to know the backend's memory policy. file:// samples never enter
+        # _mem, so the pops below are harmless no-ops and offline ref sets stay
+        # re-iterable across epochs. Idempotent + stale-generation safe.
+        with self._lock:
+            self._active_leases.pop(handle.lease_token, None)
+            cur = self._generation.get(handle.sample_id)
+            if cur is not None and handle.generation != cur:
+                return  # stale handle (sample was re-put) -> no-op
+            # Count only leases on the CURRENT generation. A sample re-put while
+            # an older generation is still leased gets a fresh generation, so the
+            # stale older-gen lease must not keep the current generation pinned —
+            # otherwise the last current-gen release would leak it.
+            still_leased = any(
+                h.sample_id == handle.sample_id and h.generation == cur
+                for h in self._active_leases.values()
+            )
+            if not still_leased:
+                self._mem.pop(handle.sample_id, None)
+                self._generation.pop(handle.sample_id, None)
+
+    def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
+        with self._lock:
+            self._mem.pop(sample_id, None)
+            self._generation.pop(sample_id, None)
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "store_id": self.store_id,
+                "resident_samples": len(self._mem),
+                "active_leases": len(self._active_leases),
+                "resident_bytes": self._resident_bytes_locked(),
+                "max_resident_bytes": self.max_resident_bytes,
+            }
+
+
+__all__ = ["FeatureStore", "LocalFeatureStore", "load_feature_file", "spec_from_tensor"]

--- a/specforge/runtime/data_plane/offline_reader.py
+++ b/specforge/runtime/data_plane/offline_reader.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""OfflineManifestReader: turn precomputed feature files into ``SampleRef``s.
+
+The reader walks a directory of SpecForge offline feature files (the ``.ckpt`` /
+``.ckpt.gz`` produced by ``scripts/prepare_hidden_states.py``) and emits one
+metadata-only ``SampleRef`` per file, referencing the file in place via a
+``file://`` URI (read-only existing-file mode — no tensor copy, no tensor
+through the controller). The actual per-sample normalization (the
+``OfflineEagle3Dataset.process_data`` swap: stored ``aux_hidden_state`` becomes
+the draft input ``hidden_state`` and stored ``hidden_state`` becomes the
+``target``) is the FeatureDataLoader's job, keeping this reader independent of
+the model code.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterator, List, Optional, Tuple
+
+from specforge.runtime.contracts import SCHEMA_VERSION, FeatureSpec, SampleRef
+from specforge.runtime.data_plane.feature_store import (
+    load_feature_file,
+    spec_from_tensor,
+)
+
+_FEATURE_SUFFIXES = (".ckpt", ".ckpt.gz")
+# Raw keys present in a SpecForge offline EAGLE3 feature file.
+_OFFLINE_EAGLE3_KEYS = ("input_ids", "loss_mask", "hidden_state", "aux_hidden_state")
+
+
+def _inspect_feature_file(
+    path: str, feature_keys: Tuple[str, ...]
+) -> Tuple[Dict[str, FeatureSpec], int, int]:
+    raw = load_feature_file(path)
+    missing = [key for key in feature_keys if key not in raw]
+    if missing:
+        raise KeyError(f"{path} missing required offline feature keys {missing}")
+
+    specs: Dict[str, FeatureSpec] = {}
+    estimated_bytes = 0
+    for key in feature_keys:
+        value = raw[key]
+        if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+            raise TypeError(f"{path} feature {key!r} is not a tensor: {type(value)!r}")
+        specs[key] = spec_from_tensor(key, value)
+        estimated_bytes += int(value.numel() * value.element_size())
+
+    input_ids = raw.get("input_ids")
+    num_tokens = int(input_ids.numel()) if input_ids is not None else 0
+    return specs, num_tokens, estimated_bytes
+
+
+def list_feature_files(path: str) -> List[str]:
+    """Deterministically (sorted) list feature files under ``path``."""
+    if os.path.isfile(path):
+        return [os.path.abspath(path)]
+    files: List[str] = []
+    for root, _dirs, names in os.walk(path):
+        for name in names:
+            if name.endswith(_FEATURE_SUFFIXES):
+                files.append(os.path.abspath(os.path.join(root, name)))
+    files.sort()  # deterministic, stable cross-rank ordering
+    return files
+
+
+class OfflineManifestReader:
+    """Reads a directory of offline feature files into ``SampleRef`` records."""
+
+    def __init__(
+        self,
+        hidden_states_path: str,
+        *,
+        run_id: str = "offline",
+        strategy: str = "eagle3",
+        target_model_version: str = "unknown",
+        tokenizer_version: str = "unknown",
+        feature_keys: tuple = _OFFLINE_EAGLE3_KEYS,
+        ttt_length: int = 7,
+        max_len: int = 2048,
+        target_repr: str = "hidden_state",
+        validate_files: bool = True,
+    ) -> None:
+        self.hidden_states_path = hidden_states_path
+        self.run_id = run_id
+        self.strategy = strategy
+        self.target_model_version = target_model_version
+        self.tokenizer_version = tokenizer_version
+        self.feature_keys = tuple(feature_keys)
+        self.ttt_length = ttt_length
+        self.max_len = max_len
+        self.target_repr = target_repr
+        self.validate_files = validate_files
+
+    def _ref_for(self, index: int, path: str) -> SampleRef:
+        sample_id = f"{self.run_id}:{index:08d}"
+        specs: Dict[str, FeatureSpec] = {}
+        num_tokens = 0
+        estimated_bytes = 0
+        if self.validate_files:
+            specs, num_tokens, estimated_bytes = _inspect_feature_file(
+                path, self.feature_keys
+            )
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=self.run_id,
+            source_task_id=None,
+            feature_store_uri=f"file://{path}",
+            feature_keys={k: k for k in self.feature_keys},
+            feature_specs=specs,
+            strategy=self.strategy,
+            schema_version=SCHEMA_VERSION,
+            target_model_version=self.target_model_version,
+            tokenizer_version=self.tokenizer_version,
+            num_tokens=num_tokens,
+            estimated_bytes=estimated_bytes,
+            metadata={
+                "format": "offline_eagle3",
+                "target_repr": self.target_repr,
+                "schema_version": SCHEMA_VERSION,
+                "ttt_length": self.ttt_length,
+                "max_len": self.max_len,
+                "file_index": index,
+            },
+        )
+
+    def __iter__(self) -> Iterator[SampleRef]:
+        for index, path in enumerate(list_feature_files(self.hidden_states_path)):
+            yield self._ref_for(index, path)
+
+    def read(self, limit: Optional[int] = None) -> List[SampleRef]:
+        refs: List[SampleRef] = []
+        for i, ref in enumerate(self):
+            if limit is not None and i >= limit:
+                break
+            refs.append(ref)
+        return refs
+
+
+__all__ = ["OfflineManifestReader", "list_feature_files"]

--- a/specforge/runtime/data_plane/sample_ref_queue.py
+++ b/specforge/runtime/data_plane/sample_ref_queue.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""SampleRefQueue: a metadata-only queue with lease / ack / fail semantics.
+
+The current implementation is in-process; the lease/ack contract is present so a
+durable queue (visibility timeout, replay) can be swapped in later without
+touching callers. Carries no tensors — only ``SampleRef`` metadata.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import List, Optional
+
+from specforge.runtime.contracts import SampleRef, assert_no_tensors
+
+
+class SampleRefQueue:
+    def __init__(self, *, lease_timeout_s: Optional[float] = None) -> None:
+        self.lease_timeout_s = lease_timeout_s
+        self._pending: "OrderedDict[str, SampleRef]" = OrderedDict()
+        self._leased: "OrderedDict[str, tuple[SampleRef, float]]" = OrderedDict()
+        self._lock = threading.Lock()
+        self._cv = threading.Condition(self._lock)
+
+    def put(
+        self, refs: List[SampleRef], *, partition_key: Optional[str] = None
+    ) -> None:
+        # partition_key reserves the per-DP-rank queue partition seam for future
+        # reshard support. Today there is a single partition, so it is accepted
+        # and ignored.
+        with self._cv:
+            for ref in refs:
+                assert_no_tensors(ref)  # structural no-tensor guard
+                # Idempotent on sample_id (at-least-once delivery).
+                if ref.sample_id in self._leased or ref.sample_id in self._pending:
+                    continue
+                self._pending[ref.sample_id] = ref
+            self._cv.notify_all()
+
+    def get(
+        self,
+        max_refs: int,
+        timeout_s: Optional[float] = None,
+        *,
+        partition_key: Optional[str] = None,
+    ) -> List[SampleRef]:
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
+        with self._cv:
+            while True:
+                self._reclaim_expired_locked()
+                if self._pending:
+                    out: List[SampleRef] = []
+                    for _ in range(max_refs):
+                        if not self._pending:
+                            break
+                        sid, ref = self._pending.popitem(last=False)
+                        self._leased[sid] = (ref, time.monotonic())
+                        out.append(ref)
+                    return out
+                if deadline is None:
+                    return []
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return []
+                self._cv.wait(timeout=remaining)
+
+    def ack(self, refs: List[SampleRef]) -> None:
+        with self._cv:
+            for ref in refs:
+                self._leased.pop(ref.sample_id, None)  # idempotent
+
+    def fail(self, refs: List[SampleRef], reason: str, retryable: bool) -> None:
+        with self._cv:
+            for ref in refs:
+                self._leased.pop(ref.sample_id, None)
+                if retryable:
+                    self._pending[ref.sample_id] = ref  # back to the tail
+            if retryable:
+                self._cv.notify_all()
+
+    def depth(self) -> int:
+        with self._lock:
+            return len(self._pending)
+
+    def in_flight(self) -> int:
+        with self._lock:
+            return len(self._leased)
+
+    def _reclaim_expired_locked(self) -> None:
+        if self.lease_timeout_s is None or not self._leased:
+            return
+        now = time.monotonic()
+        expired = [
+            sid
+            for sid, (_, leased_at) in self._leased.items()
+            if now - leased_at > self.lease_timeout_s
+        ]
+        for sid in expired:
+            ref, _ = self._leased.pop(sid)
+            self._pending[sid] = ref
+
+
+__all__ = ["SampleRefQueue"]

--- a/tests/test_runtime/test_feature_dataloader.py
+++ b/tests/test_runtime/test_feature_dataloader.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""FeatureDataLoader: queue + store -> TrainBatch, with injected transform/collate (CPU)."""
+
+import os
+import tempfile
+import unittest
+from dataclasses import replace
+
+import torch
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+def _offline_eagle3_process_data(raw):
+    """Mirror of OfflineEagle3Dataset.process_data (the aux<->target swap)."""
+    max_len = 2048
+    hidden_state = raw["aux_hidden_state"].squeeze(0)[:max_len][None, :]
+    target = raw["hidden_state"].squeeze(0)[:max_len][None, :]
+    input_ids = raw["input_ids"][:max_len][None, :]
+    loss_mask = raw["loss_mask"][:max_len][None, :].clone()
+    loss_mask[0, -1] = 0
+    return {
+        "attention_mask": torch.ones_like(loss_mask, dtype=torch.long),
+        "loss_mask": loss_mask,
+        "target": target,
+        "hidden_state": hidden_state,
+        "input_ids": input_ids,
+    }
+
+
+def _simple_collate(features):
+    keys = features[0].keys()
+    return {k: torch.cat([f[k] for f in features], dim=0) for k in keys}
+
+
+class TestFeatureDataLoader(unittest.TestCase):
+    def _write_offline_files(self, d, n=4, seq=8, h=4, aux=12):
+        for i in range(n):
+            torch.save(
+                {
+                    "input_ids": torch.arange(seq) + i,
+                    "loss_mask": torch.ones(seq, dtype=torch.long),
+                    "hidden_state": torch.randn(1, seq, h),
+                    "aux_hidden_state": torch.randn(1, seq, aux),
+                },
+                os.path.join(d, f"{i:03d}.ckpt"),
+            )
+
+    def test_offline_loader_emits_trainbatch(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=4)
+            # data-plane unit test: drive the loader from the queue primitive
+            # directly (no control plane needed here).
+            q = SampleRefQueue()
+            q.put(OfflineManifestReader(d, run_id="run").read())
+            store = LocalFeatureStore("st")
+            loader = FeatureDataLoader(
+                store,
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            batches = list(loader)
+            self.assertEqual(len(batches), 2)  # 4 samples / batch 2
+            b = batches[0]
+            self.assertEqual(len(b.sample_ids), 2)
+            self.assertEqual(b.tensors["input_ids"].shape, (2, 8))
+            self.assertEqual(b.tensors["target"].shape, (2, 8, 4))
+            self.assertEqual(b.tensors["hidden_state"].shape, (2, 8, 12))
+            # aux<->target swap preserved
+            self.assertEqual(b.metadata["target_repr"], "hidden_state")
+            # all refs acked
+            self.assertEqual(q.in_flight(), 0)
+            self.assertEqual(q.depth(), 0)
+
+    def test_drop_last(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=3)
+            q = SampleRefQueue()
+            q.put(OfflineManifestReader(d, run_id="run").read())
+            store = LocalFeatureStore("st")
+            loader = FeatureDataLoader(
+                store,
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+                drop_last=True,
+            )
+            batches = list(loader)
+            self.assertEqual(len(batches), 1)  # 3 samples, drop the trailing 1
+
+    def test_mixed_target_repr_fails_and_releases_refs(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=2)
+            refs = OfflineManifestReader(d, run_id="run").read()
+            refs[1] = replace(
+                refs[1],
+                metadata={**refs[1].metadata, "target_repr": "logits"},
+            )
+            q = SampleRefQueue()
+            q.put(refs)
+            loader = FeatureDataLoader(
+                LocalFeatureStore("st"),
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            with self.assertRaises(ValueError):
+                list(loader)
+            self.assertEqual(q.in_flight(), 0)
+            self.assertEqual(q.depth(), 0)
+
+    def test_refs_mode_is_reiterable_across_epochs(self):
+        # offline: a fixed ref set must re-iterate every epoch (no epoch-drain).
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=4)
+            refs = OfflineManifestReader(d, run_id="run").read()
+            loader = FeatureDataLoader(
+                LocalFeatureStore("st"),
+                refs=refs,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            epoch1 = [b.sample_ids for b in loader]
+            epoch2 = [b.sample_ids for b in loader]
+            self.assertEqual(len(epoch1), 2)
+            self.assertEqual(epoch1, epoch2)  # same fixed set each epoch
+
+    def test_requires_exactly_one_source(self):
+        store = LocalFeatureStore("st")
+        with self.assertRaises(ValueError):
+            FeatureDataLoader(store)  # neither queue nor refs
+        with self.assertRaises(ValueError):
+            FeatureDataLoader(store, SampleRefQueue(), refs=[])  # both
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_feature_store.py
+++ b/tests/test_runtime/test_feature_store.py
@@ -1,0 +1,214 @@
+# coding=utf-8
+"""LocalFeatureStore: atomic put, get, idempotent release, abort, file mode (CPU)."""
+
+import logging
+import os
+import tempfile
+import unittest
+
+import torch
+
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+
+class TestLocalFeatureStore(unittest.TestCase):
+    def test_put_returns_ref_with_no_tensors(self):
+        store = LocalFeatureStore("st")
+        tensors = {
+            "input_ids": torch.arange(8).view(1, 8),
+            "hidden_state": torch.randn(1, 8, 4),
+        }
+        ref = store.put(
+            tensors, sample_id="s0", metadata={"run_id": "r", "num_tokens": 8}
+        )
+        self.assertEqual(ref.sample_id, "s0")
+        self.assertTrue(ref.feature_store_uri.startswith("mem://"))
+        self.assertEqual(set(ref.feature_specs), {"input_ids", "hidden_state"})
+        self.assertEqual(ref.feature_specs["hidden_state"].shape, (1, 8, 4))
+        self.assertGreater(ref.estimated_bytes, 0)
+
+    def test_get_returns_tensors_and_handle(self):
+        store = LocalFeatureStore("st")
+        t = torch.randn(1, 4, 2)
+        ref = store.put({"x": t}, sample_id="s0", metadata={})
+        out, handle = store.get(ref)
+        self.assertTrue(torch.equal(out["x"], t))
+        self.assertEqual(handle.sample_id, "s0")
+
+    def test_release_idempotent_and_stale_safe(self):
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h = store.get(ref)
+        store.release(h)
+        store.release(h)  # idempotent: must not raise
+        # re-put bumps generation; old handle release is a no-op
+        ref2 = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h2 = store.get(ref2)
+        store.release(h)  # stale generation -> no-op
+        out, _ = store.get(ref2)
+        self.assertIn("x", out)
+        _ = h2
+
+    def test_release_frees_mem_on_last_lease(self):
+        # mem:// is consume-once: the last release must physically free tensors,
+        # otherwise an online put->get->release loop grows _mem unboundedly.
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        self.assertEqual(store.health()["resident_samples"], 1)
+        _, h = store.get(ref)
+        store.release(h)
+        self.assertEqual(store.health()["resident_samples"], 0)
+        self.assertEqual(store.health()["resident_bytes"], 0)
+        with self.assertRaises(KeyError):
+            store.get(ref)  # consumed -> gone
+
+    def test_release_keeps_mem_while_other_lease_active(self):
+        # refcount: only the LAST lease frees the sample.
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref)
+        _, h2 = store.get(ref)
+        store.release(h1)
+        self.assertEqual(store.health()["resident_samples"], 1)  # h2 still holds it
+        store.release(h2)
+        self.assertEqual(store.health()["resident_samples"], 0)  # last lease -> freed
+
+    def test_online_put_get_release_loop_is_bounded(self):
+        # The regression this fix targets: many unique samples, consumed and
+        # released, must not accumulate in the store.
+        store = LocalFeatureStore("st")
+        for i in range(50):
+            ref = store.put({"x": torch.randn(1, 8)}, sample_id=f"s{i}", metadata={})
+            _, h = store.get(ref)
+            store.release(h)
+        self.assertEqual(store.health()["resident_samples"], 0)
+        self.assertEqual(store.health()["resident_bytes"], 0)
+
+    def test_max_resident_bytes_raises_when_consumer_is_behind(self):
+        # one float32 (1,8) sample = 32 bytes; cap at 40 admits one, rejects two.
+        store = LocalFeatureStore("st", max_resident_bytes=40)
+        ref0 = store.put(
+            {"x": torch.zeros(1, 8, dtype=torch.float32)}, sample_id="s0", metadata={}
+        )
+        with self.assertRaises(MemoryError):
+            store.put(
+                {"x": torch.zeros(1, 8, dtype=torch.float32)},
+                sample_id="s1",
+                metadata={},
+            )
+        # once the first is consumed+released, there is room for the next
+        _, h = store.get(ref0)
+        store.release(h)
+        store.put(
+            {"x": torch.zeros(1, 8, dtype=torch.float32)}, sample_id="s1", metadata={}
+        )
+        self.assertEqual(store.health()["resident_samples"], 1)
+
+    def test_abort_evicts(self):
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        store.abort("s0", reason="test")
+        with self.assertRaises(KeyError):
+            store.get(ref)
+
+    def test_health(self):
+        store = LocalFeatureStore("st")
+        store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        h = store.health()
+        self.assertEqual(h["resident_samples"], 1)
+        self.assertGreater(h["resident_bytes"], 0)
+
+    def test_estimate_bytes(self):
+        store = LocalFeatureStore("st")
+        ref = store.put(
+            {"x": torch.zeros(1, 10, dtype=torch.float32)}, sample_id="s0", metadata={}
+        )
+        self.assertEqual(store.estimate_bytes(ref.feature_specs), 10 * 4)
+
+    def test_disk_dump_tap(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = LocalFeatureStore("st", dump_dir=d)
+            store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+            self.assertTrue(os.path.exists(os.path.join(d, "s0.ckpt")))
+
+    def test_file_mode_get_matches_offline_format(self):
+        # write an offline-style .ckpt and read it back through the store + reader
+        with tempfile.TemporaryDirectory() as d:
+            raw = {
+                "input_ids": torch.arange(8),
+                "loss_mask": torch.ones(8, dtype=torch.long),
+                "hidden_state": torch.randn(1, 8, 4),
+                "aux_hidden_state": torch.randn(1, 8, 12),
+            }
+            torch.save(raw, os.path.join(d, "000.ckpt"))
+            refs = OfflineManifestReader(d, run_id="off").read()
+            self.assertEqual(len(refs), 1)
+            self.assertTrue(refs[0].feature_store_uri.startswith("file://"))
+            self.assertEqual(set(refs[0].feature_specs), set(raw))
+            self.assertEqual(refs[0].feature_specs["hidden_state"].dtype, "float32")
+            self.assertEqual(refs[0].num_tokens, 8)
+            store = LocalFeatureStore("st")
+            out, handle = store.get(refs[0])
+            self.assertEqual(set(out), set(raw))
+            self.assertTrue(
+                torch.equal(out["aux_hidden_state"], raw["aux_hidden_state"])
+            )
+            store.release(handle)
+
+    def test_offline_reader_rejects_missing_required_key(self):
+        with tempfile.TemporaryDirectory() as d:
+            torch.save({"input_ids": torch.arange(4)}, os.path.join(d, "bad.ckpt"))
+            with self.assertRaises(KeyError):
+                OfflineManifestReader(d, run_id="off").read()
+
+    def test_mem_ref_carries_generation_and_rejects_stale_ref(self):
+        # The mem:// ref carries the generation it was minted for; once a sample
+        # is reclaimed and a new generation is published under the same id, the
+        # stale ref must be rejected rather than silently aliasing fresh data.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        self.assertIn("generation=", ref1.feature_store_uri)
+        _, h = store.get(ref1)
+        store.release(h)  # gen1 reclaimed
+        store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2
+        with self.assertRaises(KeyError):
+            store.get(ref1)  # stale gen1 ref -> rejected
+
+    def test_release_after_reput_while_leased_does_not_leak(self):
+        # Re-put a sample_id while an older generation is still leased, then drop
+        # the newest handle and finally the stale old handle. Freeing is keyed on
+        # the CURRENT generation's last lease, so the current generation must be
+        # freed and nothing leaks.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref1)  # lease on gen1
+        ref2 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2
+        _, h2 = store.get(ref2)  # lease on gen2
+        store.release(h2)  # newest released first (stale gen1 lease still active)
+        store.release(h1)  # stale gen1 handle released last
+        h = store.health()
+        self.assertEqual(h["resident_samples"], 0)
+        self.assertEqual(h["resident_bytes"], 0)
+
+    def test_dump_failure_does_not_abort_publish(self):
+        # The disk dump is a best-effort capture/replay tap; mem is authoritative.
+        # A dump failure must not undo an otherwise successful in-memory publish.
+        class DumpFails(LocalFeatureStore):
+            def _dump(self, sample_id, tensors):
+                raise RuntimeError("disk full")
+
+        with tempfile.TemporaryDirectory() as d:
+            store = DumpFails("st", dump_dir=d)
+            logging.disable(logging.CRITICAL)  # silence the expected warning
+            try:
+                ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+            finally:
+                logging.disable(logging.NOTSET)
+            out, h = store.get(ref)  # mem publish survived
+            self.assertIn("x", out)
+            store.release(h)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_sample_ref_queue.py
+++ b/tests/test_runtime/test_sample_ref_queue.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+"""SampleRefQueue lease / ack / fail / depth semantics (CPU-only)."""
+
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+def _ref(i: int) -> SampleRef:
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://x/s{i}",
+        feature_keys={},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestSampleRefQueue(unittest.TestCase):
+    def test_put_get_ack_depth(self):
+        q = SampleRefQueue()
+        q.put([_ref(0), _ref(1), _ref(2)])
+        self.assertEqual(q.depth(), 3)
+        got = q.get(2)
+        self.assertEqual([r.sample_id for r in got], ["s0", "s1"])
+        self.assertEqual(q.depth(), 1)
+        self.assertEqual(q.in_flight(), 2)
+        q.ack(got)
+        self.assertEqual(q.in_flight(), 0)
+
+    def test_put_is_idempotent_on_sample_id(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        q.put([_ref(0)])  # duplicate sample_id ignored (at-least-once)
+        self.assertEqual(q.depth(), 1)
+
+    def test_fail_retryable_requeues(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        got = q.get(1)
+        q.fail(got, reason="boom", retryable=True)
+        self.assertEqual(q.depth(), 1)
+        again = q.get(1)
+        self.assertEqual(again[0].sample_id, "s0")
+
+    def test_fail_terminal_drops(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        got = q.get(1)
+        q.fail(got, reason="corrupt", retryable=False)
+        self.assertEqual(q.depth(), 0)
+        self.assertEqual(q.in_flight(), 0)
+
+    def test_get_empty_returns_immediately(self):
+        q = SampleRefQueue()
+        self.assertEqual(q.get(4, timeout_s=0.0), [])
+
+    def test_ack_unknown_is_noop(self):
+        q = SampleRefQueue()
+        q.ack([_ref(99)])  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — stacked PR.** Stacked on #595 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

**Part 3/7 — data plane (FeatureStore, queue, offline reader, loader).**

Adds `specforge/runtime/data_plane/`. `FeatureStore`/`LocalFeatureStore` is the only tensor-holding component; it serves `mem://` (online, RAM, freed on last lease) and `file://` (offline `.ckpt`, mmap) behind one API. Carries lease/generation primitives (consume-once free), a `max_resident_bytes` backpressure cap, **generation-guarded refs** (a stale ref after reclaim+republish is rejected, not silently aliased), atomic lease registration, and a best-effort disk dump tap. Plus `SampleRefQueue` (metadata-only lease/ack/fail), `OfflineManifestReader` (`.ckpt` → `file://` refs), and `FeatureDataLoader` (`SampleRef` → `TrainBatch`; queue/refs modes; clone-on-fetch; injected transform/collate so it carries no model knowledge). Tests: `test_feature_store`, `test_feature_dataloader`, `test_sample_ref_queue`. Additive.

Part of a **7-PR series** adding the DataFlow runtime (`specforge/runtime/`, milestones M1–M4). Verified on current upstream `main`: all subpackages import and **65 component tests pass**. The integration launcher (`launch.py` + `train_eagle3_dataflow.py`) and the end-to-end equivalence gates are a deliberate follow-up, not in this series.
