### PR TITLE
[DataFlow runtime 6/7] Training: TrainerCore/Controller, FSDP backend, strategies

### DIFF
--- a/specforge/runtime/training/DESIGN.md
+++ b/specforge/runtime/training/DESIGN.md
@@ -1,0 +1,49 @@
+# Training Plane Design (PR 6/7 — `runtime/training`)
+
+This is the design note for the **training**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+Owns the trainer-boundary split that turns a normalized, tensor-carrying TrainBatch into optimizer steps and checkpoints. Layered as: TrainerController (lifecycle: fit/evaluate/save_checkpoint, epoch loop, optimizer-step counting, durable ack at grad-accum boundary) -> TrainerCore (exactly one branch-free train/eval step + grad-accumulation/optimizer boundary) -> DraftTrainStrategy (per-draft-model required-feature validation, forward/loss, target projection ownership, checkpoint key filtering) and TrainingBackend (model wrap / backward / optimizer step + distributed grad-norm reduction / state_dict). The plane is the ONLY tensor-carrying side besides the data plane (consumes TrainBatch.tensors). Strategy differs per draft model (EAGLE3 TTT vs DFlash block-parallel); controller/core/backend/checkpoint are shared unchanged. Submodules import SpecForge model code so they are imported explicitly by training entry points, not at specforge.runtime package load, keeping the control/data plane importable without a GPU. Note: the module docstrings still reference a not-yet-implemented weight-publication / serving accept-length gate as future work; save_checkpoint only persists training state and returns a resume-target Checkpoint.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+
+  FIT[TrainerController fit epoch loop] -->|for batch in loader| TS[TrainerCore train_step]
+  FIT -->|append sample_ids| PA[pending_ack accumulator]
+  TS -->|forward_loss| ST[DraftTrainStrategy projection plus loss]
+  TS -->|backward| BK[FSDPTrainingBackend]
+  TS -->|step at accum boundary| BK
+  TS -->|StepResult optimizer_stepped| FIT
+  FIT -->|on boundary global_step plus 1| BND[boundary actions]
+  BND -->|ack_fn ids step| ACK[ack_train_refs durable]
+  BND -->|save_interval| CKPT[save_checkpoint rank0]
+  CKPT -->|checkpoint_state_filter| ST
+  CKPT -->|state_dict FULL| BK
+
+  class FIT,TS,ST,BK,BND,PA,CKPT compute;
+  class ACK control;
+```
+
+The training plane is the only tensor-carrying side besides the data plane; it consumes `TrainBatch.tensors`. `TrainerCore` executes exactly one branch-free step: `train_step` calls `strategy.forward_loss`, divides the loss by `accumulation_steps`, calls `backend.backward`, increments `self._micro`, and only at the boundary (`self._micro % self.accumulation_steps == 0`) calls `backend.step()` for the grad-norm — `optimizer_stepped` in the returned `StepResult` is the single authoritative boundary signal, and `_scalar` ensures no live tensor leaks out. `TrainerController` owns the lifecycle: `global_step` counts optimizer steps only, and it maintains a `pending_ack` accumulator of `batch.sample_ids` that is flushed via `ack_fn(pending_ack, global_step)` as one durable transaction exactly at each boundary, then cleared. The model-specific work lives in `DraftTrainStrategy`: `validate_batch` fail-fasts on missing `required_features`, and the strategy — not the core — owns the target projection (`Eagle3TrainStrategy._prepare_target` re-runs the frozen `TargetHead` for `target_repr=='hidden_state'`, computes the decayed per-position TTT loss) and `checkpoint_state_filter` (keep `draft_model.*`, strip prefix, drop `embed`). `FSDPTrainingBackend` carries the parallel layout via `ParallelConfig.from_distributed` (handles snapshotted, never re-derived), FSDP-wraps with `use_orig_params=True`/bf16, performs the optimizer step plus a distributed L2 grad-norm all-reduce, and produces a `FULL_STATE_DICT`. `save_checkpoint` writes training state on rank0 only and returns a resume-target `Checkpoint` — not a published weight version.
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `TrainerController` | `FeatureDataLoader.__iter__` | compute |
+| `TrainerController` | `TrainerCore.train_step` | compute |
+| `TrainerController` | `TrainerCore.eval_step` | compute |
+| `TrainerController` | `DataFlowController.ack_train_refs` | control |
+| `TrainerCore` | `Eagle3TrainStrategy.forward_loss` | compute |
+| `TrainerCore` | `FSDPTrainingBackend.backward` | compute |
+| `TrainerCore` | `FSDPTrainingBackend.step` | compute |

--- a/specforge/runtime/training/__init__.py
+++ b/specforge/runtime/training/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+"""Training plane: trainer boundary split (controller / core / strategy / backend).
+
+Submodules import ``torch`` (and, in the backend, ``specforge.distributed`` /
+``yunchang`` lazily) and operate on built SpecForge model objects passed in by
+the caller, so they are imported explicitly by training entry points rather than
+at package load (keeps the control/data plane importable without a GPU/model
+environment).
+"""

--- a/specforge/runtime/training/backend.py
+++ b/specforge/runtime/training/backend.py
@@ -1,0 +1,248 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""TrainingBackend: model wrapping / backward / optimizer step / state dict.
+
+Currently implements ``FSDPTrainingBackend`` only. It carries a ``ParallelConfig``
+object (the device-mesh / parallel-group handles) rather than a bare FSDP
+module, so the existing FSDP + TP + Ulysses/Ring SP setup is preserved exactly.
+The backend does not re-derive parallelism — it reads the handles SpecForge's
+``init_distributed`` already created.
+
+``torch`` is imported at module load (fine without a GPU); ``specforge.distributed``
+and ``yunchang`` are imported lazily inside ``ParallelConfig.from_distributed`` so
+this module stays importable in a CPU-only environment.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+
+@dataclass
+class ParallelConfig:
+    """Handles describing the active parallel layout. Carried, not re-derived."""
+
+    world_size: int = 1
+    tp_size: int = 1
+    sp_ulysses_size: int = 1
+    sp_ring_size: int = 1
+    sharding_strategy: str = "SHARD_GRAD_OP"
+    param_dtype: torch.dtype = torch.bfloat16
+    # opaque process-group / device-mesh handles (None in single-process).
+    # The full set is carried so TP + Ulysses/Ring SP survive the trainer split
+    # and a later reshard step has real handles to read — the parallelism is
+    # NOT re-derived here, only snapshotted from init_distributed.
+    fsdp_process_group: Any = None
+    dp_group: Any = None
+    draft_dp_group: Any = None
+    tp_group: Any = None
+    sp_ulysses_group: Any = None
+    sp_ring_group: Any = None
+    draft_sp_group: Any = None
+    device_mesh: Any = None
+    tp_device_mesh: Any = None
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def sp_size(self) -> int:
+        return self.sp_ulysses_size * self.sp_ring_size
+
+    @classmethod
+    def from_distributed(
+        cls,
+        *,
+        tp_size: int = 1,
+        sp_ulysses_size: int = 1,
+        sp_ring_size: int = 1,
+        sharding_strategy: str = "SHARD_GRAD_OP",
+        param_dtype: torch.dtype = torch.bfloat16,
+    ) -> "ParallelConfig":
+        """Snapshot ALL parallel handles created by ``init_distributed``.
+
+        Captures the TP group + the Ulysses/Ring SP groups + both device meshes,
+        not just DP — so the backend genuinely carries the parallel layout. A
+        getter that is unexpectedly missing is logged, not silently swallowed.
+        """
+        if not dist.is_initialized():
+            return cls(
+                world_size=1,
+                tp_size=tp_size,
+                sp_ulysses_size=sp_ulysses_size,
+                sp_ring_size=sp_ring_size,
+                sharding_strategy=sharding_strategy,
+                param_dtype=param_dtype,
+            )
+        handles: Dict[str, Any] = {}
+        try:
+            from specforge import distributed as sfdist
+
+            for name, getter in (
+                ("dp_group", "get_dp_group"),
+                ("draft_dp_group", "get_draft_dp_group"),
+                ("tp_group", "get_tp_group"),
+                ("sp_ulysses_group", "get_sp_ulysses_group"),
+                ("sp_ring_group", "get_sp_ring_group"),
+                ("draft_sp_group", "get_draft_sp_group"),
+                ("device_mesh", "get_device_mesh"),
+                ("tp_device_mesh", "get_tp_device_mesh"),
+            ):
+                fn = getattr(sfdist, getter, None)
+                if fn is None:
+                    continue
+                try:
+                    handles[name] = fn()
+                except Exception as exc:  # group not built for this config
+                    logging.getLogger(__name__).warning(
+                        "ParallelConfig.from_distributed: %s() unavailable: %s",
+                        getter,
+                        exc,
+                    )
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "ParallelConfig.from_distributed: specforge.distributed import failed: %s",
+                exc,
+            )
+        return cls(
+            world_size=dist.get_world_size(),
+            tp_size=tp_size,
+            sp_ulysses_size=sp_ulysses_size,
+            sp_ring_size=sp_ring_size,
+            sharding_strategy=sharding_strategy,
+            param_dtype=param_dtype,
+            fsdp_process_group=dist.group.WORLD,
+            **handles,
+        )
+
+
+class TrainingBackend(abc.ABC):
+    name: str
+
+    @abc.abstractmethod
+    def prepare_model(self, model: nn.Module) -> nn.Module: ...
+
+    @abc.abstractmethod
+    def backward(self, loss: torch.Tensor) -> None: ...
+
+    @abc.abstractmethod
+    def step(self) -> Optional[torch.Tensor]: ...
+
+    @abc.abstractmethod
+    def state_dict(self) -> dict: ...
+
+    @abc.abstractmethod
+    def load_state_dict(self, state: dict) -> None: ...
+
+
+class FSDPTrainingBackend(TrainingBackend):
+    """FSDP1 backend mirroring today's SpecForge training math.
+
+    Wraps the composite module (e.g. ``OnlineEagle3Model``) in FSDP with
+    ``use_orig_params=True`` / bf16 mixed precision / ``SHARD_GRAD_OP`` over the
+    configured process group, while the optimizer targets the inner trainable
+    submodule (the draft model) — exactly as the legacy script.
+    """
+
+    name = "fsdp"
+
+    def __init__(
+        self,
+        parallel_config: ParallelConfig,
+        *,
+        optimizer_factory=None,
+    ) -> None:
+        self.parallel_config = parallel_config
+        self._optimizer_factory = optimizer_factory
+        self.module: Optional[nn.Module] = None
+        self.optimizer = None
+        self._wrapped = False
+
+    def prepare_model(
+        self,
+        model: nn.Module,
+        *,
+        wrap: bool = True,
+        optimizer_target: Optional[nn.Module] = None,
+    ) -> nn.Module:
+        """Register the trainable module, FSDP-wrapping it unless ``wrap=False``.
+
+        ``wrap=False`` registers the module without sharding (single-rank /
+        equivalence runs where FSDP would be a no-op) so ``state_dict`` and
+        ``step`` still work without changing the math.
+        """
+        if not wrap:
+            self.module = model
+            self._wrapped = False
+        else:
+            from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+            from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
+
+            pc = self.parallel_config
+            sharding = getattr(ShardingStrategy, pc.sharding_strategy)
+            model = FSDP(
+                model,
+                use_orig_params=True,
+                mixed_precision=MixedPrecision(
+                    param_dtype=pc.param_dtype, buffer_dtype=pc.param_dtype
+                ),
+                sharding_strategy=sharding,
+                process_group=pc.fsdp_process_group,
+            )
+            self.module = model
+            self._wrapped = True
+        if self._optimizer_factory is not None:
+            target = optimizer_target if optimizer_target is not None else self.module
+            self.optimizer = self._optimizer_factory(target)
+        return self.module
+
+    def set_optimizer(self, optimizer) -> None:
+        self.optimizer = optimizer
+
+    def backward(self, loss: torch.Tensor) -> None:
+        loss.backward()
+
+    def step(self) -> Optional[torch.Tensor]:
+        """Optimizer step + the distributed grad-norm reduction (run_backward_and_update)."""
+        if self.optimizer is None:
+            raise RuntimeError(
+                "FSDPTrainingBackend.step called before optimizer is set"
+            )
+        grad_norm = self.optimizer.step()
+        if grad_norm is not None and dist.is_initialized():
+            grad_norm = grad_norm.detach().float()
+            if torch.cuda.is_available():
+                grad_norm = grad_norm.to(torch.cuda.current_device())
+            grad_norm = grad_norm.pow(2)
+            dist.all_reduce(grad_norm, op=dist.ReduceOp.SUM)
+            grad_norm = grad_norm.sqrt()
+        return grad_norm
+
+    def state_dict(self) -> dict:
+        if self.module is None:
+            raise RuntimeError("state_dict called before prepare_model")
+        if not self._wrapped:
+            return self.module.state_dict()
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+        from torch.distributed.fsdp import StateDictType
+
+        with FSDP.state_dict_type(self.module, StateDictType.FULL_STATE_DICT):
+            return self.module.state_dict()
+
+    def load_state_dict(self, state: dict) -> None:
+        if self.optimizer is not None and "optimizer_state_dict" in state:
+            self.optimizer.load_state_dict(state)
+
+
+__all__ = ["ParallelConfig", "TrainingBackend", "FSDPTrainingBackend"]

--- a/specforge/runtime/training/strategy.py
+++ b/specforge/runtime/training/strategy.py
@@ -1,0 +1,232 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DraftTrainStrategy: per-draft-model required features + forward/loss + projection.
+
+A strategy is the only place that knows how a particular draft model
+(EAGLE3 / DFlash) turns a normalized ``TrainBatch`` into a loss. The
+``TrainerCore`` stays branch-free: it never inspects ``target_repr`` or branches
+on online/offline — the strategy owns the target projection (applying
+``TargetHead`` / the ``t2d`` vocab map).
+
+This module imports ``torch`` and is constructed with already-built SpecForge
+model objects (the draft model is injected, not imported here), so it is imported
+by training entry points rather than at ``specforge.runtime`` package load.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import TrainBatch
+
+
+@dataclass(frozen=True)
+class StepOutput:
+    """Opaque per-step result a strategy hands back for metric aggregation.
+
+    Kept generic so a TTT strategy (per-position lists) and a single-scalar
+    strategy (DFlash) share one trainer loop.
+    """
+
+    loss: torch.Tensor
+    metrics: Dict[str, Any]
+
+
+class DraftTrainStrategy(abc.ABC):
+    name: str
+    required_features: set
+
+    @abc.abstractmethod
+    def trainable_module(self) -> nn.Module:
+        """The module whose parameters the optimizer/backend owns."""
+
+    def validate_batch(self, batch: TrainBatch) -> None:
+        missing = {f for f in self.required_features if f not in batch.tensors}
+        if missing:
+            raise ValueError(
+                f"{self.name} batch missing required features {sorted(missing)}; "
+                f"present={sorted(batch.tensors)}"
+            )
+
+    @abc.abstractmethod
+    def forward_loss(self, batch: TrainBatch) -> StepOutput: ...
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Select the keys this strategy persists as draft weights."""
+        return state_dict
+
+
+class Eagle3TrainStrategy(DraftTrainStrategy):
+    """EAGLE3 TTT strategy wrapping the existing ``OnlineEagle3Model``.
+
+    Projection ownership: for ``target_repr == "hidden_state"`` the
+    strategy re-runs the frozen ``TargetHead`` (lm_head) over the stored target
+    last hidden state — exactly today's offline ``run_forward``. For
+    ``logits`` / ``pruned_logits`` the rollout already produced the distribution
+    and the strategy uses ``target`` as-is. The ``t2d`` vocab map is then applied
+    inside ``OnlineEagle3Model.forward`` (unchanged math).
+    """
+
+    name = "eagle3"
+    required_features = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+
+    def __init__(
+        self,
+        eagle3_model: nn.Module,
+        *,
+        target_head: Optional[nn.Module] = None,
+        ploss_decay: float = 0.8,
+    ) -> None:
+        self.eagle3_model = eagle3_model
+        self.target_head = target_head
+        self.ploss_decay = ploss_decay
+
+    def trainable_module(self) -> nn.Module:
+        return self.eagle3_model
+
+    def _device(self) -> torch.device:
+        return next(self.eagle3_model.parameters()).device
+
+    def _prepare_target(
+        self,
+        target_repr: Optional[str],
+        input_ids: torch.Tensor,
+        target: torch.Tensor,
+        loss_mask: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if target_repr == "hidden_state":
+            if self.target_head is None:
+                raise ValueError(
+                    "target_repr='hidden_state' requires a target_head to re-run "
+                    "the lm_head projection"
+                )
+            # mirrors offline run_forward: shift input_ids/target, add mask dim,
+            # then project the target last hidden state to full-vocab logits.
+            input_ids, target, loss_mask = self.target_head.preprocess(
+                input_ids, target, loss_mask
+            )
+            target = self.target_head(target.to(device))
+            return input_ids.to(device), target, loss_mask.to(device)
+        # logits / pruned_logits: rollout already produced the distribution and
+        # applied any shift; use the tensors as delivered.
+        return input_ids.to(device), target.to(device), loss_mask.to(device)
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        t = batch.tensors
+        device = self._device()
+        target_repr = batch.metadata.get("target_repr")
+
+        input_ids, target, loss_mask = self._prepare_target(
+            target_repr, t["input_ids"], t["target"], t["loss_mask"], device
+        )
+        position_ids = t.get("position_ids")
+        (
+            plosses,
+            acceptance_rates,
+            acces,
+            acc_corrects,
+            acc_denoms,
+            metric_losses,
+            metric_loss_denoms,
+        ) = self.eagle3_model(
+            input_ids=input_ids,
+            attention_mask=t["attention_mask"].to(device),
+            loss_mask=loss_mask,
+            target=target,
+            hidden_states=t["hidden_state"].to(device),
+            position_ids=position_ids.to(device) if position_ids is not None else None,
+        )
+        weights = [self.ploss_decay**i for i in range(len(plosses))]
+        loss = sum(weights[i] * plosses[i] for i in range(len(plosses)))
+        return StepOutput(
+            loss=loss,
+            metrics={
+                "plosses": [p.detach() for p in plosses],
+                "acces": [a.detach() for a in acces],
+                "acceptance_rates": [a.detach() for a in acceptance_rates],
+                "acc_corrects": [c.detach() for c in acc_corrects],
+                "acc_denoms": [d.detach() for d in acc_denoms],
+                "metric_losses": [m.detach() for m in metric_losses],
+                "metric_loss_denoms": [d.detach() for d in metric_loss_denoms],
+            },
+        )
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # EAGLE3 owns a frozen embedding loaded from the target; do not persist it.
+        return {
+            k.replace("draft_model.", ""): v
+            for k, v in state_dict.items()
+            if "draft_model." in k and "embed" not in k.lower()
+        }
+
+
+class DFlashTrainStrategy(DraftTrainStrategy):
+    """DFlash block-parallel strategy wrapping the existing ``OnlineDFlashModel``.
+
+    Shares ``TrainerController`` / ``FSDPTrainingBackend`` / ``FeatureDataLoader``
+    / checkpoint with EAGLE3 — only the per-step forward/loss differs (a single
+    block-wise pass returning a scalar loss, vs EAGLE3's TTT unroll). DFlash uses
+    hard real-token labels + a separately-loaded target lm_head, so it needs no
+    target distribution and no vocab map. Schema names are DFlash's own (not
+    overloaded onto EAGLE3 names): ``hidden_states`` is the captured target
+    context, distinct from EAGLE3's ``hidden_state``.
+    """
+
+    name = "dflash"
+    required_features = {"input_ids", "hidden_states", "loss_mask"}
+
+    def __init__(self, dflash_model: nn.Module) -> None:
+        self.dflash_model = dflash_model
+
+    def trainable_module(self) -> nn.Module:
+        return self.dflash_model
+
+    def _device(self) -> torch.device:
+        return next(self.dflash_model.parameters()).device
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        t = batch.tensors
+        device = self._device()
+        loss, accuracy = self.dflash_model(
+            input_ids=t["input_ids"].to(device),
+            hidden_states=t["hidden_states"].to(device),
+            loss_mask=t["loss_mask"].to(device),
+        )
+        return StepOutput(loss=loss, metrics={"accuracy": accuracy.detach()})
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # DFlash keeps everything under draft_model.; the embedding/head live in
+        # a separate target module that is NOT persisted as draft weights.
+        return {
+            k.replace("draft_model.", ""): v
+            for k, v in state_dict.items()
+            if "draft_model." in k
+        }
+
+
+__all__ = [
+    "DraftTrainStrategy",
+    "Eagle3TrainStrategy",
+    "DFlashTrainStrategy",
+    "StepOutput",
+]

--- a/specforge/runtime/training/trainer.py
+++ b/specforge/runtime/training/trainer.py
@@ -1,0 +1,271 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""TrainerCore + TrainerController: the trainer-boundary split.
+
+* ``TrainerCore`` owns exactly one train/eval step plus the grad-accumulation and
+  optimizer boundary. It is **branch-free**: it never inspects online/offline or
+  ``target_repr`` and never applies a projection — that is the strategy's job. It
+  consumes a normalized ``TrainBatch`` and delegates the forward/loss to the
+  strategy and the backward/step to the backend.
+* ``TrainerController`` owns the lifecycle: ``fit`` / ``evaluate`` /
+  ``save_checkpoint`` / weight publication. The training *script* becomes a thin
+  launcher that builds these and calls ``fit``.
+
+EAGLE3 and DFlash share this lifecycle unchanged — only the strategy differs.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import TrainBatch
+from specforge.runtime.training.backend import TrainingBackend
+from specforge.runtime.training.strategy import DraftTrainStrategy, StepOutput
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """A saved training checkpoint location (resume target).
+
+    Deliberately NOT a published "weight version" — the published-weight
+    lifecycle (versioning, publisher, serving accept-length gate, hot update) is
+    not yet implemented. This record only says where a checkpoint is and at what
+    step.
+    """
+
+    checkpoint_uri: str
+    global_step: int
+    epoch: int
+    strategy: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Result of one TrainerCore step.
+
+    ``optimizer_stepped`` is the authoritative grad-accumulation boundary signal —
+    callers branch on it rather than sniffing the metrics dict.
+    """
+
+    optimizer_stepped: bool
+    loss: float
+    grad_norm: Optional[float]
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+
+# strategy metric name -> reported metric name. EAGLE3's per-position ``acces``
+# and DFlash's scalar ``accuracy`` both report as ``acc`` so downstream logging
+# stays strategy-agnostic; the rest pass through unchanged.
+_METRIC_NAMES = {
+    "acces": "acc",
+    "acceptance_rates": "acceptance_rates",
+    "plosses": "plosses",
+    "accuracy": "acc",
+}
+
+
+def _scalar(x: Any) -> float:
+    if isinstance(x, torch.Tensor):
+        return float(x.detach().float().mean().item())
+    if isinstance(x, (list, tuple)):
+        if not x:
+            return 0.0
+        return float(torch.stack([t.detach().float() for t in x]).mean().item())
+    return float(x)
+
+
+class TrainerCore:
+    """One step: forward/loss (strategy) -> backward (backend) -> optimizer boundary."""
+
+    def __init__(
+        self,
+        strategy: DraftTrainStrategy,
+        backend: TrainingBackend,
+        *,
+        accumulation_steps: int = 1,
+    ) -> None:
+        self.strategy = strategy
+        self.backend = backend
+        self.accumulation_steps = max(1, accumulation_steps)
+        self._micro = 0
+
+    def train_step(self, batch: TrainBatch) -> StepResult:
+        out: StepOutput = self.strategy.forward_loss(batch)
+        loss = out.loss / self.accumulation_steps
+        self.backend.backward(loss)
+        self._micro += 1
+        grad_norm = None
+        stepped = self._micro % self.accumulation_steps == 0
+        if stepped:
+            grad_norm = self.backend.step()
+        return self._result(out, grad_norm, stepped, mode="train")
+
+    @torch.no_grad()
+    def eval_step(self, batch: TrainBatch) -> StepResult:
+        out: StepOutput = self.strategy.forward_loss(batch)
+        return self._result(out, None, False, mode="eval")
+
+    def _result(
+        self, out: StepOutput, grad_norm, stepped: bool, mode: str
+    ) -> StepResult:
+        metrics: Dict[str, Any] = {"loss": _scalar(out.loss), "mode": mode}
+        for src, dst in _METRIC_NAMES.items():
+            if src in out.metrics:
+                metrics[dst] = _scalar(out.metrics[src])
+        gn = _scalar(grad_norm) if grad_norm is not None else None
+        if gn is not None:
+            metrics["grad_norm"] = gn
+        return StepResult(
+            optimizer_stepped=stepped,
+            loss=metrics["loss"],
+            grad_norm=gn,
+            metrics=metrics,
+        )
+
+
+class TrainerController:
+    """Lifecycle: fit / evaluate / checkpoint. Script becomes a launcher.
+
+    Weight publishing + the serving accept-length gate are not yet implemented;
+    save_checkpoint just persists training state and returns a Checkpoint.
+    """
+
+    def __init__(
+        self,
+        core: TrainerCore,
+        *,
+        run_id: str,
+        output_dir: str = "./output",
+        save_interval: int = 0,
+        eval_interval: int = 0,
+        log_interval: int = 50,
+        max_steps: Optional[int] = None,
+        num_epochs: int = 1,
+        logger: Optional[Callable[[Dict[str, Any], int], None]] = None,
+        ack_fn: Optional[Callable[[List[str], int], None]] = None,
+        start_step: int = 0,
+        start_epoch: int = 0,
+    ) -> None:
+        self.core = core
+        self.run_id = run_id
+        self.output_dir = output_dir
+        self.save_interval = save_interval
+        self.eval_interval = eval_interval
+        self.log_interval = log_interval
+        self.max_steps = max_steps
+        self.num_epochs = num_epochs
+        self.logger = logger
+        # ack_fn(sample_ids, global_step): acks consumed refs at the optimizer-step
+        # boundary with the step number, so the controller records the durable
+        # {acked, global_step, optimizer marker} transaction. If None, the loader
+        # is assumed to ack (e.g. simple/equivalence runs).
+        self.ack_fn = ack_fn
+        # global_step counts OPTIMIZER steps (increments only at a grad-accum
+        # boundary), so ack / checkpoint / resume semantics are in true optimizer
+        # steps. micro_step counts forward/backward micro-batches.
+        self.global_step = start_step
+        self.micro_step = 0
+        self.epoch = start_epoch
+        self.last_metrics: Dict[str, Any] = {}
+
+    def fit(
+        self, data: Iterable[TrainBatch], eval_data: Optional[Iterable] = None
+    ) -> int:
+        module = self.core.strategy.trainable_module()
+        module.train()
+        pending_ack: List[str] = []
+        for epoch in range(self.epoch, self.num_epochs):
+            self.epoch = epoch
+            if hasattr(data, "set_epoch"):
+                data.set_epoch(epoch)
+            for batch in data:
+                self.micro_step += 1
+                if self.ack_fn is not None:
+                    pending_ack.extend(batch.sample_ids)
+                result = self.core.train_step(batch)
+                self.last_metrics = result.metrics
+                # grad accumulated but optimizer has not stepped yet; everything
+                # keyed on optimizer steps fires only at the boundary.
+                if not result.optimizer_stepped:
+                    continue
+                self.global_step += 1
+                if self.ack_fn is not None:
+                    # durable ack transaction at the optimizer-step boundary
+                    self.ack_fn(pending_ack, self.global_step)
+                    pending_ack = []
+                if self.logger and self.global_step % max(1, self.log_interval) == 0:
+                    self.logger(result.metrics, self.global_step)
+                if (
+                    self.eval_interval
+                    and eval_data is not None
+                    and self.global_step % self.eval_interval == 0
+                ):
+                    self.evaluate(eval_data)
+                    module.train()
+                if self.save_interval and self.global_step % self.save_interval == 0:
+                    self.save_checkpoint(self.global_step)
+                if self.max_steps is not None and self.global_step >= self.max_steps:
+                    return self.global_step
+        # NOTE: a partial accumulation window at end-of-data (or when max_steps cuts
+        # mid-window) leaves the trailing micro-batches' grads un-stepped and their
+        # sample_ids in pending_ack un-flushed — those leases simply expire and are
+        # re-leased on resume (at-least-once), never double-counted into an
+        # optimizer step. Standard grad-accum behavior; called out so it is not
+        # mistaken for a dropped-ack bug.
+        return self.global_step
+
+    @torch.no_grad()
+    def evaluate(self, data: Iterable[TrainBatch]) -> Dict[str, float]:
+        module = self.core.strategy.trainable_module()
+        module.eval()
+        agg: Dict[str, list] = {}
+        n = 0
+        for batch in data:
+            rep = self.core.eval_step(batch)
+            n += 1
+            for k, v in rep.metrics.items():
+                if isinstance(v, (int, float)):
+                    agg.setdefault(k, []).append(v)
+        return {k: sum(vs) / len(vs) for k, vs in agg.items() if vs}
+
+    def save_checkpoint(self, step: int) -> Checkpoint:
+        ckpt_dir = os.path.join(self.output_dir, f"{self.run_id}-step{step}")
+        is_rank0 = (
+            not torch.distributed.is_initialized()
+        ) or torch.distributed.get_rank() == 0
+        full_state = self.core.backend.state_dict()
+        draft_state = self.core.strategy.checkpoint_state_filter(full_state)
+        if is_rank0:
+            os.makedirs(ckpt_dir, exist_ok=True)
+            torch.save(
+                {
+                    "draft_state_dict": draft_state,
+                    "global_step": step,
+                    "epoch": self.epoch,
+                    "strategy": self.core.strategy.name,
+                    "run_id": self.run_id,
+                },
+                os.path.join(ckpt_dir, "training_state.pt"),
+            )
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        return Checkpoint(
+            checkpoint_uri=f"file://{os.path.abspath(ckpt_dir)}",
+            global_step=step,
+            epoch=self.epoch,
+            strategy=self.core.strategy.name,
+        )
+
+
+__all__ = ["TrainerCore", "TrainerController", "Checkpoint", "StepResult"]

--- a/tests/test_runtime/test_seam_fixes.py
+++ b/tests/test_runtime/test_seam_fixes.py
@@ -1,0 +1,195 @@
+# coding=utf-8
+"""CPU tests for do-now seam fixes.
+
+Covered here: durable ack, MetadataStore, TrainLease, partition_key,
+ParallelConfig handles, checkpoint record shape, and DFlash plug-in wiring.
+"""
+
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import SampleRef, TrainBatch
+from specforge.runtime.control_plane import DataFlowController, InMemoryMetadataStore
+from specforge.runtime.training.backend import ParallelConfig, TrainingBackend
+from specforge.runtime.training.strategy import DFlashTrainStrategy
+from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+
+def _ref(i):
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://x/s{i}",
+        feature_keys={},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestDurableAckTransaction(unittest.TestCase):
+    def test_ack_records_durable_marker(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        leased = ctrl.lease_train_refs("t0", 8)
+        ctrl.ack_train_refs(
+            "t0", [r.sample_id for r in leased], global_step=7, optimizer_durable=True
+        )
+        marker = ctrl.store.durable_marker()
+        self.assertEqual(marker["global_step"], 7)
+        self.assertTrue(marker["optimizer_durable"])
+        self.assertEqual(marker["acked"], {"s0", "s1"})
+        st = ctrl.status()
+        self.assertEqual(st["durable_global_step"], 7)
+        self.assertEqual(st["durable_acked"], 2)
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)  # queue released too
+
+    def test_ack_without_step_still_releases(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0)])
+        leased = ctrl.lease_train_refs("t0", 8)
+        ctrl.ack_train_refs("t0", [r.sample_id for r in leased])  # no global_step
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+
+class TestMetadataStore(unittest.TestCase):
+    def test_commit_dedup(self):
+        s = InMemoryMetadataStore()
+        self.assertTrue(s.commit_sample(_ref(0)))
+        self.assertFalse(s.commit_sample(_ref(0)))  # dup
+        self.assertEqual(s.committed_count(), 1)
+
+
+class TestTrainLease(unittest.TestCase):
+    def test_lease_ack_route_through_controller(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        lease = ctrl.train_lease("t0")
+        refs = lease.get(8)
+        self.assertEqual({r.sample_id for r in refs}, {"s0", "s1"})
+        lease.ack(refs, global_step=3)
+        self.assertEqual(ctrl.store.durable_marker()["global_step"], 3)
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+
+class TestQueuePartitionKey(unittest.TestCase):
+    def test_partition_key_accepted(self):
+        from specforge.runtime.data_plane import SampleRefQueue
+
+        q = SampleRefQueue()
+        q.put([_ref(0)], partition_key="dp0")  # reserved seam, no-op
+        got = q.get(4, timeout_s=0.0, partition_key="dp0")
+        self.assertEqual(len(got), 1)
+
+
+class TestParallelConfigHandles(unittest.TestCase):
+    def test_carries_all_parallel_fields(self):
+        pc = ParallelConfig()
+        for f in (
+            "tp_group",
+            "sp_ulysses_group",
+            "sp_ring_group",
+            "draft_sp_group",
+            "device_mesh",
+            "dp_group",
+            "draft_dp_group",
+        ):
+            self.assertTrue(hasattr(pc, f), f"ParallelConfig missing {f}")
+
+    def test_from_distributed_no_dist(self):
+        pc = ParallelConfig.from_distributed(tp_size=2, sp_ulysses_size=2)
+        self.assertEqual(pc.world_size, 1)  # no dist -> safe defaults
+        self.assertEqual(pc.tp_size, 2)
+        self.assertEqual(pc.sp_size, 2)
+
+
+class _FakeBackend(TrainingBackend):
+    name = "fake"
+
+    def __init__(self, model):
+        self.model = model
+        self.steps = 0
+
+    def prepare_model(self, model):
+        self.module = model
+        return model
+
+    def backward(self, loss):
+        loss.backward()
+
+    def step(self):
+        self.steps += 1
+        return torch.tensor(1.0)
+
+    def state_dict(self):
+        return {"draft_model.w": self.model.w.detach().clone()}
+
+    def load_state_dict(self, state):
+        pass
+
+
+class _FakeDFlashModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.ones(1))
+
+    def forward(self, input_ids, hidden_states, loss_mask):
+        loss = (self.w * hidden_states.float().sum()).abs()
+        acc = torch.tensor(0.5)
+        return loss, acc
+
+
+class TestDFlashSharesLifecycle(unittest.TestCase):
+    def test_dflash_strategy_plugs_into_trainer_core(self):
+        model = _FakeDFlashModel()
+        strat = DFlashTrainStrategy(model)
+        backend = _FakeBackend(model)
+        core = TrainerCore(strat, backend, accumulation_steps=1)
+        batch = TrainBatch(
+            sample_ids=["s0"],
+            strategy="dflash",
+            tensors={
+                "input_ids": torch.zeros(1, 4, dtype=torch.long),
+                "hidden_states": torch.randn(1, 4, 8),
+                "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            },
+            metadata={},
+        )
+        rep = core.train_step(batch)
+        self.assertTrue(rep.optimizer_stepped)  # optimizer stepped via the shared core
+        self.assertEqual(backend.steps, 1)
+        self.assertAlmostEqual(rep.metrics["acc"], 0.5)
+
+    def test_dflash_validate_batch_rejects_missing(self):
+        strat = DFlashTrainStrategy(_FakeDFlashModel())
+        bad = TrainBatch(
+            sample_ids=["s"],
+            strategy="dflash",
+            tensors={"input_ids": torch.zeros(1, 4, dtype=torch.long)},
+            metadata={},
+        )
+        with self.assertRaises(ValueError):
+            strat.forward_loss(bad)
+
+
+class TestCheckpointRecord(unittest.TestCase):
+    def test_save_checkpoint_returns_plain_record(self):
+        model = _FakeDFlashModel()
+        strat = DFlashTrainStrategy(model)
+        backend = _FakeBackend(model)
+        backend.prepare_model(model)
+        core = TrainerCore(strat, backend)
+        with tempfile.TemporaryDirectory() as d:
+            ctrl = TrainerController(core, run_id="r", output_dir=d)
+            ckpt = ctrl.save_checkpoint(10)
+        # weight-version/publish/serving-gate deferred to M7: just a checkpoint record
+        self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+        self.assertEqual(ckpt.global_step, 10)
+        self.assertEqual(ckpt.strategy, "dflash")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+"""TrainerCore grad-accum + TrainerController fit/checkpoint (CPU)."""
+
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import TrainBatch
+from specforge.runtime.training.backend import TrainingBackend
+from specforge.runtime.training.strategy import DraftTrainStrategy, StepOutput
+from specforge.runtime.training.trainer import (
+    Checkpoint,
+    TrainerController,
+    TrainerCore,
+)
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.ones(1))
+
+
+class FakeStrategy(DraftTrainStrategy):
+    name = "fake"
+    required_features = {"x"}
+
+    def __init__(self):
+        self.model = TinyModel()
+
+    def trainable_module(self):
+        return self.model
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        loss = (self.model.w * batch.tensors["x"].sum()).abs()
+        return StepOutput(loss=loss, metrics={"accuracy": torch.tensor(0.5)})
+
+
+class FakeBackend(TrainingBackend):
+    name = "fake"
+
+    def __init__(self, model):
+        self.model = model
+        self.steps = 0
+        self.backwards = 0
+
+    def prepare_model(self, model):
+        return model
+
+    def backward(self, loss):
+        self.backwards += 1
+        loss.backward()
+
+    def step(self):
+        self.steps += 1
+        return torch.tensor(1.0)
+
+    def state_dict(self):
+        return {"draft_model.w": self.model.w.detach().clone()}
+
+    def load_state_dict(self, state):
+        pass
+
+
+def _batch():
+    return TrainBatch(
+        sample_ids=["s"], strategy="fake", tensors={"x": torch.ones(2)}, metadata={}
+    )
+
+
+class TestTrainerCore(unittest.TestCase):
+    def test_accumulation_boundary(self):
+        strat = FakeStrategy()
+        backend = FakeBackend(strat.model)
+        core = TrainerCore(strat, backend, accumulation_steps=2)
+        m0 = core.train_step(_batch())
+        self.assertFalse(m0.optimizer_stepped)  # no optimizer step yet
+        self.assertIsNone(m0.grad_norm)
+        self.assertEqual(backend.steps, 0)
+        m1 = core.train_step(_batch())
+        self.assertTrue(m1.optimizer_stepped)  # step on the 2nd micro-batch
+        self.assertIsNotNone(m1.grad_norm)
+        self.assertEqual(backend.steps, 1)
+        self.assertEqual(backend.backwards, 2)
+
+    def test_validate_batch_missing_feature(self):
+        strat = FakeStrategy()
+        bad = TrainBatch(sample_ids=["s"], strategy="fake", tensors={}, metadata={})
+        with self.assertRaises(ValueError):
+            strat.forward_loss(bad)
+
+
+class TestTrainerController(unittest.TestCase):
+    def test_fit_and_checkpoint(self):
+        strat = FakeStrategy()
+        backend = FakeBackend(strat.model)
+        core = TrainerCore(strat, backend, accumulation_steps=1)
+        with tempfile.TemporaryDirectory() as d:
+            ctrl = TrainerController(
+                core,
+                run_id="r",
+                output_dir=d,
+                max_steps=3,
+                num_epochs=5,
+            )
+            data = [_batch() for _ in range(10)]
+            step = ctrl.fit(data)
+            self.assertEqual(step, 3)  # max_steps honored
+            self.assertEqual(backend.steps, 3)
+            ckpt = ctrl.save_checkpoint(step)
+            self.assertIsInstance(ckpt, Checkpoint)
+            self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+            self.assertEqual(ckpt.global_step, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — stacked PR.** Stacked on #598 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

**Part 6/7 — training (TrainerCore/Controller, FSDP backend, strategies).**

Adds `specforge/runtime/training/`. `TrainerCore`/`TrainerController` is a branch-free loop (`global_step` counts optimizer steps; gradient accumulation; checkpoint/eval hooks; ack at the optimizer boundary). `FSDPTrainingBackend` + `ParallelConfig` wrap the model preserving TP + Ulysses/Ring SP, with the optimizer built over the wrapped module so FSDP is in the forward/backward path. `Eagle3TrainStrategy` (+ `DFlashTrainStrategy`) own loss/projection so the core stays branch-free (the `FeatureSpec.target_repr` tagged union selects hidden_state vs (pruned-)logits). Tests: `test_trainer`, `test_seam_fixes`. Additive.

Part of a **7-PR series** adding the DataFlow runtime (`specforge/runtime/`, milestones M1–M4). Verified on current upstream `main`: all subpackages import and **65 component tests pass**. The integration launcher (`launch.py` + `train_eagle3_dataflow.py`) and the end-to-end equivalence gates are a deliberate follow-up, not in this series.
