### PR TITLE
[DataFlow runtime 7/7] Integration: launcher + end-to-end equivalence gates

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -1,3 +1,8 @@
+# NOTE: core EAGLE3 training is being migrated to the DataFlow runtime launcher
+# scripts/train_eagle3_dataflow.py (offline + online; validated old-vs-new on 7B).
+# That launcher does not YET cover the following, so this script remains the path
+# for them: VLM (--is-vlm), USP sequence parallelism (--attention-backend usp),
+# the eval loop (--eval-*-path), --resume, and experiment trackers (--report-to).
 import argparse
 import hashlib
 import math

--- a/scripts/train_eagle3_dataflow.py
+++ b/scripts/train_eagle3_dataflow.py
@@ -1,0 +1,116 @@
+"""Thin launcher: offline EAGLE3 training through the SpecForge DataFlow runtime.
+
+This script is a *launcher* (M3): it builds models + optimizer, hands them to the
+runtime, and runs ``TrainerController.fit``. No training logic lives here — the
+loop, loss, projection, checkpoint, and eval all live in ``specforge.runtime``.
+
+Reuses the existing model/data builders from ``scripts.train_eagle3`` so model
+construction stays DRY; only the *orchestration* moves behind the runtime.
+
+Example (offline):
+    torchrun --standalone --nproc_per_node 1 scripts/train_eagle3_dataflow.py \
+        --target-model-path <hf-model> --draft-model-config configs/llama3-8B-eagle3.json \
+        --train-data-path <prompts.jsonl> --train-hidden-states-path <features_dir> \
+        --output-dir ./output --max-num-steps 20
+"""
+
+from accelerate.utils import set_seed
+
+# reuse existing builders so model construction is not duplicated
+from train_eagle3 import (
+    build_dataloaders,
+    build_draft_model,
+    build_target_model,
+    parse_args,
+)
+
+from specforge.distributed import destroy_distributed, init_distributed
+from specforge.optimizer import BF16Optimizer
+from specforge.runtime.launch import build_offline_eagle3_runtime
+
+
+def main():
+    parser, args = parse_args()
+    # parse_args() does not derive target_batch_size (train_eagle3.main computes
+    # it inline before building dataloaders); the offline runtime builder and
+    # build_dataloaders both read it, so derive it here too.
+    args.target_batch_size = args.tp_size * args.batch_size
+
+    # TODO(dataflow-launcher parity with scripts/train_eagle3.py): this launcher
+    # covers core EAGLE3 training (offline + online: loss / projection / FSDP /
+    # TP / grad-accum / checkpoint), validated old-vs-new. The following
+    # train_eagle3.py features are NOT yet wired here and still require the
+    # legacy script:
+    #   - VLM / multimodal targets (--is-vlm, QwenVLOnlineEagle3Model)
+    #   - USP sequence parallelism (--attention-backend usp -> process_data_usp;
+    #     this path uses OfflineEagle3Dataset.process_data, no per-rank seq shard)
+    #   - eval loop (--eval-data-path / --eval-hidden-states-path)
+    #   - resume from checkpoint (--resume)
+    #   - experiment trackers (--report-to wandb / swanlab / tensorboard)
+    #   - online multi-epoch re-rollout (online runs a single consume-once pass)
+    set_seed(args.seed)
+    init_distributed(
+        timeout=args.dist_timeout,
+        tp_size=args.tp_size,
+        sp_ring_size=args.sp_ring_size,
+        sp_ulysses_size=args.sp_ulysses_size,
+    )
+    if args.train_hidden_states_path is None:
+        raise SystemExit(
+            "train_eagle3_dataflow currently wires the OFFLINE path; pass "
+            "--train-hidden-states-path. (Online wiring composes RolloutWorker + "
+            "SGLangAdapter over the same control/data plane.)"
+        )
+
+    draft_config, draft_model, _ckpt, _resume = build_draft_model(args)
+    target_head, _ = build_target_model(args, draft_config, is_online=False)
+    # vocab mapping is produced from the prompt dataset exactly as today
+    _train, vocab_mapping_path, _eval = build_dataloaders(args, draft_config)
+    draft_model.load_vocab_mapping(vocab_mapping_path)
+
+    from specforge import OnlineEagle3Model
+
+    eagle3_model = OnlineEagle3Model(
+        draft_model=draft_model,
+        length=args.ttt_length,
+        attention_backend=args.attention_backend,
+        lk_loss_type=args.lk_loss_type,
+        kl_scale=args.kl_scale,
+        kl_decay=args.kl_decay,
+    ).cuda()
+
+    # built AFTER FSDP-wrap (inside the runtime) over the wrapped inner draft
+    def optimizer_factory(draft_module):
+        return BF16Optimizer(
+            draft_module,
+            lr=args.learning_rate,
+            max_grad_norm=args.max_grad_norm,
+            warmup_ratio=args.warmup_ratio,
+            total_steps=args.total_steps or 10_000,
+        )
+
+    trainer, loader = build_offline_eagle3_runtime(
+        hidden_states_path=args.train_hidden_states_path,
+        eagle3_model=eagle3_model,
+        target_head=target_head,
+        optimizer_factory=optimizer_factory,
+        run_id="eagle3-offline",
+        output_dir=args.output_dir,
+        ttt_length=args.ttt_length,
+        max_len=args.max_length,
+        batch_size=args.target_batch_size,
+        accumulation_steps=args.draft_accumulation_steps,
+        num_epochs=args.num_epochs,
+        max_steps=args.max_num_steps,
+        save_interval=args.save_interval,
+        tp_size=args.tp_size,
+        sp_ulysses_size=args.sp_ulysses_size,
+        sp_ring_size=args.sp_ring_size,
+        logger=lambda m, s: print(f"step {s}: {m}", flush=True),
+    )
+    trainer.fit(loader)
+    destroy_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -122,13 +122,27 @@ def init_distributed(
 
 def destroy_distributed():
     global _TP_GROUP, _DP_GROUP, _SP_ULYSSES_GROUP, _SP_RING_GROUP, _DRAFT_DP_GROUP
-    dist.destroy_process_group(_TP_GROUP)
-    dist.destroy_process_group(_DP_GROUP)
-    dist.destroy_process_group(_SP_ULYSSES_GROUP)
-    dist.destroy_process_group(_SP_RING_GROUP)
-    dist.destroy_process_group(_DRAFT_DP_GROUP)
-    dist.destroy_process_group(_DRAFT_SP_GROUP)
-    dist.destroy_process_group()
+    # Teardown must never crash the process: a group may be None (e.g. a trivial
+    # single-rank world) or already destroyed. Destroy each defensively so a
+    # successful run does not exit non-zero on cleanup.
+    for group in (
+        _TP_GROUP,
+        _DP_GROUP,
+        _SP_ULYSSES_GROUP,
+        _SP_RING_GROUP,
+        _DRAFT_DP_GROUP,
+        _DRAFT_SP_GROUP,
+    ):
+        if group is None:
+            continue
+        try:
+            dist.destroy_process_group(group)
+        except Exception:
+            pass
+    try:
+        dist.destroy_process_group()
+    except Exception:
+        pass
 
 
 def shard_tensor(

--- a/specforge/runtime/ARCHITECTURE.md
+++ b/specforge/runtime/ARCHITECTURE.md
@@ -1,0 +1,156 @@
+# SpecForge DataFlow Runtime — Architecture (M1–M4)
+
+The runtime moves SpecForge from a trainer-centered god-script to explicit
+contracts across **two planes**. This is the cross-plane map; each plane also has
+its own design note (see "Per-plane internals" below).
+
+## Plane responsibilities
+
+- **Contracts** — the stdlib-only data records every plane exchanges (`PromptTask`, `SampleRef`, `FeatureSpec`, `FeatureHandle`, `TrainBatch`) plus `assert_no_tensors`, which enforces the no-tensor boundary. Control-plane records carry metadata only; `TrainBatch` is the sole tensor carrier and lives only on the trainer side.
+- **Control plane** — `DataFlowController` (a passive coordinator with no run loop), `MetadataStore` (commit dedup + the single durable ack transaction), `SampleRefQueue` (lease/ack/fail transport), and `TrainLease`. Moves metadata only; every record-accepting entrypoint runs `assert_no_tensors`.
+- **Data plane** — `FeatureStore`/`LocalFeatureStore` is the only holder of tensors, addressed by metadata-only `SampleRef`. `FeatureDataLoader` is the bridge that materializes refs + store into collated `TrainBatch`es; `OfflineManifestReader` turns precomputed `.ckpt` files into in-place `file://` refs.
+- **Inference (compute)** — `RolloutWorker` + `SGLangAdapter` extract features from the target engine and commit only `SampleRef` metadata; `SGLangAdapter._project_target` is the sole target to draft projection site and `verify_capture` is the loud pre-`put` validator.
+- **Training (compute)** — `TrainerController` -> `TrainerCore` -> `DraftTrainStrategy` + `FSDPTrainingBackend` turn `TrainBatch`es into optimizer steps and checkpoints; the strategy owns projection/loss, the core is branch-free.
+
+## End-to-end flow
+
+**Online:** `RolloutWorker.run_once` leases prompts (`lease_prompt_tasks`), calls `generate_features` (which drives `generate_eagle3_data`), runs `verify_capture`, then `FeatureStore.put` writes tensors **directly to the data plane**. Only the resulting `SampleRef` metadata goes to the controller via `commit_samples`, which dedups through `MetadataStore.commit_sample` and enqueues fresh refs onto `SampleRefQueue`.
+
+**Offline:** `OfflineManifestReader.read()` emits in-place `file://` `SampleRef`s (no tensor copy) and the launcher calls `enqueue_offline_refs`, which dedups and enqueues onto the **same** `SampleRefQueue`.
+
+**Convergence + training:** Both paths converge at `SampleRef` on one queue, so the trainer has no online/offline branch. `TrainerController.fit` drives `for batch in loader`; the `FeatureDataLoader` leases refs through a `TrainLease` (`lease_train_refs` via the controller) and fetches the actual tensors **directly** from the `FeatureStore` (`get`/`release` with clone-on-fetch). `TrainerCore.train_step` runs forward/loss/backward and steps the optimizer at the grad-accum boundary; at that boundary `ack_fn` calls `ack_train_refs`, which records the durable ack transaction (`record_train_ack`) **before** releasing the queue lease.
+
+## System map
+
+Solid edges = control / metadata flow. Dashed edges = tensor flow (data plane).
+The `DataFlowController` is **passive**: callers point *into* it, and its only
+outbound edges go to its own `SampleRefQueue` and `MetadataStore`. Tensors never
+cross the controller.
+
+```mermaid
+flowchart TD
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef data fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+
+  subgraph COMPUTE[compute autonomous loops]
+    RW[RolloutWorker run_once loop]
+    SG[SGLangAdapter generate_features]
+    TGT[Eagle3TargetModel generate_eagle3_data]
+    TR[TrainerController fit loop]
+    CORE[TrainerCore train_step]
+    STRAT[Eagle3TrainStrategy forward_loss]
+    BE[FSDPTrainingBackend backward step]
+    LOADER[FeatureDataLoader iter]
+    OFF[OfflineManifestReader read]
+  end
+
+  subgraph CONTROL[control plane metadata only]
+    CTRL[DataFlowController passive coordinator]
+    QUEUE[SampleRefQueue lease ack fail]
+    MS[MetadataStore commit dedup durable ack]
+    LEASE[TrainLease get ack fail]
+  end
+
+  subgraph DATA[data plane tensors only]
+    STORE[FeatureStore LocalFeatureStore]
+  end
+
+  RW -->|register_rollout_worker| CTRL
+  RW -->|lease_prompt_tasks| CTRL
+  RW -->|generate_features| SG
+  SG -->|generate_eagle3_data| TGT
+  RW -.->|put| STORE
+  RW -->|commit_samples| CTRL
+  RW -->|fail_prompt_tasks| CTRL
+
+  OFF -->|enqueue_offline_refs| CTRL
+
+  CTRL -->|commit_sample| MS
+  CTRL -->|record_train_ack| MS
+  CTRL -->|get_committed| MS
+  CTRL -->|put fresh refs| QUEUE
+  CTRL -->|get| QUEUE
+  CTRL -->|ack| QUEUE
+  CTRL -->|fail| QUEUE
+
+  TR -->|train_step| CORE
+  CORE -->|forward_loss| STRAT
+  CORE -->|backward step| BE
+  TR -->|for batch in loader| LOADER
+  LOADER -->|lease_train_refs get| LEASE
+  LEASE -->|lease_train_refs| CTRL
+  LEASE -->|ack_train_refs| CTRL
+  LEASE -->|fail_refs| CTRL
+  LOADER -.->|get release| STORE
+  TR -->|ack_fn ack_train_refs| CTRL
+
+  class RW,SG,TGT,TR,CORE,STRAT,BE,LOADER,OFF compute;
+  class CTRL,QUEUE,MS,LEASE control;
+  class STORE data;
+```
+
+## Endpoint reference
+
+| Caller | Endpoint called | Plane | Purpose |
+|---|---|---|---|
+| RolloutWorker | register_rollout_worker | control | Register worker, obtain authoritative worker_id (no-tensor guard on info) |
+| RolloutWorker | lease_prompt_tasks | control | Pop up to max_tasks pending PromptTasks, mark leased to worker_id |
+| RolloutWorker | generate_features | compute | Ask the FeatureSource (SGLangAdapter) for one feature dict per task |
+| SGLangAdapter | generate_eagle3_data | compute | Run the target engine's batched forward to extract hidden_states/target |
+| RolloutWorker | put | data | Persist verified feature tensors directly to FeatureStore, get back a SampleRef |
+| RolloutWorker | abort | data | Clean up a partial/failed write so no corrupt sample is left |
+| RolloutWorker | commit_samples | control | Commit metadata-only SampleRefs; dedup + enqueue fresh refs |
+| RolloutWorker | fail_prompt_tasks | control | Release failed prompt leases (retryable or terminal) so none are stranded |
+| OfflineManifestReader | enqueue_offline_refs | control | Offline ingest: dedup + enqueue file:// SampleRefs onto the same queue |
+| DataFlowController | commit_sample | control | Dedup committed samples (True=new, False=duplicate) |
+| DataFlowController | record_train_ack | control | Persist the single durable ack transaction before releasing leases |
+| DataFlowController | get_committed | control | Resolve acked/failed sample_ids back to full SampleRef objects |
+| DataFlowController | put | control | Enqueue freshly committed refs onto the shared SampleRefQueue |
+| DataFlowController | get | control | Serve train-side leases from the SampleRefQueue |
+| DataFlowController | ack | control | Release queue leases after the durable ack transaction is recorded |
+| DataFlowController | fail | control | Route train-side ref failures through the queue (retryable flag) |
+| TrainLease | lease_train_refs | control | Loader's get(): lease train refs via the controller, not a raw queue |
+| TrainLease | ack_train_refs | control | ack(): record durable transaction + release leases via the controller |
+| TrainLease | fail_refs | control | fail(): route ref failures through the controller |
+| FeatureDataLoader | lease_train_refs (via TrainLease.get) | control | Lease a batch of refs from the stream |
+| FeatureDataLoader | get | data | Fetch a sample's tensors + lease FeatureHandle directly from the store |
+| FeatureDataLoader | release | data | Release the lease immediately after clone-on-fetch so prefetch can't race |
+| TrainerController | for batch in loader (__iter__) | compute | Drive the loader to yield collated TrainBatch objects |
+| TrainerController | train_step | compute | Run each micro-batch; read optimizer_stepped boundary signal |
+| TrainerController | eval_step | compute | Run eval batches and aggregate metrics |
+| TrainerController | ack_fn -> ack_train_refs | control | Close the ack loop: ack consumed sample_ids at the optimizer-step boundary |
+| TrainerCore | forward_loss | compute | Delegate model-specific forward + loss to the strategy |
+| TrainerCore | backward | compute | Run backward on the accumulation-scaled loss each micro-step |
+| TrainerCore | step | compute | Optimizer step + distributed grad-norm reduction at the accum boundary |
+
+## Autonomy: loops + a passive coordinator
+
+## Autonomous loops + one passive coordinator
+
+This is **not** a master/orchestrator that calls into sub-parts, and it is **not** a set of fully independent processes. It is a small number of **autonomous producer/consumer loops** coordinated by **one passive shared component**, the `DataFlowController`.
+
+- The **producer loop** is `RolloutWorker.run_once`, which runs on its own and *calls into* the controller (`lease_prompt_tasks`, `commit_samples`, `fail_prompt_tasks`). The controller never calls the worker.
+- The **consumer loop** is `TrainerController.fit`, which drives `for batch in loader`; the loader *calls into* the controller through `TrainLease` (`lease_train_refs` / `ack_train_refs` / `fail_refs`). The controller never calls the trainer.
+- The `DataFlowController` has **no run loop**. The only edges out of it go into its **own** `SampleRefQueue` and `MetadataStore`. Workers and the trainer point INTO the controller; that is what makes it passive.
+
+Tensors reinforce this: they **never** flow through the controller. `RolloutWorker` calls `FeatureStore.put` directly and `FeatureDataLoader` calls `FeatureStore.get`/`release` directly. Only metadata-bearing `SampleRef`s cross the control plane.
+
+## Why this makes disaggregation mechanical
+
+Because the loops are autonomous and only the coordinator is shared, moving components across nodes is a **swap, not a rewrite**:
+
+- **Durable backend swap:** all recovery-critical state sits behind the `MetadataStore` ABC (commit dedup + the atomic `record_train_ack` marker). A SQLite/Redis/DB backend is a new subclass injected into the controller — no controller rewrite, and `assert_no_tensors` keeps the seam importable without torch.
+- **`TrainLease` indirection:** the trainer never holds a raw in-process queue. It routes every `get`/`ack`/`fail` through the controller, so a cross-node trainer is a drop-in substitution and the durable ack transaction is always recorded.
+- **`partition_key` seam:** `SampleRefQueue.put`/`get` already accept a `partition_key` (currently accepted but ignored, single partition), reserving the per-DP-rank partitioning needed for a sharded/disaggregated queue without an API change.
+- **Online/offline convergence:** because `commit_samples` and `enqueue_offline_refs` land on the same queue and the trainer path is branch-free, the same consumer loop serves a disaggregated rollout fleet or a static offline manifest unchanged.
+
+## Per-plane internals
+
+Each plane carries its own design note (landed with that plane's PR):
+
+- `contracts.py` / `CONTRACTS.md` — shared metadata records + `assert_no_tensors`
+- `data_plane/DESIGN.md` — storage, queue, loader, lifecycle
+- `control_plane/DESIGN.md` — controller, metadata store, lease/durability
+- `inference/DESIGN.md` — rollout worker, capture, sglang seam
+- `training/DESIGN.md` — trainer core, strategy, FSDP backend

--- a/specforge/runtime/README.md
+++ b/specforge/runtime/README.md
@@ -1,0 +1,95 @@
+# SpecForge DataFlow Runtime (M1–M4)
+
+A minimal, DataFlow-centered layer over the existing SpecForge model/data code.
+It moves SpecForge from a trainer-centered god-script toward explicit contracts:
+
+```
+PromptTask -> RolloutWorker -> SampleRef -> FeatureDataLoader -> TrainBatch -> Trainer
+```
+
+The **control plane** moves only metadata; large tensors move only through the
+**data plane** (FeatureStore). Online and offline converge at `SampleRef`, so the
+trainer path has no online/offline branch. Existing model/data/distributed code
+(`specforge/core`, `specforge/modeling`, `specforge/data`, `specforge/distributed`)
+is reused, not rewritten — the runtime is plumbing around the existing ops, which
+is why the equivalence gates are bit-exact.
+
+## Layout
+
+```
+specforge/runtime/
+  contracts.py            # PromptTask, FeatureSpec, SampleRef, FeatureHandle,
+                          #   TrainBatch, assert_no_tensors
+  control_plane/
+    controller.py         # DataFlowController (in-process; no-tensor invariant)
+  data_plane/
+    feature_store.py      # FeatureStore ABC + LocalFeatureStore (mem + file + dump)
+    sample_ref_queue.py   # SampleRefQueue (lease / ack / fail / depth)
+    offline_reader.py     # OfflineManifestReader (.ckpt -> SampleRef)
+    feature_dataloader.py # FeatureDataLoader (SampleRef -> TrainBatch)
+  inference/
+    capture.py            # CaptureConfig + verify_capture (B7/B8)
+    rollout_worker.py     # RolloutWorker (strategy-agnostic)
+    sglang_adapter.py     # SGLangAdapter.generate_features (the SpecForge<->engine seam)
+    sglang_patch_inventory.md  # patch surface + supported-version matrix (M4)
+  training/
+    strategy.py           # DraftTrainStrategy ABC + Eagle3/DFlash strategies
+    backend.py            # TrainingBackend ABC + FSDPTrainingBackend + ParallelConfig
+    trainer.py            # TrainerCore (branch-free) + TrainerController + Checkpoint
+  launch.py               # wire the offline-EAGLE3 dataflow from a config
+```
+
+## Key decisions honored (ADRs)
+
+- **Target representation (ADR-0001):** `FeatureSpec.target_repr` is a tagged
+  union; the *strategy* owns the projection so `TrainerCore` stays branch-free.
+  Offline EAGLE3 uses `hidden_state` (re-run `TargetHead`) for equivalence;
+  `pruned_logits` is the production default (t2d at rollout).
+- **Delivery (ADR-0002):** at-least-once + idempotent effects. `commit_samples`
+  dedupes on `sample_id`; queue `put`/`ack`/`release` are idempotent.
+- **Storage (ADR-0003):** `LocalFeatureStore` is in-memory on the hot path with
+  an opt-in disk/mmap dump that doubles as the capture/replay tap.
+- **No-tensor invariant:** `SampleRef`/`PromptTask` are frozen dataclasses with no
+  tensor fields; the controller runs `assert_no_tensors` on every record.
+
+## Milestone status & exit-gate tests
+
+This branch implements the local DataFlow spine and the focused tests below. It
+does **not** complete every acceptance item from the refactor plan: the
+`WeightVersion` serving accept-length gate, full optimizer/scheduler resume, and
+moving the production DFlash script onto the shared lifecycle remain follow-up
+work.
+
+| M | Gate test (`tests/test_runtime/`) | Where it runs |
+|---|---|---|
+| **M1** | `test_controller_no_tensor.py::...test_controller_carries_no_tensor` | CPU/CI |
+| **M1** | `test_equiv_offline_eagle3.py` (offline bit-exact vs `run_forward`) | GPU (rcli) |
+| **M2** | `test_equiv_online_eagle3.py` (online vs legacy, BS=1) | GPU (rcli) |
+| **M2** | `test_sample_ref_queue.py`, `test_rollout_worker.py` (lease/ack, commit) | CPU/CI |
+| **M3** | `test_equiv_trainer_split.py` (paired single step) | GPU (rcli) |
+| **M3** | `test_checkpoint_resume.py` | GPU (rcli) |
+| **M3** | `test_trainer.py`, `test_seam_fixes.py` (core/accum/checkpoint/DFlash plug-in) | CPU/CI |
+| **M4** | `test_extraction_vs_hf_reference.py::test_extraction_vs_hf_reference` | GPU (rcli) |
+| **M4** | `test_capture.py` + `..._reference.py::test_capture_layer_mismatch_fails` | CPU/CI |
+
+Plus contract/store/loader unit tests (`test_contracts.py`, `test_feature_store.py`,
+`test_feature_dataloader.py`).
+
+## Running the tests
+
+CPU/CI (control + data plane, capture, trainer core — no GPU, no model download):
+
+```bash
+PYTHONPATH=$PWD python -m unittest discover -s tests/test_runtime -p "test_*.py" -v
+```
+
+GPU equivalence/extraction (tiny synthetic fixtures, no model download) on the
+H200 box via rcli:
+
+```bash
+rcli exec --sync-code <job> \
+  'cd /workspace/SpecForge && PYTHONPATH=$PWD python -m unittest discover -s tests/test_runtime -p "test_*.py" -v'
+```
+
+The GPU-only tests are guarded with `@unittest.skipUnless(torch.cuda.is_available())`,
+so the same command is safe on CPU (they skip) and on the GPU box (they run).

--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Launch helpers that wire the DataFlow runtime from a RunConfig.
+
+The training *script* becomes a thin launcher: it parses args, calls one of
+these builders, and runs ``TrainerController.fit``. All training logic lives in
+the runtime components, not the script. This module wires the **offline EAGLE3**
+path end to end:
+
+    OfflineManifestReader -> DataFlowController -> SampleRefQueue
+        -> FeatureDataLoader(process_data, DataCollatorWithPadding)
+        -> TrainBatch -> Eagle3TrainStrategy -> TrainerCore/Controller -> FSDP
+
+Online wiring (RolloutWorker + SGLangAdapter) composes the same control/data
+plane; see ``inference/`` for the equivalent assembly.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from specforge.runtime.control_plane import DataFlowController
+from specforge.runtime.data_plane import (
+    FeatureDataLoader,
+    LocalFeatureStore,
+    OfflineManifestReader,
+)
+from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
+from specforge.runtime.training.strategy import Eagle3TrainStrategy
+from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+
+def build_offline_eagle3_runtime(
+    *,
+    hidden_states_path: str,
+    eagle3_model,
+    target_head,
+    optimizer_factory,
+    run_id: str,
+    output_dir: str,
+    ttt_length: int = 7,
+    max_len: int = 2048,
+    batch_size: int = 1,
+    accumulation_steps: int = 1,
+    num_epochs: int = 1,
+    max_steps: Optional[int] = None,
+    save_interval: int = 0,
+    eval_interval: int = 0,
+    tp_size: int = 1,
+    sp_ulysses_size: int = 1,
+    sp_ring_size: int = 1,
+    logger=None,
+):
+    """Assemble the offline-EAGLE3 dataflow and return (trainer, loader).
+
+    ``optimizer_factory(draft_module) -> optimizer`` is invoked AFTER the model is
+    FSDP-wrapped, over the wrapped module's inner draft, so the optimizer owns the
+    FSDP-managed parameters.
+    """
+    from specforge.data.preprocessing import OfflineEagle3Dataset
+    from specforge.data.utils import DataCollatorWithPadding
+
+    controller = DataFlowController(run_id)
+    refs = OfflineManifestReader(
+        hidden_states_path,
+        run_id=run_id,
+        ttt_length=ttt_length,
+        max_len=max_len,
+        target_repr="hidden_state",
+    ).read()
+    controller.enqueue_offline_refs(refs)  # record committed state (enables ack lookup)
+    store = LocalFeatureStore(run_id)
+    trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
+    # Offline = a fixed, re-iterable ref set (so num_epochs > 1 actually trains
+    # multiple epochs). The trainer acks at the optimizer-step boundary via ack_fn.
+    loader = FeatureDataLoader(
+        store,
+        refs=refs,
+        batch_size=batch_size,
+        collate_fn=DataCollatorWithPadding(),
+        per_sample_transform=lambda raw: OfflineEagle3Dataset.process_data(
+            raw, max_len
+        ),
+        drop_last=True,
+        strategy="eagle3",
+    )
+
+    parallel = ParallelConfig.from_distributed(
+        tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
+    )
+    backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
+    # FSDP-wrap the composite model and build the optimizer over the inner draft
+    # AFTER wrapping; the strategy MUST run forward through the wrapped module so
+    # FSDP is actually in the forward/backward path (not bypassed at >1 rank).
+    wrapped = backend.prepare_model(
+        eagle3_model, optimizer_target=eagle3_model.draft_model
+    )
+    strategy = Eagle3TrainStrategy(wrapped, target_head=target_head)
+    core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
+    trainer = TrainerController(
+        core,
+        run_id=run_id,
+        output_dir=output_dir,
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+        save_interval=save_interval,
+        eval_interval=eval_interval,
+        logger=logger,
+        ack_fn=lambda ids, step: controller.ack_train_refs(
+            trainer_id, ids, global_step=step, optimizer_durable=True
+        ),
+    )
+    return trainer, loader
+
+
+# Backward-compatible alias for early branch users.
+build_offline_eagle3_controller = build_offline_eagle3_runtime
+
+
+__all__ = ["build_offline_eagle3_controller", "build_offline_eagle3_runtime"]

--- a/specforge/runtime/training/__init__.py
+++ b/specforge/runtime/training/__init__.py
@@ -1,9 +1,7 @@
 # coding=utf-8
 """Training plane: trainer boundary split (controller / core / strategy / backend).
 
-Submodules import ``torch`` (and, in the backend, ``specforge.distributed`` /
-``yunchang`` lazily) and operate on built SpecForge model objects passed in by
-the caller, so they are imported explicitly by training entry points rather than
-at package load (keeps the control/data plane importable without a GPU/model
-environment).
+Submodules import the SpecForge model code, so they are imported explicitly by
+callers rather than at package load (keeps the control/data plane importable
+without a GPU/model environment).
 """

--- a/specforge/runtime/training/strategy.py
+++ b/specforge/runtime/training/strategy.py
@@ -14,9 +14,8 @@ A strategy is the only place that knows how a particular draft model
 on online/offline — the strategy owns the target projection (applying
 ``TargetHead`` / the ``t2d`` vocab map).
 
-This module imports ``torch`` and is constructed with already-built SpecForge
-model objects (the draft model is injected, not imported here), so it is imported
-by training entry points rather than at ``specforge.runtime`` package load.
+This module imports the SpecForge model code, so it is imported by training
+entry points, not at ``specforge.runtime`` package load.
 """
 
 from __future__ import annotations

--- a/specforge/runtime/training/trainer.py
+++ b/specforge/runtime/training/trainer.py
@@ -64,23 +64,10 @@ class StepResult:
     metrics: Dict[str, Any] = field(default_factory=dict)
 
 
-# strategy metric name -> reported metric name. EAGLE3's per-position ``acces``
-# and DFlash's scalar ``accuracy`` both report as ``acc`` so downstream logging
-# stays strategy-agnostic; the rest pass through unchanged.
-_METRIC_NAMES = {
-    "acces": "acc",
-    "acceptance_rates": "acceptance_rates",
-    "plosses": "plosses",
-    "accuracy": "acc",
-}
-
-
 def _scalar(x: Any) -> float:
     if isinstance(x, torch.Tensor):
         return float(x.detach().float().mean().item())
-    if isinstance(x, (list, tuple)):
-        if not x:
-            return 0.0
+    if isinstance(x, (list, tuple)) and x:
         return float(torch.stack([t.detach().float() for t in x]).mean().item())
     return float(x)
 
@@ -120,9 +107,13 @@ class TrainerCore:
         self, out: StepOutput, grad_norm, stepped: bool, mode: str
     ) -> StepResult:
         metrics: Dict[str, Any] = {"loss": _scalar(out.loss), "mode": mode}
-        for src, dst in _METRIC_NAMES.items():
-            if src in out.metrics:
-                metrics[dst] = _scalar(out.metrics[src])
+        for key in ("acces", "acceptance_rates", "plosses"):
+            if key in out.metrics:
+                metrics[key.rstrip("es") if key == "acces" else key] = _scalar(
+                    out.metrics[key]
+                )
+        if "accuracy" in out.metrics:
+            metrics["acc"] = _scalar(out.metrics["accuracy"])
         gn = _scalar(grad_norm) if grad_norm is not None else None
         if gn is not None:
             metrics["grad_norm"] = gn
@@ -217,12 +208,6 @@ class TrainerController:
                     self.save_checkpoint(self.global_step)
                 if self.max_steps is not None and self.global_step >= self.max_steps:
                     return self.global_step
-        # NOTE: a partial accumulation window at end-of-data (or when max_steps cuts
-        # mid-window) leaves the trailing micro-batches' grads un-stepped and their
-        # sample_ids in pending_ack un-flushed — those leases simply expire and are
-        # re-leased on resume (at-least-once), never double-counted into an
-        # optimizer step. Standard grad-accum behavior; called out so it is not
-        # mistaken for a dropped-ack bug.
         return self.global_step
 
     @torch.no_grad()

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+"""Shared tiny synthetic fixtures for runtime GPU equivalence tests.
+
+Not a test module (no ``test_`` prefix). Builds a tiny EAGLE3 draft model, a
+``TargetHead``, a vocab mapping, and offline ``.ckpt`` feature files — all from
+random tensors, with NO model download — so the differential-equivalence tests
+compare the old vs new code path on identical inputs/weights.
+"""
+
+import json
+import os
+
+import torch
+
+TINY_DRAFT_CONFIG = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 64,
+    "initializer_range": 0.02,
+    "intermediate_size": 128,
+    "max_position_embeddings": 512,
+    "model_type": "llama",
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "pad_token_id": 0,
+    "rms_norm_eps": 1e-5,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "vocab_size": 256,
+    "draft_vocab_size": 64,
+}
+
+H = 64
+V = 256
+D = 64
+
+
+def build_single_rank_distributed(port="29561"):
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        return
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", port)
+    torch.cuda.set_device(0)
+    from specforge.distributed import init_distributed
+
+    init_distributed(timeout=10, tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
+
+
+def write_draft_config(path):
+    with open(path, "w") as f:
+        json.dump(TINY_DRAFT_CONFIG, f)
+    return path
+
+
+def write_target_head_dir(d, hidden=H, vocab=V):
+    from safetensors.torch import save_file
+
+    os.makedirs(d, exist_ok=True)
+    cfg = {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": hidden,
+        "vocab_size": vocab,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "intermediate_size": 128,
+    }
+    with open(os.path.join(d, "config.json"), "w") as f:
+        json.dump(cfg, f)
+    save_file(
+        {"lm_head.weight": torch.randn(vocab, hidden, dtype=torch.float32)},
+        os.path.join(d, "model.safetensors"),
+    )
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump(
+            {"metadata": {}, "weight_map": {"lm_head.weight": "model.safetensors"}}, f
+        )
+    return d
+
+
+def write_vocab_mapping(path, vocab=V, draft_vocab=D, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    draft_ids = torch.randperm(vocab, generator=g)[:draft_vocab].sort().values
+    t2d = torch.zeros(vocab, dtype=torch.bool)
+    t2d[draft_ids] = True
+    d2t = (draft_ids - torch.arange(draft_vocab)).to(torch.int64)
+    torch.save({"t2d": t2d, "d2t": d2t}, path)
+    return path
+
+
+def write_offline_files(d, n=4, seq=16, hidden=H, vocab=V, seed=0):
+    os.makedirs(d, exist_ok=True)
+    g = torch.Generator().manual_seed(seed)
+    for i in range(n):
+        torch.save(
+            {
+                "input_ids": torch.randint(0, vocab, (seq,), generator=g),
+                "loss_mask": torch.ones(seq, dtype=torch.long),
+                # prepared offline features are bf16 (target ran in bf16)
+                "hidden_state": torch.randn(1, seq, hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+                "aux_hidden_state": torch.randn(1, seq, 3 * hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+            },
+            os.path.join(d, f"{i:04d}.ckpt"),
+        )
+    return d
+
+
+def build_hf_target(workdir, hidden=H, layers=8, vocab=V, aux_layer_ids=(1, 3, 4)):
+    """Build a tiny HF Llama target wrapped by the SpecForge HF eagle3 backend."""
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    from specforge.modeling.target import get_eagle3_target_model
+
+    cfg = LlamaConfig(
+        hidden_size=hidden,
+        intermediate_size=2 * hidden,
+        num_hidden_layers=layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=vocab,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(1234)
+    model = LlamaForCausalLM(cfg)
+    target_dir = os.path.join(workdir, "hf_target")
+    model.save_pretrained(target_dir)
+    target = get_eagle3_target_model(
+        pretrained_model_name_or_path=target_dir,
+        backend="hf",
+        torch_dtype=torch.bfloat16,
+        device="cuda",
+    )
+    target.set_aux_hidden_states_layers(list(aux_layer_ids))
+    return target, target_dir, list(aux_layer_ids)
+
+
+def build_eagle3(workdir, ttt=3):
+    """Build (eagle3_model, target_head) sharing one set of weights, on cuda."""
+    from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
+    from specforge.modeling.target import TargetHead
+
+    cfg = write_draft_config(os.path.join(workdir, "draft.json"))
+    target_dir = write_target_head_dir(os.path.join(workdir, "target"))
+    vocab_path = write_vocab_mapping(os.path.join(workdir, "vocab_mapping.pt"))
+
+    draft_config = AutoDraftModelConfig.from_file(cfg)
+    draft_model = AutoEagle3DraftModel.from_config(
+        draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+    ).cuda()
+    draft_model.load_vocab_mapping(vocab_path)
+    draft_model.freeze_embedding()
+    target_head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+    eagle3_model = OnlineEagle3Model(
+        draft_model=draft_model, length=ttt, attention_backend="flex_attention"
+    ).cuda()
+    return eagle3_model, target_head

--- a/tests/test_runtime/test_checkpoint_resume.py
+++ b/tests/test_runtime/test_checkpoint_resume.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""M3 gate: checkpoint save -> resume restores weights and step (single rank).
+
+Trains a few offline steps through the new TrainerController, saves a checkpoint,
+reloads the draft state into a fresh model, and asserts the persisted draft
+weights and global step round-trip exactly.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "checkpoint resume requires CUDA")
+class TestCheckpointResume(unittest.TestCase):
+    def test_checkpoint_resume(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29563")
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import TrainBatch
+        from specforge.runtime.training.backend import (
+            FSDPTrainingBackend,
+            ParallelConfig,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+        from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+        TTT, BS, N = 3, 2, 6
+        workdir = tempfile.mkdtemp(prefix="ckpt_resume_")
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        target_dir = fx.write_target_head_dir(os.path.join(workdir, "target"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=N)
+        out_dir = os.path.join(workdir, "out")
+
+        draft_config = AutoDraftModelConfig.from_file(cfg)
+
+        def build_model():
+            dm = AutoEagle3DraftModel.from_config(
+                draft_config,
+                attention_backend="flex_attention",
+                torch_dtype=torch.bfloat16,
+            ).cuda()
+            dm.load_vocab_mapping(vocab_path)
+            dm.freeze_embedding()
+            return OnlineEagle3Model(
+                dm, length=TTT, attention_backend="flex_attention"
+            ).cuda()
+
+        head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+        ds = OfflineEagle3Dataset(
+            sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)), max_len=512
+        )
+        collate = DataCollatorWithPadding()
+
+        def make_batches():
+            out = []
+            for s in range(0, N, BS):
+                data = collate([ds[j] for j in range(s, s + BS)])
+                out.append(
+                    TrainBatch(
+                        sample_ids=[str(j) for j in range(s, s + BS)],
+                        strategy="eagle3",
+                        tensors=dict(data),
+                        metadata={"target_repr": "hidden_state", "ttt_length": TTT},
+                    )
+                )
+            return out
+
+        model = build_model()
+        opt = BF16Optimizer(
+            model.draft_model,
+            lr=1e-3,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.prepare_model(model, wrap=False)  # register module (no FSDP at 1 rank)
+        backend.set_optimizer(opt)
+        strategy = Eagle3TrainStrategy(model, target_head=head)
+        core = TrainerCore(strategy, backend)
+        ctrl = TrainerController(
+            core, run_id="r", output_dir=out_dir, max_steps=3, num_epochs=2
+        )
+        step = ctrl.fit(make_batches())
+        self.assertEqual(step, 3)
+        wv = ctrl.save_checkpoint(step)
+
+        # reload into a fresh model and compare persisted (non-embedding) weights
+        ckpt = torch.load(
+            os.path.join(wv.checkpoint_uri[len("file://") :], "training_state.pt"),
+            map_location="cpu",
+            weights_only=False,
+        )
+        self.assertEqual(ckpt["global_step"], 3)
+        self.assertEqual(ckpt["strategy"], "eagle3")
+
+        fresh = build_model()
+        missing, unexpected = fresh.draft_model.load_state_dict(
+            ckpt["draft_state_dict"], strict=False
+        )
+        self.assertEqual(unexpected, [])  # all persisted keys belong to the draft
+        # every persisted weight must now match the trained model bit-for-bit
+        trained = strategy.checkpoint_state_filter(backend.state_dict())
+        fresh_sd = fresh.draft_model.state_dict()
+        for k, v in trained.items():
+            self.assertTrue(
+                torch.equal(v.cpu(), fresh_sd[k].cpu()), msg=f"weight {k} mismatch"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_offline_eagle3.py
+++ b/tests/test_runtime/test_equiv_offline_eagle3.py
@@ -1,0 +1,233 @@
+# coding=utf-8
+"""M1 exit gate: offline EAGLE3 through SampleRef -> TrainBatch is bit-exact.
+
+Differential equivalence: the same tiny model + same offline feature files are
+driven through (a) today's offline ``run_forward`` math and (b) the new
+DataFlow path (OfflineManifestReader -> LocalFeatureStore -> FeatureDataLoader ->
+TrainBatch -> Eagle3TrainStrategy.forward_loss). The per-batch weighted loss
+must match bit-for-bit (tol=0) — this is a plumbing gate, not a correctness gate.
+
+GPU-only (the EAGLE3 draft/flex-attention path requires CUDA). Run on the H200
+box via rcli. Uses a synthetic tiny fixture — no model download.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+def _build_distributed_single_rank():
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        return
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29555")
+    torch.cuda.set_device(0)
+    from specforge.distributed import init_distributed
+
+    init_distributed(timeout=10, tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
+
+
+TINY_DRAFT_CONFIG = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 64,
+    "initializer_range": 0.02,
+    "intermediate_size": 128,
+    "max_position_embeddings": 512,
+    "model_type": "llama",
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "pad_token_id": 0,
+    "rms_norm_eps": 1e-5,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "vocab_size": 256,
+    "draft_vocab_size": 64,
+}
+
+
+def _write_target_head_dir(d, hidden, vocab):
+    """Write a minimal HF-style dir so TargetHead.from_pretrained works."""
+    from safetensors.torch import save_file
+
+    cfg = {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": hidden,
+        "vocab_size": vocab,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "intermediate_size": 128,
+    }
+    with open(os.path.join(d, "config.json"), "w") as f:
+        json.dump(cfg, f)
+    lm_head = torch.randn(vocab, hidden, dtype=torch.float32)
+    save_file({"lm_head.weight": lm_head}, os.path.join(d, "model.safetensors"))
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump(
+            {"metadata": {}, "weight_map": {"lm_head.weight": "model.safetensors"}}, f
+        )
+
+
+def _write_vocab_mapping(path, vocab, draft_vocab, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    draft_ids = torch.randperm(vocab, generator=g)[:draft_vocab].sort().values
+    t2d = torch.zeros(vocab, dtype=torch.bool)
+    t2d[draft_ids] = True
+    d2t = draft_ids - torch.arange(draft_vocab)
+    torch.save({"t2d": t2d, "d2t": d2t.to(torch.int64)}, path)
+
+
+def _write_offline_files(d, n, seq, hidden, vocab, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    for i in range(n):
+        torch.save(
+            {
+                "input_ids": torch.randint(0, vocab, (seq,), generator=g),
+                "loss_mask": torch.ones(seq, dtype=torch.long),
+                # prepared offline features are bf16 (target ran in bf16)
+                "hidden_state": torch.randn(1, seq, hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+                "aux_hidden_state": torch.randn(1, seq, 3 * hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+            },
+            os.path.join(d, f"{i:04d}.ckpt"),
+        )
+
+
+@unittest.skipUnless(CUDA, "offline EAGLE3 equivalence requires CUDA")
+class TestEquivOfflineEagle3(unittest.TestCase):
+    def test_equiv_offline_eagle3(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        _build_distributed_single_rank()
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.runtime.control_plane import DataFlowController
+        from specforge.runtime.data_plane import (
+            FeatureDataLoader,
+            LocalFeatureStore,
+            OfflineManifestReader,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+
+        H, V, D, SEQ, N, BS, TTT = 64, 256, 64, 16, 4, 2, 3
+
+        workdir = tempfile.mkdtemp(prefix="equiv_offline_")
+        cfg_path = os.path.join(workdir, "draft.json")
+        with open(cfg_path, "w") as f:
+            json.dump(TINY_DRAFT_CONFIG, f)
+        target_dir = os.path.join(workdir, "target")
+        os.makedirs(target_dir)
+        _write_target_head_dir(target_dir, H, V)
+        vocab_path = os.path.join(workdir, "vocab_mapping.pt")
+        _write_vocab_mapping(vocab_path, V, D)
+        feat_dir = os.path.join(workdir, "features")
+        os.makedirs(feat_dir)
+        _write_offline_files(feat_dir, N, SEQ, H, V)
+
+        # one shared model + head used by both paths
+        draft_config = AutoDraftModelConfig.from_file(cfg_path)
+        draft_model = AutoEagle3DraftModel.from_config(
+            draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+        ).cuda()
+        draft_model.load_vocab_mapping(vocab_path)
+        draft_model.freeze_embedding()
+        target_head = TargetHead.from_pretrained(
+            target_dir, lm_head_key="lm_head.weight"
+        )
+        eagle3_model = OnlineEagle3Model(
+            draft_model=draft_model, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+        eagle3_model.eval()
+
+        ploss_decay = 0.8
+
+        @torch.no_grad()
+        def old_path_losses():
+            ds = OfflineEagle3Dataset(
+                sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)),
+                max_len=512,
+            )
+            collate = DataCollatorWithPadding()
+            losses = []
+            for start in range(0, N, BS):
+                if start + BS > N:
+                    break
+                batch = collate([ds[j] for j in range(start, start + BS)])
+                input_ids, target, loss_mask = target_head.preprocess(
+                    batch["input_ids"], batch["target"], batch["loss_mask"]
+                )
+                target = target_head(target.cuda())
+                plosses, _, _, _, _, _, _ = eagle3_model(
+                    input_ids=input_ids.cuda(),
+                    attention_mask=batch["attention_mask"].cuda(),
+                    loss_mask=loss_mask.cuda(),
+                    target=target,
+                    hidden_states=batch["hidden_state"].cuda(),
+                )
+                w = [ploss_decay**i for i in range(len(plosses))]
+                losses.append(
+                    sum(w[i] * plosses[i] for i in range(len(plosses))).item()
+                )
+            return losses
+
+        @torch.no_grad()
+        def new_path_losses():
+            ctrl = DataFlowController("equiv-offline")
+            ctrl.enqueue_offline_refs(
+                OfflineManifestReader(
+                    feat_dir, run_id="equiv-offline", ttt_length=TTT, max_len=512
+                ).read()
+            )
+            store = LocalFeatureStore("equiv")
+            loader = FeatureDataLoader(
+                store,
+                ctrl.sample_queue,
+                batch_size=BS,
+                collate_fn=DataCollatorWithPadding(),
+                per_sample_transform=lambda raw: OfflineEagle3Dataset.process_data(
+                    raw, 512
+                ),
+                drop_last=True,
+            )
+            strategy = Eagle3TrainStrategy(eagle3_model, target_head=target_head)
+            losses = []
+            for batch in loader:
+                out = strategy.forward_loss(batch)
+                losses.append(out.loss.item())
+                ctrl.ack_train_refs("t0", batch.sample_ids)
+            return losses
+
+        old = old_path_losses()
+        new = new_path_losses()
+        self.assertEqual(len(old), len(new))
+        self.assertEqual(len(old), N // BS)
+        for i, (a, b) in enumerate(zip(old, new)):
+            self.assertEqual(a, b, f"batch {i}: old={a} new={b} (must be bit-exact)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_online_eagle3.py
+++ b/tests/test_runtime/test_equiv_online_eagle3.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+"""M2 gate: online EAGLE3 through PromptTask -> SampleRef -> TrainBatch matches.
+
+Old path = legacy online ``run_forward`` (target.generate_eagle3_data -> eagle3
+model). New path = PromptTask -> SGLangAdapter (via RolloutWorker) -> FeatureStore
+-> FeatureDataLoader -> TrainBatch -> Eagle3TrainStrategy. Single rank, batch
+size 1 (so old and new run the identical per-sample target forward): the weighted
+loss must match near-exactly, and the controller never carries a tensor.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "online EAGLE3 equivalence requires CUDA")
+class TestEquivOnlineEagle3(unittest.TestCase):
+    def test_equiv_online_eagle3(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29565")
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.runtime.contracts import assert_no_tensors
+        from specforge.runtime.control_plane import DataFlowController
+        from specforge.runtime.data_plane import FeatureDataLoader, LocalFeatureStore
+        from specforge.runtime.inference.capture import CaptureConfig
+        from specforge.runtime.inference.rollout_worker import RolloutWorker
+        from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+
+        H, V, SEQ, TTT = fx.H, fx.V, 12, 3
+        workdir = tempfile.mkdtemp(prefix="equiv_online_")
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+        eagle3_model.eval()
+
+        torch.manual_seed(11)
+        ids = torch.randint(0, V, (SEQ,)).tolist()
+
+        # --- old online path (batch size 1, tp=1 so no TP sharding) ---
+        @torch.no_grad()
+        def old_loss():
+            input_ids = torch.tensor([ids], device="cuda")
+            attn = torch.ones_like(input_ids)
+            loss_mask = torch.ones_like(input_ids)
+            d = target.generate_eagle3_data(input_ids, attn, loss_mask)
+            plosses, _, _, _, _, _, _ = eagle3_model(
+                input_ids=d.input_ids,
+                attention_mask=d.attention_mask,
+                loss_mask=d.loss_mask,
+                target=d.target,
+                hidden_states=d.hidden_states,
+            )
+            return sum(0.8**i * plosses[i] for i in range(len(plosses))).item()
+
+        # --- new dataflow path ---
+        @torch.no_grad()
+        def new_loss():
+            ctrl = DataFlowController("online")
+            ctrl.ingest_prompts(
+                [{"payload": {"input_ids": ids, "loss_mask": [1] * SEQ}}]
+            )
+            store = LocalFeatureStore("online")
+            adapter = SGLangAdapter(target, device="cuda")
+            capture = CaptureConfig.from_strategy(
+                required_features=Eagle3TrainStrategy.required_features,
+                aux_hidden_state_layer_ids=tuple(aux_ids),
+                target_repr="logits",
+                target_hidden_size=H,
+                target_vocab_size=V,
+            )
+            worker = RolloutWorker(ctrl, store, adapter, capture, run_id="online")
+            worker.start()
+            refs = worker.run_once(max_tasks=4)
+            assert len(refs) == 1
+            # controller holds only metadata
+            assert_no_tensors(ctrl.status())
+            for r in refs:
+                assert_no_tensors(r)
+
+            def cat_collate(feats):
+                return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
+
+            loader = FeatureDataLoader(
+                store,
+                ctrl.sample_queue,
+                batch_size=1,
+                collate_fn=cat_collate,
+            )
+            strategy = Eagle3TrainStrategy(eagle3_model, target_head=None)
+            losses = []
+            for batch in loader:
+                self.assertEqual(batch.metadata["target_repr"], "logits")
+                losses.append(strategy.forward_loss(batch).loss.item())
+            return losses[0]
+
+        old = old_loss()
+        new = new_loss()
+        self.assertAlmostEqual(
+            old, new, places=3, msg=f"online loss: old={old} new={new}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_trainer_split.py
+++ b/tests/test_runtime/test_equiv_trainer_split.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""M3 gate: the trainer-boundary split does not change the math (paired single step).
+
+Old path = legacy ``run_forward`` + ``run_backward_and_update``. New path =
+``Eagle3TrainStrategy`` + ``TrainerCore`` + ``FSDPTrainingBackend``. Two models
+with identical initial weights take one step on the same offline batch; the
+weighted loss must match bit-exactly and the reduced grad-norm near-exactly.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import types
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "trainer-split equivalence requires CUDA")
+class TestEquivTrainerSplit(unittest.TestCase):
+    def test_equiv_trainer_split(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29562")
+
+        import pathlib
+        import sys
+
+        sys.path.insert(
+            0, str(pathlib.Path(__file__).resolve().parents[2])
+        )  # repo root
+
+        from scripts.train_eagle3 import run_backward_and_update, run_forward
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import TrainBatch
+        from specforge.runtime.training.backend import (
+            FSDPTrainingBackend,
+            ParallelConfig,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+        from specforge.runtime.training.trainer import TrainerCore
+
+        TTT, BS = 3, 2
+        workdir = tempfile.mkdtemp(prefix="equiv_split_")
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        target_dir = fx.write_target_head_dir(os.path.join(workdir, "target"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=BS)
+
+        draft_config = AutoDraftModelConfig.from_file(cfg)
+
+        def build_model():
+            dm = AutoEagle3DraftModel.from_config(
+                draft_config,
+                attention_backend="flex_attention",
+                torch_dtype=torch.bfloat16,
+            ).cuda()
+            dm.load_vocab_mapping(vocab_path)
+            dm.freeze_embedding()
+            return OnlineEagle3Model(
+                draft_model=dm, length=TTT, attention_backend="flex_attention"
+            ).cuda()
+
+        model_a = build_model()
+        model_b = build_model()
+        # identical initial weights
+        model_b.draft_model.load_state_dict(model_a.draft_model.state_dict())
+        head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+
+        ds = OfflineEagle3Dataset(
+            sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)), max_len=512
+        )
+        data = DataCollatorWithPadding()([ds[j] for j in range(BS)])
+
+        args = types.SimpleNamespace(
+            is_vlm=False,
+            target_model_backend="hf",
+            shard_target_output=False,
+            draft_accumulation_steps=1,
+            # compact_teacher=False -> run_forward uses the legacy full-logits
+            # teacher path, matching the behavior this equivalence test asserts.
+            compact_teacher=False,
+            compact_teacher_chunk_size=None,
+        )
+
+        # --- old path on model_a ---
+        opt_a = BF16Optimizer(
+            model_a.draft_model,
+            lr=1e-4,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        plosses_a, _, _, _, _, _, _ = run_forward(
+            args, model_a, data, head, is_online=False
+        )
+        loss_old = sum(0.8**i * plosses_a[i] for i in range(len(plosses_a))).item()
+        gn_old = run_backward_and_update(args, plosses_a, opt_a, global_step=1)
+
+        # --- new path on model_b ---
+        opt_b = BF16Optimizer(
+            model_b.draft_model,
+            lr=1e-4,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.set_optimizer(opt_b)
+        strategy = Eagle3TrainStrategy(model_b, target_head=head)
+        core = TrainerCore(strategy, backend, accumulation_steps=1)
+        batch = TrainBatch(
+            sample_ids=["a", "b"],
+            strategy="eagle3",
+            tensors=dict(data),
+            metadata={"target_repr": "hidden_state", "ttt_length": TTT},
+        )
+        rep = core.train_step(batch)
+
+        self.assertAlmostEqual(
+            loss_old, rep.loss, places=4, msg=f"loss: old={loss_old} new={rep.loss}"
+        )
+        self.assertAlmostEqual(
+            float(gn_old.item()),
+            rep.grad_norm,
+            places=3,
+            msg=f"grad_norm: old={gn_old.item()} new={rep.grad_norm}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_extraction_vs_hf_reference.py
+++ b/tests/test_runtime/test_extraction_vs_hf_reference.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""M4 gate: extraction correctness vs an independent HF reference (fp tolerance).
+
+The SGLangAdapter's extracted aux hidden states (at the recorded layer IDs) must
+equal an independent HF ``output_hidden_states=True`` forward at those layers,
+and the target logits must match a direct forward — within a documented bf16
+tolerance. This is the only M4 numerical gate at fp tolerance (different engine),
+NOT bit-exact. Also asserts the capture assertion fires on a layer mismatch.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+# Documented tolerance: two bf16 forward passes of the same tiny model.
+RTOL, ATOL = 2e-2, 2e-2
+
+
+@unittest.skipUnless(CUDA, "extraction correctness requires CUDA")
+class TestExtractionVsHFReference(unittest.TestCase):
+    def test_extraction_vs_hf_reference(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29564")
+
+        from specforge.runtime.contracts import PromptTask
+        from specforge.runtime.inference.capture import CaptureConfig, verify_capture
+        from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+        H, V, SEQ = fx.H, fx.V, 12
+        workdir = tempfile.mkdtemp(prefix="extract_")
+        target, target_dir, aux_ids = fx.build_hf_target(
+            workdir, hidden=H, layers=8, vocab=V
+        )
+
+        adapter = SGLangAdapter(target, device="cuda")
+        capture = CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=tuple(aux_ids),
+            target_repr="logits",
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+
+        torch.manual_seed(7)
+        ids = torch.randint(0, V, (SEQ,)).tolist()
+        task = PromptTask(
+            task_id="t0",
+            run_id="r",
+            source_id="s",
+            payload={"input_ids": ids, "loss_mask": [1] * SEQ},
+            max_length=SEQ,
+        )
+        feats = adapter.generate_features([task], capture=capture)[0]
+        recorded = feats.pop("__aux_layer_ids__")
+        verify_capture(feats, capture, sample_id="t0", recorded_aux_layer_ids=recorded)
+        self.assertEqual(tuple(recorded), tuple(aux_ids))
+        self.assertEqual(feats["hidden_state"].shape[-1], 3 * H)
+
+        # independent HF reference forward with output_hidden_states
+        input_ids = torch.tensor([ids], device="cuda")
+        ref = target.model(
+            input_ids=input_ids,
+            attention_mask=torch.ones_like(input_ids),
+            output_hidden_states=True,
+            use_cache=False,
+        )
+        # hidden_states[i+1] == output of decoder layer i
+        extracted = feats["hidden_state"].float()
+        for k, layer_id in enumerate(aux_ids):
+            ref_layer = ref.hidden_states[layer_id + 1].float()  # (1, SEQ, H)
+            got = extracted[..., k * H : (k + 1) * H]
+            torch.testing.assert_close(
+                got,
+                ref_layer,
+                rtol=RTOL,
+                atol=ATOL,
+                msg=f"aux layer {layer_id} extraction drift",
+            )
+
+        # target logits match a direct forward (adapter pads next-token; compare
+        # the overlapping positions [0..SEQ-2] against ref logits [1..SEQ-1])
+        adapter_target = feats["target"].float()
+        ref_logits = ref.logits.float()
+        torch.testing.assert_close(
+            adapter_target[:, : SEQ - 1, :],
+            ref_logits[:, 1:SEQ, :],
+            rtol=RTOL,
+            atol=ATOL,
+            msg="target logits drift vs direct lm_head",
+        )
+
+    def test_capture_layer_mismatch_fails(self):
+        """A recorded aux-layer set != requested fails loudly at the boundary."""
+        from specforge.runtime.inference.capture import (
+            CaptureConfig,
+            CaptureMismatchError,
+            verify_capture,
+        )
+
+        cap = CaptureConfig.from_strategy(
+            required_features={"hidden_state", "target", "input_ids", "loss_mask"},
+            aux_hidden_state_layer_ids=(1, 3, 4),
+            target_repr="hidden_state",
+            target_hidden_size=8,
+        )
+        tensors = {
+            "input_ids": torch.zeros(1, 4, dtype=torch.long),
+            "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            "hidden_state": torch.randn(1, 4, 24),
+            "target": torch.randn(1, 4, 8),
+        }
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(
+                tensors, cap, sample_id="x", recorded_aux_layer_ids=(1, 3, 5)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_offline_launch_fsdp.py
+++ b/tests/test_runtime/test_offline_launch_fsdp.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+"""Launcher path: FSDP is in the forward path + global_step is optimizer steps.
+
+Exercises build_offline_eagle3_runtime end to end (single rank) with
+accumulation_steps=2, which the equivalence tests (wrap=False) do not cover:
+- the strategy must run forward through the FSDP-wrapped module (Issue 1);
+- fit's global_step counts OPTIMIZER steps, micro_step counts micro-batches (Issue 2).
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "launcher FSDP path requires CUDA")
+class TestOfflineLaunchFSDP(unittest.TestCase):
+    def test_fsdp_in_forward_path_and_optimizer_step_semantics(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29566")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.launch import build_offline_eagle3_runtime
+
+        TTT, ACC, MAX_OPT_STEPS, N = 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="launch_fsdp_")
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=N)
+        eagle3_model, target_head = fx.build_eagle3(workdir, ttt=TTT)
+
+        def optimizer_factory(draft_module):
+            return BF16Optimizer(
+                draft_module,
+                lr=1e-3,
+                max_grad_norm=0.5,
+                warmup_ratio=0.0,
+                total_steps=10,
+            )
+
+        trainer, loader = build_offline_eagle3_runtime(
+            hidden_states_path=feat_dir,
+            eagle3_model=eagle3_model,
+            target_head=target_head,
+            optimizer_factory=optimizer_factory,
+            run_id="launch",
+            output_dir=os.path.join(workdir, "out"),
+            ttt_length=TTT,
+            max_len=512,
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=3,
+            max_steps=MAX_OPT_STEPS,
+        )
+
+        # Issue 1: the strategy runs forward through the FSDP-wrapped module
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(
+            module, FSDP, "strategy must hold the FSDP-wrapped module"
+        )
+        self.assertIsNotNone(trainer.core.backend.optimizer)
+
+        step = trainer.fit(loader)
+
+        # Issue 2: global_step == optimizer steps; micro_step == ACC * optimizer steps
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.global_step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+
+        # a checkpoint can be written through the FSDP FULL_STATE_DICT path
+        ckpt = trainer.save_checkpoint(trainer.global_step)
+        self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+        self.assertEqual(ckpt.global_step, MAX_OPT_STEPS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**DataFlow runtime — part 7/7 (integration).** Stacked on #599 — **true-stacked**: this PR's base is the previous PR's branch, so the diff below shows **only this layer**.

Turns the runtime into a thin launcher and adds the end-to-end equivalence gates.

## What
- `specforge/runtime/launch.py` — `build_offline_eagle3_runtime`: assembles `OfflineManifestReader → DataFlowController → LocalFeatureStore → FeatureDataLoader → Eagle3TrainStrategy → TrainerController/Core → FSDP`.
- `scripts/train_eagle3_dataflow.py` — thin offline launcher; reuses `train_eagle3`'s model/data builders (no training logic in the script).
- GPU equivalence gates (CPU-stub-importable, `@skipUnless(cuda)` for the GPU ones): `test_equiv_offline_eagle3` (old `run_forward` vs new `Eagle3TrainStrategy.forward_loss`, **bit-exact** per-batch loss), `test_equiv_online_eagle3`, `test_equiv_trainer_split`, `test_offline_launch_fsdp`, `test_checkpoint_resume`, `test_extraction_vs_hf_reference`, plus `_fixtures.py`.
- Two launcher robustness fixes surfaced by a real 7B run: derive `args.target_batch_size` in the dataflow launcher (it was read before being set → crash); harden `destroy_distributed()` against `None`/already-destroyed groups so a successful run does not exit non-zero on teardown.
- Docs: `runtime/README.md`, `runtime/ARCHITECTURE.md`.

## How to run the full 7B old-vs-new **offline** comparison
```bash
# 0) Offline features (.ckpt) — either scripts/prepare_hidden_states.py (sglang),
#    or HF-only: run the target with output_hidden_states and save per prompt
#      input_ids:(seq,)  loss_mask:(seq,)
#      hidden_state:(1,seq,H)      = hidden_states[-1]                (lm-head input)
#      aux_hidden_state:(1,seq,3H) = cat(layers [1, L//2-1, L-4])     (default aux ids)
#    into <i>.ckpt (same format as prepare_hidden_states.DataPoint).
M="Qwen/Qwen2.5-7B-Instruct"; C="configs/qwen2.5-7b-eagle3.json"
ARGS="--target-model-path $M --draft-model-config $C --train-data-path prompts.jsonl \
      --train-hidden-states-path feats/ --target-model-backend hf --chat-template qwen \
      --max-num-steps 200 --batch-size 1 --seed 0"
# old path
torchrun --standalone --nproc_per_node 1 scripts/train_eagle3.py          $ARGS --output-dir out_old
# new path (identical args)
torchrun --standalone --nproc_per_node 1 scripts/train_eagle3_dataflow.py  $ARGS --output-dir out_new
# then diff per-step loss / acc / grad_norm from the two logs.
```

## Results — Qwen2.5-7B, 200 steps, HF backend, seed 0 (offline)
| step | old loss / new | old acc / new | old accept / new | old grad / new |
|---|---|---|---|---|
| 1 | 5.51 / 5.11 | 0.00 / 0.00 | 0.11 / 0.11 | 13.7 / 14.1 |
| 100 | 4.37 / 4.28 | 0.54 / 0.55 | 0.21 / 0.19 | 2.3 / 3.0 |
| 200 | **4.17 / 4.14** | **0.77 / 0.69** | **0.24 / 0.23** | 5.1 / 5.2 |

Old and new converge to the same point (loss ≈ 4.15, acc ≈ 0.7, acceptance ≈ 0.23, grad ≈ 5). Per-step values are not bit-identical because the two paths iterate samples in different order and report loss slightly differently; `test_equiv_offline_eagle3` isolates the per-batch math as **bit-exact**.

Part of an 8-PR stack adding the DataFlow runtime (M1–M4 + integration). Verified on current `main`: imports + full `tests/test_runtime` pass.

