### PR TITLE
[DataFlow runtime 4/7] Control plane: DataFlowController + MetadataStore

### DIFF
--- a/specforge/runtime/control_plane/DESIGN.md
+++ b/specforge/runtime/control_plane/DESIGN.md
@@ -1,0 +1,73 @@
+# Control Plane Design (PR 4/7 — `runtime/control_plane`)
+
+This is the design note for the **control plane**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+Metadata-only scheduling, lifecycle, leasing, and recovery durability. Owns prompt and sample lifecycle, prompt/train leases, worker/trainer registration, dedup of committed samples, and the durable ack transaction. NEVER touches tensors (every record-accepting entrypoint runs assert_no_tensors) — all large tensors travel through the data plane. Online commit_samples and offline enqueue_offline_refs converge onto the same SampleRefQueue so the trainer path has no online/offline branch. Recovery-critical state sits behind a MetadataStore seam so a durable backend (SQLite/Redis/DB) is a swap, not a rewrite. (Note: weight publishing / weight-version registry is explicitly NOT yet implemented — flagged in source NOTE comments in both controller.py and metadata_store.py.)
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+
+  subgraph CTRL[DataFlowController passive]
+    PEND[_prompt_pending deque]
+    LEASED[_prompt_leased map]
+    FAILEDP[_prompt_failed map]
+  end
+  ING[ingest_prompts] --> PEND
+  LPT[lease_prompt_tasks popleft] --> LEASED
+  FPT[fail_prompt_tasks requeue or fail] --> PEND
+
+  COMMIT[commit_samples per ref] -->|commit_sample dedup| MS[MetadataStore]
+  COMMIT -->|put fresh| Q[SampleRefQueue]
+  ENQ[enqueue_offline_refs] -->|commit_sample dedup| MS
+  ENQ -->|put fresh| Q
+
+  LTR[lease_train_refs] -->|get| Q
+  ATR[ack_train_refs] -->|record_train_ack first| MS
+  ATR -->|get_committed then ack| Q
+  FR[fail_refs] -->|get_committed then fail| Q
+
+  TL[TrainLease get ack fail] --> LTR
+  TL --> ATR
+  TL --> FR
+
+  class PEND,LEASED,FAILEDP,ING,LPT,FPT,COMMIT,ENQ,LTR,ATR,FR,TL,MS,Q control;
+```
+
+The `DataFlowController` is a passive metadata-only coordinator: it has no run loop, and every record-accepting entrypoint runs `assert_no_tensors`. It holds prompt lifecycle state — `_prompts`, a `_prompt_pending` deque, `_prompt_leased`, and `_prompt_failed` — under a single `_lock` that guards only the prompt/worker/trainer mutations and the `status()` snapshot; the sample-commit and train paths instead rely on the store's and queue's own internal locking. Durable/recovery state lives behind the `MetadataStore` seam: `commit_sample` dedups by `sample_id` (False = duplicate, dropped) and `record_train_ack` commits {acked sample_ids, global_step, optimizer_durable} as one atomic transaction. Online `commit_samples` and offline `enqueue_offline_refs` converge by enqueuing only fresh refs onto the same `SampleRefQueue`, so the trainer path has no online/offline branch. `ack_train_refs` deliberately orders `record_train_ack` BEFORE `sample_queue.ack` so a restart reconciles release state from the single committed marker. `TrainLease` is a stateless adapter that forwards `get`/`ack`/`fail` through the controller, so a cross-node trainer never holds a raw in-process queue and the durable ack is always recorded. Weight publishing / a weight-version registry is explicitly not yet implemented (flagged in source NOTEs).
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `DataFlowController` | `MetadataStore.commit_sample` | control |
+| `DataFlowController` | `MetadataStore.record_train_ack` | control |
+| `DataFlowController` | `MetadataStore.get_committed` | control |
+| `DataFlowController` | `SampleRefQueue.put` | control |
+| `DataFlowController` | `SampleRefQueue.get` | control |
+| `DataFlowController` | `SampleRefQueue.ack` | control |
+| `DataFlowController` | `SampleRefQueue.fail` | control |
+| `TrainLease` | `DataFlowController.lease_train_refs` | control |
+| `TrainLease` | `DataFlowController.ack_train_refs` | control |
+| `TrainLease` | `DataFlowController.fail_refs` | control |
+
+### Who calls into this plane
+
+| Caller | Endpoint | Plane |
+|---|---|---|
+| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
+| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
+| `RolloutWorker` | `DataFlowController.commit_samples` | control |
+| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |
+| `OfflineManifestReader` | `DataFlowController.enqueue_offline_refs` | control |
+| `FeatureDataLoader` | `TrainLease.get` | control |
+| `TrainerController` | `DataFlowController.ack_train_refs` | control |

--- a/specforge/runtime/control_plane/__init__.py
+++ b/specforge/runtime/control_plane/__init__.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+"""Control plane: metadata-only scheduling, queues, lifecycle, version policy."""
+
+from specforge.runtime.control_plane.controller import DataFlowController, TrainLease
+from specforge.runtime.control_plane.metadata_store import (
+    InMemoryMetadataStore,
+    MetadataStore,
+)
+
+__all__ = ["DataFlowController", "TrainLease", "MetadataStore", "InMemoryMetadataStore"]

--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -1,0 +1,270 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DataFlowController: the metadata-only scheduler / debug boundary.
+
+The controller owns prompt and sample lifecycle, leases, and worker registration.
+It NEVER touches tensors — every public method that accepts
+a record runs ``assert_no_tensors`` (this is what ``test_controller_carries_no_tensor``
+exercises). All large tensors travel through the data plane (FeatureStore);
+online ``commit_samples`` and offline ``enqueue_offline_refs`` converge onto the
+same ``SampleRefQueue`` so the trainer path has no online/offline branch.
+
+Recovery-critical state (committed-sample dedup and the durable ack transaction)
+lives behind a ``MetadataStore`` so a durable backend (SQLite → Redis/DB) is a
+swap, not a rewrite. The current backend is in-process; the public surface already
+matches the durable controller shape so a later Ray/service deployment is mechanical.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import uuid
+from collections import OrderedDict, deque
+from typing import Any, Deque, Dict, List, Optional
+
+from specforge.runtime.contracts import PromptTask, SampleRef, assert_no_tensors
+from specforge.runtime.control_plane.metadata_store import (
+    InMemoryMetadataStore,
+    MetadataStore,
+)
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+class TrainLease:
+    """A train-side lease client that routes lease/ack/fail through the controller.
+
+    Exposes the loader-facing ``get/ack/fail`` shape so ``FeatureDataLoader`` can
+    consume it interchangeably with a raw queue — but every op goes through the
+    controller, so the durable ack transaction is recorded and a disaggregated
+    (cross-node) trainer is a drop-in (it never holds a raw in-process queue).
+    """
+
+    def __init__(self, controller: "DataFlowController", trainer_id: str) -> None:
+        self._controller = controller
+        self._trainer_id = trainer_id
+
+    def get(self, max_refs: int, timeout_s: Optional[float] = None) -> List[SampleRef]:
+        return self._controller.lease_train_refs(self._trainer_id, max_refs, timeout_s)
+
+    def ack(
+        self,
+        refs: List[SampleRef],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        self._controller.ack_train_refs(
+            self._trainer_id,
+            [r.sample_id for r in refs],
+            global_step=global_step,
+            optimizer_durable=optimizer_durable,
+        )
+
+    def fail(self, refs: List[SampleRef], reason: str, retryable: bool) -> None:
+        self._controller.fail_refs(
+            self._trainer_id, [r.sample_id for r in refs], reason, retryable
+        )
+
+
+class DataFlowController:
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        sample_queue: Optional[SampleRefQueue] = None,
+        metadata_store: Optional[MetadataStore] = None,
+    ) -> None:
+        self.run_id = run_id
+        self.sample_queue = sample_queue or SampleRefQueue()
+        self.store = metadata_store or InMemoryMetadataStore()
+        self._prompts: "OrderedDict[str, PromptTask]" = OrderedDict()
+        self._prompt_pending: Deque[str] = deque()
+        self._prompt_leased: Dict[str, str] = {}  # task_id -> worker_id
+        self._prompt_failed: Dict[str, str] = {}  # task_id -> terminal reason
+        self._workers: Dict[str, Dict[str, Any]] = {}
+        self._trainers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    # -- registration ------------------------------------------------------
+    def register_rollout_worker(self, info: Dict[str, Any]) -> str:
+        assert_no_tensors(info)
+        worker_id = info.get("worker_id") or f"rollout-{uuid.uuid4().hex[:8]}"
+        with self._lock:
+            self._workers[worker_id] = dict(info)
+        return worker_id
+
+    def register_trainer(self, info: Dict[str, Any]) -> str:
+        assert_no_tensors(info)
+        trainer_id = info.get("trainer_id") or f"trainer-{uuid.uuid4().hex[:8]}"
+        with self._lock:
+            self._trainers[trainer_id] = dict(info)
+        return trainer_id
+
+    def train_lease(self, trainer_id: Optional[str] = None) -> TrainLease:
+        """Return a train-side lease client (lease + ack route through here)."""
+        if trainer_id is None:
+            trainer_id = self.register_trainer({"role": "trainer"})
+        return TrainLease(self, trainer_id)
+
+    # -- prompt lifecycle (online) ----------------------------------------
+    def ingest_prompts(self, prompts: List[Dict[str, Any]]) -> List[str]:
+        task_ids: List[str] = []
+        with self._lock:
+            for p in prompts:
+                assert_no_tensors(p)
+                task_id = p.get("task_id") or f"task-{uuid.uuid4().hex[:12]}"
+                task = PromptTask(
+                    task_id=task_id,
+                    run_id=self.run_id,
+                    source_id=str(p.get("source_id", "prompt_source")),
+                    payload=p.get("payload", p),
+                    max_length=int(p.get("max_length", 2048)),
+                    chat_template=p.get("chat_template"),
+                    loss_mask_policy=p.get("loss_mask_policy", {}),
+                    target_model_version=str(p.get("target_model_version", "unknown")),
+                    draft_weight_version=p.get("draft_weight_version"),
+                    metadata=p.get("metadata", {}),
+                )
+                assert_no_tensors(task)
+                self._prompts[task_id] = task
+                self._prompt_pending.append(task_id)
+                task_ids.append(task_id)
+        return task_ids
+
+    def lease_prompt_tasks(self, worker_id: str, max_tasks: int) -> List[PromptTask]:
+        out: List[PromptTask] = []
+        with self._lock:
+            for _ in range(max_tasks):
+                if not self._prompt_pending:
+                    break
+                task_id = self._prompt_pending.popleft()
+                self._prompt_leased[task_id] = worker_id
+                out.append(self._prompts[task_id])
+        return out
+
+    def fail_prompt_tasks(
+        self, worker_id: str, task_ids: List[str], reason: str, retryable: bool
+    ) -> None:
+        """Release failed prompt leases and optionally requeue them.
+
+        This is intentionally separate from ``fail_refs``. Prompt failures happen
+        before a ``SampleRef`` exists, so routing them through the train-sample
+        queue would be a no-op and would leave prompt leases stuck.
+        """
+        with self._lock:
+            for task_id in task_ids:
+                owner = self._prompt_leased.get(task_id)
+                if owner is not None and owner != worker_id:
+                    continue
+                self._prompt_leased.pop(task_id, None)
+                task = self._prompts.get(task_id)
+                if task is None:
+                    continue
+                if retryable:
+                    self._prompts[task_id] = dataclasses.replace(
+                        task, attempt=task.attempt + 1
+                    )
+                    if task_id not in self._prompt_pending:
+                        self._prompt_pending.append(task_id)
+                else:
+                    self._prompt_failed[task_id] = reason
+
+    def commit_samples(self, worker_id: str, refs: List[SampleRef]) -> None:
+        fresh: List[SampleRef] = []
+        for ref in refs:
+            assert_no_tensors(ref)  # online no-tensor guard
+            if not self.store.commit_sample(ref):
+                continue  # idempotent on sample_id (at-least-once delivery)
+            if ref.source_task_id is not None:
+                with self._lock:
+                    self._prompt_leased.pop(ref.source_task_id, None)
+            fresh.append(ref)
+        if fresh:
+            self.sample_queue.put(fresh)
+
+    # -- offline ingest ----------------------------------------------------
+    def enqueue_offline_refs(self, refs: List[SampleRef]) -> None:
+        fresh: List[SampleRef] = []
+        for ref in refs:
+            assert_no_tensors(ref)
+            if self.store.commit_sample(ref):
+                fresh.append(ref)
+        if fresh:
+            self.sample_queue.put(fresh)
+
+    # -- train-side lease/ack ---------------------------------------------
+    def lease_train_refs(
+        self, trainer_id: str, max_refs: int, timeout_s: Optional[float] = None
+    ) -> List[SampleRef]:
+        return self.sample_queue.get(max_refs, timeout_s=timeout_s)
+
+    def ack_train_refs(
+        self,
+        trainer_id: str,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        """Ack consumed refs at the trainer's optimizer-step boundary.
+
+        Records the durable ``{acked sample_ids, global_step, optimizer-durable
+        marker}`` transaction *then* releases the queue lease, so restart can
+        derive release state from the single committed marker.
+        """
+        self.store.record_train_ack(
+            sample_ids, global_step=global_step, optimizer_durable=optimizer_durable
+        )
+        refs = [
+            r
+            for r in (self.store.get_committed(s) for s in sample_ids)
+            if r is not None
+        ]
+        self.sample_queue.ack(refs)
+
+    def fail_refs(
+        self, owner_id: str, sample_ids: List[str], reason: str, retryable: bool
+    ) -> None:
+        refs = [
+            r
+            for r in (self.store.get_committed(s) for s in sample_ids)
+            if r is not None
+        ]
+        self.sample_queue.fail(refs, reason, retryable)
+
+    # NOTE: weight publishing (publish_weight_version / latest_weight_version) is
+    # not yet implemented; it lands with the rest of the weight-version lifecycle.
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            prompts = len(self._prompts)
+            pending = len(self._prompt_pending)
+            leased = len(self._prompt_leased)
+            failed = len(self._prompt_failed)
+            workers = len(self._workers)
+            trainers = len(self._trainers)
+        marker = self.store.durable_marker()
+        return {
+            "run_id": self.run_id,
+            "prompts": prompts,
+            "prompts_pending": pending,
+            "prompts_leased": leased,
+            "prompts_failed": failed,
+            "samples_committed": self.store.committed_count(),
+            "queue_depth": self.sample_queue.depth(),
+            "queue_in_flight": self.sample_queue.in_flight(),
+            "rollout_workers": workers,
+            "trainers": trainers,
+            "durable_global_step": marker["global_step"],
+            "durable_acked": len(marker["acked"]),
+        }
+
+
+__all__ = ["DataFlowController", "TrainLease"]

--- a/specforge/runtime/control_plane/metadata_store.py
+++ b/specforge/runtime/control_plane/metadata_store.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""MetadataStore: the durability seam for recovery-critical control-plane state.
+
+The controller's *recovery-critical* state — committed sample dedup and the
+at-least-once durable ack transaction (``{acked sample_ids, global_step,
+optimizer-durable marker}``) — lives behind this interface rather than in inline
+dicts. The current implementation ships ``InMemoryMetadataStore``; a SQLite
+(dev) or Redis/DB (prod) backend is then a *new subclass*, not a
+method-by-method rewrite of the controller. The single durable transaction
+(``record_train_ack``) is the unit a restart reconciles release state from.
+
+Dependency-light (stdlib only) so it stays importable without torch.
+"""
+
+from __future__ import annotations
+
+import abc
+import threading
+from typing import Any, Dict, List, Optional, Set
+
+from specforge.runtime.contracts import SampleRef
+
+
+class MetadataStore(abc.ABC):
+    # -- sample commit / dedup (at-least-once: idempotent on sample_id) ----
+    @abc.abstractmethod
+    def commit_sample(self, ref: SampleRef) -> bool:
+        """Record a committed sample. Returns True if new, False if duplicate."""
+
+    @abc.abstractmethod
+    def is_committed(self, sample_id: str) -> bool: ...
+
+    @abc.abstractmethod
+    def get_committed(self, sample_id: str) -> Optional[SampleRef]: ...
+
+    @abc.abstractmethod
+    def committed_count(self) -> int: ...
+
+    # -- durable ack transaction -------------------------------------------
+    @abc.abstractmethod
+    def record_train_ack(
+        self,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int],
+        optimizer_durable: bool,
+    ) -> None:
+        """Commit {acked sample_ids, global_step, optimizer-durable marker} atomically.
+
+        Release state is *derived* from this on restart — it is the single
+        transaction recovery reconciles against; never split it.
+        """
+
+    @abc.abstractmethod
+    def durable_marker(self) -> Dict[str, Any]:
+        """{acked: set[str], global_step: int|None, optimizer_durable: bool}."""
+
+    # NOTE: a weight-version registry (put/latest/count) is not yet implemented;
+    # it belongs with the rest of the published-weight lifecycle.
+
+
+class InMemoryMetadataStore(MetadataStore):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._committed: Dict[str, SampleRef] = {}
+        self._acked: Set[str] = set()
+        self._global_step: Optional[int] = None
+        self._optimizer_durable: bool = False
+
+    def commit_sample(self, ref: SampleRef) -> bool:
+        with self._lock:
+            if ref.sample_id in self._committed:
+                return False
+            self._committed[ref.sample_id] = ref
+            return True
+
+    def is_committed(self, sample_id: str) -> bool:
+        with self._lock:
+            return sample_id in self._committed
+
+    def get_committed(self, sample_id: str) -> Optional[SampleRef]:
+        with self._lock:
+            return self._committed.get(sample_id)
+
+    def committed_count(self) -> int:
+        with self._lock:
+            return len(self._committed)
+
+    def record_train_ack(
+        self,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int],
+        optimizer_durable: bool,
+    ) -> None:
+        # one atomic update of {acked ids, global_step, optimizer marker}
+        with self._lock:
+            self._acked.update(sample_ids)
+            if global_step is not None:
+                self._global_step = global_step
+            self._optimizer_durable = optimizer_durable
+
+    def durable_marker(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "acked": set(self._acked),
+                "global_step": self._global_step,
+                "optimizer_durable": self._optimizer_durable,
+            }
+
+
+__all__ = ["MetadataStore", "InMemoryMetadataStore"]

--- a/tests/test_runtime/test_controller_no_tensor.py
+++ b/tests/test_runtime/test_controller_no_tensor.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""M1 gate: the controller carries no tensor across any API (CPU-only)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import FeatureSpec, SampleRef
+from specforge.runtime.control_plane.controller import DataFlowController
+
+
+def _ref(i: int, store_uri="mem://x") -> SampleRef:
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"{store_uri}/s{i}",
+        feature_keys={"input_ids": f"s{i}/input_ids"},
+        feature_specs={"input_ids": FeatureSpec("input_ids", (1, 8), "int64")},
+        strategy="eagle3",
+    )
+
+
+class TestControllerCarriesNoTensor(unittest.TestCase):
+    def test_controller_carries_no_tensor(self):
+        """Online + offline ingest paths reject any tensor payload."""
+        ctrl = DataFlowController("run1")
+
+        # offline refs (metadata only) flow fine
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        self.assertEqual(ctrl.status()["samples_committed"], 2)
+
+        # a SampleRef with a tensor smuggled into metadata must be rejected
+        bad = SampleRef(
+            sample_id="bad",
+            run_id="r",
+            source_task_id=None,
+            feature_store_uri="mem://x/bad",
+            feature_keys={},
+            feature_specs={},
+            strategy="eagle3",
+            metadata={"sneaky": torch.zeros(4)},
+        )
+        with self.assertRaises(TypeError):
+            ctrl.enqueue_offline_refs([bad])
+        with self.assertRaises(TypeError):
+            ctrl.commit_samples("w0", [bad])
+
+        # a prompt carrying a tensor in its payload must be rejected
+        with self.assertRaises(TypeError):
+            ctrl.ingest_prompts([{"payload": {"ids": torch.zeros(3)}}])
+
+    def test_online_offline_converge_at_same_queue(self):
+        ctrl = DataFlowController("run1")
+        ctrl.enqueue_offline_refs([_ref(0)])
+        ctrl.commit_samples("w0", [_ref(1)])  # online path, same queue
+        leased = ctrl.lease_train_refs("t0", 8)
+        self.assertEqual({r.sample_id for r in leased}, {"s0", "s1"})
+        ctrl.ack_train_refs("t0", [r.sample_id for r in leased])
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+    def test_commit_samples_idempotent(self):
+        ctrl = DataFlowController("run1")
+        ctrl.commit_samples("w0", [_ref(0)])
+        ctrl.commit_samples("w0", [_ref(0)])  # at-least-once: dedup on sample_id
+        self.assertEqual(ctrl.status()["samples_committed"], 1)
+        self.assertEqual(ctrl.sample_queue.depth(), 1)
+
+    def test_prompt_lease_and_commit_clears_lease(self):
+        ctrl = DataFlowController("run1")
+        ids = ctrl.ingest_prompts([{"payload": {"text": "hi"}, "max_length": 16}])
+        tasks = ctrl.lease_prompt_tasks("w0", 4)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].task_id, ids[0])
+        ref = _ref(0)
+        ref = SampleRef(**{**ref.__dict__, "source_task_id": ids[0]})
+        ctrl.commit_samples("w0", [ref])
+        self.assertEqual(ctrl.status()["prompts_leased"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — stacked PR.** Stacked on #596 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

**Part 4/7 — control plane (DataFlowController + MetadataStore).**

Adds `specforge/runtime/control_plane/`. `DataFlowController` ingests/leases prompts, commits samples onto the queue, and acks trainer refs at the optimizer-step boundary; `MetadataStore` backs it. The controller moves only `SampleRef` metadata — never tensors; `tests/test_runtime/test_controller_no_tensor.py` asserts the invariant structurally. Additive.

Part of a **7-PR series** adding the DataFlow runtime (`specforge/runtime/`, milestones M1–M4). Verified on current upstream `main`: all subpackages import and **65 component tests pass**. The integration launcher (`launch.py` + `train_eagle3_dataflow.py`) and the end-to-end equivalence gates are a deliberate follow-up, not in this series.
