### PR TITLE
[DataFlow runtime 5/7] Inference: CaptureConfig, RolloutWorker, SGLangAdapter

### DIFF
--- a/specforge/runtime/inference/DESIGN.md
+++ b/specforge/runtime/inference/DESIGN.md
@@ -1,0 +1,52 @@
+# Inference Plane Design (PR 5/7 — `runtime/inference`)
+
+This is the design note for the **inference**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+The rollout/inference plane turns leased PromptTasks into per-sample feature tensors and commits only their typed SampleRef metadata to the controller — it never hands a tensor to the controller. It owns the clean boundary to the target engine (Eagle3TargetModel via generate_eagle3_data), the only place target→draft projection/pruning happens, and the loud pre-write validation (verify_capture against a typed CaptureConfig) that converts layer/name/width/target-dim mismatches into immediate, localized errors at the extraction boundary instead of downstream trainer bugs.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef data fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+
+  A[lease_prompt_tasks] --> B[generate_features per batch]
+  B --> C[SGLangAdapter group by len single forward]
+  C --> D[generate_eagle3_data]
+  D --> E[_project_target logits or pruned_logits]
+  E --> F[verify_capture vs CaptureConfig]
+  F -->|mismatch| G[fail_prompt_tasks non retryable]
+  F -->|ok| H[FeatureStore put]
+  H -->|put error| I[abort then fail retryable]
+  H -->|ok| J[append SampleRef]
+  J --> K[commit_samples metadata only]
+
+  class A,K control;
+  class B,C,D,E,F,J compute;
+  class H,I data;
+  class G control;
+```
+
+The rollout plane turns leased `PromptTask`s into per-sample feature tensors and commits only their typed `SampleRef` metadata — it never hands a tensor to the controller. `RolloutWorker.run_once` is the core loop: lease up to `max_tasks`, call `feature_source.generate_features(tasks, capture=...)` once for the whole batch, enforce a strict `len(feats)==len(tasks)` contract, then per sample pop the out-of-band `__aux_layer_ids__`, run `verify_capture`, and on success `FeatureStore.put` (tensors go straight to the data plane). Every leased task ends in exactly one terminal controller action — `commit_samples` on success or `fail_prompt_tasks` on generate failure / wrong count / capture mismatch / put failure — with `sample_id = f"{run_id}:{task.task_id}"` deterministic and a put exception triggering `abort`. `CaptureConfig` is a frozen, strategy-derived contract carrying `feature_names`, `aux_hidden_state_layer_ids`, `target_repr`, and the derived `expected_aux_width` / `expected_target_dim()`. `verify_capture` is the loud pre-`put` validator: it checks name presence, aux-layer-id equality, aux last-dim width, and target last-dim, gating `pruned_logits` on a non-None `vocab_map_version`, raising `CaptureMismatchError` at the boundary. `SGLangAdapter` is the only place target to draft projection happens (`_project_target`: passthrough for `logits`, `t2d`-indexing for `pruned_logits`), batching equal-length tasks into one padding-free `generate_eagle3_data` forward and slicing rows back into original task order.
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
+| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
+| `RolloutWorker` | `SGLangAdapter.generate_features` | compute |
+| `SGLangAdapter` | `Eagle3TargetModel.generate_eagle3_data` | compute |
+| `RolloutWorker` | `FeatureStore.put` | data |
+| `RolloutWorker` | `FeatureStore.abort` | data |
+| `RolloutWorker` | `DataFlowController.commit_samples` | control |
+| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |

--- a/specforge/runtime/inference/__init__.py
+++ b/specforge/runtime/inference/__init__.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+"""Inference / rollout plane: SGLang adapter, capture config, rollout worker.
+
+Submodules import the SpecForge model / SGLang code, so they are imported
+explicitly by callers rather than at package load.
+"""

--- a/specforge/runtime/inference/capture.py
+++ b/specforge/runtime/inference/capture.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""CaptureConfig: the typed contract for what a rollout must extract (B7/B8).
+
+``capture`` is NOT an untyped ``dict[str, Any]``. It is a frozen config *derived
+from the active strategy* (``feature_names == DraftTrainStrategy.required_features``,
+``aux_hidden_state_layer_ids`` == the layers the draft config requested). Before
+any ``FeatureStore.put`` the rollout runs :func:`verify_capture`, which fails
+loudly on a name / aux-layer-id / width / target-dim mismatch — turning what
+would otherwise be a confusing downstream trainer bug into an immediate,
+localized error at the extraction boundary.
+
+Import-light (stdlib only) so the assertions are unit-testable without a GPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Optional, Tuple
+
+from specforge.runtime.contracts import TargetRepr
+
+
+class CaptureMismatchError(AssertionError):
+    """Raised when extracted features do not match the requested CaptureConfig."""
+
+
+@dataclass(frozen=True)
+class CaptureConfig:
+    feature_names: FrozenSet[str]
+    aux_hidden_state_layer_ids: Tuple[int, ...]
+    target_repr: TargetRepr
+    target_hidden_size: int
+    target_vocab_size: Optional[int] = None
+    draft_vocab_size: Optional[int] = None
+    vocab_map_version: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_strategy(
+        cls,
+        required_features,
+        aux_hidden_state_layer_ids,
+        *,
+        target_repr: TargetRepr,
+        target_hidden_size: int,
+        target_vocab_size: Optional[int] = None,
+        draft_vocab_size: Optional[int] = None,
+        vocab_map_version: Optional[str] = None,
+    ) -> "CaptureConfig":
+        return cls(
+            feature_names=frozenset(required_features),
+            aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
+            target_repr=target_repr,
+            target_hidden_size=int(target_hidden_size),
+            target_vocab_size=target_vocab_size,
+            draft_vocab_size=draft_vocab_size,
+            vocab_map_version=vocab_map_version,
+        )
+
+    @property
+    def expected_aux_width(self) -> int:
+        return len(self.aux_hidden_state_layer_ids) * self.target_hidden_size
+
+    def expected_target_dim(self) -> Optional[int]:
+        if self.target_repr == "pruned_logits":
+            return self.draft_vocab_size
+        if self.target_repr == "logits":
+            return self.target_vocab_size
+        if self.target_repr == "hidden_state":
+            return self.target_hidden_size
+        return None
+
+
+def verify_capture(
+    tensors: Dict[str, Any],
+    capture: CaptureConfig,
+    *,
+    sample_id: str,
+    recorded_aux_layer_ids: Optional[Tuple[int, ...]] = None,
+    aux_feature_name: str = "hidden_state",
+    target_feature_name: str = "target",
+) -> None:
+    """Loud, pre-put validation that extracted ``tensors`` match ``capture``.
+
+    Raises :class:`CaptureMismatchError` on the first mismatch with a
+    requested-vs-actual diff and the offending ``sample_id``.
+    """
+    # (1) all requested feature names present
+    missing = sorted(n for n in capture.feature_names if n not in tensors)
+    if missing:
+        raise CaptureMismatchError(
+            f"[{sample_id}] capture missing features {missing}; "
+            f"got {sorted(tensors)}; requested {sorted(capture.feature_names)}"
+        )
+
+    # (2) recorded aux-layer IDs == requested
+    if recorded_aux_layer_ids is not None:
+        if tuple(recorded_aux_layer_ids) != capture.aux_hidden_state_layer_ids:
+            raise CaptureMismatchError(
+                f"[{sample_id}] aux-layer id mismatch: recorded "
+                f"{tuple(recorded_aux_layer_ids)} != requested "
+                f"{capture.aux_hidden_state_layer_ids}"
+            )
+
+    # (3) aux width == len(aux_layer_ids) * target_hidden_size
+    if aux_feature_name in tensors and capture.aux_hidden_state_layer_ids:
+        width = int(tuple(tensors[aux_feature_name].shape)[-1])
+        if width != capture.expected_aux_width:
+            raise CaptureMismatchError(
+                f"[{sample_id}] aux width {width} != "
+                f"len(aux_layer_ids)*target_hidden_size="
+                f"{len(capture.aux_hidden_state_layer_ids)}*"
+                f"{capture.target_hidden_size}={capture.expected_aux_width}"
+            )
+
+    # (4) target last-dim matches target_repr (+ vocab-map dim for pruned_logits)
+    expected = capture.expected_target_dim()
+    if target_feature_name in tensors and expected is not None:
+        dim = int(tuple(tensors[target_feature_name].shape)[-1])
+        if dim != expected:
+            raise CaptureMismatchError(
+                f"[{sample_id}] target last-dim {dim} != expected {expected} "
+                f"for target_repr={capture.target_repr!r}"
+            )
+        if capture.target_repr == "pruned_logits" and capture.vocab_map_version is None:
+            raise CaptureMismatchError(
+                f"[{sample_id}] target_repr='pruned_logits' requires a "
+                f"vocab_map_version so the trainer-side mapping is gated"
+            )
+
+
+__all__ = ["CaptureConfig", "CaptureMismatchError", "verify_capture"]

--- a/specforge/runtime/inference/rollout_worker.py
+++ b/specforge/runtime/inference/rollout_worker.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""RolloutWorker: PromptTask -> features -> FeatureStore -> SampleRef commit.
+
+The worker is deliberately small and strategy-agnostic: it leases prompt tasks,
+asks a ``feature_source`` (e.g. a wrapper over the target model's
+``generate_eagle3_data``, or ``SGLangAdapter``) for per-sample features,
+verifies them against the typed ``CaptureConfig`` *before* writing, writes them
+to the ``FeatureStore``, and commits the resulting ``SampleRef`` metadata to the
+controller. It never hands a tensor to the controller. Strategy-specific capture
+requirements live in ``CaptureConfig`` + the feature schema, not here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+from specforge.runtime.contracts import PromptTask, SampleRef
+from specforge.runtime.inference.capture import (
+    CaptureConfig,
+    CaptureMismatchError,
+    verify_capture,
+)
+
+# health states: a worker REPORTS health; the controller decides scheduling.
+HEALTH_STATES = ("starting", "ready", "paused", "draining", "unhealthy", "stopped")
+
+
+class FeatureSource(Protocol):
+    def generate_features(
+        self, tasks: List[PromptTask], *, capture: CaptureConfig
+    ) -> List[Dict[str, Any]]: ...
+
+
+class RolloutWorker:
+    def __init__(
+        self,
+        controller,
+        feature_store,
+        feature_source: FeatureSource,
+        capture: CaptureConfig,
+        *,
+        run_id: str,
+        worker_id: Optional[str] = None,
+        strategy: str = "eagle3",
+        target_model_version: str = "unknown",
+        tokenizer_version: str = "unknown",
+        draft_weight_version: Optional[str] = None,
+    ) -> None:
+        self.controller = controller
+        self.feature_store = feature_store
+        self.feature_source = feature_source
+        self.capture = capture
+        self.run_id = run_id
+        self.strategy = strategy
+        self.target_model_version = target_model_version
+        self.tokenizer_version = tokenizer_version
+        self.draft_weight_version = draft_weight_version
+        self._state = "starting"
+        self._inflight = 0
+        self._recent_failures: List[str] = []
+        self._last_commit_count = 0
+        self.worker_id = controller.register_rollout_worker(
+            {"worker_id": worker_id, "strategy": strategy, "role": "rollout"}
+        )
+
+    def start(self) -> None:
+        self._state = "ready"
+
+    def stop(self, reason: str = "stopped") -> None:
+        # graceful: finish in-flight, then mark stopped (drain happens in run_once)
+        self._state = "stopped"
+
+    def _sample_id(self, task: PromptTask) -> str:
+        return f"{self.run_id}:{task.task_id}"
+
+    def run_once(self, max_tasks: int) -> List[SampleRef]:
+        if self._state in ("stopped", "draining"):
+            return []
+        tasks = self.controller.lease_prompt_tasks(self.worker_id, max_tasks)
+        if not tasks:
+            return []
+        self._inflight = len(tasks)
+        self._state = "ready"
+        try:
+            feats_list = self.feature_source.generate_features(
+                tasks, capture=self.capture
+            )
+        except Exception as exc:  # rollout failure before any feature write
+            self._state = "unhealthy"
+            self._recent_failures.append(f"generate_features: {exc}")
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=f"generate_features:{exc}",
+                retryable=True,
+            )
+            self._inflight = 0
+            raise
+        if len(feats_list) != len(tasks):
+            reason = (
+                f"generate_features returned {len(feats_list)} feature records "
+                f"for {len(tasks)} tasks"
+            )
+            self._state = "unhealthy"
+            self._recent_failures.append(reason)
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=reason,
+                retryable=False,
+            )
+            self._inflight = 0
+            raise ValueError(reason)
+
+        refs: List[SampleRef] = []
+        capture_error: Optional[CaptureMismatchError] = None
+        for task, feats in zip(tasks, feats_list):
+            sample_id = self._sample_id(task)
+            recorded = feats.pop("__aux_layer_ids__", None)
+            try:
+                verify_capture(
+                    feats,
+                    self.capture,
+                    sample_id=sample_id,
+                    recorded_aux_layer_ids=recorded,
+                )
+            except CaptureMismatchError as exc:
+                # Loud failure: do not persist a corrupt sample, but keep this
+                # batch's other prompt leases moving so no lease is stranded.
+                self._recent_failures.append(str(exc))
+                self.controller.fail_prompt_tasks(
+                    self.worker_id, [task.task_id], reason=str(exc), retryable=False
+                )
+                if capture_error is None:
+                    capture_error = exc
+                continue
+            try:
+                ref = self.feature_store.put(
+                    feats,
+                    sample_id=sample_id,
+                    metadata=self._put_metadata(task),
+                )
+            except Exception as exc:  # partial write -> abort, report
+                self.feature_store.abort(sample_id, reason=f"put_failed:{exc}")
+                self.controller.fail_prompt_tasks(
+                    self.worker_id, [task.task_id], reason=str(exc), retryable=True
+                )
+                continue
+            refs.append(ref)
+
+        if refs:
+            self.controller.commit_samples(self.worker_id, refs)
+            self._last_commit_count += len(refs)
+        self._inflight = 0
+        if capture_error is not None:
+            self._state = "unhealthy"
+            raise capture_error
+        return refs
+
+    def _put_metadata(self, task: PromptTask) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "source_task_id": task.task_id,
+            "strategy": self.strategy,
+            "target_repr": self.capture.target_repr,
+            "vocab_map_version": self.capture.vocab_map_version,
+            "ttt_length": self.capture.extra.get("ttt_length"),
+            "target_model_version": self.target_model_version,
+            "tokenizer_version": self.tokenizer_version,
+            "draft_weight_version": self.draft_weight_version,
+            "num_tokens": int(task.metadata.get("num_tokens", 0)),
+        }
+
+    def drain(self) -> None:
+        """Stop leasing new work; in-flight is finished by the active run_once."""
+        self._state = "draining"
+
+    # Draft-weight hot update (update_weights -> adapter) is not yet supported.
+    # draft_weight_version is still recorded as rollout provenance on each sample.
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "state": self._state,
+            "strategy": self.strategy,
+            "draft_weight_version": self.draft_weight_version,
+            "in_flight": self._inflight,
+            "recent_failures": self._recent_failures[-5:],
+            "committed": self._last_commit_count,
+        }
+
+
+__all__ = ["RolloutWorker", "FeatureSource", "HEALTH_STATES"]

--- a/specforge/runtime/inference/sglang_adapter.py
+++ b/specforge/runtime/inference/sglang_adapter.py
@@ -1,0 +1,157 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""SGLangAdapter: the clean boundary between SpecForge and the target engine.
+
+``generate_features(tasks, *, capture)`` is the single extraction entry point.
+``capture`` is the typed :class:`CaptureConfig` derived from the active strategy,
+not an untyped dict. The adapter wraps the existing ``Eagle3TargetModel`` (sglang
+/ hf / custom backends all expose ``generate_eagle3_data``), records the exact
+aux-layer IDs it captured, applies the target→draft projection demanded by
+``capture.target_repr`` (the only place pruning happens), and returns per-sample
+feature dicts. The RolloutWorker then runs :func:`verify_capture` before any
+store write, so a layer/name/width mismatch fails loudly at this boundary rather
+than as a downstream trainer bug.
+
+Imports the SpecForge model code, so it is imported by rollout entry points.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import PromptTask
+from specforge.runtime.inference.capture import CaptureConfig
+
+
+def _as_2d_long(values, device) -> torch.Tensor:
+    t = torch.as_tensor(values, dtype=torch.long, device=device)
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    return t
+
+
+class SGLangAdapter:
+    """Adapter over a SpecForge ``Eagle3TargetModel`` (or any ``generate_eagle3_data``)."""
+
+    SUPPORTED_FEATURE_NAMES = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+
+    def __init__(
+        self,
+        target_model,
+        *,
+        device: str = "cuda",
+        t2d: Optional[torch.Tensor] = None,
+        shard_returns: bool = False,
+    ) -> None:
+        self.target_model = target_model
+        self.device = device
+        # t2d (target->draft vocab mask) only needed for pruned_logits capture.
+        self.t2d = t2d
+        self.shard_returns = shard_returns
+        self._healthy = True
+
+    def _recorded_aux_layer_ids(self) -> tuple:
+        ids = getattr(self.target_model, "aux_hidden_states_layers", None)
+        return tuple(ids) if ids is not None else ()
+
+    # target representations this online adapter actually implements
+    SUPPORTED_TARGET_REPRS = ("logits", "pruned_logits")
+
+    def _project_target(
+        self, target: torch.Tensor, capture: CaptureConfig
+    ) -> torch.Tensor:
+        if capture.target_repr == "logits":
+            return target
+        if capture.target_repr == "pruned_logits":
+            if self.t2d is None:
+                raise ValueError("pruned_logits capture requires a t2d vocab map")
+            return target[..., self.t2d.to(target.device)]
+        # Only advertise what we implement. 'hidden_state' capture (storing the
+        # target's last hidden state) is not wired in the online adapter yet; the
+        # offline path supports it (the strategy re-runs TargetHead).
+        raise NotImplementedError(
+            f"SGLangAdapter does not implement online capture for target_repr="
+            f"{capture.target_repr!r}; supported: {self.SUPPORTED_TARGET_REPRS}"
+        )
+
+    def generate_features(
+        self, tasks: List[PromptTask], *, capture: CaptureConfig
+    ) -> List[Dict[str, Any]]:
+        """Extract per-sample features, batching the engine call.
+
+        Tasks are grouped by sequence length and each group is run through
+        ``generate_eagle3_data`` in ONE batched forward (the engine's native
+        batching), instead of a per-sample loop that would serialize N forwards.
+        Equal-length grouping avoids intra-batch padding, so per-sample features
+        are sliced out cleanly. The result preserves task order.
+        """
+        recorded = self._recorded_aux_layer_ids()
+        out: List[Optional[Dict[str, Any]]] = [None] * len(tasks)
+
+        groups: Dict[int, List[int]] = {}
+        for i, task in enumerate(tasks):
+            groups.setdefault(len(task.payload["input_ids"]), []).append(i)
+
+        for _length, idxs in groups.items():
+            input_ids = torch.stack(
+                [
+                    _as_2d_long(tasks[i].payload["input_ids"], self.device)[0]
+                    for i in idxs
+                ],
+                dim=0,
+            )  # (G, L)
+            loss_mask = torch.stack(
+                [
+                    _as_2d_long(
+                        tasks[i].payload.get("loss_mask", [1] * input_ids.shape[1]),
+                        self.device,
+                    )[0]
+                    for i in idxs
+                ],
+                dim=0,
+            )
+            attention_mask = torch.ones_like(input_ids)
+            data = self.target_model.generate_eagle3_data(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                loss_mask=loss_mask,
+                shard_returns=self.shard_returns,
+            )
+            target = self._project_target(data.target, capture)
+            for j, gi in enumerate(idxs):
+                out[gi] = {
+                    "input_ids": data.input_ids[j : j + 1],
+                    "attention_mask": data.attention_mask[j : j + 1],
+                    "loss_mask": data.loss_mask[j : j + 1],
+                    "hidden_state": data.hidden_states[j : j + 1],
+                    "target": target[j : j + 1],
+                    # carried out-of-band for verify_capture; popped before put
+                    "__aux_layer_ids__": recorded,
+                }
+        return out
+
+    # NOTE: draft-weight hot update (update_draft_weights) is not implemented yet.
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "healthy": self._healthy,
+            "aux_hidden_state_layer_ids": list(self._recorded_aux_layer_ids()),
+            "backend": getattr(self.target_model, "backend", "unknown"),
+        }
+
+
+__all__ = ["SGLangAdapter"]

--- a/specforge/runtime/inference/sglang_patch_inventory.md
+++ b/specforge/runtime/inference/sglang_patch_inventory.md
@@ -1,0 +1,60 @@
+# SGLang Patch Inventory & Supported-Version Matrix (M4 / B7-B8)
+
+This is the published inventory the M4 exit gate requires: every place SpecForge
+depends on SGLang internals to extract EAGLE3/DFlash features, and the SGLang
+versions that are validated against the extraction-correctness gate
+(`test_extraction_vs_hf_reference`).
+
+Per ADR (`open_questions.md` #1), the SGLang patch surface is treated as a
+**version-pinned fork**, surfaced through one boundary — `SGLangAdapter` in
+[`sglang_adapter.py`](sglang_adapter.py). The decision is **versioned `.patch`
+files + a declared version matrix + a CI extraction-drift gate**, not runtime
+monkey-patching, so a patch is auditable and an SGLang upgrade can never silently
+change what is extracted.
+
+## Extraction surface (what we depend on)
+
+| # | Dependency | Where | Why it can break on upgrade |
+|---|---|---|---|
+| 1 | `CaptureHiddenMode.FULL` + `LogitsProcessorForEAGLE3` returning `aux_hidden_states` / `last_hidden_states` | `specforge/modeling/target/eagle3_target_model.py` `_extend`, `sglang_backend/` | SGLang may rename the capture mode, change `logits_output` fields, or change aux-state layout |
+| 2 | `model.set_eagle3_layers_to_capture(layer_ids)` | `set_aux_hidden_states_layers` | Aux-layer registration API may move/rename |
+| 3 | `ScheduleBatch` / `ForwardBatch` / `ModelRunner` construction signature | `_extend` | New required ctor args on minor releases (e.g. `is_draft_worker`, `moe_dp_rank`) |
+| 4 | Per-request split of `aux_hidden_states` by `input_lens` | `_extend`, `_get_sharded_return` | Token packing / padding convention changes |
+| 5 | `wrap_eagle3_logits_processors_in_module(..., return_full_logits=False)` | `from_pretrained` | Logits-processor wrapping hook may change |
+
+The `SGLangAdapter` is the *only* code that touches these; everything downstream
+sees the typed `Eagle3TargetOutput` / per-sample feature dicts.
+
+## Supported version matrix
+
+The extraction-correctness gate must be green on every pinned version. `status`:
+**validated** = `test_extraction_vs_hf_reference` green in CI on this version;
+**target** = intended next pin.
+
+| SGLang version | torch / transformers | Backend(s) | Aux capture | Status |
+|---|---|---|---|---|
+| `0.5.5` (`lmsysorg/sglang:v0.5.5`) | 2.x / 4.x | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (repo CI image) |
+| `dev` (`lmsysorg/sglang:dev`) | 2.11 / 5.8 | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (H200 box) |
+| `0.5.9` (pyproject pin) | 2.9.1 / 4.57.1 | sglang, hf, custom | `set_eagle3_layers_to_capture` | target |
+
+`0.5.9` is the dependency pin, but it is not an M4 sign-off until the
+extraction-correctness gate is green on that exact image/version.
+
+The **HF backend** path (`HFEagle3TargetModel`, forward hooks on the aux layers)
+is version-robust and is what `test_extraction_vs_hf_reference` exercises in CI
+without a GPU SGLang server; the **sglang backend** is validated on the GPU box.
+
+## CI extraction-drift gate
+
+`test_extraction_vs_hf_reference` asserts the adapter's extracted aux hidden
+states equal an independent HF `output_hidden_states=True` forward at the
+recorded layer IDs (and target logits match a direct `lm_head`) within a
+documented bf16 tolerance (`rtol=atol=2e-2`). Run it against each pinned image;
+a failure on a new image blocks the version bump.
+
+## Patch files
+
+When an SGLang upgrade requires source changes to the extraction surface, add a
+versioned patch under `specforge/runtime/inference/patches/<sglang-version>.patch`
+and record it in the matrix above. None are required for the validated versions
+(extraction goes through the public capture API).

--- a/tests/test_runtime/test_capture.py
+++ b/tests/test_runtime/test_capture.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""CaptureConfig assertions, incl. the M4 gate test_capture_layer_mismatch_fails (CPU)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.inference.capture import (
+    CaptureConfig,
+    CaptureMismatchError,
+    verify_capture,
+)
+
+H = 8
+DRAFT_V = 16
+TARGET_V = 64
+
+
+def _capture(layer_ids=(10, 15, 20), target_repr="hidden_state", **kw):
+    return CaptureConfig.from_strategy(
+        required_features={"input_ids", "loss_mask", "hidden_state", "target"},
+        aux_hidden_state_layer_ids=layer_ids,
+        target_repr=target_repr,
+        target_hidden_size=H,
+        target_vocab_size=TARGET_V,
+        draft_vocab_size=DRAFT_V,
+        **kw,
+    )
+
+
+def _good_tensors(target_dim=H):
+    return {
+        "input_ids": torch.zeros(1, 4, dtype=torch.long),
+        "loss_mask": torch.ones(1, 4, dtype=torch.long),
+        "hidden_state": torch.randn(1, 4, 3 * H),  # 3 aux layers * H
+        "target": torch.randn(1, 4, target_dim),
+    }
+
+
+class TestCapture(unittest.TestCase):
+    def test_ok(self):
+        verify_capture(
+            _good_tensors(),
+            _capture(),
+            sample_id="s0",
+            recorded_aux_layer_ids=(10, 15, 20),
+        )
+
+    def test_capture_layer_mismatch_fails(self):
+        """Requested aux layers [10,15,20] vs recorded [10,15,21] -> loud failure."""
+        with self.assertRaises(CaptureMismatchError) as ctx:
+            verify_capture(
+                _good_tensors(),
+                _capture(layer_ids=(10, 15, 20)),
+                sample_id="s0",
+                recorded_aux_layer_ids=(10, 15, 21),
+            )
+        self.assertIn("aux-layer id mismatch", str(ctx.exception))
+
+    def test_missing_feature_fails(self):
+        t = _good_tensors()
+        del t["target"]
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(t, _capture(), sample_id="s0")
+
+    def test_aux_width_mismatch_fails(self):
+        t = _good_tensors()
+        t["hidden_state"] = torch.randn(1, 4, 2 * H)  # only 2 layers' worth
+        with self.assertRaises(CaptureMismatchError) as ctx:
+            verify_capture(t, _capture(), sample_id="s0")
+        self.assertIn("aux width", str(ctx.exception))
+
+    def test_target_dim_mismatch_pruned_logits(self):
+        cap = _capture(target_repr="pruned_logits", vocab_map_version="v1")
+        # pruned_logits expects draft_vocab_size on the last dim
+        ok = _good_tensors(target_dim=DRAFT_V)
+        verify_capture(ok, cap, sample_id="s0")
+        bad = _good_tensors(target_dim=TARGET_V)  # full vocab, wrong for pruned
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(bad, cap, sample_id="s0")
+
+    def test_pruned_logits_requires_vocab_map_version(self):
+        cap = _capture(target_repr="pruned_logits")  # no vocab_map_version
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(_good_tensors(target_dim=DRAFT_V), cap, sample_id="s0")
+
+    def test_logits_expects_full_vocab(self):
+        cap = _capture(target_repr="logits")
+        verify_capture(_good_tensors(target_dim=TARGET_V), cap, sample_id="s0")
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(_good_tensors(target_dim=DRAFT_V), cap, sample_id="s0")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_rollout_worker.py
+++ b/tests/test_runtime/test_rollout_worker.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+"""RolloutWorker drives PromptTask -> features -> SampleRef commit (CPU, fake source)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.control_plane import DataFlowController
+from specforge.runtime.data_plane import LocalFeatureStore
+from specforge.runtime.inference.capture import CaptureConfig
+from specforge.runtime.inference.rollout_worker import RolloutWorker
+
+H = 8
+
+
+def _capture(layer_ids=(1, 2, 3)):
+    return CaptureConfig.from_strategy(
+        required_features={
+            "input_ids",
+            "attention_mask",
+            "loss_mask",
+            "hidden_state",
+            "target",
+        },
+        aux_hidden_state_layer_ids=layer_ids,
+        target_repr="logits",
+        target_hidden_size=H,
+        target_vocab_size=32,
+    )
+
+
+class FakeSource:
+    """Stand-in for SGLangAdapter: returns per-sample feature dicts."""
+
+    def __init__(self, seq=4, target_dim=32, aux_layers=3, bad_layers=False):
+        self.seq = seq
+        self.target_dim = target_dim
+        self.aux_layers = aux_layers
+        self.bad_layers = bad_layers
+
+    def generate_features(self, tasks, *, capture):
+        out = []
+        for _ in tasks:
+            feats = {
+                "input_ids": torch.zeros(1, self.seq, dtype=torch.long),
+                "attention_mask": torch.ones(1, self.seq, dtype=torch.long),
+                "loss_mask": torch.ones(1, self.seq, dtype=torch.long),
+                "hidden_state": torch.randn(1, self.seq, self.aux_layers * H),
+                "target": torch.randn(1, self.seq, self.target_dim),
+            }
+            ids = (1, 2, 99) if self.bad_layers else (1, 2, 3)
+            feats["__aux_layer_ids__"] = ids
+            out.append(feats)
+        return out
+
+
+class RaisingSource:
+    def generate_features(self, tasks, *, capture):
+        raise RuntimeError("temporary engine failure")
+
+
+class ShortSource:
+    def generate_features(self, tasks, *, capture):
+        return []
+
+
+class MixedLayerSource(FakeSource):
+    def generate_features(self, tasks, *, capture):
+        out = super().generate_features(tasks, capture=capture)
+        out[-1]["__aux_layer_ids__"] = (1, 2, 99)
+        return out
+
+
+class TestRolloutWorker(unittest.TestCase):
+    def test_run_once_commits_refs(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}, {"payload": {"text": "b"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, FakeSource(), _capture(), run_id="run")
+        w.start()
+        refs = w.run_once(max_tasks=8)
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(ctrl.status()["samples_committed"], 2)
+        self.assertEqual(ctrl.sample_queue.depth(), 2)
+        # features landed in the store, retrievable by ref
+        out, _ = store.get(refs[0])
+        self.assertEqual(
+            set(out),
+            {"input_ids", "attention_mask", "loss_mask", "hidden_state", "target"},
+        )
+        self.assertEqual(w.health()["state"], "ready")
+
+    def test_capture_mismatch_fails_loudly_and_commits_nothing(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(
+            ctrl, store, FakeSource(bad_layers=True), _capture(), run_id="run"
+        )
+        w.start()
+        from specforge.runtime.inference.capture import CaptureMismatchError
+
+        with self.assertRaises(CaptureMismatchError):
+            w.run_once(max_tasks=8)
+        self.assertEqual(ctrl.status()["samples_committed"], 0)
+        self.assertEqual(ctrl.sample_queue.depth(), 0)
+        self.assertEqual(ctrl.status()["prompts_leased"], 0)
+        self.assertEqual(ctrl.status()["prompts_failed"], 1)
+
+    def test_partial_capture_mismatch_releases_all_leases(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}, {"payload": {"text": "bad"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, MixedLayerSource(), _capture(), run_id="run")
+        w.start()
+        from specforge.runtime.inference.capture import CaptureMismatchError
+
+        with self.assertRaises(CaptureMismatchError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["samples_committed"], 1)
+        self.assertEqual(st["queue_depth"], 1)
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_failed"], 1)
+
+    def test_generate_failure_requeues_prompt(self):
+        ctrl = DataFlowController("run")
+        ids = ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, RaisingSource(), _capture(), run_id="run")
+        w.start()
+        with self.assertRaises(RuntimeError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_pending"], 1)
+        self.assertEqual(ctrl.lease_prompt_tasks("w2", 1)[0].task_id, ids[0])
+
+    def test_wrong_feature_count_fails_prompt(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, ShortSource(), _capture(), run_id="run")
+        w.start()
+        with self.assertRaises(ValueError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_failed"], 1)
+
+    def test_no_tasks_returns_empty(self):
+        ctrl = DataFlowController("run")
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, FakeSource(), _capture(), run_id="run")
+        w.start()
+        self.assertEqual(w.run_once(8), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_sglang_adapter_batching.py
+++ b/tests/test_runtime/test_sglang_adapter_batching.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+"""SGLangAdapter batches the engine call by sequence length (CPU, fake target)."""
+
+import types
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import PromptTask
+from specforge.runtime.inference.capture import CaptureConfig
+from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+H, V = 4, 16
+
+
+class FakeTarget:
+    """Records each generate_eagle3_data call's batch size; encodes the first
+    token id into hidden_states so per-sample slicing can be verified."""
+
+    aux_hidden_states_layers = [1, 2, 3]
+
+    def __init__(self):
+        self.call_batch_sizes = []
+
+    def generate_eagle3_data(
+        self, input_ids, attention_mask, loss_mask, shard_returns=False
+    ):
+        G, L = input_ids.shape
+        self.call_batch_sizes.append(G)
+        o = types.SimpleNamespace()
+        o.input_ids = input_ids
+        o.attention_mask = attention_mask
+        o.loss_mask = loss_mask.unsqueeze(-1)
+        first_tok = input_ids[:, :1].float()  # (G,1)
+        o.hidden_states = first_tok.unsqueeze(-1).expand(G, L, 3 * H).clone()
+        o.target = torch.zeros(G, L, V)
+        return o
+
+
+class TestAdapterBatching(unittest.TestCase):
+    def _capture(self):
+        return CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=(1, 2, 3),
+            target_repr="logits",
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+
+    def test_groups_by_length_one_call_per_group(self):
+        target = FakeTarget()
+        adapter = SGLangAdapter(target, device="cpu")
+        tasks = [
+            PromptTask("t0", "r", "s", {"input_ids": [10, 11, 12, 13]}, 4),
+            PromptTask("t1", "r", "s", {"input_ids": [20, 21, 22, 23]}, 4),
+            PromptTask("t2", "r", "s", {"input_ids": [30, 31, 32, 33, 34, 35]}, 6),
+        ]
+        feats = adapter.generate_features(tasks, capture=self._capture())
+        # 2 length-groups (len4 x2, len6 x1) -> 2 batched calls, not 3 per-sample
+        self.assertEqual(sorted(target.call_batch_sizes), [1, 2])
+        self.assertEqual(len(feats), 3)
+        # order preserved + correct per-sample mapping (first-token encoding)
+        self.assertEqual(feats[0]["hidden_state"].shape, (1, 4, 3 * H))
+        self.assertEqual(feats[2]["hidden_state"].shape, (1, 6, 3 * H))
+        self.assertEqual(int(feats[0]["hidden_state"][0, 0, 0]), 10)
+        self.assertEqual(int(feats[1]["hidden_state"][0, 0, 0]), 20)
+        self.assertEqual(int(feats[2]["hidden_state"][0, 0, 0]), 30)
+        for f in feats:
+            self.assertEqual(f["__aux_layer_ids__"], (1, 2, 3))
+            self.assertEqual(f["target"].shape[-1], V)
+
+    def test_rejects_unimplemented_target_repr(self):
+        # the online adapter must only advertise reprs it implements
+        adapter = SGLangAdapter(FakeTarget(), device="cpu")
+        cap = CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=(1, 2, 3),
+            target_repr="hidden_state",  # not implemented online
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+        task = PromptTask("t0", "r", "s", {"input_ids": [1, 2, 3, 4]}, 4)
+        with self.assertRaises(NotImplementedError):
+            adapter.generate_features([task], capture=cap)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — stacked PR.** Stacked on #597 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

**Part 5/7 — inference (CaptureConfig, RolloutWorker, SGLangAdapter).**

Adds `specforge/runtime/inference/`. `CaptureConfig` + `verify_capture` is the typed contract for what rollout must produce (verified before persisting). `RolloutWorker` is strategy-agnostic — it leases PromptTasks, asks a `feature_source` for features, verifies them, writes to the store, and commits refs; it never hands a tensor to the controller. `SGLangAdapter` wraps any `Eagle3TargetModel.generate_eagle3_data` (HF, SGLang, or custom backend). Tests: `test_capture`, `test_rollout_worker`, `test_sglang_adapter_batching`. Additive.

Part of a **7-PR series** adding the DataFlow runtime (`specforge/runtime/`, milestones M1–M4). Verified on current upstream `main`: all subpackages import and **65 component tests pass**. The integration launcher (`launch.py` + `train_eagle3_dataflow.py`) and the end-to-end equivalence gates are a deliberate follow-up, not in this series.
