### PR TITLE
[DataFlow runtime] Land integrated stack (M1–M4 + integration + online) into main

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -1,3 +1,8 @@
+# NOTE: core EAGLE3 training is being migrated to the DataFlow runtime launcher
+# scripts/train_eagle3_dataflow.py (offline + online; validated old-vs-new on 7B).
+# That launcher does not YET cover the following, so this script remains the path
+# for them: VLM (--is-vlm), USP sequence parallelism (--attention-backend usp),
+# the eval loop (--eval-*-path), --resume, and experiment trackers (--report-to).
 import argparse
 import hashlib
 import math

--- a/scripts/train_eagle3_dataflow.py
+++ b/scripts/train_eagle3_dataflow.py
@@ -1,17 +1,29 @@
-"""Thin launcher: offline EAGLE3 training through the SpecForge DataFlow runtime.
+"""Thin launcher: EAGLE3 training through the SpecForge DataFlow runtime.
 
 This script is a *launcher* (M3): it builds models + optimizer, hands them to the
 runtime, and runs ``TrainerController.fit``. No training logic lives here — the
 loop, loss, projection, checkpoint, and eval all live in ``specforge.runtime``.
 
 Reuses the existing model/data builders from ``scripts.train_eagle3`` so model
-construction stays DRY; only the *orchestration* moves behind the runtime.
+construction stays DRY; only the *orchestration* moves behind the runtime. Both
+modes converge at ``SampleRef`` and share one trainer/strategy/FSDP path:
 
-Example (offline):
+* **offline** (``--train-hidden-states-path`` set): an ``OfflineManifestReader``
+  turns precomputed ``.ckpt`` files into refs.
+* **online** (no hidden-states path): a ``RolloutWorker`` generates features from
+  the target model and commits refs onto the control plane's queue.
+
+Examples:
+    # offline
     torchrun --standalone --nproc_per_node 1 scripts/train_eagle3_dataflow.py \
-        --target-model-path <hf-model> --draft-model-config configs/llama3-8B-eagle3.json \
+        --target-model-path <hf-model> --draft-model-config <cfg.json> \
         --train-data-path <prompts.jsonl> --train-hidden-states-path <features_dir> \
         --output-dir ./output --max-num-steps 20
+
+    # online (no --train-hidden-states-path)
+    torchrun --standalone --nproc_per_node 1 scripts/train_eagle3_dataflow.py \
+        --target-model-path <hf-model> --draft-model-config <cfg.json> \
+        --train-data-path <prompts.jsonl> --output-dir ./output --max-num-steps 20
 """
 
 from accelerate.utils import set_seed
@@ -26,13 +38,46 @@ from train_eagle3 import (
 
 from specforge.distributed import destroy_distributed, init_distributed
 from specforge.optimizer import BF16Optimizer
-from specforge.runtime.launch import build_offline_eagle3_runtime
+
+
+def _target_hidden_and_vocab(target_model):
+    """Best-effort (hidden_size, vocab_size) from an Eagle3 target backend."""
+    cfg = getattr(getattr(target_model, "model", None), "config", None)
+    if cfg is not None:
+        return int(cfg.hidden_size), int(cfg.vocab_size)
+    raise RuntimeError(
+        "could not read hidden_size/vocab_size from the target model; pass them explicitly"
+    )
+
+
+def _extract_prompts(train_dataloader):
+    """Flatten the online train dataloader into metadata-only PromptTask payloads.
+
+    Each prompt carries only ``input_ids`` + ``loss_mask`` (the control plane
+    never holds tensors); ``attention_mask`` recovers the true unpadded length.
+    """
+    prompts = []
+    for batch in train_dataloader:
+        input_ids = batch["input_ids"]
+        loss_mask = batch["loss_mask"]
+        attn = batch.get("attention_mask")
+        for i in range(input_ids.shape[0]):
+            n = int(attn[i].sum().item()) if attn is not None else input_ids.shape[1]
+            prompts.append(
+                {
+                    "payload": {
+                        "input_ids": input_ids[i, :n].tolist(),
+                        "loss_mask": loss_mask[i, :n].tolist(),
+                    }
+                }
+            )
+    return prompts
 
 
 def main():
     parser, args = parse_args()
     # parse_args() does not derive target_batch_size (train_eagle3.main computes
-    # it inline before building dataloaders); the offline runtime builder and
+    # it inline before building dataloaders); the runtime builder and
     # build_dataloaders both read it, so derive it here too.
     args.target_batch_size = args.tp_size * args.batch_size
 
@@ -55,17 +100,12 @@ def main():
         sp_ring_size=args.sp_ring_size,
         sp_ulysses_size=args.sp_ulysses_size,
     )
-    if args.train_hidden_states_path is None:
-        raise SystemExit(
-            "train_eagle3_dataflow currently wires the OFFLINE path; pass "
-            "--train-hidden-states-path. (Online wiring composes RolloutWorker + "
-            "SGLangAdapter over the same control/data plane.)"
-        )
+
+    online = args.train_hidden_states_path is None
 
     draft_config, draft_model, _ckpt, _resume = build_draft_model(args)
-    target_head, _ = build_target_model(args, draft_config, is_online=False)
     # vocab mapping is produced from the prompt dataset exactly as today
-    _train, vocab_mapping_path, _eval = build_dataloaders(args, draft_config)
+    train_dataloader, vocab_mapping_path, _eval = build_dataloaders(args, draft_config)
     draft_model.load_vocab_mapping(vocab_mapping_path)
 
     from specforge import OnlineEagle3Model
@@ -79,7 +119,7 @@ def main():
         kl_decay=args.kl_decay,
     ).cuda()
 
-    # built AFTER FSDP-wrap (inside the runtime) over the wrapped inner draft
+    # optimizer is built AFTER FSDP-wrap (inside the runtime) over the inner draft
     def optimizer_factory(draft_module):
         return BF16Optimizer(
             draft_module,
@@ -89,26 +129,71 @@ def main():
             total_steps=args.total_steps or 10_000,
         )
 
-    trainer, loader = build_offline_eagle3_runtime(
-        hidden_states_path=args.train_hidden_states_path,
-        eagle3_model=eagle3_model,
-        target_head=target_head,
-        optimizer_factory=optimizer_factory,
-        run_id="eagle3-offline",
-        output_dir=args.output_dir,
-        ttt_length=args.ttt_length,
-        max_len=args.max_length,
-        batch_size=args.target_batch_size,
-        accumulation_steps=args.draft_accumulation_steps,
-        num_epochs=args.num_epochs,
-        max_steps=args.max_num_steps,
-        save_interval=args.save_interval,
-        tp_size=args.tp_size,
-        sp_ulysses_size=args.sp_ulysses_size,
-        sp_ring_size=args.sp_ring_size,
-        logger=lambda m, s: print(f"step {s}: {m}", flush=True),
-    )
-    trainer.fit(loader)
+    logger = lambda m, s: print(f"step {s}: {m}", flush=True)
+
+    if online:
+        from specforge.runtime.launch import build_online_eagle3_runtime
+
+        # Online target produces features in-loop (any backend exposing
+        # generate_eagle3_data — HF or SGLang). is_online=True returns the model.
+        target_model, _ = build_target_model(args, draft_config, is_online=True)
+        hidden_size, vocab_size = _target_hidden_and_vocab(target_model)
+        prompts = _extract_prompts(train_dataloader)
+        print(f"[online] ingesting {len(prompts)} prompts for rollout", flush=True)
+
+        # num_epochs=1: the rollout output is a consume-once stream. Multi-epoch
+        # online (re-rollout each epoch) is a follow-up; one rollout pass here.
+        trainer, loader, workers, controller, drive_rollout = (
+            build_online_eagle3_runtime(
+                target_model=target_model,
+                prompts=prompts,
+                eagle3_model=eagle3_model,
+                optimizer_factory=optimizer_factory,
+                run_id="eagle3-online",
+                output_dir=args.output_dir,
+                target_hidden_size=hidden_size,
+                target_vocab_size=vocab_size,
+                target_repr="logits",
+                ttt_length=args.ttt_length,
+                batch_size=args.target_batch_size,
+                accumulation_steps=args.draft_accumulation_steps,
+                num_epochs=1,
+                max_steps=args.max_num_steps,
+                save_interval=args.save_interval,
+                tp_size=args.tp_size,
+                sp_ulysses_size=args.sp_ulysses_size,
+                sp_ring_size=args.sp_ring_size,
+                logger=logger,
+            )
+        )
+        produced = drive_rollout()
+        print(f"[online] rollout produced {produced} samples", flush=True)
+        trainer.fit(loader)
+    else:
+        from specforge.runtime.launch import build_offline_eagle3_runtime
+
+        target_head, _ = build_target_model(args, draft_config, is_online=False)
+        trainer, loader = build_offline_eagle3_runtime(
+            hidden_states_path=args.train_hidden_states_path,
+            eagle3_model=eagle3_model,
+            target_head=target_head,
+            optimizer_factory=optimizer_factory,
+            run_id="eagle3-offline",
+            output_dir=args.output_dir,
+            ttt_length=args.ttt_length,
+            max_len=args.max_length,
+            batch_size=args.target_batch_size,
+            accumulation_steps=args.draft_accumulation_steps,
+            num_epochs=args.num_epochs,
+            max_steps=args.max_num_steps,
+            save_interval=args.save_interval,
+            tp_size=args.tp_size,
+            sp_ulysses_size=args.sp_ulysses_size,
+            sp_ring_size=args.sp_ring_size,
+            logger=logger,
+        )
+        trainer.fit(loader)
+
     destroy_distributed()
 
 

--- a/scripts/train_eagle3_dataflow.py
+++ b/scripts/train_eagle3_dataflow.py
@@ -1,0 +1,116 @@
+"""Thin launcher: offline EAGLE3 training through the SpecForge DataFlow runtime.
+
+This script is a *launcher* (M3): it builds models + optimizer, hands them to the
+runtime, and runs ``TrainerController.fit``. No training logic lives here — the
+loop, loss, projection, checkpoint, and eval all live in ``specforge.runtime``.
+
+Reuses the existing model/data builders from ``scripts.train_eagle3`` so model
+construction stays DRY; only the *orchestration* moves behind the runtime.
+
+Example (offline):
+    torchrun --standalone --nproc_per_node 1 scripts/train_eagle3_dataflow.py \
+        --target-model-path <hf-model> --draft-model-config configs/llama3-8B-eagle3.json \
+        --train-data-path <prompts.jsonl> --train-hidden-states-path <features_dir> \
+        --output-dir ./output --max-num-steps 20
+"""
+
+from accelerate.utils import set_seed
+
+# reuse existing builders so model construction is not duplicated
+from train_eagle3 import (
+    build_dataloaders,
+    build_draft_model,
+    build_target_model,
+    parse_args,
+)
+
+from specforge.distributed import destroy_distributed, init_distributed
+from specforge.optimizer import BF16Optimizer
+from specforge.runtime.launch import build_offline_eagle3_runtime
+
+
+def main():
+    parser, args = parse_args()
+    # parse_args() does not derive target_batch_size (train_eagle3.main computes
+    # it inline before building dataloaders); the offline runtime builder and
+    # build_dataloaders both read it, so derive it here too.
+    args.target_batch_size = args.tp_size * args.batch_size
+
+    # TODO(dataflow-launcher parity with scripts/train_eagle3.py): this launcher
+    # covers core EAGLE3 training (offline + online: loss / projection / FSDP /
+    # TP / grad-accum / checkpoint), validated old-vs-new. The following
+    # train_eagle3.py features are NOT yet wired here and still require the
+    # legacy script:
+    #   - VLM / multimodal targets (--is-vlm, QwenVLOnlineEagle3Model)
+    #   - USP sequence parallelism (--attention-backend usp -> process_data_usp;
+    #     this path uses OfflineEagle3Dataset.process_data, no per-rank seq shard)
+    #   - eval loop (--eval-data-path / --eval-hidden-states-path)
+    #   - resume from checkpoint (--resume)
+    #   - experiment trackers (--report-to wandb / swanlab / tensorboard)
+    #   - online multi-epoch re-rollout (online runs a single consume-once pass)
+    set_seed(args.seed)
+    init_distributed(
+        timeout=args.dist_timeout,
+        tp_size=args.tp_size,
+        sp_ring_size=args.sp_ring_size,
+        sp_ulysses_size=args.sp_ulysses_size,
+    )
+    if args.train_hidden_states_path is None:
+        raise SystemExit(
+            "train_eagle3_dataflow currently wires the OFFLINE path; pass "
+            "--train-hidden-states-path. (Online wiring composes RolloutWorker + "
+            "SGLangAdapter over the same control/data plane.)"
+        )
+
+    draft_config, draft_model, _ckpt, _resume = build_draft_model(args)
+    target_head, _ = build_target_model(args, draft_config, is_online=False)
+    # vocab mapping is produced from the prompt dataset exactly as today
+    _train, vocab_mapping_path, _eval = build_dataloaders(args, draft_config)
+    draft_model.load_vocab_mapping(vocab_mapping_path)
+
+    from specforge import OnlineEagle3Model
+
+    eagle3_model = OnlineEagle3Model(
+        draft_model=draft_model,
+        length=args.ttt_length,
+        attention_backend=args.attention_backend,
+        lk_loss_type=args.lk_loss_type,
+        kl_scale=args.kl_scale,
+        kl_decay=args.kl_decay,
+    ).cuda()
+
+    # built AFTER FSDP-wrap (inside the runtime) over the wrapped inner draft
+    def optimizer_factory(draft_module):
+        return BF16Optimizer(
+            draft_module,
+            lr=args.learning_rate,
+            max_grad_norm=args.max_grad_norm,
+            warmup_ratio=args.warmup_ratio,
+            total_steps=args.total_steps or 10_000,
+        )
+
+    trainer, loader = build_offline_eagle3_runtime(
+        hidden_states_path=args.train_hidden_states_path,
+        eagle3_model=eagle3_model,
+        target_head=target_head,
+        optimizer_factory=optimizer_factory,
+        run_id="eagle3-offline",
+        output_dir=args.output_dir,
+        ttt_length=args.ttt_length,
+        max_len=args.max_length,
+        batch_size=args.target_batch_size,
+        accumulation_steps=args.draft_accumulation_steps,
+        num_epochs=args.num_epochs,
+        max_steps=args.max_num_steps,
+        save_interval=args.save_interval,
+        tp_size=args.tp_size,
+        sp_ulysses_size=args.sp_ulysses_size,
+        sp_ring_size=args.sp_ring_size,
+        logger=lambda m, s: print(f"step {s}: {m}", flush=True),
+    )
+    trainer.fit(loader)
+    destroy_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/distributed.py
+++ b/specforge/distributed.py
@@ -122,13 +122,27 @@ def init_distributed(
 
 def destroy_distributed():
     global _TP_GROUP, _DP_GROUP, _SP_ULYSSES_GROUP, _SP_RING_GROUP, _DRAFT_DP_GROUP
-    dist.destroy_process_group(_TP_GROUP)
-    dist.destroy_process_group(_DP_GROUP)
-    dist.destroy_process_group(_SP_ULYSSES_GROUP)
-    dist.destroy_process_group(_SP_RING_GROUP)
-    dist.destroy_process_group(_DRAFT_DP_GROUP)
-    dist.destroy_process_group(_DRAFT_SP_GROUP)
-    dist.destroy_process_group()
+    # Teardown must never crash the process: a group may be None (e.g. a trivial
+    # single-rank world) or already destroyed. Destroy each defensively so a
+    # successful run does not exit non-zero on cleanup.
+    for group in (
+        _TP_GROUP,
+        _DP_GROUP,
+        _SP_ULYSSES_GROUP,
+        _SP_RING_GROUP,
+        _DRAFT_DP_GROUP,
+        _DRAFT_SP_GROUP,
+    ):
+        if group is None:
+            continue
+        try:
+            dist.destroy_process_group(group)
+        except Exception:
+            pass
+    try:
+        dist.destroy_process_group()
+    except Exception:
+        pass
 
 
 def shard_tensor(

--- a/specforge/runtime/ARCHITECTURE.md
+++ b/specforge/runtime/ARCHITECTURE.md
@@ -1,0 +1,156 @@
+# SpecForge DataFlow Runtime — Architecture (M1–M4)
+
+The runtime moves SpecForge from a trainer-centered god-script to explicit
+contracts across **two planes**. This is the cross-plane map; each plane also has
+its own design note (see "Per-plane internals" below).
+
+## Plane responsibilities
+
+- **Contracts** — the stdlib-only data records every plane exchanges (`PromptTask`, `SampleRef`, `FeatureSpec`, `FeatureHandle`, `TrainBatch`) plus `assert_no_tensors`, which enforces the no-tensor boundary. Control-plane records carry metadata only; `TrainBatch` is the sole tensor carrier and lives only on the trainer side.
+- **Control plane** — `DataFlowController` (a passive coordinator with no run loop), `MetadataStore` (commit dedup + the single durable ack transaction), `SampleRefQueue` (lease/ack/fail transport), and `TrainLease`. Moves metadata only; every record-accepting entrypoint runs `assert_no_tensors`.
+- **Data plane** — `FeatureStore`/`LocalFeatureStore` is the only holder of tensors, addressed by metadata-only `SampleRef`. `FeatureDataLoader` is the bridge that materializes refs + store into collated `TrainBatch`es; `OfflineManifestReader` turns precomputed `.ckpt` files into in-place `file://` refs.
+- **Inference (compute)** — `RolloutWorker` + `SGLangAdapter` extract features from the target engine and commit only `SampleRef` metadata; `SGLangAdapter._project_target` is the sole target to draft projection site and `verify_capture` is the loud pre-`put` validator.
+- **Training (compute)** — `TrainerController` -> `TrainerCore` -> `DraftTrainStrategy` + `FSDPTrainingBackend` turn `TrainBatch`es into optimizer steps and checkpoints; the strategy owns projection/loss, the core is branch-free.
+
+## End-to-end flow
+
+**Online:** `RolloutWorker.run_once` leases prompts (`lease_prompt_tasks`), calls `generate_features` (which drives `generate_eagle3_data`), runs `verify_capture`, then `FeatureStore.put` writes tensors **directly to the data plane**. Only the resulting `SampleRef` metadata goes to the controller via `commit_samples`, which dedups through `MetadataStore.commit_sample` and enqueues fresh refs onto `SampleRefQueue`.
+
+**Offline:** `OfflineManifestReader.read()` emits in-place `file://` `SampleRef`s (no tensor copy) and the launcher calls `enqueue_offline_refs`, which dedups and enqueues onto the **same** `SampleRefQueue`.
+
+**Convergence + training:** Both paths converge at `SampleRef` on one queue, so the trainer has no online/offline branch. `TrainerController.fit` drives `for batch in loader`; the `FeatureDataLoader` leases refs through a `TrainLease` (`lease_train_refs` via the controller) and fetches the actual tensors **directly** from the `FeatureStore` (`get`/`release` with clone-on-fetch). `TrainerCore.train_step` runs forward/loss/backward and steps the optimizer at the grad-accum boundary; at that boundary `ack_fn` calls `ack_train_refs`, which records the durable ack transaction (`record_train_ack`) **before** releasing the queue lease.
+
+## System map
+
+Solid edges = control / metadata flow. Dashed edges = tensor flow (data plane).
+The `DataFlowController` is **passive**: callers point *into* it, and its only
+outbound edges go to its own `SampleRefQueue` and `MetadataStore`. Tensors never
+cross the controller.
+
+```mermaid
+flowchart TD
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef data fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+
+  subgraph COMPUTE[compute autonomous loops]
+    RW[RolloutWorker run_once loop]
+    SG[SGLangAdapter generate_features]
+    TGT[Eagle3TargetModel generate_eagle3_data]
+    TR[TrainerController fit loop]
+    CORE[TrainerCore train_step]
+    STRAT[Eagle3TrainStrategy forward_loss]
+    BE[FSDPTrainingBackend backward step]
+    LOADER[FeatureDataLoader iter]
+    OFF[OfflineManifestReader read]
+  end
+
+  subgraph CONTROL[control plane metadata only]
+    CTRL[DataFlowController passive coordinator]
+    QUEUE[SampleRefQueue lease ack fail]
+    MS[MetadataStore commit dedup durable ack]
+    LEASE[TrainLease get ack fail]
+  end
+
+  subgraph DATA[data plane tensors only]
+    STORE[FeatureStore LocalFeatureStore]
+  end
+
+  RW -->|register_rollout_worker| CTRL
+  RW -->|lease_prompt_tasks| CTRL
+  RW -->|generate_features| SG
+  SG -->|generate_eagle3_data| TGT
+  RW -.->|put| STORE
+  RW -->|commit_samples| CTRL
+  RW -->|fail_prompt_tasks| CTRL
+
+  OFF -->|enqueue_offline_refs| CTRL
+
+  CTRL -->|commit_sample| MS
+  CTRL -->|record_train_ack| MS
+  CTRL -->|get_committed| MS
+  CTRL -->|put fresh refs| QUEUE
+  CTRL -->|get| QUEUE
+  CTRL -->|ack| QUEUE
+  CTRL -->|fail| QUEUE
+
+  TR -->|train_step| CORE
+  CORE -->|forward_loss| STRAT
+  CORE -->|backward step| BE
+  TR -->|for batch in loader| LOADER
+  LOADER -->|lease_train_refs get| LEASE
+  LEASE -->|lease_train_refs| CTRL
+  LEASE -->|ack_train_refs| CTRL
+  LEASE -->|fail_refs| CTRL
+  LOADER -.->|get release| STORE
+  TR -->|ack_fn ack_train_refs| CTRL
+
+  class RW,SG,TGT,TR,CORE,STRAT,BE,LOADER,OFF compute;
+  class CTRL,QUEUE,MS,LEASE control;
+  class STORE data;
+```
+
+## Endpoint reference
+
+| Caller | Endpoint called | Plane | Purpose |
+|---|---|---|---|
+| RolloutWorker | register_rollout_worker | control | Register worker, obtain authoritative worker_id (no-tensor guard on info) |
+| RolloutWorker | lease_prompt_tasks | control | Pop up to max_tasks pending PromptTasks, mark leased to worker_id |
+| RolloutWorker | generate_features | compute | Ask the FeatureSource (SGLangAdapter) for one feature dict per task |
+| SGLangAdapter | generate_eagle3_data | compute | Run the target engine's batched forward to extract hidden_states/target |
+| RolloutWorker | put | data | Persist verified feature tensors directly to FeatureStore, get back a SampleRef |
+| RolloutWorker | abort | data | Clean up a partial/failed write so no corrupt sample is left |
+| RolloutWorker | commit_samples | control | Commit metadata-only SampleRefs; dedup + enqueue fresh refs |
+| RolloutWorker | fail_prompt_tasks | control | Release failed prompt leases (retryable or terminal) so none are stranded |
+| OfflineManifestReader | enqueue_offline_refs | control | Offline ingest: dedup + enqueue file:// SampleRefs onto the same queue |
+| DataFlowController | commit_sample | control | Dedup committed samples (True=new, False=duplicate) |
+| DataFlowController | record_train_ack | control | Persist the single durable ack transaction before releasing leases |
+| DataFlowController | get_committed | control | Resolve acked/failed sample_ids back to full SampleRef objects |
+| DataFlowController | put | control | Enqueue freshly committed refs onto the shared SampleRefQueue |
+| DataFlowController | get | control | Serve train-side leases from the SampleRefQueue |
+| DataFlowController | ack | control | Release queue leases after the durable ack transaction is recorded |
+| DataFlowController | fail | control | Route train-side ref failures through the queue (retryable flag) |
+| TrainLease | lease_train_refs | control | Loader's get(): lease train refs via the controller, not a raw queue |
+| TrainLease | ack_train_refs | control | ack(): record durable transaction + release leases via the controller |
+| TrainLease | fail_refs | control | fail(): route ref failures through the controller |
+| FeatureDataLoader | lease_train_refs (via TrainLease.get) | control | Lease a batch of refs from the stream |
+| FeatureDataLoader | get | data | Fetch a sample's tensors + lease FeatureHandle directly from the store |
+| FeatureDataLoader | release | data | Release the lease immediately after clone-on-fetch so prefetch can't race |
+| TrainerController | for batch in loader (__iter__) | compute | Drive the loader to yield collated TrainBatch objects |
+| TrainerController | train_step | compute | Run each micro-batch; read optimizer_stepped boundary signal |
+| TrainerController | eval_step | compute | Run eval batches and aggregate metrics |
+| TrainerController | ack_fn -> ack_train_refs | control | Close the ack loop: ack consumed sample_ids at the optimizer-step boundary |
+| TrainerCore | forward_loss | compute | Delegate model-specific forward + loss to the strategy |
+| TrainerCore | backward | compute | Run backward on the accumulation-scaled loss each micro-step |
+| TrainerCore | step | compute | Optimizer step + distributed grad-norm reduction at the accum boundary |
+
+## Autonomy: loops + a passive coordinator
+
+## Autonomous loops + one passive coordinator
+
+This is **not** a master/orchestrator that calls into sub-parts, and it is **not** a set of fully independent processes. It is a small number of **autonomous producer/consumer loops** coordinated by **one passive shared component**, the `DataFlowController`.
+
+- The **producer loop** is `RolloutWorker.run_once`, which runs on its own and *calls into* the controller (`lease_prompt_tasks`, `commit_samples`, `fail_prompt_tasks`). The controller never calls the worker.
+- The **consumer loop** is `TrainerController.fit`, which drives `for batch in loader`; the loader *calls into* the controller through `TrainLease` (`lease_train_refs` / `ack_train_refs` / `fail_refs`). The controller never calls the trainer.
+- The `DataFlowController` has **no run loop**. The only edges out of it go into its **own** `SampleRefQueue` and `MetadataStore`. Workers and the trainer point INTO the controller; that is what makes it passive.
+
+Tensors reinforce this: they **never** flow through the controller. `RolloutWorker` calls `FeatureStore.put` directly and `FeatureDataLoader` calls `FeatureStore.get`/`release` directly. Only metadata-bearing `SampleRef`s cross the control plane.
+
+## Why this makes disaggregation mechanical
+
+Because the loops are autonomous and only the coordinator is shared, moving components across nodes is a **swap, not a rewrite**:
+
+- **Durable backend swap:** all recovery-critical state sits behind the `MetadataStore` ABC (commit dedup + the atomic `record_train_ack` marker). A SQLite/Redis/DB backend is a new subclass injected into the controller — no controller rewrite, and `assert_no_tensors` keeps the seam importable without torch.
+- **`TrainLease` indirection:** the trainer never holds a raw in-process queue. It routes every `get`/`ack`/`fail` through the controller, so a cross-node trainer is a drop-in substitution and the durable ack transaction is always recorded.
+- **`partition_key` seam:** `SampleRefQueue.put`/`get` already accept a `partition_key` (currently accepted but ignored, single partition), reserving the per-DP-rank partitioning needed for a sharded/disaggregated queue without an API change.
+- **Online/offline convergence:** because `commit_samples` and `enqueue_offline_refs` land on the same queue and the trainer path is branch-free, the same consumer loop serves a disaggregated rollout fleet or a static offline manifest unchanged.
+
+## Per-plane internals
+
+Each plane carries its own design note (landed with that plane's PR):
+
+- `contracts.py` / `CONTRACTS.md` — shared metadata records + `assert_no_tensors`
+- `data_plane/DESIGN.md` — storage, queue, loader, lifecycle
+- `control_plane/DESIGN.md` — controller, metadata store, lease/durability
+- `inference/DESIGN.md` — rollout worker, capture, sglang seam
+- `training/DESIGN.md` — trainer core, strategy, FSDP backend

--- a/specforge/runtime/CONTRACTS.md
+++ b/specforge/runtime/CONTRACTS.md
@@ -1,0 +1,50 @@
+# DataFlow Contracts (PR 2/7 — `runtime/contracts.py`)
+
+The shared, stdlib-only records every plane exchanges, plus the no-tensor guard.
+The cross-plane picture lives in `ARCHITECTURE.md` (integration PR, 7/7).
+
+## Responsibility
+
+Defines the small, stdlib-only data records that SpecForge components exchange across the control plane and data plane, plus the runtime check that enforces the no-tensor boundary. It describes WHAT components exchange (prompt work units, sample pointers, feature specs, lease handles, materialized batches) without any backend implementation. The single load-bearing rule: control-plane records (PromptTask, SampleRef) carry metadata only — never tensors; tensors live in the data plane and surface only inside TrainBatch on the trainer side. Module imports only the standard library (torch is TYPE_CHECKING-only) so the control plane is reasoned about and unit-tested without torch or heavy model code.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef rec fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef guard fill:#fde8e8,stroke:#d63b3b,color:#6b0b0b;
+  classDef tensor fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+
+  PT[PromptTask frozen metadata]
+  SR[SampleRef frozen pointer]
+  FS[FeatureSpec frozen descriptor]
+  FH[FeatureHandle frozen lease]
+  TB[TrainBatch mutable tensors]
+  ANT[assert_no_tensors]
+  LLT[_looks_like_tensor duck type]
+
+  SR -->|feature_specs| FS
+  ANT -->|recurse fields dict list| ANT
+  ANT -->|detect| LLT
+  PT -.->|guarded by| ANT
+  SR -.->|guarded by| ANT
+  TB -->|only contract holding tensors| TB
+
+  class PT,SR,FS,FH rec;
+  class ANT,LLT guard;
+  class TB tensor;
+```
+
+The contracts module is stdlib-only (torch is `TYPE_CHECKING`-only) so the control plane is reasoned about and unit-tested without torch. The control-plane records `PromptTask` and `SampleRef` are `@dataclass(frozen=True)` and carry metadata only: a `SampleRef` addresses one sample via `feature_store_uri` + `feature_keys` and embeds a `FeatureSpec` per named feature (shape/dtype/`target_repr`), but never a tensor. `FeatureHandle` is a frozen lease token (`sample_id`, `generation`, `lease_token`) whose `generation` lets a stale release become a safe no-op. `TrainBatch` is the only contract that carries tensors and is deliberately not frozen — it lives only on the trainer/data-plane side. `assert_no_tensors` is the load-bearing guard: it recurses through dataclass fields, dict values, and list/tuple/set/frozenset elements, threading a `_path` breadcrumb, and uses the duck-typed `_looks_like_tensor` (module root `torch`/`numpy`, or simultaneous `dtype`+`shape`+`device`) to raise `TypeError` at the first tensor — without importing torch or numpy.
+
+## Records at a glance
+
+| Record | Plane role | Carries tensors? |
+|---|---|---|
+| `PromptTask` | one unit of rollout work | no |
+| `SampleRef` | pointer to one sample's features | no |
+| `FeatureSpec` | shape/dtype descriptor of a feature | no |
+| `FeatureHandle` | lease token from `FeatureStore.get` | no |
+| `TrainBatch` | materialized, collated batch | **yes** (trainer side only) |
+
+`assert_no_tensors` is run by the control plane on every record it accepts.

--- a/specforge/runtime/README.md
+++ b/specforge/runtime/README.md
@@ -1,0 +1,95 @@
+# SpecForge DataFlow Runtime (M1–M4)
+
+A minimal, DataFlow-centered layer over the existing SpecForge model/data code.
+It moves SpecForge from a trainer-centered god-script toward explicit contracts:
+
+```
+PromptTask -> RolloutWorker -> SampleRef -> FeatureDataLoader -> TrainBatch -> Trainer
+```
+
+The **control plane** moves only metadata; large tensors move only through the
+**data plane** (FeatureStore). Online and offline converge at `SampleRef`, so the
+trainer path has no online/offline branch. Existing model/data/distributed code
+(`specforge/core`, `specforge/modeling`, `specforge/data`, `specforge/distributed`)
+is reused, not rewritten — the runtime is plumbing around the existing ops, which
+is why the equivalence gates are bit-exact.
+
+## Layout
+
+```
+specforge/runtime/
+  contracts.py            # PromptTask, FeatureSpec, SampleRef, FeatureHandle,
+                          #   TrainBatch, assert_no_tensors
+  control_plane/
+    controller.py         # DataFlowController (in-process; no-tensor invariant)
+  data_plane/
+    feature_store.py      # FeatureStore ABC + LocalFeatureStore (mem + file + dump)
+    sample_ref_queue.py   # SampleRefQueue (lease / ack / fail / depth)
+    offline_reader.py     # OfflineManifestReader (.ckpt -> SampleRef)
+    feature_dataloader.py # FeatureDataLoader (SampleRef -> TrainBatch)
+  inference/
+    capture.py            # CaptureConfig + verify_capture (B7/B8)
+    rollout_worker.py     # RolloutWorker (strategy-agnostic)
+    sglang_adapter.py     # SGLangAdapter.generate_features (the SpecForge<->engine seam)
+    sglang_patch_inventory.md  # patch surface + supported-version matrix (M4)
+  training/
+    strategy.py           # DraftTrainStrategy ABC + Eagle3/DFlash strategies
+    backend.py            # TrainingBackend ABC + FSDPTrainingBackend + ParallelConfig
+    trainer.py            # TrainerCore (branch-free) + TrainerController + Checkpoint
+  launch.py               # wire the offline-EAGLE3 dataflow from a config
+```
+
+## Key decisions honored (ADRs)
+
+- **Target representation (ADR-0001):** `FeatureSpec.target_repr` is a tagged
+  union; the *strategy* owns the projection so `TrainerCore` stays branch-free.
+  Offline EAGLE3 uses `hidden_state` (re-run `TargetHead`) for equivalence;
+  `pruned_logits` is the production default (t2d at rollout).
+- **Delivery (ADR-0002):** at-least-once + idempotent effects. `commit_samples`
+  dedupes on `sample_id`; queue `put`/`ack`/`release` are idempotent.
+- **Storage (ADR-0003):** `LocalFeatureStore` is in-memory on the hot path with
+  an opt-in disk/mmap dump that doubles as the capture/replay tap.
+- **No-tensor invariant:** `SampleRef`/`PromptTask` are frozen dataclasses with no
+  tensor fields; the controller runs `assert_no_tensors` on every record.
+
+## Milestone status & exit-gate tests
+
+This branch implements the local DataFlow spine and the focused tests below. It
+does **not** complete every acceptance item from the refactor plan: the
+`WeightVersion` serving accept-length gate, full optimizer/scheduler resume, and
+moving the production DFlash script onto the shared lifecycle remain follow-up
+work.
+
+| M | Gate test (`tests/test_runtime/`) | Where it runs |
+|---|---|---|
+| **M1** | `test_controller_no_tensor.py::...test_controller_carries_no_tensor` | CPU/CI |
+| **M1** | `test_equiv_offline_eagle3.py` (offline bit-exact vs `run_forward`) | GPU (rcli) |
+| **M2** | `test_equiv_online_eagle3.py` (online vs legacy, BS=1) | GPU (rcli) |
+| **M2** | `test_sample_ref_queue.py`, `test_rollout_worker.py` (lease/ack, commit) | CPU/CI |
+| **M3** | `test_equiv_trainer_split.py` (paired single step) | GPU (rcli) |
+| **M3** | `test_checkpoint_resume.py` | GPU (rcli) |
+| **M3** | `test_trainer.py`, `test_seam_fixes.py` (core/accum/checkpoint/DFlash plug-in) | CPU/CI |
+| **M4** | `test_extraction_vs_hf_reference.py::test_extraction_vs_hf_reference` | GPU (rcli) |
+| **M4** | `test_capture.py` + `..._reference.py::test_capture_layer_mismatch_fails` | CPU/CI |
+
+Plus contract/store/loader unit tests (`test_contracts.py`, `test_feature_store.py`,
+`test_feature_dataloader.py`).
+
+## Running the tests
+
+CPU/CI (control + data plane, capture, trainer core — no GPU, no model download):
+
+```bash
+PYTHONPATH=$PWD python -m unittest discover -s tests/test_runtime -p "test_*.py" -v
+```
+
+GPU equivalence/extraction (tiny synthetic fixtures, no model download) on the
+H200 box via rcli:
+
+```bash
+rcli exec --sync-code <job> \
+  'cd /workspace/SpecForge && PYTHONPATH=$PWD python -m unittest discover -s tests/test_runtime -p "test_*.py" -v'
+```
+
+The GPU-only tests are guarded with `@unittest.skipUnless(torch.cuda.is_available())`,
+so the same command is safe on CPU (they skip) and on the GPU box (they run).

--- a/specforge/runtime/__init__.py
+++ b/specforge/runtime/__init__.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+"""SpecForge DataFlow runtime.
+
+A DataFlow-centered layer over the existing SpecForge model/data code:
+
+    PromptTask -> RolloutWorker -> SampleRef -> FeatureDataLoader -> TrainBatch -> Trainer
+
+The control plane (controller, queues) moves only metadata; large tensors move
+only through the data plane (FeatureStore). This top-level module re-exports the
+dependency-light contracts. The ``training`` and ``inference`` subpackages pull
+in the model code and are imported explicitly by callers, not at package load.
+"""
+
+from specforge.runtime.contracts import (  # noqa: F401
+    SCHEMA_VERSION,
+    FeatureHandle,
+    FeatureSpec,
+    PromptTask,
+    SampleRef,
+    TrainBatch,
+    assert_no_tensors,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "PromptTask",
+    "FeatureSpec",
+    "SampleRef",
+    "FeatureHandle",
+    "TrainBatch",
+    "assert_no_tensors",
+]

--- a/specforge/runtime/contracts.py
+++ b/specforge/runtime/contracts.py
@@ -1,0 +1,196 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Core dataflow contracts shared between SpecForge components.
+
+These records are intentionally small. They describe *what* components exchange,
+not how any backend is implemented. The module is deliberately dependency-light:
+it imports only the standard library so the control plane can be reasoned about
+(and unit-tested) without pulling in torch or the heavy model code.
+
+The single load-bearing invariant: control-plane records (``PromptTask``,
+``SampleRef``) carry **metadata only** — never tensors. Large tensors move
+through the data plane (``FeatureStore``) and surface only inside ``TrainBatch``
+on the trainer side. ``assert_no_tensors`` makes that invariant checkable.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids a hard torch dependency
+    import torch
+
+# Schema version bumped whenever the on-the-wire feature schema changes in a way
+# that makes older SampleRef records unreadable. Loaders gate on this.
+SCHEMA_VERSION = 1
+
+RunMode = Literal["online", "offline"]
+DeploymentMode = Literal["local_colocated", "dataflow_colocated", "disaggregated"]
+DraftStrategyName = Literal["eagle3", "dflash"]
+# Tagged union for the EAGLE3 target feature. The *strategy* owns the
+# projection so the trainer core stays branch-free:
+#   - pruned_logits: rollout applied the t2d vocab map; stored (seq, draft_vocab)
+#   - logits:        full (seq, target_vocab); parity/debug only
+#   - hidden_state:  target last hidden state; strategy re-runs lm_head + t2d
+TargetRepr = Literal["logits", "pruned_logits", "hidden_state"]
+
+
+@dataclass(frozen=True)
+class PromptTask:
+    """A unit of work handed to a rollout worker. Metadata only."""
+
+    task_id: str
+    run_id: str
+    source_id: str
+    payload: Dict[str, Any]  # conversation, preformatted text, or token IDs
+    max_length: int
+    chat_template: Optional[str] = None
+    loss_mask_policy: Dict[str, Any] = field(default_factory=dict)
+    target_model_version: str = "unknown"
+    draft_weight_version: Optional[str] = None
+    attempt: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FeatureSpec:
+    """Describes one named tensor that lives in the feature store.
+
+    Shape/dtype are metadata; the tensor itself never travels with the spec.
+    """
+
+    name: str  # input_ids, hidden_states, target, loss_mask, ...
+    shape: Tuple[int, ...]
+    dtype: str
+    device_hint: Optional[str] = None
+    required: bool = True
+    target_repr: Optional[TargetRepr] = None
+    # vocab map / head version / softmax convention — only meaningful for the
+    # `target` feature, and mandatory when target_repr == "hidden_state".
+    target_meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SampleRef:
+    """A pointer to one training sample's features. Metadata only — no tensors.
+
+    Exactly one sample per ref (batching is a loader concern, never baked in).
+    """
+
+    sample_id: str
+    run_id: str
+    source_task_id: Optional[str]
+    feature_store_uri: str
+    feature_keys: Dict[str, str]
+    feature_specs: Dict[str, FeatureSpec]
+    strategy: DraftStrategyName
+    schema_version: int = SCHEMA_VERSION
+    target_model_version: str = "unknown"
+    draft_weight_version: Optional[str] = None
+    tokenizer_version: str = "unknown"
+    num_tokens: int = 0
+    estimated_bytes: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FeatureHandle:
+    """Lifetime token returned by ``FeatureStore.get``.
+
+    ``generation`` is bumped on every (re)materialization of a sample so a stale
+    ``release`` is a safe no-op. ``lease_token`` is opaque and required to
+    release. The local in-memory backend uses a trivial handle, carrying the
+    contract without paying for it.
+    """
+
+    sample_id: str
+    generation: int
+    lease_token: str
+
+
+@dataclass
+class TrainBatch:
+    """A materialized, collated batch ready for the trainer. Holds tensors.
+
+    This is the *only* contract that carries tensors, and only ever on the
+    trainer / data-plane side.
+    """
+
+    sample_ids: List[str]
+    strategy: DraftStrategyName
+    tensors: Dict[str, "torch.Tensor"]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+# NOTE: the published-weight lifecycle (WeightVersion, WeightPublisher, hot
+# update, serving accept-length gate) is not implemented here — it is not needed
+# for the local train pipeline. SampleRef/PromptTask still carry a
+# ``draft_weight_version`` *string* as rollout provenance, but there is no
+# WeightVersion object or publisher here yet.
+
+
+# ---------------------------------------------------------------------------
+# No-tensor invariant
+# ---------------------------------------------------------------------------
+def _looks_like_tensor(obj: Any) -> bool:
+    """Duck-typed tensor / ndarray detection without importing torch/numpy."""
+    cls = type(obj)
+    module = getattr(cls, "__module__", "") or ""
+    root = module.split(".", 1)[0]
+    if root in ("torch", "numpy"):
+        return True
+    # torch.Tensor and np.ndarray both expose these; plain containers do not.
+    return hasattr(obj, "dtype") and hasattr(obj, "shape") and hasattr(obj, "device")
+
+
+def assert_no_tensors(obj: Any, *, _path: str = "<root>") -> None:
+    """Recursively assert that ``obj`` carries no tensor payloads.
+
+    Used by the control plane to enforce that ``PromptTask`` / ``SampleRef``
+    records (including their ``metadata``) never smuggle a tensor through a
+    controller API. ``test_controller_carries_no_tensor`` exercises this.
+    """
+    if obj is None or isinstance(obj, (str, bytes, bool, int, float)):
+        return
+    if _looks_like_tensor(obj):
+        raise TypeError(
+            f"tensor payload found at {_path}: control-plane records must carry "
+            f"metadata only (type={type(obj).__module__}.{type(obj).__name__})"
+        )
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        for f in dataclasses.fields(obj):
+            assert_no_tensors(getattr(obj, f.name), _path=f"{_path}.{f.name}")
+        return
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            assert_no_tensors(v, _path=f"{_path}[{k!r}]")
+        return
+    if isinstance(obj, (list, tuple, set, frozenset)):
+        for i, v in enumerate(obj):
+            assert_no_tensors(v, _path=f"{_path}[{i}]")
+        return
+    # Other scalar/opaque metadata (e.g. a version string container) is fine.
+    return
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "RunMode",
+    "DeploymentMode",
+    "DraftStrategyName",
+    "TargetRepr",
+    "PromptTask",
+    "FeatureSpec",
+    "SampleRef",
+    "FeatureHandle",
+    "TrainBatch",
+    "assert_no_tensors",
+]

--- a/specforge/runtime/control_plane/DESIGN.md
+++ b/specforge/runtime/control_plane/DESIGN.md
@@ -1,0 +1,73 @@
+# Control Plane Design (PR 4/7 — `runtime/control_plane`)
+
+This is the design note for the **control plane**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+Metadata-only scheduling, lifecycle, leasing, and recovery durability. Owns prompt and sample lifecycle, prompt/train leases, worker/trainer registration, dedup of committed samples, and the durable ack transaction. NEVER touches tensors (every record-accepting entrypoint runs assert_no_tensors) — all large tensors travel through the data plane. Online commit_samples and offline enqueue_offline_refs converge onto the same SampleRefQueue so the trainer path has no online/offline branch. Recovery-critical state sits behind a MetadataStore seam so a durable backend (SQLite/Redis/DB) is a swap, not a rewrite. (Note: weight publishing / weight-version registry is explicitly NOT yet implemented — flagged in source NOTE comments in both controller.py and metadata_store.py.)
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+
+  subgraph CTRL[DataFlowController passive]
+    PEND[_prompt_pending deque]
+    LEASED[_prompt_leased map]
+    FAILEDP[_prompt_failed map]
+  end
+  ING[ingest_prompts] --> PEND
+  LPT[lease_prompt_tasks popleft] --> LEASED
+  FPT[fail_prompt_tasks requeue or fail] --> PEND
+
+  COMMIT[commit_samples per ref] -->|commit_sample dedup| MS[MetadataStore]
+  COMMIT -->|put fresh| Q[SampleRefQueue]
+  ENQ[enqueue_offline_refs] -->|commit_sample dedup| MS
+  ENQ -->|put fresh| Q
+
+  LTR[lease_train_refs] -->|get| Q
+  ATR[ack_train_refs] -->|record_train_ack first| MS
+  ATR -->|get_committed then ack| Q
+  FR[fail_refs] -->|get_committed then fail| Q
+
+  TL[TrainLease get ack fail] --> LTR
+  TL --> ATR
+  TL --> FR
+
+  class PEND,LEASED,FAILEDP,ING,LPT,FPT,COMMIT,ENQ,LTR,ATR,FR,TL,MS,Q control;
+```
+
+The `DataFlowController` is a passive metadata-only coordinator: it has no run loop, and every record-accepting entrypoint runs `assert_no_tensors`. It holds prompt lifecycle state — `_prompts`, a `_prompt_pending` deque, `_prompt_leased`, and `_prompt_failed` — under a single `_lock` that guards only the prompt/worker/trainer mutations and the `status()` snapshot; the sample-commit and train paths instead rely on the store's and queue's own internal locking. Durable/recovery state lives behind the `MetadataStore` seam: `commit_sample` dedups by `sample_id` (False = duplicate, dropped) and `record_train_ack` commits {acked sample_ids, global_step, optimizer_durable} as one atomic transaction. Online `commit_samples` and offline `enqueue_offline_refs` converge by enqueuing only fresh refs onto the same `SampleRefQueue`, so the trainer path has no online/offline branch. `ack_train_refs` deliberately orders `record_train_ack` BEFORE `sample_queue.ack` so a restart reconciles release state from the single committed marker. `TrainLease` is a stateless adapter that forwards `get`/`ack`/`fail` through the controller, so a cross-node trainer never holds a raw in-process queue and the durable ack is always recorded. Weight publishing / a weight-version registry is explicitly not yet implemented (flagged in source NOTEs).
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `DataFlowController` | `MetadataStore.commit_sample` | control |
+| `DataFlowController` | `MetadataStore.record_train_ack` | control |
+| `DataFlowController` | `MetadataStore.get_committed` | control |
+| `DataFlowController` | `SampleRefQueue.put` | control |
+| `DataFlowController` | `SampleRefQueue.get` | control |
+| `DataFlowController` | `SampleRefQueue.ack` | control |
+| `DataFlowController` | `SampleRefQueue.fail` | control |
+| `TrainLease` | `DataFlowController.lease_train_refs` | control |
+| `TrainLease` | `DataFlowController.ack_train_refs` | control |
+| `TrainLease` | `DataFlowController.fail_refs` | control |
+
+### Who calls into this plane
+
+| Caller | Endpoint | Plane |
+|---|---|---|
+| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
+| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
+| `RolloutWorker` | `DataFlowController.commit_samples` | control |
+| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |
+| `OfflineManifestReader` | `DataFlowController.enqueue_offline_refs` | control |
+| `FeatureDataLoader` | `TrainLease.get` | control |
+| `TrainerController` | `DataFlowController.ack_train_refs` | control |

--- a/specforge/runtime/control_plane/__init__.py
+++ b/specforge/runtime/control_plane/__init__.py
@@ -1,0 +1,10 @@
+# coding=utf-8
+"""Control plane: metadata-only scheduling, queues, lifecycle, version policy."""
+
+from specforge.runtime.control_plane.controller import DataFlowController, TrainLease
+from specforge.runtime.control_plane.metadata_store import (
+    InMemoryMetadataStore,
+    MetadataStore,
+)
+
+__all__ = ["DataFlowController", "TrainLease", "MetadataStore", "InMemoryMetadataStore"]

--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -1,0 +1,270 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DataFlowController: the metadata-only scheduler / debug boundary.
+
+The controller owns prompt and sample lifecycle, leases, and worker registration.
+It NEVER touches tensors — every public method that accepts
+a record runs ``assert_no_tensors`` (this is what ``test_controller_carries_no_tensor``
+exercises). All large tensors travel through the data plane (FeatureStore);
+online ``commit_samples`` and offline ``enqueue_offline_refs`` converge onto the
+same ``SampleRefQueue`` so the trainer path has no online/offline branch.
+
+Recovery-critical state (committed-sample dedup and the durable ack transaction)
+lives behind a ``MetadataStore`` so a durable backend (SQLite → Redis/DB) is a
+swap, not a rewrite. The current backend is in-process; the public surface already
+matches the durable controller shape so a later Ray/service deployment is mechanical.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import threading
+import uuid
+from collections import OrderedDict, deque
+from typing import Any, Deque, Dict, List, Optional
+
+from specforge.runtime.contracts import PromptTask, SampleRef, assert_no_tensors
+from specforge.runtime.control_plane.metadata_store import (
+    InMemoryMetadataStore,
+    MetadataStore,
+)
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+class TrainLease:
+    """A train-side lease client that routes lease/ack/fail through the controller.
+
+    Exposes the loader-facing ``get/ack/fail`` shape so ``FeatureDataLoader`` can
+    consume it interchangeably with a raw queue — but every op goes through the
+    controller, so the durable ack transaction is recorded and a disaggregated
+    (cross-node) trainer is a drop-in (it never holds a raw in-process queue).
+    """
+
+    def __init__(self, controller: "DataFlowController", trainer_id: str) -> None:
+        self._controller = controller
+        self._trainer_id = trainer_id
+
+    def get(self, max_refs: int, timeout_s: Optional[float] = None) -> List[SampleRef]:
+        return self._controller.lease_train_refs(self._trainer_id, max_refs, timeout_s)
+
+    def ack(
+        self,
+        refs: List[SampleRef],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        self._controller.ack_train_refs(
+            self._trainer_id,
+            [r.sample_id for r in refs],
+            global_step=global_step,
+            optimizer_durable=optimizer_durable,
+        )
+
+    def fail(self, refs: List[SampleRef], reason: str, retryable: bool) -> None:
+        self._controller.fail_refs(
+            self._trainer_id, [r.sample_id for r in refs], reason, retryable
+        )
+
+
+class DataFlowController:
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        sample_queue: Optional[SampleRefQueue] = None,
+        metadata_store: Optional[MetadataStore] = None,
+    ) -> None:
+        self.run_id = run_id
+        self.sample_queue = sample_queue or SampleRefQueue()
+        self.store = metadata_store or InMemoryMetadataStore()
+        self._prompts: "OrderedDict[str, PromptTask]" = OrderedDict()
+        self._prompt_pending: Deque[str] = deque()
+        self._prompt_leased: Dict[str, str] = {}  # task_id -> worker_id
+        self._prompt_failed: Dict[str, str] = {}  # task_id -> terminal reason
+        self._workers: Dict[str, Dict[str, Any]] = {}
+        self._trainers: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    # -- registration ------------------------------------------------------
+    def register_rollout_worker(self, info: Dict[str, Any]) -> str:
+        assert_no_tensors(info)
+        worker_id = info.get("worker_id") or f"rollout-{uuid.uuid4().hex[:8]}"
+        with self._lock:
+            self._workers[worker_id] = dict(info)
+        return worker_id
+
+    def register_trainer(self, info: Dict[str, Any]) -> str:
+        assert_no_tensors(info)
+        trainer_id = info.get("trainer_id") or f"trainer-{uuid.uuid4().hex[:8]}"
+        with self._lock:
+            self._trainers[trainer_id] = dict(info)
+        return trainer_id
+
+    def train_lease(self, trainer_id: Optional[str] = None) -> TrainLease:
+        """Return a train-side lease client (lease + ack route through here)."""
+        if trainer_id is None:
+            trainer_id = self.register_trainer({"role": "trainer"})
+        return TrainLease(self, trainer_id)
+
+    # -- prompt lifecycle (online) ----------------------------------------
+    def ingest_prompts(self, prompts: List[Dict[str, Any]]) -> List[str]:
+        task_ids: List[str] = []
+        with self._lock:
+            for p in prompts:
+                assert_no_tensors(p)
+                task_id = p.get("task_id") or f"task-{uuid.uuid4().hex[:12]}"
+                task = PromptTask(
+                    task_id=task_id,
+                    run_id=self.run_id,
+                    source_id=str(p.get("source_id", "prompt_source")),
+                    payload=p.get("payload", p),
+                    max_length=int(p.get("max_length", 2048)),
+                    chat_template=p.get("chat_template"),
+                    loss_mask_policy=p.get("loss_mask_policy", {}),
+                    target_model_version=str(p.get("target_model_version", "unknown")),
+                    draft_weight_version=p.get("draft_weight_version"),
+                    metadata=p.get("metadata", {}),
+                )
+                assert_no_tensors(task)
+                self._prompts[task_id] = task
+                self._prompt_pending.append(task_id)
+                task_ids.append(task_id)
+        return task_ids
+
+    def lease_prompt_tasks(self, worker_id: str, max_tasks: int) -> List[PromptTask]:
+        out: List[PromptTask] = []
+        with self._lock:
+            for _ in range(max_tasks):
+                if not self._prompt_pending:
+                    break
+                task_id = self._prompt_pending.popleft()
+                self._prompt_leased[task_id] = worker_id
+                out.append(self._prompts[task_id])
+        return out
+
+    def fail_prompt_tasks(
+        self, worker_id: str, task_ids: List[str], reason: str, retryable: bool
+    ) -> None:
+        """Release failed prompt leases and optionally requeue them.
+
+        This is intentionally separate from ``fail_refs``. Prompt failures happen
+        before a ``SampleRef`` exists, so routing them through the train-sample
+        queue would be a no-op and would leave prompt leases stuck.
+        """
+        with self._lock:
+            for task_id in task_ids:
+                owner = self._prompt_leased.get(task_id)
+                if owner is not None and owner != worker_id:
+                    continue
+                self._prompt_leased.pop(task_id, None)
+                task = self._prompts.get(task_id)
+                if task is None:
+                    continue
+                if retryable:
+                    self._prompts[task_id] = dataclasses.replace(
+                        task, attempt=task.attempt + 1
+                    )
+                    if task_id not in self._prompt_pending:
+                        self._prompt_pending.append(task_id)
+                else:
+                    self._prompt_failed[task_id] = reason
+
+    def commit_samples(self, worker_id: str, refs: List[SampleRef]) -> None:
+        fresh: List[SampleRef] = []
+        for ref in refs:
+            assert_no_tensors(ref)  # online no-tensor guard
+            if not self.store.commit_sample(ref):
+                continue  # idempotent on sample_id (at-least-once delivery)
+            if ref.source_task_id is not None:
+                with self._lock:
+                    self._prompt_leased.pop(ref.source_task_id, None)
+            fresh.append(ref)
+        if fresh:
+            self.sample_queue.put(fresh)
+
+    # -- offline ingest ----------------------------------------------------
+    def enqueue_offline_refs(self, refs: List[SampleRef]) -> None:
+        fresh: List[SampleRef] = []
+        for ref in refs:
+            assert_no_tensors(ref)
+            if self.store.commit_sample(ref):
+                fresh.append(ref)
+        if fresh:
+            self.sample_queue.put(fresh)
+
+    # -- train-side lease/ack ---------------------------------------------
+    def lease_train_refs(
+        self, trainer_id: str, max_refs: int, timeout_s: Optional[float] = None
+    ) -> List[SampleRef]:
+        return self.sample_queue.get(max_refs, timeout_s=timeout_s)
+
+    def ack_train_refs(
+        self,
+        trainer_id: str,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        """Ack consumed refs at the trainer's optimizer-step boundary.
+
+        Records the durable ``{acked sample_ids, global_step, optimizer-durable
+        marker}`` transaction *then* releases the queue lease, so restart can
+        derive release state from the single committed marker.
+        """
+        self.store.record_train_ack(
+            sample_ids, global_step=global_step, optimizer_durable=optimizer_durable
+        )
+        refs = [
+            r
+            for r in (self.store.get_committed(s) for s in sample_ids)
+            if r is not None
+        ]
+        self.sample_queue.ack(refs)
+
+    def fail_refs(
+        self, owner_id: str, sample_ids: List[str], reason: str, retryable: bool
+    ) -> None:
+        refs = [
+            r
+            for r in (self.store.get_committed(s) for s in sample_ids)
+            if r is not None
+        ]
+        self.sample_queue.fail(refs, reason, retryable)
+
+    # NOTE: weight publishing (publish_weight_version / latest_weight_version) is
+    # not yet implemented; it lands with the rest of the weight-version lifecycle.
+
+    def status(self) -> Dict[str, Any]:
+        with self._lock:
+            prompts = len(self._prompts)
+            pending = len(self._prompt_pending)
+            leased = len(self._prompt_leased)
+            failed = len(self._prompt_failed)
+            workers = len(self._workers)
+            trainers = len(self._trainers)
+        marker = self.store.durable_marker()
+        return {
+            "run_id": self.run_id,
+            "prompts": prompts,
+            "prompts_pending": pending,
+            "prompts_leased": leased,
+            "prompts_failed": failed,
+            "samples_committed": self.store.committed_count(),
+            "queue_depth": self.sample_queue.depth(),
+            "queue_in_flight": self.sample_queue.in_flight(),
+            "rollout_workers": workers,
+            "trainers": trainers,
+            "durable_global_step": marker["global_step"],
+            "durable_acked": len(marker["acked"]),
+        }
+
+
+__all__ = ["DataFlowController", "TrainLease"]

--- a/specforge/runtime/control_plane/metadata_store.py
+++ b/specforge/runtime/control_plane/metadata_store.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""MetadataStore: the durability seam for recovery-critical control-plane state.
+
+The controller's *recovery-critical* state — committed sample dedup and the
+at-least-once durable ack transaction (``{acked sample_ids, global_step,
+optimizer-durable marker}``) — lives behind this interface rather than in inline
+dicts. The current implementation ships ``InMemoryMetadataStore``; a SQLite
+(dev) or Redis/DB (prod) backend is then a *new subclass*, not a
+method-by-method rewrite of the controller. The single durable transaction
+(``record_train_ack``) is the unit a restart reconciles release state from.
+
+Dependency-light (stdlib only) so it stays importable without torch.
+"""
+
+from __future__ import annotations
+
+import abc
+import threading
+from typing import Any, Dict, List, Optional, Set
+
+from specforge.runtime.contracts import SampleRef
+
+
+class MetadataStore(abc.ABC):
+    # -- sample commit / dedup (at-least-once: idempotent on sample_id) ----
+    @abc.abstractmethod
+    def commit_sample(self, ref: SampleRef) -> bool:
+        """Record a committed sample. Returns True if new, False if duplicate."""
+
+    @abc.abstractmethod
+    def is_committed(self, sample_id: str) -> bool: ...
+
+    @abc.abstractmethod
+    def get_committed(self, sample_id: str) -> Optional[SampleRef]: ...
+
+    @abc.abstractmethod
+    def committed_count(self) -> int: ...
+
+    # -- durable ack transaction -------------------------------------------
+    @abc.abstractmethod
+    def record_train_ack(
+        self,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int],
+        optimizer_durable: bool,
+    ) -> None:
+        """Commit {acked sample_ids, global_step, optimizer-durable marker} atomically.
+
+        Release state is *derived* from this on restart — it is the single
+        transaction recovery reconciles against; never split it.
+        """
+
+    @abc.abstractmethod
+    def durable_marker(self) -> Dict[str, Any]:
+        """{acked: set[str], global_step: int|None, optimizer_durable: bool}."""
+
+    # NOTE: a weight-version registry (put/latest/count) is not yet implemented;
+    # it belongs with the rest of the published-weight lifecycle.
+
+
+class InMemoryMetadataStore(MetadataStore):
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._committed: Dict[str, SampleRef] = {}
+        self._acked: Set[str] = set()
+        self._global_step: Optional[int] = None
+        self._optimizer_durable: bool = False
+
+    def commit_sample(self, ref: SampleRef) -> bool:
+        with self._lock:
+            if ref.sample_id in self._committed:
+                return False
+            self._committed[ref.sample_id] = ref
+            return True
+
+    def is_committed(self, sample_id: str) -> bool:
+        with self._lock:
+            return sample_id in self._committed
+
+    def get_committed(self, sample_id: str) -> Optional[SampleRef]:
+        with self._lock:
+            return self._committed.get(sample_id)
+
+    def committed_count(self) -> int:
+        with self._lock:
+            return len(self._committed)
+
+    def record_train_ack(
+        self,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int],
+        optimizer_durable: bool,
+    ) -> None:
+        # one atomic update of {acked ids, global_step, optimizer marker}
+        with self._lock:
+            self._acked.update(sample_ids)
+            if global_step is not None:
+                self._global_step = global_step
+            self._optimizer_durable = optimizer_durable
+
+    def durable_marker(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "acked": set(self._acked),
+                "global_step": self._global_step,
+                "optimizer_durable": self._optimizer_durable,
+            }
+
+
+__all__ = ["MetadataStore", "InMemoryMetadataStore"]

--- a/specforge/runtime/data_plane/DESIGN.md
+++ b/specforge/runtime/data_plane/DESIGN.md
@@ -1,0 +1,209 @@
+# Data Plane Design (PR 3/7 — `runtime/data_plane`)
+
+This is the design note for the **data plane**: the large-tensor storage and
+transfer boundary, plus the two metadata-only iteration sources that feed it and
+the loader that turns references into training batches.
+
+It is one slice of the larger DataFlow refactor. The end-to-end motivation and
+staged plan live in `docs/dataflow_centered_scaleout_refactor_plan.md` on the
+`refactor/specforge-redesign` branch; the shared records this layer exchanges are
+defined in [`runtime/contracts.py`](../contracts.py).
+
+## The one load-bearing invariant
+
+There are **two planes**, and they never mix:
+
+- **Control plane** moves only `SampleRef` — *metadata, never tensors*
+  (`assert_no_tensors` enforces this structurally).
+- **Data plane** (`FeatureStore`) is the *only* component that holds tensors.
+
+Everything below is a consequence of keeping those two separate.
+
+## Online vs offline: where they diverge, where they converge
+
+```mermaid
+flowchart TD
+    subgraph produce["① produce — online / offline diverge"]
+        direction LR
+        subgraph online["online (rollout)"]
+            direction TB
+            O1["rollout worker<br/><i>computes features on GPU</i>"]
+            O2["FeatureStore · mem://<br/><i>tensors in RAM, freed on release</i>"]
+            O3["SampleRefQueue<br/><i>ref stream, consume-once</i>"]
+            O1 --> O2 --> O3
+        end
+        subgraph offline["offline (precomputed)"]
+            direction TB
+            F1["prepare_hidden_states.py<br/><i>earlier job, writes to disk</i>"]
+            F2[".ckpt files on disk<br/><i>tensors already on disk</i>"]
+            F3["OfflineManifestReader<br/><i>scan → refs (file://)</i>"]
+            F1 --> F2 --> F3
+        end
+    end
+
+    SR["SampleRef<br/><i>metadata only · no tensors</i>"]
+    O3 -->|control flow| SR
+    F3 -->|control flow| SR
+
+    SR --> DL["FeatureDataLoader<br/><i>get → clone → collate</i>"]
+    DL --> TB["TrainBatch<br/><i>the only tensor-carrying contract</i>"]
+    TB --> TR["Trainer<br/><i>draft model training</i>"]
+
+    O2 -.->|fetch tensors| DL
+    F2 -.->|fetch tensors| DL
+
+    classDef data fill:#E1F5EE,stroke:#0F6E56,color:#085041;
+    classDef control fill:#EEEDFE,stroke:#534AB7,color:#3C3489;
+    classDef compute fill:#F1EFE8,stroke:#5F5E5A,color:#444441;
+    class O2,F2,TB data;
+    class O3,F3,SR control;
+    class O1,F1,DL,TR compute;
+```
+
+Legend: teal = **data plane** (carries tensors) · purple = **control plane**
+(metadata only) · gray = compute. Solid = control flow · dashed = tensor fetch.
+
+Read it in three bands:
+
+1. **Produce (diverge).** This is the *only* place the two modes differ — and
+   they differ on both planes at once:
+   - *Data plane:* online's `rollout_worker` computes tensors on the GPU and
+     `put()`s them into `FeatureStore` as `mem://` (RAM). Offline's tensors were
+     written to disk **earlier** by `prepare_hidden_states.py`; nobody re-writes
+     them — the reader just points at the existing `.ckpt` files.
+   - *Control plane:* online refs flow through `SampleRefQueue` (a consume-once
+     stream); offline refs are produced by `OfflineManifestReader` scanning files
+     (`file://`).
+
+2. **Converge.** Both control-plane paths meet at `SampleRef` — a metadata-only
+   contract. From here down, **no code branches on online vs offline.**
+
+3. **Consume (shared).** `FeatureDataLoader → TrainBatch → Trainer` is one code
+   path for both modes.
+
+### The subtle part: control flow converges, tensors do not
+
+Notice the dashed arrows **bypass** `SampleRef` and go straight into the loader.
+Only the *control flow* (refs) actually merges. The *tensors* are fetched
+separately by the loader via `store.get(ref)`, which **re-routes by URI**:
+
+| ref URI    | source              | populates `_mem`? |
+|------------|---------------------|-------------------|
+| `mem://`   | `_mem` (RAM)        | yes (online only) |
+| `file://`  | disk file (mmap)    | no                |
+
+So the loader and trainer share one API and one code path, but the physical data
+source stays split until the very last moment, behind `FeatureStore.get`.
+
+## Components
+
+All four live in this folder; each carries no knowledge of the model.
+
+### `FeatureStore` / `LocalFeatureStore` — [`feature_store.py`](feature_store.py)
+
+The data plane's storage and transfer boundary. `FeatureStore` is the abstract
+contract; `LocalFeatureStore` is the only backend today (shared-memory and
+Mooncake/RDMA backends slot in behind the same API later).
+
+`LocalFeatureStore` serves both ref flavours transparently:
+
+- `mem://<store_id>/<sample_id>` — produced by `put()` (online rollout), held in
+  RAM on the hot path, with an opt-in disk/mmap `dump_dir` that doubles as the
+  capture/replay tap.
+- `file://<abs_path>` — produced by `OfflineManifestReader`; `get()` lazily loads
+  the named keys out of the existing file. No tensor copy, no `_mem` residency.
+
+Why RAM for the online hot path (not disk): online samples are computed fresh,
+consumed once, and require freshness — there is no reuse to amortize a disk
+round-trip, and disk bandwidth would bottleneck rollout. Offline samples are the
+opposite (computed once, reused every epoch), which is exactly why offline lives
+on disk.
+
+### `SampleRefQueue` — [`sample_ref_queue.py`](sample_ref_queue.py)
+
+A **metadata-only** queue with lease / ack / fail semantics (carries no
+tensors). In-process today, but the lease contract is present so a durable queue
+(visibility timeout, replay) can be swapped in without touching callers.
+`put` is idempotent on `sample_id` (at-least-once delivery); `fail(retryable=…)`
+either requeues or drops.
+
+### `OfflineManifestReader` — [`offline_reader.py`](offline_reader.py)
+
+Walks a directory of precomputed `.ckpt` files and emits one metadata-only
+`SampleRef` per file, referencing each file in place via a `file://` URI. It is
+the offline **ref producer** — it never `put()`s tensors. (Its online counterpart
+is `rollout_worker`, not the queue.)
+
+### `FeatureDataLoader` — [`feature_dataloader.py`](feature_dataloader.py)
+
+The bridge from `SampleRef` to `TrainBatch`, and the one place the online/offline
+difference is erased. Two iteration modes:
+
+- `queue` — online stream, consume-once, owns ack/fail of the queue.
+- `refs` — offline fixed set, re-iterable across epochs.
+
+For each ref it materializes (`store.get` → clone-on-fetch → `store.release`),
+applies an **injected** `per_sample_transform`, validates batch homogeneity,
+collates via an **injected** `collate_fn`, and emits a `TrainBatch`. Because
+transform and collate are injected, the loader carries no model knowledge and is
+unit-testable on CPU.
+
+What is explicitly **not** the loader's job: model semantics (injected), physical
+tensor free (the store's job — see below), and how samples are produced.
+
+## Lifecycle and memory semantics
+
+The store has five lifetime ops:
+
+| op          | who calls it                          | effect on `_mem`            |
+|-------------|---------------------------------------|-----------------------------|
+| `put`       | `rollout_worker` (online only)        | adds the sample             |
+| `get`       | `FeatureDataLoader`                   | none (hands out a lease)    |
+| `release`   | `FeatureDataLoader` after fetch       | frees on the last lease     |
+| `abort`     | `rollout_worker` / terminal drop      | evicts (or debug-retains)   |
+| `gc`        | controller/orchestrator on a timer    | force-frees abandoned bytes |
+
+### Consume-once free (the design point worth remembering)
+
+`mem://` samples are **consume-once**. The store owns the tensors, and physical
+free is the *store's* responsibility — the consumer never needs to know the
+backend's memory policy. `release()` therefore frees the sample's tensors once
+the **last lease on the current generation** drops (reference-counted). `file://`
+samples never enter `_mem`, so release is a harmless no-op for them and offline
+ref sets stay re-iterable across epochs.
+
+Generation is a **global monotonic counter**: a re-`put` of the same `sample_id`
+always gets a strictly higher generation, so a stale handle released after the
+re-put is a safe no-op and can never alias freshly stored data. This is what lets
+`release()` drop the `_generation` entry too, bounding metadata growth.
+
+> **History / rationale.** An earlier version made `release()` free only the
+> *lease*, leaving tensors in `_mem` until `abort()`. But on the online success
+> path nothing calls `abort()` (it is only reached on a failed `put`), so a
+> `put → get → release` loop over unique `sample_id`s grew `_mem` without bound —
+> an OOM on long online runs. Offline was unaffected (it uses `file://`, never
+> `_mem`). The fix moves physical free into `release()` as above; see the
+> `test_release_*` and `test_online_put_get_release_loop_is_bounded` tests.
+
+### Backpressure guard
+
+`LocalFeatureStore(max_resident_bytes=…)` (opt-in, default unbounded) makes
+`put()` raise a descriptive `MemoryError` once residency would exceed the budget
+— a defined failure instead of a silent OOM when the consumer falls behind.
+Residency is observable via `health()`.
+
+## Tests
+
+CPU-only, in [`tests/test_runtime/`](../../../tests/test_runtime):
+
+- `test_feature_store.py` — atomic put, get/handle, idempotent + stale-safe
+  release, **consume-once free**, refcounted multi-lease, **bounded online
+  loop**, `max_resident_bytes`, abort, disk dump, `file://` mode.
+- `test_sample_ref_queue.py` — lease / ack / fail / depth, idempotent put.
+- `test_feature_dataloader.py` — queue and refs modes, drop_last, batch
+  homogeneity validation, offline re-iteration across epochs.
+
+```bash
+# heavy model imports are stubbed on CPU; runs without a GPU or model download
+python -m unittest discover -s tests/test_runtime
+```

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+"""Data plane: large-tensor storage, transfer, and materialization."""
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.feature_store import (
+    FeatureStore,
+    LocalFeatureStore,
+    load_feature_file,
+    spec_from_tensor,
+)
+from specforge.runtime.data_plane.offline_reader import (
+    OfflineManifestReader,
+    list_feature_files,
+)
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+__all__ = [
+    "FeatureStore",
+    "LocalFeatureStore",
+    "load_feature_file",
+    "spec_from_tensor",
+    "SampleRefQueue",
+    "FeatureDataLoader",
+    "OfflineManifestReader",
+    "list_feature_files",
+]

--- a/specforge/runtime/data_plane/feature_dataloader.py
+++ b/specforge/runtime/data_plane/feature_dataloader.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""FeatureDataLoader: ``SampleRef`` + ``FeatureStore`` -> ``TrainBatch``.
+
+The loader is the one place the online/offline difference is erased: it leases
+refs from a queue, fetches their tensors from the store, normalizes each sample
+(an injectable ``per_sample_transform``), collates a batch (an injectable
+``collate_fn``), and emits a ``TrainBatch``. Because both transform and collate
+are injected, the loader carries no model knowledge and is unit-testable on CPU;
+the offline-EAGLE3 run injects the existing ``OfflineEagle3Dataset.process_data``
+and ``DataCollatorWithPadding`` so the result is bit-identical to today's path.
+
+clone-on-fetch is the default: the loader clones tensors out of the store and
+releases the store handle immediately, so prefetch can never race a release.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterator, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import SampleRef, TrainBatch
+from specforge.runtime.data_plane.feature_store import FeatureStore
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+PerSampleTransform = Callable[[Dict[str, torch.Tensor]], Dict[str, torch.Tensor]]
+CollateFn = Callable[[List[Dict[str, torch.Tensor]]], Dict[str, Any]]
+
+
+def _default_collate(features: List[Dict[str, torch.Tensor]]) -> Dict[str, Any]:
+    """Trivial stack collate (used only when no collate_fn is injected)."""
+    keys = features[0].keys()
+    return {k: torch.stack([f[k] for f in features], dim=0) for k in keys}
+
+
+class FeatureDataLoader:
+    def __init__(
+        self,
+        store: FeatureStore,
+        queue: Optional[SampleRefQueue] = None,
+        *,
+        refs: Optional[List[SampleRef]] = None,
+        batch_size: int = 1,
+        collate_fn: Optional[CollateFn] = None,
+        per_sample_transform: Optional[PerSampleTransform] = None,
+        device: "torch.device | str" = "cpu",
+        clone_on_fetch: bool = True,
+        drop_last: bool = True,
+        strategy: str = "eagle3",
+        ack: bool = True,
+    ) -> None:
+        # Two iteration modes, reflecting that online and offline differ in
+        # *iteration* even though they converge at SampleRef:
+        #   - queue: a consume-once stream (online rollout produces over time)
+        #   - refs:  a fixed set, re-iterable across epochs (offline manifest)
+        if (queue is None) == (refs is None):
+            raise ValueError(
+                "provide exactly one of `queue` (stream) or `refs` (re-iterable)"
+            )
+        self.store = store
+        self.queue = queue
+        self._refs = list(refs) if refs is not None else None
+        self.batch_size = batch_size
+        self.collate_fn = collate_fn or _default_collate
+        self.per_sample_transform = per_sample_transform
+        self.device = device
+        self.clone_on_fetch = clone_on_fetch
+        self.drop_last = drop_last
+        self.strategy = strategy
+        self.ack = ack
+
+    def _validate_refs(self, refs: List[SampleRef]) -> None:
+        strategies = {ref.strategy for ref in refs}
+        if strategies != {self.strategy}:
+            raise ValueError(
+                f"loader strategy={self.strategy!r} received refs with "
+                f"strategies={sorted(strategies)}"
+            )
+
+        schema_versions = {ref.schema_version for ref in refs}
+        if len(schema_versions) != 1:
+            raise ValueError(
+                f"mixed schema versions in batch: {sorted(schema_versions)}"
+            )
+
+        target_reprs = {ref.metadata.get("target_repr") for ref in refs}
+        if len(target_reprs) != 1:
+            raise ValueError(
+                f"mixed target_repr values in batch: {sorted(map(repr, target_reprs))}"
+            )
+
+        spec_sets = [set(ref.feature_specs) for ref in refs if ref.feature_specs]
+        if spec_sets and any(spec_set != spec_sets[0] for spec_set in spec_sets[1:]):
+            raise ValueError(f"mixed feature spec names in batch: {spec_sets}")
+
+        if not spec_sets:
+            return
+        first_specs = next(ref.feature_specs for ref in refs if ref.feature_specs)
+        for ref in refs:
+            if not ref.feature_specs:
+                continue
+            for name, spec in ref.feature_specs.items():
+                expected = first_specs[name]
+                if spec.dtype != expected.dtype or len(spec.shape) != len(
+                    expected.shape
+                ):
+                    raise ValueError(
+                        f"incompatible feature spec for sample {ref.sample_id}, "
+                        f"feature {name!r}: {spec} vs {expected}"
+                    )
+
+    def _materialize(self, ref: SampleRef) -> Dict[str, torch.Tensor]:
+        tensors, handle = self.store.get(ref, device=self.device)
+        if self.clone_on_fetch:
+            tensors = {k: v.clone() for k, v in tensors.items()}
+        self.store.release(handle, reason="loaded")
+        if self.per_sample_transform is not None:
+            tensors = self.per_sample_transform(tensors)
+        return tensors
+
+    def _make_batch(self, refs: List[SampleRef]) -> TrainBatch:
+        self._validate_refs(refs)
+        per_sample = [self._materialize(r) for r in refs]
+        batch_tensors = self.collate_fn(per_sample)
+        non_tensors = [
+            name
+            for name, value in batch_tensors.items()
+            if not isinstance(value, torch.Tensor)
+        ]
+        if non_tensors:
+            raise TypeError(f"collate_fn returned non-tensors for {non_tensors}")
+        return TrainBatch(
+            sample_ids=[r.sample_id for r in refs],
+            strategy=self.strategy,
+            tensors=batch_tensors,
+            metadata={
+                "target_repr": refs[0].metadata.get("target_repr"),
+                "ttt_length": refs[0].metadata.get("ttt_length"),
+            },
+        )
+
+    def __iter__(self) -> Iterator[TrainBatch]:
+        if self._refs is not None:
+            yield from self._iter_refs()
+        else:
+            yield from self._iter_queue()
+
+    def _iter_refs(self) -> Iterator[TrainBatch]:
+        # Offline: a fixed ref set, re-iterable every epoch. Acking (durable
+        # marker) is the trainer's job via its ack callback, not the loader's.
+        for start in range(0, len(self._refs), self.batch_size):
+            chunk = self._refs[start : start + self.batch_size]
+            if self.drop_last and len(chunk) < self.batch_size:
+                break
+            yield self._make_batch(chunk)
+
+    def _iter_queue(self) -> Iterator[TrainBatch]:
+        while True:
+            refs = self.queue.get(self.batch_size, timeout_s=0.0)
+            if not refs:
+                return
+            if self.drop_last and len(refs) < self.batch_size:
+                # Incomplete trailing batch: fail-retryable so it is not lost,
+                # then stop (mirrors DataLoader(drop_last=True) per epoch pass).
+                self.queue.fail(refs, reason="drop_last", retryable=True)
+                return
+            try:
+                batch = self._make_batch(refs)
+            except Exception as exc:
+                self.queue.fail(refs, reason=f"materialize:{exc}", retryable=False)
+                raise
+            yield batch
+            if self.ack:
+                self.queue.ack(refs)
+
+    def set_epoch(self, epoch: int) -> None:
+        # hook for per-epoch shuffling of the offline ref set (no-op for now)
+        self._epoch = epoch
+
+    def close(self) -> None:
+        pass
+
+
+__all__ = ["FeatureDataLoader", "PerSampleTransform", "CollateFn"]

--- a/specforge/runtime/data_plane/feature_store.py
+++ b/specforge/runtime/data_plane/feature_store.py
@@ -1,0 +1,391 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""FeatureStore: the data plane's large-tensor storage and transfer boundary.
+
+``FeatureStore`` is the abstract contract; ``LocalFeatureStore`` is the local
+implementation. The local backend keeps features in memory on the hot path,
+with an *optional* disk/mmap debug dump that doubles as the capture/replay tap.
+It also supports a read-only "existing file" mode so the
+``OfflineManifestReader`` can reference precomputed ``.ckpt`` files without
+copying them.
+
+Other backends (shared memory, Mooncake/RDMA) slot in behind the same API; the
+lease/generation/clone-on-fetch primitives are carried here so the in-memory
+backend pays nothing for them but the contract is already exercised.
+
+This is the *minimal core*: relative to the first cut it adds exactly three
+correctness fixes and nothing else.
+
+* **generation-in-URI**: ``mem://`` refs carry their generation in the URI, and
+  ``get()`` rejects a ref whose generation no longer matches the resident
+  sample. This closes the at-least-once redelivery hole where a stale ref could
+  silently alias a freshly re-put sample.
+* **atomic lease registration**: for ``mem://``, the resident read and the lease
+  registration happen under one lock, so a concurrent ``abort`` can never slip
+  between "I read the tensors" and "I registered my borrow".
+* **best-effort dump**: an optional debug dump failure no longer aborts an
+  otherwise successful in-memory publish (mem is authoritative, disk is a tap).
+"""
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import gzip
+import io
+import itertools
+import logging
+import os
+import threading
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, quote, urlparse
+
+import torch
+
+from specforge.runtime.contracts import (
+    SCHEMA_VERSION,
+    FeatureHandle,
+    FeatureSpec,
+    SampleRef,
+)
+
+logger = logging.getLogger(__name__)
+
+_DTYPE_BYTES = {  # best-effort; falls back to element_size() for real tensors
+    "float32": 4,
+    "float16": 2,
+    "bfloat16": 2,
+    "int64": 8,
+    "int32": 4,
+    "int16": 2,
+    "uint8": 1,
+    "bool": 1,
+}
+
+_GENERATION_QUERY_KEY = "generation"
+
+
+def _dtype_str(t: torch.Tensor) -> str:
+    return str(t.dtype).replace("torch.", "")
+
+
+def spec_from_tensor(name: str, t: torch.Tensor, **kw: Any) -> FeatureSpec:
+    return FeatureSpec(name=name, shape=tuple(t.shape), dtype=_dtype_str(t), **kw)
+
+
+def _make_mem_uri(store_id: str, sample_id: str, generation: int) -> str:
+    return (
+        f"mem://{store_id}/{quote(sample_id, safe='')}"
+        f"?{_GENERATION_QUERY_KEY}={generation}"
+    )
+
+
+def _mem_uri_generation(uri: str) -> Optional[int]:
+    """Extract the generation a ``mem://`` ref was minted for, if present."""
+    values = parse_qs(urlparse(uri).query).get(_GENERATION_QUERY_KEY)
+    return int(values[0]) if values else None
+
+
+class FeatureStore(abc.ABC):
+    """Stores and serves large feature tensors. Carries no scheduling state."""
+
+    @abc.abstractmethod
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef: ...
+
+    @abc.abstractmethod
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]: ...
+
+    @abc.abstractmethod
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None: ...
+
+    @abc.abstractmethod
+    def abort(self, sample_id: str, *, reason: str) -> None: ...
+
+    def estimate_bytes(self, specs: Dict[str, FeatureSpec]) -> int:
+        total = 0
+        for spec in specs.values():
+            n = 1
+            for d in spec.shape:
+                n *= int(d)
+            total += n * _DTYPE_BYTES.get(spec.dtype, 4)
+        return total
+
+    @abc.abstractmethod
+    def health(self) -> Dict[str, Any]: ...
+
+
+def load_feature_file(path: str) -> Dict[str, torch.Tensor]:
+    """Load a SpecForge offline feature file (mirrors OfflineEagle3Dataset)."""
+    if path.endswith(".gz"):
+        with gzip.open(path, "rb") as f:
+            return torch.load(io.BytesIO(f.read()), weights_only=False)
+    return torch.load(path, weights_only=False, mmap=True)
+
+
+class LocalFeatureStore(FeatureStore):
+    """In-memory feature store with optional disk dump and read-only file mode.
+
+    Two ref flavours are served transparently so the loader/trainer path is
+    identical online vs offline:
+
+    * ``mem://<store_id>/<sample_id>?generation=<n>`` — produced by :meth:`put`
+      (online rollout).
+    * ``file://<abs_path>`` — produced by ``OfflineManifestReader``; :meth:`get`
+      lazily loads the named keys out of the existing file.
+    """
+
+    def __init__(
+        self,
+        store_id: Optional[str] = None,
+        *,
+        dump_dir: Optional[str] = None,
+        clone_on_get: bool = False,
+        max_resident_bytes: Optional[int] = None,
+    ) -> None:
+        self.store_id = store_id or uuid.uuid4().hex[:8]
+        self.dump_dir = dump_dir
+        # When True the store itself clones on get(); normally the *loader* owns
+        # the clone policy (clone-on-fetch default lives there), so this is off.
+        self.clone_on_get = clone_on_get
+        # Optional cap on mem:// residency. None = unbounded. When set, put()
+        # raises loudly once exceeded — a defined failure instead of silent OOM.
+        self.max_resident_bytes = max_resident_bytes
+        self._mem: Dict[str, Dict[str, torch.Tensor]] = {}
+        self._generation: Dict[str, int] = {}
+        self._active_leases: Dict[str, FeatureHandle] = {}
+        self._lock = threading.RLock()
+        self._counter = itertools.count()
+        # Global monotonic generation: a re-put never reuses a prior generation,
+        # so a stale handle can never alias freshly stored data. This lets
+        # release() drop the _generation entry too (bounding metadata growth).
+        self._gen_counter = itertools.count(1)
+        if dump_dir:
+            os.makedirs(dump_dir, exist_ok=True)
+
+    def _resident_bytes_locked(self) -> int:
+        return sum(
+            t.numel() * t.element_size()
+            for feats in self._mem.values()
+            for t in feats.values()
+        )
+
+    # -- write -------------------------------------------------------------
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef:
+        if not tensors:
+            raise ValueError("put requires at least one tensor")
+        # Atomic from the controller's view: materialize fully, *then* return a
+        # ref. The over-budget check raises *before* the entry is committed, so
+        # there is nothing to roll back on that path.
+        staged = {k: v for k, v in tensors.items()}
+        specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
+        # Stamp the target feature's representation + vocab-map version onto its
+        # spec so the trainer-side mapping is version-gated. For pruned_logits the
+        # token-to-draft (t2d) map is applied at rollout, so the version must travel
+        # with the feature.
+        target_repr = metadata.get("target_repr")
+        target_name = metadata.get("target_feature_name", "target")
+        if target_repr and target_name in specs:
+            vmv = metadata.get("vocab_map_version")
+            specs[target_name] = dataclasses.replace(
+                specs[target_name],
+                target_repr=target_repr,
+                target_meta={"vocab_map_version": vmv} if vmv else {},
+            )
+        num_tokens = int(metadata.get("num_tokens", 0))
+        staged_bytes = sum(t.numel() * t.element_size() for t in staged.values())
+        with self._lock:
+            if self.max_resident_bytes is not None:
+                projected = self._resident_bytes_locked() + staged_bytes
+                if projected > self.max_resident_bytes:
+                    raise MemoryError(
+                        f"feature store {self.store_id} over budget: "
+                        f"{projected} > {self.max_resident_bytes} bytes "
+                        f"(resident_samples={len(self._mem)}); consumer is behind"
+                    )
+            gen = next(self._gen_counter)
+            self._generation[sample_id] = gen
+            self._mem[sample_id] = staged
+        # Best-effort capture/replay tap. mem is authoritative; a dump failure
+        # must not undo a successful in-memory publish, so it is logged, not
+        # raised.
+        if self.dump_dir:
+            try:
+                self._dump(sample_id, staged)
+            except Exception:  # pragma: no cover - disk is a debug side channel
+                logger.warning(
+                    "feature dump failed for sample %s in store %s; "
+                    "mem publish kept",
+                    sample_id,
+                    self.store_id,
+                    exc_info=True,
+                )
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=str(metadata.get("run_id", "unknown")),
+            source_task_id=metadata.get("source_task_id"),
+            feature_store_uri=_make_mem_uri(self.store_id, sample_id, gen),
+            feature_keys={k: f"{sample_id}/{k}" for k in staged},
+            feature_specs=specs,
+            strategy=metadata.get("strategy", "eagle3"),
+            schema_version=int(metadata.get("schema_version", SCHEMA_VERSION)),
+            target_model_version=str(metadata.get("target_model_version", "unknown")),
+            draft_weight_version=metadata.get("draft_weight_version"),
+            tokenizer_version=str(metadata.get("tokenizer_version", "unknown")),
+            num_tokens=num_tokens,
+            estimated_bytes=staged_bytes,
+            metadata={k: v for k, v in metadata.items() if k not in ("num_tokens",)},
+        )
+
+    def _dump(self, sample_id: str, tensors: Dict[str, torch.Tensor]) -> None:
+        path = os.path.join(self.dump_dir, f"{sample_id}.ckpt")
+        tmp = path + ".tmp"
+        torch.save({k: v.detach().cpu() for k, v in tensors.items()}, tmp)
+        os.replace(tmp, path)  # atomic publish
+
+    # -- read --------------------------------------------------------------
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        uri = sample_ref.feature_store_uri
+        wanted = names or list(sample_ref.feature_keys.keys())
+        if uri.startswith("file://"):
+            tensors = self._get_from_file(uri[len("file://") :], sample_ref, wanted)
+            handle = self._register_file_lease(sample_ref)
+        else:
+            tensors, handle = self._get_from_mem(sample_ref, wanted)
+        # Materialization (device move / clone) can fail or OOM. It happens
+        # *after* the lease exists, so on failure we drop the lease before
+        # propagating — no leaked borrow.
+        try:
+            if str(device) != "cpu":
+                tensors = {k: v.to(device) for k, v in tensors.items()}
+            if self.clone_on_get:
+                tensors = {k: v.clone() for k, v in tensors.items()}
+        except Exception:
+            self.release(handle, reason="materialization_failed")
+            raise
+        return tensors, handle
+
+    def _get_from_mem(
+        self, ref: SampleRef, wanted: List[str]
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        # The resident read and the lease registration share one lock so a
+        # concurrent abort() cannot reclaim the sample between them.
+        expected_generation = _mem_uri_generation(ref.feature_store_uri)
+        with self._lock:
+            if ref.sample_id not in self._mem:
+                raise KeyError(f"sample {ref.sample_id} not in store {self.store_id}")
+            gen = self._generation.get(ref.sample_id, 0)
+            if expected_generation is not None and gen != expected_generation:
+                raise KeyError(
+                    f"sample {ref.sample_id} generation {expected_generation} "
+                    f"is not resident in store {self.store_id} (current={gen})"
+                )
+            stored = self._mem[ref.sample_id]
+            missing = [n for n in wanted if n not in stored]
+            if missing:
+                raise KeyError(f"sample {ref.sample_id} missing features {missing}")
+            handle = FeatureHandle(
+                sample_id=ref.sample_id,
+                generation=gen,
+                lease_token=f"{ref.sample_id}:{gen}:{next(self._counter)}",
+            )
+            self._active_leases[handle.lease_token] = handle
+            out = {n: stored[n] for n in wanted}
+        return out, handle
+
+    def _register_file_lease(self, ref: SampleRef) -> FeatureHandle:
+        handle = FeatureHandle(
+            sample_id=ref.sample_id,
+            generation=0,
+            lease_token=f"{ref.sample_id}:0:{next(self._counter)}",
+        )
+        with self._lock:
+            self._active_leases[handle.lease_token] = handle
+        return handle
+
+    def _get_from_file(
+        self, path: str, ref: SampleRef, wanted: List[str]
+    ) -> Dict[str, torch.Tensor]:
+        raw = load_feature_file(path)
+        out = {}
+        for n in wanted:
+            # feature_keys may remap a logical name -> a raw file key.
+            raw_key = ref.feature_keys.get(n, n)
+            raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
+            if raw_key not in raw:
+                raise KeyError(f"{path} missing key {raw_key!r} for feature {n!r}")
+            out[n] = raw[raw_key]
+        return out
+
+    # -- lifetime ----------------------------------------------------------
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
+        # mem:// samples are consume-once: when the LAST lease on the current
+        # generation is released, free the tensors. This is what bounds online
+        # residency — release() owns physical free here, so the consumer never
+        # needs to know the backend's memory policy. file:// samples never enter
+        # _mem, so the pops below are harmless no-ops and offline ref sets stay
+        # re-iterable across epochs. Idempotent + stale-generation safe.
+        with self._lock:
+            self._active_leases.pop(handle.lease_token, None)
+            cur = self._generation.get(handle.sample_id)
+            if cur is not None and handle.generation != cur:
+                return  # stale handle (sample was re-put) -> no-op
+            # Count only leases on the CURRENT generation. A sample re-put while
+            # an older generation is still leased gets a fresh generation, so the
+            # stale older-gen lease must not keep the current generation pinned —
+            # otherwise the last current-gen release would leak it.
+            still_leased = any(
+                h.sample_id == handle.sample_id and h.generation == cur
+                for h in self._active_leases.values()
+            )
+            if not still_leased:
+                self._mem.pop(handle.sample_id, None)
+                self._generation.pop(handle.sample_id, None)
+
+    def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
+        with self._lock:
+            self._mem.pop(sample_id, None)
+            self._generation.pop(sample_id, None)
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "store_id": self.store_id,
+                "resident_samples": len(self._mem),
+                "active_leases": len(self._active_leases),
+                "resident_bytes": self._resident_bytes_locked(),
+                "max_resident_bytes": self.max_resident_bytes,
+            }
+
+
+__all__ = ["FeatureStore", "LocalFeatureStore", "load_feature_file", "spec_from_tensor"]

--- a/specforge/runtime/data_plane/offline_reader.py
+++ b/specforge/runtime/data_plane/offline_reader.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""OfflineManifestReader: turn precomputed feature files into ``SampleRef``s.
+
+The reader walks a directory of SpecForge offline feature files (the ``.ckpt`` /
+``.ckpt.gz`` produced by ``scripts/prepare_hidden_states.py``) and emits one
+metadata-only ``SampleRef`` per file, referencing the file in place via a
+``file://`` URI (read-only existing-file mode — no tensor copy, no tensor
+through the controller). The actual per-sample normalization (the
+``OfflineEagle3Dataset.process_data`` swap: stored ``aux_hidden_state`` becomes
+the draft input ``hidden_state`` and stored ``hidden_state`` becomes the
+``target``) is the FeatureDataLoader's job, keeping this reader independent of
+the model code.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterator, List, Optional, Tuple
+
+from specforge.runtime.contracts import SCHEMA_VERSION, FeatureSpec, SampleRef
+from specforge.runtime.data_plane.feature_store import (
+    load_feature_file,
+    spec_from_tensor,
+)
+
+_FEATURE_SUFFIXES = (".ckpt", ".ckpt.gz")
+# Raw keys present in a SpecForge offline EAGLE3 feature file.
+_OFFLINE_EAGLE3_KEYS = ("input_ids", "loss_mask", "hidden_state", "aux_hidden_state")
+
+
+def _inspect_feature_file(
+    path: str, feature_keys: Tuple[str, ...]
+) -> Tuple[Dict[str, FeatureSpec], int, int]:
+    raw = load_feature_file(path)
+    missing = [key for key in feature_keys if key not in raw]
+    if missing:
+        raise KeyError(f"{path} missing required offline feature keys {missing}")
+
+    specs: Dict[str, FeatureSpec] = {}
+    estimated_bytes = 0
+    for key in feature_keys:
+        value = raw[key]
+        if not hasattr(value, "shape") or not hasattr(value, "dtype"):
+            raise TypeError(f"{path} feature {key!r} is not a tensor: {type(value)!r}")
+        specs[key] = spec_from_tensor(key, value)
+        estimated_bytes += int(value.numel() * value.element_size())
+
+    input_ids = raw.get("input_ids")
+    num_tokens = int(input_ids.numel()) if input_ids is not None else 0
+    return specs, num_tokens, estimated_bytes
+
+
+def list_feature_files(path: str) -> List[str]:
+    """Deterministically (sorted) list feature files under ``path``."""
+    if os.path.isfile(path):
+        return [os.path.abspath(path)]
+    files: List[str] = []
+    for root, _dirs, names in os.walk(path):
+        for name in names:
+            if name.endswith(_FEATURE_SUFFIXES):
+                files.append(os.path.abspath(os.path.join(root, name)))
+    files.sort()  # deterministic, stable cross-rank ordering
+    return files
+
+
+class OfflineManifestReader:
+    """Reads a directory of offline feature files into ``SampleRef`` records."""
+
+    def __init__(
+        self,
+        hidden_states_path: str,
+        *,
+        run_id: str = "offline",
+        strategy: str = "eagle3",
+        target_model_version: str = "unknown",
+        tokenizer_version: str = "unknown",
+        feature_keys: tuple = _OFFLINE_EAGLE3_KEYS,
+        ttt_length: int = 7,
+        max_len: int = 2048,
+        target_repr: str = "hidden_state",
+        validate_files: bool = True,
+    ) -> None:
+        self.hidden_states_path = hidden_states_path
+        self.run_id = run_id
+        self.strategy = strategy
+        self.target_model_version = target_model_version
+        self.tokenizer_version = tokenizer_version
+        self.feature_keys = tuple(feature_keys)
+        self.ttt_length = ttt_length
+        self.max_len = max_len
+        self.target_repr = target_repr
+        self.validate_files = validate_files
+
+    def _ref_for(self, index: int, path: str) -> SampleRef:
+        sample_id = f"{self.run_id}:{index:08d}"
+        specs: Dict[str, FeatureSpec] = {}
+        num_tokens = 0
+        estimated_bytes = 0
+        if self.validate_files:
+            specs, num_tokens, estimated_bytes = _inspect_feature_file(
+                path, self.feature_keys
+            )
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=self.run_id,
+            source_task_id=None,
+            feature_store_uri=f"file://{path}",
+            feature_keys={k: k for k in self.feature_keys},
+            feature_specs=specs,
+            strategy=self.strategy,
+            schema_version=SCHEMA_VERSION,
+            target_model_version=self.target_model_version,
+            tokenizer_version=self.tokenizer_version,
+            num_tokens=num_tokens,
+            estimated_bytes=estimated_bytes,
+            metadata={
+                "format": "offline_eagle3",
+                "target_repr": self.target_repr,
+                "schema_version": SCHEMA_VERSION,
+                "ttt_length": self.ttt_length,
+                "max_len": self.max_len,
+                "file_index": index,
+            },
+        )
+
+    def __iter__(self) -> Iterator[SampleRef]:
+        for index, path in enumerate(list_feature_files(self.hidden_states_path)):
+            yield self._ref_for(index, path)
+
+    def read(self, limit: Optional[int] = None) -> List[SampleRef]:
+        refs: List[SampleRef] = []
+        for i, ref in enumerate(self):
+            if limit is not None and i >= limit:
+                break
+            refs.append(ref)
+        return refs
+
+
+__all__ = ["OfflineManifestReader", "list_feature_files"]

--- a/specforge/runtime/data_plane/sample_ref_queue.py
+++ b/specforge/runtime/data_plane/sample_ref_queue.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""SampleRefQueue: a metadata-only queue with lease / ack / fail semantics.
+
+The current implementation is in-process; the lease/ack contract is present so a
+durable queue (visibility timeout, replay) can be swapped in later without
+touching callers. Carries no tensors — only ``SampleRef`` metadata.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import List, Optional
+
+from specforge.runtime.contracts import SampleRef, assert_no_tensors
+
+
+class SampleRefQueue:
+    def __init__(self, *, lease_timeout_s: Optional[float] = None) -> None:
+        self.lease_timeout_s = lease_timeout_s
+        self._pending: "OrderedDict[str, SampleRef]" = OrderedDict()
+        self._leased: "OrderedDict[str, tuple[SampleRef, float]]" = OrderedDict()
+        self._lock = threading.Lock()
+        self._cv = threading.Condition(self._lock)
+
+    def put(
+        self, refs: List[SampleRef], *, partition_key: Optional[str] = None
+    ) -> None:
+        # partition_key reserves the per-DP-rank queue partition seam for future
+        # reshard support. Today there is a single partition, so it is accepted
+        # and ignored.
+        with self._cv:
+            for ref in refs:
+                assert_no_tensors(ref)  # structural no-tensor guard
+                # Idempotent on sample_id (at-least-once delivery).
+                if ref.sample_id in self._leased or ref.sample_id in self._pending:
+                    continue
+                self._pending[ref.sample_id] = ref
+            self._cv.notify_all()
+
+    def get(
+        self,
+        max_refs: int,
+        timeout_s: Optional[float] = None,
+        *,
+        partition_key: Optional[str] = None,
+    ) -> List[SampleRef]:
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
+        with self._cv:
+            while True:
+                self._reclaim_expired_locked()
+                if self._pending:
+                    out: List[SampleRef] = []
+                    for _ in range(max_refs):
+                        if not self._pending:
+                            break
+                        sid, ref = self._pending.popitem(last=False)
+                        self._leased[sid] = (ref, time.monotonic())
+                        out.append(ref)
+                    return out
+                if deadline is None:
+                    return []
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return []
+                self._cv.wait(timeout=remaining)
+
+    def ack(self, refs: List[SampleRef]) -> None:
+        with self._cv:
+            for ref in refs:
+                self._leased.pop(ref.sample_id, None)  # idempotent
+
+    def fail(self, refs: List[SampleRef], reason: str, retryable: bool) -> None:
+        with self._cv:
+            for ref in refs:
+                self._leased.pop(ref.sample_id, None)
+                if retryable:
+                    self._pending[ref.sample_id] = ref  # back to the tail
+            if retryable:
+                self._cv.notify_all()
+
+    def depth(self) -> int:
+        with self._lock:
+            return len(self._pending)
+
+    def in_flight(self) -> int:
+        with self._lock:
+            return len(self._leased)
+
+    def _reclaim_expired_locked(self) -> None:
+        if self.lease_timeout_s is None or not self._leased:
+            return
+        now = time.monotonic()
+        expired = [
+            sid
+            for sid, (_, leased_at) in self._leased.items()
+            if now - leased_at > self.lease_timeout_s
+        ]
+        for sid in expired:
+            ref, _ = self._leased.pop(sid)
+            self._pending[sid] = ref
+
+
+__all__ = ["SampleRefQueue"]

--- a/specforge/runtime/inference/DESIGN.md
+++ b/specforge/runtime/inference/DESIGN.md
@@ -1,0 +1,52 @@
+# Inference Plane Design (PR 5/7 — `runtime/inference`)
+
+This is the design note for the **inference**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+The rollout/inference plane turns leased PromptTasks into per-sample feature tensors and commits only their typed SampleRef metadata to the controller — it never hands a tensor to the controller. It owns the clean boundary to the target engine (Eagle3TargetModel via generate_eagle3_data), the only place target→draft projection/pruning happens, and the loud pre-write validation (verify_capture against a typed CaptureConfig) that converts layer/name/width/target-dim mismatches into immediate, localized errors at the extraction boundary instead of downstream trainer bugs.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+  classDef data fill:#fdeede,stroke:#d6893b,color:#6b3a0b;
+
+  A[lease_prompt_tasks] --> B[generate_features per batch]
+  B --> C[SGLangAdapter group by len single forward]
+  C --> D[generate_eagle3_data]
+  D --> E[_project_target logits or pruned_logits]
+  E --> F[verify_capture vs CaptureConfig]
+  F -->|mismatch| G[fail_prompt_tasks non retryable]
+  F -->|ok| H[FeatureStore put]
+  H -->|put error| I[abort then fail retryable]
+  H -->|ok| J[append SampleRef]
+  J --> K[commit_samples metadata only]
+
+  class A,K control;
+  class B,C,D,E,F,J compute;
+  class H,I data;
+  class G control;
+```
+
+The rollout plane turns leased `PromptTask`s into per-sample feature tensors and commits only their typed `SampleRef` metadata — it never hands a tensor to the controller. `RolloutWorker.run_once` is the core loop: lease up to `max_tasks`, call `feature_source.generate_features(tasks, capture=...)` once for the whole batch, enforce a strict `len(feats)==len(tasks)` contract, then per sample pop the out-of-band `__aux_layer_ids__`, run `verify_capture`, and on success `FeatureStore.put` (tensors go straight to the data plane). Every leased task ends in exactly one terminal controller action — `commit_samples` on success or `fail_prompt_tasks` on generate failure / wrong count / capture mismatch / put failure — with `sample_id = f"{run_id}:{task.task_id}"` deterministic and a put exception triggering `abort`. `CaptureConfig` is a frozen, strategy-derived contract carrying `feature_names`, `aux_hidden_state_layer_ids`, `target_repr`, and the derived `expected_aux_width` / `expected_target_dim()`. `verify_capture` is the loud pre-`put` validator: it checks name presence, aux-layer-id equality, aux last-dim width, and target last-dim, gating `pruned_logits` on a non-None `vocab_map_version`, raising `CaptureMismatchError` at the boundary. `SGLangAdapter` is the only place target to draft projection happens (`_project_target`: passthrough for `logits`, `t2d`-indexing for `pruned_logits`), batching equal-length tasks into one padding-free `generate_eagle3_data` forward and slicing rows back into original task order.
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
+| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
+| `RolloutWorker` | `SGLangAdapter.generate_features` | compute |
+| `SGLangAdapter` | `Eagle3TargetModel.generate_eagle3_data` | compute |
+| `RolloutWorker` | `FeatureStore.put` | data |
+| `RolloutWorker` | `FeatureStore.abort` | data |
+| `RolloutWorker` | `DataFlowController.commit_samples` | control |
+| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |

--- a/specforge/runtime/inference/__init__.py
+++ b/specforge/runtime/inference/__init__.py
@@ -1,0 +1,6 @@
+# coding=utf-8
+"""Inference / rollout plane: SGLang adapter, capture config, rollout worker.
+
+Submodules import the SpecForge model / SGLang code, so they are imported
+explicitly by callers rather than at package load.
+"""

--- a/specforge/runtime/inference/capture.py
+++ b/specforge/runtime/inference/capture.py
@@ -1,0 +1,139 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""CaptureConfig: the typed contract for what a rollout must extract (B7/B8).
+
+``capture`` is NOT an untyped ``dict[str, Any]``. It is a frozen config *derived
+from the active strategy* (``feature_names == DraftTrainStrategy.required_features``,
+``aux_hidden_state_layer_ids`` == the layers the draft config requested). Before
+any ``FeatureStore.put`` the rollout runs :func:`verify_capture`, which fails
+loudly on a name / aux-layer-id / width / target-dim mismatch — turning what
+would otherwise be a confusing downstream trainer bug into an immediate,
+localized error at the extraction boundary.
+
+Import-light (stdlib only) so the assertions are unit-testable without a GPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Optional, Tuple
+
+from specforge.runtime.contracts import TargetRepr
+
+
+class CaptureMismatchError(AssertionError):
+    """Raised when extracted features do not match the requested CaptureConfig."""
+
+
+@dataclass(frozen=True)
+class CaptureConfig:
+    feature_names: FrozenSet[str]
+    aux_hidden_state_layer_ids: Tuple[int, ...]
+    target_repr: TargetRepr
+    target_hidden_size: int
+    target_vocab_size: Optional[int] = None
+    draft_vocab_size: Optional[int] = None
+    vocab_map_version: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_strategy(
+        cls,
+        required_features,
+        aux_hidden_state_layer_ids,
+        *,
+        target_repr: TargetRepr,
+        target_hidden_size: int,
+        target_vocab_size: Optional[int] = None,
+        draft_vocab_size: Optional[int] = None,
+        vocab_map_version: Optional[str] = None,
+    ) -> "CaptureConfig":
+        return cls(
+            feature_names=frozenset(required_features),
+            aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
+            target_repr=target_repr,
+            target_hidden_size=int(target_hidden_size),
+            target_vocab_size=target_vocab_size,
+            draft_vocab_size=draft_vocab_size,
+            vocab_map_version=vocab_map_version,
+        )
+
+    @property
+    def expected_aux_width(self) -> int:
+        return len(self.aux_hidden_state_layer_ids) * self.target_hidden_size
+
+    def expected_target_dim(self) -> Optional[int]:
+        if self.target_repr == "pruned_logits":
+            return self.draft_vocab_size
+        if self.target_repr == "logits":
+            return self.target_vocab_size
+        if self.target_repr == "hidden_state":
+            return self.target_hidden_size
+        return None
+
+
+def verify_capture(
+    tensors: Dict[str, Any],
+    capture: CaptureConfig,
+    *,
+    sample_id: str,
+    recorded_aux_layer_ids: Optional[Tuple[int, ...]] = None,
+    aux_feature_name: str = "hidden_state",
+    target_feature_name: str = "target",
+) -> None:
+    """Loud, pre-put validation that extracted ``tensors`` match ``capture``.
+
+    Raises :class:`CaptureMismatchError` on the first mismatch with a
+    requested-vs-actual diff and the offending ``sample_id``.
+    """
+    # (1) all requested feature names present
+    missing = sorted(n for n in capture.feature_names if n not in tensors)
+    if missing:
+        raise CaptureMismatchError(
+            f"[{sample_id}] capture missing features {missing}; "
+            f"got {sorted(tensors)}; requested {sorted(capture.feature_names)}"
+        )
+
+    # (2) recorded aux-layer IDs == requested
+    if recorded_aux_layer_ids is not None:
+        if tuple(recorded_aux_layer_ids) != capture.aux_hidden_state_layer_ids:
+            raise CaptureMismatchError(
+                f"[{sample_id}] aux-layer id mismatch: recorded "
+                f"{tuple(recorded_aux_layer_ids)} != requested "
+                f"{capture.aux_hidden_state_layer_ids}"
+            )
+
+    # (3) aux width == len(aux_layer_ids) * target_hidden_size
+    if aux_feature_name in tensors and capture.aux_hidden_state_layer_ids:
+        width = int(tuple(tensors[aux_feature_name].shape)[-1])
+        if width != capture.expected_aux_width:
+            raise CaptureMismatchError(
+                f"[{sample_id}] aux width {width} != "
+                f"len(aux_layer_ids)*target_hidden_size="
+                f"{len(capture.aux_hidden_state_layer_ids)}*"
+                f"{capture.target_hidden_size}={capture.expected_aux_width}"
+            )
+
+    # (4) target last-dim matches target_repr (+ vocab-map dim for pruned_logits)
+    expected = capture.expected_target_dim()
+    if target_feature_name in tensors and expected is not None:
+        dim = int(tuple(tensors[target_feature_name].shape)[-1])
+        if dim != expected:
+            raise CaptureMismatchError(
+                f"[{sample_id}] target last-dim {dim} != expected {expected} "
+                f"for target_repr={capture.target_repr!r}"
+            )
+        if capture.target_repr == "pruned_logits" and capture.vocab_map_version is None:
+            raise CaptureMismatchError(
+                f"[{sample_id}] target_repr='pruned_logits' requires a "
+                f"vocab_map_version so the trainer-side mapping is gated"
+            )
+
+
+__all__ = ["CaptureConfig", "CaptureMismatchError", "verify_capture"]

--- a/specforge/runtime/inference/rollout_worker.py
+++ b/specforge/runtime/inference/rollout_worker.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""RolloutWorker: PromptTask -> features -> FeatureStore -> SampleRef commit.
+
+The worker is deliberately small and strategy-agnostic: it leases prompt tasks,
+asks a ``feature_source`` (e.g. a wrapper over the target model's
+``generate_eagle3_data``, or ``SGLangAdapter``) for per-sample features,
+verifies them against the typed ``CaptureConfig`` *before* writing, writes them
+to the ``FeatureStore``, and commits the resulting ``SampleRef`` metadata to the
+controller. It never hands a tensor to the controller. Strategy-specific capture
+requirements live in ``CaptureConfig`` + the feature schema, not here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol
+
+from specforge.runtime.contracts import PromptTask, SampleRef
+from specforge.runtime.inference.capture import (
+    CaptureConfig,
+    CaptureMismatchError,
+    verify_capture,
+)
+
+# health states: a worker REPORTS health; the controller decides scheduling.
+HEALTH_STATES = ("starting", "ready", "paused", "draining", "unhealthy", "stopped")
+
+
+class FeatureSource(Protocol):
+    def generate_features(
+        self, tasks: List[PromptTask], *, capture: CaptureConfig
+    ) -> List[Dict[str, Any]]: ...
+
+
+class RolloutWorker:
+    def __init__(
+        self,
+        controller,
+        feature_store,
+        feature_source: FeatureSource,
+        capture: CaptureConfig,
+        *,
+        run_id: str,
+        worker_id: Optional[str] = None,
+        strategy: str = "eagle3",
+        target_model_version: str = "unknown",
+        tokenizer_version: str = "unknown",
+        draft_weight_version: Optional[str] = None,
+    ) -> None:
+        self.controller = controller
+        self.feature_store = feature_store
+        self.feature_source = feature_source
+        self.capture = capture
+        self.run_id = run_id
+        self.strategy = strategy
+        self.target_model_version = target_model_version
+        self.tokenizer_version = tokenizer_version
+        self.draft_weight_version = draft_weight_version
+        self._state = "starting"
+        self._inflight = 0
+        self._recent_failures: List[str] = []
+        self._last_commit_count = 0
+        self.worker_id = controller.register_rollout_worker(
+            {"worker_id": worker_id, "strategy": strategy, "role": "rollout"}
+        )
+
+    def start(self) -> None:
+        self._state = "ready"
+
+    def stop(self, reason: str = "stopped") -> None:
+        # graceful: finish in-flight, then mark stopped (drain happens in run_once)
+        self._state = "stopped"
+
+    def _sample_id(self, task: PromptTask) -> str:
+        return f"{self.run_id}:{task.task_id}"
+
+    def run_once(self, max_tasks: int) -> List[SampleRef]:
+        if self._state in ("stopped", "draining"):
+            return []
+        tasks = self.controller.lease_prompt_tasks(self.worker_id, max_tasks)
+        if not tasks:
+            return []
+        self._inflight = len(tasks)
+        self._state = "ready"
+        try:
+            feats_list = self.feature_source.generate_features(
+                tasks, capture=self.capture
+            )
+        except Exception as exc:  # rollout failure before any feature write
+            self._state = "unhealthy"
+            self._recent_failures.append(f"generate_features: {exc}")
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=f"generate_features:{exc}",
+                retryable=True,
+            )
+            self._inflight = 0
+            raise
+        if len(feats_list) != len(tasks):
+            reason = (
+                f"generate_features returned {len(feats_list)} feature records "
+                f"for {len(tasks)} tasks"
+            )
+            self._state = "unhealthy"
+            self._recent_failures.append(reason)
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=reason,
+                retryable=False,
+            )
+            self._inflight = 0
+            raise ValueError(reason)
+
+        refs: List[SampleRef] = []
+        capture_error: Optional[CaptureMismatchError] = None
+        for task, feats in zip(tasks, feats_list):
+            sample_id = self._sample_id(task)
+            recorded = feats.pop("__aux_layer_ids__", None)
+            try:
+                verify_capture(
+                    feats,
+                    self.capture,
+                    sample_id=sample_id,
+                    recorded_aux_layer_ids=recorded,
+                )
+            except CaptureMismatchError as exc:
+                # Loud failure: do not persist a corrupt sample, but keep this
+                # batch's other prompt leases moving so no lease is stranded.
+                self._recent_failures.append(str(exc))
+                self.controller.fail_prompt_tasks(
+                    self.worker_id, [task.task_id], reason=str(exc), retryable=False
+                )
+                if capture_error is None:
+                    capture_error = exc
+                continue
+            try:
+                ref = self.feature_store.put(
+                    feats,
+                    sample_id=sample_id,
+                    metadata=self._put_metadata(task),
+                )
+            except Exception as exc:  # partial write -> abort, report
+                self.feature_store.abort(sample_id, reason=f"put_failed:{exc}")
+                self.controller.fail_prompt_tasks(
+                    self.worker_id, [task.task_id], reason=str(exc), retryable=True
+                )
+                continue
+            refs.append(ref)
+
+        if refs:
+            self.controller.commit_samples(self.worker_id, refs)
+            self._last_commit_count += len(refs)
+        self._inflight = 0
+        if capture_error is not None:
+            self._state = "unhealthy"
+            raise capture_error
+        return refs
+
+    def _put_metadata(self, task: PromptTask) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "source_task_id": task.task_id,
+            "strategy": self.strategy,
+            "target_repr": self.capture.target_repr,
+            "vocab_map_version": self.capture.vocab_map_version,
+            "ttt_length": self.capture.extra.get("ttt_length"),
+            "target_model_version": self.target_model_version,
+            "tokenizer_version": self.tokenizer_version,
+            "draft_weight_version": self.draft_weight_version,
+            "num_tokens": int(task.metadata.get("num_tokens", 0)),
+        }
+
+    def drain(self) -> None:
+        """Stop leasing new work; in-flight is finished by the active run_once."""
+        self._state = "draining"
+
+    # Draft-weight hot update (update_weights -> adapter) is not yet supported.
+    # draft_weight_version is still recorded as rollout provenance on each sample.
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "worker_id": self.worker_id,
+            "state": self._state,
+            "strategy": self.strategy,
+            "draft_weight_version": self.draft_weight_version,
+            "in_flight": self._inflight,
+            "recent_failures": self._recent_failures[-5:],
+            "committed": self._last_commit_count,
+        }
+
+
+__all__ = ["RolloutWorker", "FeatureSource", "HEALTH_STATES"]

--- a/specforge/runtime/inference/sglang_adapter.py
+++ b/specforge/runtime/inference/sglang_adapter.py
@@ -1,0 +1,157 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""SGLangAdapter: the clean boundary between SpecForge and the target engine.
+
+``generate_features(tasks, *, capture)`` is the single extraction entry point.
+``capture`` is the typed :class:`CaptureConfig` derived from the active strategy,
+not an untyped dict. The adapter wraps the existing ``Eagle3TargetModel`` (sglang
+/ hf / custom backends all expose ``generate_eagle3_data``), records the exact
+aux-layer IDs it captured, applies the target→draft projection demanded by
+``capture.target_repr`` (the only place pruning happens), and returns per-sample
+feature dicts. The RolloutWorker then runs :func:`verify_capture` before any
+store write, so a layer/name/width mismatch fails loudly at this boundary rather
+than as a downstream trainer bug.
+
+Imports the SpecForge model code, so it is imported by rollout entry points.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import PromptTask
+from specforge.runtime.inference.capture import CaptureConfig
+
+
+def _as_2d_long(values, device) -> torch.Tensor:
+    t = torch.as_tensor(values, dtype=torch.long, device=device)
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    return t
+
+
+class SGLangAdapter:
+    """Adapter over a SpecForge ``Eagle3TargetModel`` (or any ``generate_eagle3_data``)."""
+
+    SUPPORTED_FEATURE_NAMES = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+
+    def __init__(
+        self,
+        target_model,
+        *,
+        device: str = "cuda",
+        t2d: Optional[torch.Tensor] = None,
+        shard_returns: bool = False,
+    ) -> None:
+        self.target_model = target_model
+        self.device = device
+        # t2d (target->draft vocab mask) only needed for pruned_logits capture.
+        self.t2d = t2d
+        self.shard_returns = shard_returns
+        self._healthy = True
+
+    def _recorded_aux_layer_ids(self) -> tuple:
+        ids = getattr(self.target_model, "aux_hidden_states_layers", None)
+        return tuple(ids) if ids is not None else ()
+
+    # target representations this online adapter actually implements
+    SUPPORTED_TARGET_REPRS = ("logits", "pruned_logits")
+
+    def _project_target(
+        self, target: torch.Tensor, capture: CaptureConfig
+    ) -> torch.Tensor:
+        if capture.target_repr == "logits":
+            return target
+        if capture.target_repr == "pruned_logits":
+            if self.t2d is None:
+                raise ValueError("pruned_logits capture requires a t2d vocab map")
+            return target[..., self.t2d.to(target.device)]
+        # Only advertise what we implement. 'hidden_state' capture (storing the
+        # target's last hidden state) is not wired in the online adapter yet; the
+        # offline path supports it (the strategy re-runs TargetHead).
+        raise NotImplementedError(
+            f"SGLangAdapter does not implement online capture for target_repr="
+            f"{capture.target_repr!r}; supported: {self.SUPPORTED_TARGET_REPRS}"
+        )
+
+    def generate_features(
+        self, tasks: List[PromptTask], *, capture: CaptureConfig
+    ) -> List[Dict[str, Any]]:
+        """Extract per-sample features, batching the engine call.
+
+        Tasks are grouped by sequence length and each group is run through
+        ``generate_eagle3_data`` in ONE batched forward (the engine's native
+        batching), instead of a per-sample loop that would serialize N forwards.
+        Equal-length grouping avoids intra-batch padding, so per-sample features
+        are sliced out cleanly. The result preserves task order.
+        """
+        recorded = self._recorded_aux_layer_ids()
+        out: List[Optional[Dict[str, Any]]] = [None] * len(tasks)
+
+        groups: Dict[int, List[int]] = {}
+        for i, task in enumerate(tasks):
+            groups.setdefault(len(task.payload["input_ids"]), []).append(i)
+
+        for _length, idxs in groups.items():
+            input_ids = torch.stack(
+                [
+                    _as_2d_long(tasks[i].payload["input_ids"], self.device)[0]
+                    for i in idxs
+                ],
+                dim=0,
+            )  # (G, L)
+            loss_mask = torch.stack(
+                [
+                    _as_2d_long(
+                        tasks[i].payload.get("loss_mask", [1] * input_ids.shape[1]),
+                        self.device,
+                    )[0]
+                    for i in idxs
+                ],
+                dim=0,
+            )
+            attention_mask = torch.ones_like(input_ids)
+            data = self.target_model.generate_eagle3_data(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                loss_mask=loss_mask,
+                shard_returns=self.shard_returns,
+            )
+            target = self._project_target(data.target, capture)
+            for j, gi in enumerate(idxs):
+                out[gi] = {
+                    "input_ids": data.input_ids[j : j + 1],
+                    "attention_mask": data.attention_mask[j : j + 1],
+                    "loss_mask": data.loss_mask[j : j + 1],
+                    "hidden_state": data.hidden_states[j : j + 1],
+                    "target": target[j : j + 1],
+                    # carried out-of-band for verify_capture; popped before put
+                    "__aux_layer_ids__": recorded,
+                }
+        return out
+
+    # NOTE: draft-weight hot update (update_draft_weights) is not implemented yet.
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "healthy": self._healthy,
+            "aux_hidden_state_layer_ids": list(self._recorded_aux_layer_ids()),
+            "backend": getattr(self.target_model, "backend", "unknown"),
+        }
+
+
+__all__ = ["SGLangAdapter"]

--- a/specforge/runtime/inference/sglang_patch_inventory.md
+++ b/specforge/runtime/inference/sglang_patch_inventory.md
@@ -1,0 +1,60 @@
+# SGLang Patch Inventory & Supported-Version Matrix (M4 / B7-B8)
+
+This is the published inventory the M4 exit gate requires: every place SpecForge
+depends on SGLang internals to extract EAGLE3/DFlash features, and the SGLang
+versions that are validated against the extraction-correctness gate
+(`test_extraction_vs_hf_reference`).
+
+Per ADR (`open_questions.md` #1), the SGLang patch surface is treated as a
+**version-pinned fork**, surfaced through one boundary — `SGLangAdapter` in
+[`sglang_adapter.py`](sglang_adapter.py). The decision is **versioned `.patch`
+files + a declared version matrix + a CI extraction-drift gate**, not runtime
+monkey-patching, so a patch is auditable and an SGLang upgrade can never silently
+change what is extracted.
+
+## Extraction surface (what we depend on)
+
+| # | Dependency | Where | Why it can break on upgrade |
+|---|---|---|---|
+| 1 | `CaptureHiddenMode.FULL` + `LogitsProcessorForEAGLE3` returning `aux_hidden_states` / `last_hidden_states` | `specforge/modeling/target/eagle3_target_model.py` `_extend`, `sglang_backend/` | SGLang may rename the capture mode, change `logits_output` fields, or change aux-state layout |
+| 2 | `model.set_eagle3_layers_to_capture(layer_ids)` | `set_aux_hidden_states_layers` | Aux-layer registration API may move/rename |
+| 3 | `ScheduleBatch` / `ForwardBatch` / `ModelRunner` construction signature | `_extend` | New required ctor args on minor releases (e.g. `is_draft_worker`, `moe_dp_rank`) |
+| 4 | Per-request split of `aux_hidden_states` by `input_lens` | `_extend`, `_get_sharded_return` | Token packing / padding convention changes |
+| 5 | `wrap_eagle3_logits_processors_in_module(..., return_full_logits=False)` | `from_pretrained` | Logits-processor wrapping hook may change |
+
+The `SGLangAdapter` is the *only* code that touches these; everything downstream
+sees the typed `Eagle3TargetOutput` / per-sample feature dicts.
+
+## Supported version matrix
+
+The extraction-correctness gate must be green on every pinned version. `status`:
+**validated** = `test_extraction_vs_hf_reference` green in CI on this version;
+**target** = intended next pin.
+
+| SGLang version | torch / transformers | Backend(s) | Aux capture | Status |
+|---|---|---|---|---|
+| `0.5.5` (`lmsysorg/sglang:v0.5.5`) | 2.x / 4.x | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (repo CI image) |
+| `dev` (`lmsysorg/sglang:dev`) | 2.11 / 5.8 | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (H200 box) |
+| `0.5.9` (pyproject pin) | 2.9.1 / 4.57.1 | sglang, hf, custom | `set_eagle3_layers_to_capture` | target |
+
+`0.5.9` is the dependency pin, but it is not an M4 sign-off until the
+extraction-correctness gate is green on that exact image/version.
+
+The **HF backend** path (`HFEagle3TargetModel`, forward hooks on the aux layers)
+is version-robust and is what `test_extraction_vs_hf_reference` exercises in CI
+without a GPU SGLang server; the **sglang backend** is validated on the GPU box.
+
+## CI extraction-drift gate
+
+`test_extraction_vs_hf_reference` asserts the adapter's extracted aux hidden
+states equal an independent HF `output_hidden_states=True` forward at the
+recorded layer IDs (and target logits match a direct `lm_head`) within a
+documented bf16 tolerance (`rtol=atol=2e-2`). Run it against each pinned image;
+a failure on a new image blocks the version bump.
+
+## Patch files
+
+When an SGLang upgrade requires source changes to the extraction surface, add a
+versioned patch under `specforge/runtime/inference/patches/<sglang-version>.patch`
+and record it in the matrix above. None are required for the validated versions
+(extraction goes through the public capture API).

--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -119,8 +119,165 @@ def build_offline_eagle3_runtime(
     return trainer, loader
 
 
+def build_online_eagle3_runtime(
+    *,
+    target_model,
+    prompts,
+    eagle3_model,
+    optimizer_factory,
+    run_id: str,
+    output_dir: str,
+    target_hidden_size: int,
+    target_vocab_size: Optional[int] = None,
+    draft_vocab_size: Optional[int] = None,
+    target_repr: str = "logits",
+    aux_hidden_state_layer_ids=None,
+    vocab_map_version: Optional[str] = None,
+    t2d=None,
+    num_rollout_workers: int = 1,
+    device: str = "cuda",
+    ttt_length: int = 7,
+    batch_size: int = 1,
+    accumulation_steps: int = 1,
+    num_epochs: int = 1,
+    max_steps: Optional[int] = None,
+    save_interval: int = 0,
+    eval_interval: int = 0,
+    tp_size: int = 1,
+    sp_ulysses_size: int = 1,
+    sp_ring_size: int = 1,
+    collate_fn=None,
+    logger=None,
+):
+    """Assemble the online-EAGLE3 dataflow and return
+    ``(trainer, loader, workers, controller, drive_rollout)``.
+
+    Mirror of :func:`build_offline_eagle3_runtime`; the only difference is the
+    *producer* of ``SampleRef``s. Instead of an ``OfflineManifestReader`` reading
+    ``.ckpt`` files, a ``RolloutWorker`` leases ``PromptTask``s, asks the
+    ``target_model`` (any backend exposing ``generate_eagle3_data`` — HF, SGLang,
+    or custom; **sglang is not required**) for per-sample features via
+    ``SGLangAdapter``, writes them to the ``mem://`` ``FeatureStore``, and commits
+    ``SampleRef``s onto the controller's ``SampleRefQueue``. From ``SampleRef``
+    down (loader -> strategy -> trainer) the code path is identical to offline.
+
+    ``prompts`` is the metadata-only PromptTask source (e.g.
+    ``[{"payload": {"input_ids": [...], "loss_mask": [...]}}]``). The returned
+    ``drive_rollout()`` runs the workers until the prompt pool is exhausted,
+    populating the queue the loader consumes; the launcher script calls it before
+    ``trainer.fit(loader)``. (Fully-async rollout/train interleaving with
+    backpressure is the control-plane's job — a follow-up, not this seam.)
+
+    ``target_head`` is ``None`` on purpose: online rollout already materialized the
+    ``target`` distribution, so the strategy consumes it directly rather than
+    re-running an lm-head (that is the offline ``hidden_state`` path's job).
+    """
+    import torch
+
+    from specforge.runtime.inference.capture import CaptureConfig
+    from specforge.runtime.inference.rollout_worker import RolloutWorker
+    from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+    controller = DataFlowController(run_id)
+    controller.ingest_prompts(prompts)
+    # PR8 colocated store has no residency cap (max_resident_bytes is the M5
+    # backpressure follow-up); mirror the offline launcher's plain construction.
+    store = LocalFeatureStore(run_id)
+
+    if aux_hidden_state_layer_ids is None:
+        aux_hidden_state_layer_ids = tuple(
+            getattr(target_model, "aux_hidden_states_layers", ()) or ()
+        )
+
+    adapter = SGLangAdapter(target_model, device=device, t2d=t2d)
+    capture = CaptureConfig.from_strategy(
+        required_features=Eagle3TrainStrategy.required_features,
+        aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
+        target_repr=target_repr,
+        target_hidden_size=target_hidden_size,
+        target_vocab_size=target_vocab_size,
+        draft_vocab_size=draft_vocab_size,
+        vocab_map_version=vocab_map_version,
+    )
+    workers = [
+        RolloutWorker(
+            controller,
+            store,
+            adapter,
+            capture,
+            run_id=run_id,
+            worker_id=f"rollout-{i}",
+        )
+        for i in range(num_rollout_workers)
+    ]
+
+    # Queue mode (online consume-once stream). Online features arrive from the
+    # adapter already in train form (input_ids/attention_mask/loss_mask/
+    # hidden_state/target), so there is no per_sample_transform (unlike offline).
+    def _cat_collate(feats):
+        # Concatenate per-sample features along the batch dim. The offline
+        # ``DataCollatorWithPadding`` assumes 2D (B,n) inputs and would choke on
+        # the 3D hidden_state/target tensors; online features are pre-formed, so
+        # a plain cat is correct for equal-length / batch_size=1 batches (the
+        # adapter already groups equal-length prompts). Variable-length padded
+        # batching is a follow-up; pass ``collate_fn`` to override.
+        return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
+
+    loader = FeatureDataLoader(
+        store,
+        controller.sample_queue,
+        batch_size=batch_size,
+        collate_fn=collate_fn or _cat_collate,
+        drop_last=True,
+        strategy="eagle3",
+    )
+
+    parallel = ParallelConfig.from_distributed(
+        tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
+    )
+    backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
+    wrapped = backend.prepare_model(
+        eagle3_model, optimizer_target=eagle3_model.draft_model
+    )
+    strategy = Eagle3TrainStrategy(wrapped, target_head=None)
+    core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
+    trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
+    trainer = TrainerController(
+        core,
+        run_id=run_id,
+        output_dir=output_dir,
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+        save_interval=save_interval,
+        eval_interval=eval_interval,
+        logger=logger,
+        ack_fn=lambda ids, step: controller.ack_train_refs(
+            trainer_id, ids, global_step=step, optimizer_durable=True
+        ),
+    )
+
+    def drive_rollout(max_rounds: int = 100_000) -> int:
+        """Run the workers until the prompt pool drains; returns refs produced."""
+        for w in workers:
+            w.start()
+        produced = 0
+        lease = max(batch_size * 8, 8)
+        for _ in range(max_rounds):
+            got = sum(len(w.run_once(max_tasks=lease)) for w in workers)
+            if got == 0:
+                break
+            produced += got
+        return produced
+
+    return trainer, loader, workers, controller, drive_rollout
+
+
 # Backward-compatible alias for early branch users.
 build_offline_eagle3_controller = build_offline_eagle3_runtime
 
 
-__all__ = ["build_offline_eagle3_controller", "build_offline_eagle3_runtime"]
+__all__ = [
+    "build_offline_eagle3_controller",
+    "build_offline_eagle3_runtime",
+    "build_online_eagle3_runtime",
+]

--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Launch helpers that wire the DataFlow runtime from a RunConfig.
+
+The training *script* becomes a thin launcher: it parses args, calls one of
+these builders, and runs ``TrainerController.fit``. All training logic lives in
+the runtime components, not the script. This module wires the **offline EAGLE3**
+path end to end:
+
+    OfflineManifestReader -> DataFlowController -> SampleRefQueue
+        -> FeatureDataLoader(process_data, DataCollatorWithPadding)
+        -> TrainBatch -> Eagle3TrainStrategy -> TrainerCore/Controller -> FSDP
+
+Online wiring (RolloutWorker + SGLangAdapter) composes the same control/data
+plane; see ``inference/`` for the equivalent assembly.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from specforge.runtime.control_plane import DataFlowController
+from specforge.runtime.data_plane import (
+    FeatureDataLoader,
+    LocalFeatureStore,
+    OfflineManifestReader,
+)
+from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
+from specforge.runtime.training.strategy import Eagle3TrainStrategy
+from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+
+def build_offline_eagle3_runtime(
+    *,
+    hidden_states_path: str,
+    eagle3_model,
+    target_head,
+    optimizer_factory,
+    run_id: str,
+    output_dir: str,
+    ttt_length: int = 7,
+    max_len: int = 2048,
+    batch_size: int = 1,
+    accumulation_steps: int = 1,
+    num_epochs: int = 1,
+    max_steps: Optional[int] = None,
+    save_interval: int = 0,
+    eval_interval: int = 0,
+    tp_size: int = 1,
+    sp_ulysses_size: int = 1,
+    sp_ring_size: int = 1,
+    logger=None,
+):
+    """Assemble the offline-EAGLE3 dataflow and return (trainer, loader).
+
+    ``optimizer_factory(draft_module) -> optimizer`` is invoked AFTER the model is
+    FSDP-wrapped, over the wrapped module's inner draft, so the optimizer owns the
+    FSDP-managed parameters.
+    """
+    from specforge.data.preprocessing import OfflineEagle3Dataset
+    from specforge.data.utils import DataCollatorWithPadding
+
+    controller = DataFlowController(run_id)
+    refs = OfflineManifestReader(
+        hidden_states_path,
+        run_id=run_id,
+        ttt_length=ttt_length,
+        max_len=max_len,
+        target_repr="hidden_state",
+    ).read()
+    controller.enqueue_offline_refs(refs)  # record committed state (enables ack lookup)
+    store = LocalFeatureStore(run_id)
+    trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
+    # Offline = a fixed, re-iterable ref set (so num_epochs > 1 actually trains
+    # multiple epochs). The trainer acks at the optimizer-step boundary via ack_fn.
+    loader = FeatureDataLoader(
+        store,
+        refs=refs,
+        batch_size=batch_size,
+        collate_fn=DataCollatorWithPadding(),
+        per_sample_transform=lambda raw: OfflineEagle3Dataset.process_data(
+            raw, max_len
+        ),
+        drop_last=True,
+        strategy="eagle3",
+    )
+
+    parallel = ParallelConfig.from_distributed(
+        tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
+    )
+    backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
+    # FSDP-wrap the composite model and build the optimizer over the inner draft
+    # AFTER wrapping; the strategy MUST run forward through the wrapped module so
+    # FSDP is actually in the forward/backward path (not bypassed at >1 rank).
+    wrapped = backend.prepare_model(
+        eagle3_model, optimizer_target=eagle3_model.draft_model
+    )
+    strategy = Eagle3TrainStrategy(wrapped, target_head=target_head)
+    core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
+    trainer = TrainerController(
+        core,
+        run_id=run_id,
+        output_dir=output_dir,
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+        save_interval=save_interval,
+        eval_interval=eval_interval,
+        logger=logger,
+        ack_fn=lambda ids, step: controller.ack_train_refs(
+            trainer_id, ids, global_step=step, optimizer_durable=True
+        ),
+    )
+    return trainer, loader
+
+
+# Backward-compatible alias for early branch users.
+build_offline_eagle3_controller = build_offline_eagle3_runtime
+
+
+__all__ = ["build_offline_eagle3_controller", "build_offline_eagle3_runtime"]

--- a/specforge/runtime/training/DESIGN.md
+++ b/specforge/runtime/training/DESIGN.md
@@ -1,0 +1,49 @@
+# Training Plane Design (PR 6/7 — `runtime/training`)
+
+This is the design note for the **training**, scoped to this plane.
+The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
+`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
+plane exchanges are in [`../contracts.py`](../contracts.py).
+
+## Responsibility
+
+Owns the trainer-boundary split that turns a normalized, tensor-carrying TrainBatch into optimizer steps and checkpoints. Layered as: TrainerController (lifecycle: fit/evaluate/save_checkpoint, epoch loop, optimizer-step counting, durable ack at grad-accum boundary) -> TrainerCore (exactly one branch-free train/eval step + grad-accumulation/optimizer boundary) -> DraftTrainStrategy (per-draft-model required-feature validation, forward/loss, target projection ownership, checkpoint key filtering) and TrainingBackend (model wrap / backward / optimizer step + distributed grad-norm reduction / state_dict). The plane is the ONLY tensor-carrying side besides the data plane (consumes TrainBatch.tensors). Strategy differs per draft model (EAGLE3 TTT vs DFlash block-parallel); controller/core/backend/checkpoint are shared unchanged. Submodules import SpecForge model code so they are imported explicitly by training entry points, not at specforge.runtime package load, keeping the control/data plane importable without a GPU. Note: the module docstrings still reference a not-yet-implemented weight-publication / serving accept-length gate as future work; save_checkpoint only persists training state and returns a resume-target Checkpoint.
+
+## Internal mechanics
+
+```mermaid
+flowchart TD
+  classDef compute fill:#e6f6ea,stroke:#3bb061,color:#0b4a22;
+  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
+
+  FIT[TrainerController fit epoch loop] -->|for batch in loader| TS[TrainerCore train_step]
+  FIT -->|append sample_ids| PA[pending_ack accumulator]
+  TS -->|forward_loss| ST[DraftTrainStrategy projection plus loss]
+  TS -->|backward| BK[FSDPTrainingBackend]
+  TS -->|step at accum boundary| BK
+  TS -->|StepResult optimizer_stepped| FIT
+  FIT -->|on boundary global_step plus 1| BND[boundary actions]
+  BND -->|ack_fn ids step| ACK[ack_train_refs durable]
+  BND -->|save_interval| CKPT[save_checkpoint rank0]
+  CKPT -->|checkpoint_state_filter| ST
+  CKPT -->|state_dict FULL| BK
+
+  class FIT,TS,ST,BK,BND,PA,CKPT compute;
+  class ACK control;
+```
+
+The training plane is the only tensor-carrying side besides the data plane; it consumes `TrainBatch.tensors`. `TrainerCore` executes exactly one branch-free step: `train_step` calls `strategy.forward_loss`, divides the loss by `accumulation_steps`, calls `backend.backward`, increments `self._micro`, and only at the boundary (`self._micro % self.accumulation_steps == 0`) calls `backend.step()` for the grad-norm — `optimizer_stepped` in the returned `StepResult` is the single authoritative boundary signal, and `_scalar` ensures no live tensor leaks out. `TrainerController` owns the lifecycle: `global_step` counts optimizer steps only, and it maintains a `pending_ack` accumulator of `batch.sample_ids` that is flushed via `ack_fn(pending_ack, global_step)` as one durable transaction exactly at each boundary, then cleared. The model-specific work lives in `DraftTrainStrategy`: `validate_batch` fail-fasts on missing `required_features`, and the strategy — not the core — owns the target projection (`Eagle3TrainStrategy._prepare_target` re-runs the frozen `TargetHead` for `target_repr=='hidden_state'`, computes the decayed per-position TTT loss) and `checkpoint_state_filter` (keep `draft_model.*`, strip prefix, drop `embed`). `FSDPTrainingBackend` carries the parallel layout via `ParallelConfig.from_distributed` (handles snapshotted, never re-derived), FSDP-wraps with `use_orig_params=True`/bf16, performs the optimizer step plus a distributed L2 grad-norm all-reduce, and produces a `FULL_STATE_DICT`. `save_checkpoint` writes training state on rank0 only and returns a resume-target `Checkpoint` — not a published weight version.
+
+## Endpoints
+
+### What this plane calls into
+
+| From | Endpoint | Plane |
+|---|---|---|
+| `TrainerController` | `FeatureDataLoader.__iter__` | compute |
+| `TrainerController` | `TrainerCore.train_step` | compute |
+| `TrainerController` | `TrainerCore.eval_step` | compute |
+| `TrainerController` | `DataFlowController.ack_train_refs` | control |
+| `TrainerCore` | `Eagle3TrainStrategy.forward_loss` | compute |
+| `TrainerCore` | `FSDPTrainingBackend.backward` | compute |
+| `TrainerCore` | `FSDPTrainingBackend.step` | compute |

--- a/specforge/runtime/training/__init__.py
+++ b/specforge/runtime/training/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+"""Training plane: trainer boundary split (controller / core / strategy / backend).
+
+Submodules import ``torch`` (and, in the backend, ``specforge.distributed`` /
+``yunchang`` lazily) and operate on built SpecForge model objects passed in by
+the caller, so they are imported explicitly by training entry points rather than
+at package load (keeps the control/data plane importable without a GPU/model
+environment).
+"""

--- a/specforge/runtime/training/__init__.py
+++ b/specforge/runtime/training/__init__.py
@@ -1,9 +1,7 @@
 # coding=utf-8
 """Training plane: trainer boundary split (controller / core / strategy / backend).
 
-Submodules import ``torch`` (and, in the backend, ``specforge.distributed`` /
-``yunchang`` lazily) and operate on built SpecForge model objects passed in by
-the caller, so they are imported explicitly by training entry points rather than
-at package load (keeps the control/data plane importable without a GPU/model
-environment).
+Submodules import the SpecForge model code, so they are imported explicitly by
+callers rather than at package load (keeps the control/data plane importable
+without a GPU/model environment).
 """

--- a/specforge/runtime/training/backend.py
+++ b/specforge/runtime/training/backend.py
@@ -1,0 +1,248 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""TrainingBackend: model wrapping / backward / optimizer step / state dict.
+
+Currently implements ``FSDPTrainingBackend`` only. It carries a ``ParallelConfig``
+object (the device-mesh / parallel-group handles) rather than a bare FSDP
+module, so the existing FSDP + TP + Ulysses/Ring SP setup is preserved exactly.
+The backend does not re-derive parallelism — it reads the handles SpecForge's
+``init_distributed`` already created.
+
+``torch`` is imported at module load (fine without a GPU); ``specforge.distributed``
+and ``yunchang`` are imported lazily inside ``ParallelConfig.from_distributed`` so
+this module stays importable in a CPU-only environment.
+"""
+
+from __future__ import annotations
+
+import abc
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+
+@dataclass
+class ParallelConfig:
+    """Handles describing the active parallel layout. Carried, not re-derived."""
+
+    world_size: int = 1
+    tp_size: int = 1
+    sp_ulysses_size: int = 1
+    sp_ring_size: int = 1
+    sharding_strategy: str = "SHARD_GRAD_OP"
+    param_dtype: torch.dtype = torch.bfloat16
+    # opaque process-group / device-mesh handles (None in single-process).
+    # The full set is carried so TP + Ulysses/Ring SP survive the trainer split
+    # and a later reshard step has real handles to read — the parallelism is
+    # NOT re-derived here, only snapshotted from init_distributed.
+    fsdp_process_group: Any = None
+    dp_group: Any = None
+    draft_dp_group: Any = None
+    tp_group: Any = None
+    sp_ulysses_group: Any = None
+    sp_ring_group: Any = None
+    draft_sp_group: Any = None
+    device_mesh: Any = None
+    tp_device_mesh: Any = None
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def sp_size(self) -> int:
+        return self.sp_ulysses_size * self.sp_ring_size
+
+    @classmethod
+    def from_distributed(
+        cls,
+        *,
+        tp_size: int = 1,
+        sp_ulysses_size: int = 1,
+        sp_ring_size: int = 1,
+        sharding_strategy: str = "SHARD_GRAD_OP",
+        param_dtype: torch.dtype = torch.bfloat16,
+    ) -> "ParallelConfig":
+        """Snapshot ALL parallel handles created by ``init_distributed``.
+
+        Captures the TP group + the Ulysses/Ring SP groups + both device meshes,
+        not just DP — so the backend genuinely carries the parallel layout. A
+        getter that is unexpectedly missing is logged, not silently swallowed.
+        """
+        if not dist.is_initialized():
+            return cls(
+                world_size=1,
+                tp_size=tp_size,
+                sp_ulysses_size=sp_ulysses_size,
+                sp_ring_size=sp_ring_size,
+                sharding_strategy=sharding_strategy,
+                param_dtype=param_dtype,
+            )
+        handles: Dict[str, Any] = {}
+        try:
+            from specforge import distributed as sfdist
+
+            for name, getter in (
+                ("dp_group", "get_dp_group"),
+                ("draft_dp_group", "get_draft_dp_group"),
+                ("tp_group", "get_tp_group"),
+                ("sp_ulysses_group", "get_sp_ulysses_group"),
+                ("sp_ring_group", "get_sp_ring_group"),
+                ("draft_sp_group", "get_draft_sp_group"),
+                ("device_mesh", "get_device_mesh"),
+                ("tp_device_mesh", "get_tp_device_mesh"),
+            ):
+                fn = getattr(sfdist, getter, None)
+                if fn is None:
+                    continue
+                try:
+                    handles[name] = fn()
+                except Exception as exc:  # group not built for this config
+                    logging.getLogger(__name__).warning(
+                        "ParallelConfig.from_distributed: %s() unavailable: %s",
+                        getter,
+                        exc,
+                    )
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "ParallelConfig.from_distributed: specforge.distributed import failed: %s",
+                exc,
+            )
+        return cls(
+            world_size=dist.get_world_size(),
+            tp_size=tp_size,
+            sp_ulysses_size=sp_ulysses_size,
+            sp_ring_size=sp_ring_size,
+            sharding_strategy=sharding_strategy,
+            param_dtype=param_dtype,
+            fsdp_process_group=dist.group.WORLD,
+            **handles,
+        )
+
+
+class TrainingBackend(abc.ABC):
+    name: str
+
+    @abc.abstractmethod
+    def prepare_model(self, model: nn.Module) -> nn.Module: ...
+
+    @abc.abstractmethod
+    def backward(self, loss: torch.Tensor) -> None: ...
+
+    @abc.abstractmethod
+    def step(self) -> Optional[torch.Tensor]: ...
+
+    @abc.abstractmethod
+    def state_dict(self) -> dict: ...
+
+    @abc.abstractmethod
+    def load_state_dict(self, state: dict) -> None: ...
+
+
+class FSDPTrainingBackend(TrainingBackend):
+    """FSDP1 backend mirroring today's SpecForge training math.
+
+    Wraps the composite module (e.g. ``OnlineEagle3Model``) in FSDP with
+    ``use_orig_params=True`` / bf16 mixed precision / ``SHARD_GRAD_OP`` over the
+    configured process group, while the optimizer targets the inner trainable
+    submodule (the draft model) — exactly as the legacy script.
+    """
+
+    name = "fsdp"
+
+    def __init__(
+        self,
+        parallel_config: ParallelConfig,
+        *,
+        optimizer_factory=None,
+    ) -> None:
+        self.parallel_config = parallel_config
+        self._optimizer_factory = optimizer_factory
+        self.module: Optional[nn.Module] = None
+        self.optimizer = None
+        self._wrapped = False
+
+    def prepare_model(
+        self,
+        model: nn.Module,
+        *,
+        wrap: bool = True,
+        optimizer_target: Optional[nn.Module] = None,
+    ) -> nn.Module:
+        """Register the trainable module, FSDP-wrapping it unless ``wrap=False``.
+
+        ``wrap=False`` registers the module without sharding (single-rank /
+        equivalence runs where FSDP would be a no-op) so ``state_dict`` and
+        ``step`` still work without changing the math.
+        """
+        if not wrap:
+            self.module = model
+            self._wrapped = False
+        else:
+            from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+            from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
+
+            pc = self.parallel_config
+            sharding = getattr(ShardingStrategy, pc.sharding_strategy)
+            model = FSDP(
+                model,
+                use_orig_params=True,
+                mixed_precision=MixedPrecision(
+                    param_dtype=pc.param_dtype, buffer_dtype=pc.param_dtype
+                ),
+                sharding_strategy=sharding,
+                process_group=pc.fsdp_process_group,
+            )
+            self.module = model
+            self._wrapped = True
+        if self._optimizer_factory is not None:
+            target = optimizer_target if optimizer_target is not None else self.module
+            self.optimizer = self._optimizer_factory(target)
+        return self.module
+
+    def set_optimizer(self, optimizer) -> None:
+        self.optimizer = optimizer
+
+    def backward(self, loss: torch.Tensor) -> None:
+        loss.backward()
+
+    def step(self) -> Optional[torch.Tensor]:
+        """Optimizer step + the distributed grad-norm reduction (run_backward_and_update)."""
+        if self.optimizer is None:
+            raise RuntimeError(
+                "FSDPTrainingBackend.step called before optimizer is set"
+            )
+        grad_norm = self.optimizer.step()
+        if grad_norm is not None and dist.is_initialized():
+            grad_norm = grad_norm.detach().float()
+            if torch.cuda.is_available():
+                grad_norm = grad_norm.to(torch.cuda.current_device())
+            grad_norm = grad_norm.pow(2)
+            dist.all_reduce(grad_norm, op=dist.ReduceOp.SUM)
+            grad_norm = grad_norm.sqrt()
+        return grad_norm
+
+    def state_dict(self) -> dict:
+        if self.module is None:
+            raise RuntimeError("state_dict called before prepare_model")
+        if not self._wrapped:
+            return self.module.state_dict()
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+        from torch.distributed.fsdp import StateDictType
+
+        with FSDP.state_dict_type(self.module, StateDictType.FULL_STATE_DICT):
+            return self.module.state_dict()
+
+    def load_state_dict(self, state: dict) -> None:
+        if self.optimizer is not None and "optimizer_state_dict" in state:
+            self.optimizer.load_state_dict(state)
+
+
+__all__ = ["ParallelConfig", "TrainingBackend", "FSDPTrainingBackend"]

--- a/specforge/runtime/training/strategy.py
+++ b/specforge/runtime/training/strategy.py
@@ -14,9 +14,8 @@ A strategy is the only place that knows how a particular draft model
 on online/offline — the strategy owns the target projection (applying
 ``TargetHead`` / the ``t2d`` vocab map).
 
-This module imports ``torch`` and is constructed with already-built SpecForge
-model objects (the draft model is injected, not imported here), so it is imported
-by training entry points rather than at ``specforge.runtime`` package load.
+This module imports the SpecForge model code, so it is imported by training
+entry points, not at ``specforge.runtime`` package load.
 """
 
 from __future__ import annotations

--- a/specforge/runtime/training/strategy.py
+++ b/specforge/runtime/training/strategy.py
@@ -1,0 +1,232 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DraftTrainStrategy: per-draft-model required features + forward/loss + projection.
+
+A strategy is the only place that knows how a particular draft model
+(EAGLE3 / DFlash) turns a normalized ``TrainBatch`` into a loss. The
+``TrainerCore`` stays branch-free: it never inspects ``target_repr`` or branches
+on online/offline — the strategy owns the target projection (applying
+``TargetHead`` / the ``t2d`` vocab map).
+
+This module imports ``torch`` and is constructed with already-built SpecForge
+model objects (the draft model is injected, not imported here), so it is imported
+by training entry points rather than at ``specforge.runtime`` package load.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import TrainBatch
+
+
+@dataclass(frozen=True)
+class StepOutput:
+    """Opaque per-step result a strategy hands back for metric aggregation.
+
+    Kept generic so a TTT strategy (per-position lists) and a single-scalar
+    strategy (DFlash) share one trainer loop.
+    """
+
+    loss: torch.Tensor
+    metrics: Dict[str, Any]
+
+
+class DraftTrainStrategy(abc.ABC):
+    name: str
+    required_features: set
+
+    @abc.abstractmethod
+    def trainable_module(self) -> nn.Module:
+        """The module whose parameters the optimizer/backend owns."""
+
+    def validate_batch(self, batch: TrainBatch) -> None:
+        missing = {f for f in self.required_features if f not in batch.tensors}
+        if missing:
+            raise ValueError(
+                f"{self.name} batch missing required features {sorted(missing)}; "
+                f"present={sorted(batch.tensors)}"
+            )
+
+    @abc.abstractmethod
+    def forward_loss(self, batch: TrainBatch) -> StepOutput: ...
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """Select the keys this strategy persists as draft weights."""
+        return state_dict
+
+
+class Eagle3TrainStrategy(DraftTrainStrategy):
+    """EAGLE3 TTT strategy wrapping the existing ``OnlineEagle3Model``.
+
+    Projection ownership: for ``target_repr == "hidden_state"`` the
+    strategy re-runs the frozen ``TargetHead`` (lm_head) over the stored target
+    last hidden state — exactly today's offline ``run_forward``. For
+    ``logits`` / ``pruned_logits`` the rollout already produced the distribution
+    and the strategy uses ``target`` as-is. The ``t2d`` vocab map is then applied
+    inside ``OnlineEagle3Model.forward`` (unchanged math).
+    """
+
+    name = "eagle3"
+    required_features = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+
+    def __init__(
+        self,
+        eagle3_model: nn.Module,
+        *,
+        target_head: Optional[nn.Module] = None,
+        ploss_decay: float = 0.8,
+    ) -> None:
+        self.eagle3_model = eagle3_model
+        self.target_head = target_head
+        self.ploss_decay = ploss_decay
+
+    def trainable_module(self) -> nn.Module:
+        return self.eagle3_model
+
+    def _device(self) -> torch.device:
+        return next(self.eagle3_model.parameters()).device
+
+    def _prepare_target(
+        self,
+        target_repr: Optional[str],
+        input_ids: torch.Tensor,
+        target: torch.Tensor,
+        loss_mask: torch.Tensor,
+        device: torch.device,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if target_repr == "hidden_state":
+            if self.target_head is None:
+                raise ValueError(
+                    "target_repr='hidden_state' requires a target_head to re-run "
+                    "the lm_head projection"
+                )
+            # mirrors offline run_forward: shift input_ids/target, add mask dim,
+            # then project the target last hidden state to full-vocab logits.
+            input_ids, target, loss_mask = self.target_head.preprocess(
+                input_ids, target, loss_mask
+            )
+            target = self.target_head(target.to(device))
+            return input_ids.to(device), target, loss_mask.to(device)
+        # logits / pruned_logits: rollout already produced the distribution and
+        # applied any shift; use the tensors as delivered.
+        return input_ids.to(device), target.to(device), loss_mask.to(device)
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        t = batch.tensors
+        device = self._device()
+        target_repr = batch.metadata.get("target_repr")
+
+        input_ids, target, loss_mask = self._prepare_target(
+            target_repr, t["input_ids"], t["target"], t["loss_mask"], device
+        )
+        position_ids = t.get("position_ids")
+        (
+            plosses,
+            acceptance_rates,
+            acces,
+            acc_corrects,
+            acc_denoms,
+            metric_losses,
+            metric_loss_denoms,
+        ) = self.eagle3_model(
+            input_ids=input_ids,
+            attention_mask=t["attention_mask"].to(device),
+            loss_mask=loss_mask,
+            target=target,
+            hidden_states=t["hidden_state"].to(device),
+            position_ids=position_ids.to(device) if position_ids is not None else None,
+        )
+        weights = [self.ploss_decay**i for i in range(len(plosses))]
+        loss = sum(weights[i] * plosses[i] for i in range(len(plosses)))
+        return StepOutput(
+            loss=loss,
+            metrics={
+                "plosses": [p.detach() for p in plosses],
+                "acces": [a.detach() for a in acces],
+                "acceptance_rates": [a.detach() for a in acceptance_rates],
+                "acc_corrects": [c.detach() for c in acc_corrects],
+                "acc_denoms": [d.detach() for d in acc_denoms],
+                "metric_losses": [m.detach() for m in metric_losses],
+                "metric_loss_denoms": [d.detach() for d in metric_loss_denoms],
+            },
+        )
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # EAGLE3 owns a frozen embedding loaded from the target; do not persist it.
+        return {
+            k.replace("draft_model.", ""): v
+            for k, v in state_dict.items()
+            if "draft_model." in k and "embed" not in k.lower()
+        }
+
+
+class DFlashTrainStrategy(DraftTrainStrategy):
+    """DFlash block-parallel strategy wrapping the existing ``OnlineDFlashModel``.
+
+    Shares ``TrainerController`` / ``FSDPTrainingBackend`` / ``FeatureDataLoader``
+    / checkpoint with EAGLE3 — only the per-step forward/loss differs (a single
+    block-wise pass returning a scalar loss, vs EAGLE3's TTT unroll). DFlash uses
+    hard real-token labels + a separately-loaded target lm_head, so it needs no
+    target distribution and no vocab map. Schema names are DFlash's own (not
+    overloaded onto EAGLE3 names): ``hidden_states`` is the captured target
+    context, distinct from EAGLE3's ``hidden_state``.
+    """
+
+    name = "dflash"
+    required_features = {"input_ids", "hidden_states", "loss_mask"}
+
+    def __init__(self, dflash_model: nn.Module) -> None:
+        self.dflash_model = dflash_model
+
+    def trainable_module(self) -> nn.Module:
+        return self.dflash_model
+
+    def _device(self) -> torch.device:
+        return next(self.dflash_model.parameters()).device
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        t = batch.tensors
+        device = self._device()
+        loss, accuracy = self.dflash_model(
+            input_ids=t["input_ids"].to(device),
+            hidden_states=t["hidden_states"].to(device),
+            loss_mask=t["loss_mask"].to(device),
+        )
+        return StepOutput(loss=loss, metrics={"accuracy": accuracy.detach()})
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # DFlash keeps everything under draft_model.; the embedding/head live in
+        # a separate target module that is NOT persisted as draft weights.
+        return {
+            k.replace("draft_model.", ""): v
+            for k, v in state_dict.items()
+            if "draft_model." in k
+        }
+
+
+__all__ = [
+    "DraftTrainStrategy",
+    "Eagle3TrainStrategy",
+    "DFlashTrainStrategy",
+    "StepOutput",
+]

--- a/specforge/runtime/training/trainer.py
+++ b/specforge/runtime/training/trainer.py
@@ -1,0 +1,271 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""TrainerCore + TrainerController: the trainer-boundary split.
+
+* ``TrainerCore`` owns exactly one train/eval step plus the grad-accumulation and
+  optimizer boundary. It is **branch-free**: it never inspects online/offline or
+  ``target_repr`` and never applies a projection — that is the strategy's job. It
+  consumes a normalized ``TrainBatch`` and delegates the forward/loss to the
+  strategy and the backward/step to the backend.
+* ``TrainerController`` owns the lifecycle: ``fit`` / ``evaluate`` /
+  ``save_checkpoint`` / weight publication. The training *script* becomes a thin
+  launcher that builds these and calls ``fit``.
+
+EAGLE3 and DFlash share this lifecycle unchanged — only the strategy differs.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import TrainBatch
+from specforge.runtime.training.backend import TrainingBackend
+from specforge.runtime.training.strategy import DraftTrainStrategy, StepOutput
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """A saved training checkpoint location (resume target).
+
+    Deliberately NOT a published "weight version" — the published-weight
+    lifecycle (versioning, publisher, serving accept-length gate, hot update) is
+    not yet implemented. This record only says where a checkpoint is and at what
+    step.
+    """
+
+    checkpoint_uri: str
+    global_step: int
+    epoch: int
+    strategy: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Result of one TrainerCore step.
+
+    ``optimizer_stepped`` is the authoritative grad-accumulation boundary signal —
+    callers branch on it rather than sniffing the metrics dict.
+    """
+
+    optimizer_stepped: bool
+    loss: float
+    grad_norm: Optional[float]
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+
+# strategy metric name -> reported metric name. EAGLE3's per-position ``acces``
+# and DFlash's scalar ``accuracy`` both report as ``acc`` so downstream logging
+# stays strategy-agnostic; the rest pass through unchanged.
+_METRIC_NAMES = {
+    "acces": "acc",
+    "acceptance_rates": "acceptance_rates",
+    "plosses": "plosses",
+    "accuracy": "acc",
+}
+
+
+def _scalar(x: Any) -> float:
+    if isinstance(x, torch.Tensor):
+        return float(x.detach().float().mean().item())
+    if isinstance(x, (list, tuple)):
+        if not x:
+            return 0.0
+        return float(torch.stack([t.detach().float() for t in x]).mean().item())
+    return float(x)
+
+
+class TrainerCore:
+    """One step: forward/loss (strategy) -> backward (backend) -> optimizer boundary."""
+
+    def __init__(
+        self,
+        strategy: DraftTrainStrategy,
+        backend: TrainingBackend,
+        *,
+        accumulation_steps: int = 1,
+    ) -> None:
+        self.strategy = strategy
+        self.backend = backend
+        self.accumulation_steps = max(1, accumulation_steps)
+        self._micro = 0
+
+    def train_step(self, batch: TrainBatch) -> StepResult:
+        out: StepOutput = self.strategy.forward_loss(batch)
+        loss = out.loss / self.accumulation_steps
+        self.backend.backward(loss)
+        self._micro += 1
+        grad_norm = None
+        stepped = self._micro % self.accumulation_steps == 0
+        if stepped:
+            grad_norm = self.backend.step()
+        return self._result(out, grad_norm, stepped, mode="train")
+
+    @torch.no_grad()
+    def eval_step(self, batch: TrainBatch) -> StepResult:
+        out: StepOutput = self.strategy.forward_loss(batch)
+        return self._result(out, None, False, mode="eval")
+
+    def _result(
+        self, out: StepOutput, grad_norm, stepped: bool, mode: str
+    ) -> StepResult:
+        metrics: Dict[str, Any] = {"loss": _scalar(out.loss), "mode": mode}
+        for src, dst in _METRIC_NAMES.items():
+            if src in out.metrics:
+                metrics[dst] = _scalar(out.metrics[src])
+        gn = _scalar(grad_norm) if grad_norm is not None else None
+        if gn is not None:
+            metrics["grad_norm"] = gn
+        return StepResult(
+            optimizer_stepped=stepped,
+            loss=metrics["loss"],
+            grad_norm=gn,
+            metrics=metrics,
+        )
+
+
+class TrainerController:
+    """Lifecycle: fit / evaluate / checkpoint. Script becomes a launcher.
+
+    Weight publishing + the serving accept-length gate are not yet implemented;
+    save_checkpoint just persists training state and returns a Checkpoint.
+    """
+
+    def __init__(
+        self,
+        core: TrainerCore,
+        *,
+        run_id: str,
+        output_dir: str = "./output",
+        save_interval: int = 0,
+        eval_interval: int = 0,
+        log_interval: int = 50,
+        max_steps: Optional[int] = None,
+        num_epochs: int = 1,
+        logger: Optional[Callable[[Dict[str, Any], int], None]] = None,
+        ack_fn: Optional[Callable[[List[str], int], None]] = None,
+        start_step: int = 0,
+        start_epoch: int = 0,
+    ) -> None:
+        self.core = core
+        self.run_id = run_id
+        self.output_dir = output_dir
+        self.save_interval = save_interval
+        self.eval_interval = eval_interval
+        self.log_interval = log_interval
+        self.max_steps = max_steps
+        self.num_epochs = num_epochs
+        self.logger = logger
+        # ack_fn(sample_ids, global_step): acks consumed refs at the optimizer-step
+        # boundary with the step number, so the controller records the durable
+        # {acked, global_step, optimizer marker} transaction. If None, the loader
+        # is assumed to ack (e.g. simple/equivalence runs).
+        self.ack_fn = ack_fn
+        # global_step counts OPTIMIZER steps (increments only at a grad-accum
+        # boundary), so ack / checkpoint / resume semantics are in true optimizer
+        # steps. micro_step counts forward/backward micro-batches.
+        self.global_step = start_step
+        self.micro_step = 0
+        self.epoch = start_epoch
+        self.last_metrics: Dict[str, Any] = {}
+
+    def fit(
+        self, data: Iterable[TrainBatch], eval_data: Optional[Iterable] = None
+    ) -> int:
+        module = self.core.strategy.trainable_module()
+        module.train()
+        pending_ack: List[str] = []
+        for epoch in range(self.epoch, self.num_epochs):
+            self.epoch = epoch
+            if hasattr(data, "set_epoch"):
+                data.set_epoch(epoch)
+            for batch in data:
+                self.micro_step += 1
+                if self.ack_fn is not None:
+                    pending_ack.extend(batch.sample_ids)
+                result = self.core.train_step(batch)
+                self.last_metrics = result.metrics
+                # grad accumulated but optimizer has not stepped yet; everything
+                # keyed on optimizer steps fires only at the boundary.
+                if not result.optimizer_stepped:
+                    continue
+                self.global_step += 1
+                if self.ack_fn is not None:
+                    # durable ack transaction at the optimizer-step boundary
+                    self.ack_fn(pending_ack, self.global_step)
+                    pending_ack = []
+                if self.logger and self.global_step % max(1, self.log_interval) == 0:
+                    self.logger(result.metrics, self.global_step)
+                if (
+                    self.eval_interval
+                    and eval_data is not None
+                    and self.global_step % self.eval_interval == 0
+                ):
+                    self.evaluate(eval_data)
+                    module.train()
+                if self.save_interval and self.global_step % self.save_interval == 0:
+                    self.save_checkpoint(self.global_step)
+                if self.max_steps is not None and self.global_step >= self.max_steps:
+                    return self.global_step
+        # NOTE: a partial accumulation window at end-of-data (or when max_steps cuts
+        # mid-window) leaves the trailing micro-batches' grads un-stepped and their
+        # sample_ids in pending_ack un-flushed — those leases simply expire and are
+        # re-leased on resume (at-least-once), never double-counted into an
+        # optimizer step. Standard grad-accum behavior; called out so it is not
+        # mistaken for a dropped-ack bug.
+        return self.global_step
+
+    @torch.no_grad()
+    def evaluate(self, data: Iterable[TrainBatch]) -> Dict[str, float]:
+        module = self.core.strategy.trainable_module()
+        module.eval()
+        agg: Dict[str, list] = {}
+        n = 0
+        for batch in data:
+            rep = self.core.eval_step(batch)
+            n += 1
+            for k, v in rep.metrics.items():
+                if isinstance(v, (int, float)):
+                    agg.setdefault(k, []).append(v)
+        return {k: sum(vs) / len(vs) for k, vs in agg.items() if vs}
+
+    def save_checkpoint(self, step: int) -> Checkpoint:
+        ckpt_dir = os.path.join(self.output_dir, f"{self.run_id}-step{step}")
+        is_rank0 = (
+            not torch.distributed.is_initialized()
+        ) or torch.distributed.get_rank() == 0
+        full_state = self.core.backend.state_dict()
+        draft_state = self.core.strategy.checkpoint_state_filter(full_state)
+        if is_rank0:
+            os.makedirs(ckpt_dir, exist_ok=True)
+            torch.save(
+                {
+                    "draft_state_dict": draft_state,
+                    "global_step": step,
+                    "epoch": self.epoch,
+                    "strategy": self.core.strategy.name,
+                    "run_id": self.run_id,
+                },
+                os.path.join(ckpt_dir, "training_state.pt"),
+            )
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        return Checkpoint(
+            checkpoint_uri=f"file://{os.path.abspath(ckpt_dir)}",
+            global_step=step,
+            epoch=self.epoch,
+            strategy=self.core.strategy.name,
+        )
+
+
+__all__ = ["TrainerCore", "TrainerController", "Checkpoint", "StepResult"]

--- a/specforge/runtime/training/trainer.py
+++ b/specforge/runtime/training/trainer.py
@@ -64,23 +64,10 @@ class StepResult:
     metrics: Dict[str, Any] = field(default_factory=dict)
 
 
-# strategy metric name -> reported metric name. EAGLE3's per-position ``acces``
-# and DFlash's scalar ``accuracy`` both report as ``acc`` so downstream logging
-# stays strategy-agnostic; the rest pass through unchanged.
-_METRIC_NAMES = {
-    "acces": "acc",
-    "acceptance_rates": "acceptance_rates",
-    "plosses": "plosses",
-    "accuracy": "acc",
-}
-
-
 def _scalar(x: Any) -> float:
     if isinstance(x, torch.Tensor):
         return float(x.detach().float().mean().item())
-    if isinstance(x, (list, tuple)):
-        if not x:
-            return 0.0
+    if isinstance(x, (list, tuple)) and x:
         return float(torch.stack([t.detach().float() for t in x]).mean().item())
     return float(x)
 
@@ -120,9 +107,13 @@ class TrainerCore:
         self, out: StepOutput, grad_norm, stepped: bool, mode: str
     ) -> StepResult:
         metrics: Dict[str, Any] = {"loss": _scalar(out.loss), "mode": mode}
-        for src, dst in _METRIC_NAMES.items():
-            if src in out.metrics:
-                metrics[dst] = _scalar(out.metrics[src])
+        for key in ("acces", "acceptance_rates", "plosses"):
+            if key in out.metrics:
+                metrics[key.rstrip("es") if key == "acces" else key] = _scalar(
+                    out.metrics[key]
+                )
+        if "accuracy" in out.metrics:
+            metrics["acc"] = _scalar(out.metrics["accuracy"])
         gn = _scalar(grad_norm) if grad_norm is not None else None
         if gn is not None:
             metrics["grad_norm"] = gn
@@ -217,12 +208,6 @@ class TrainerController:
                     self.save_checkpoint(self.global_step)
                 if self.max_steps is not None and self.global_step >= self.max_steps:
                     return self.global_step
-        # NOTE: a partial accumulation window at end-of-data (or when max_steps cuts
-        # mid-window) leaves the trailing micro-batches' grads un-stepped and their
-        # sample_ids in pending_ack un-flushed — those leases simply expire and are
-        # re-leased on resume (at-least-once), never double-counted into an
-        # optimizer step. Standard grad-accum behavior; called out so it is not
-        # mistaken for a dropped-ack bug.
         return self.global_step
 
     @torch.no_grad()

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+"""Shared tiny synthetic fixtures for runtime GPU equivalence tests.
+
+Not a test module (no ``test_`` prefix). Builds a tiny EAGLE3 draft model, a
+``TargetHead``, a vocab mapping, and offline ``.ckpt`` feature files — all from
+random tensors, with NO model download — so the differential-equivalence tests
+compare the old vs new code path on identical inputs/weights.
+"""
+
+import json
+import os
+
+import torch
+
+TINY_DRAFT_CONFIG = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 64,
+    "initializer_range": 0.02,
+    "intermediate_size": 128,
+    "max_position_embeddings": 512,
+    "model_type": "llama",
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "pad_token_id": 0,
+    "rms_norm_eps": 1e-5,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "vocab_size": 256,
+    "draft_vocab_size": 64,
+}
+
+H = 64
+V = 256
+D = 64
+
+
+def build_single_rank_distributed(port="29561"):
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        return
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", port)
+    torch.cuda.set_device(0)
+    from specforge.distributed import init_distributed
+
+    init_distributed(timeout=10, tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
+
+
+def write_draft_config(path):
+    with open(path, "w") as f:
+        json.dump(TINY_DRAFT_CONFIG, f)
+    return path
+
+
+def write_target_head_dir(d, hidden=H, vocab=V):
+    from safetensors.torch import save_file
+
+    os.makedirs(d, exist_ok=True)
+    cfg = {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": hidden,
+        "vocab_size": vocab,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "intermediate_size": 128,
+    }
+    with open(os.path.join(d, "config.json"), "w") as f:
+        json.dump(cfg, f)
+    save_file(
+        {"lm_head.weight": torch.randn(vocab, hidden, dtype=torch.float32)},
+        os.path.join(d, "model.safetensors"),
+    )
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump(
+            {"metadata": {}, "weight_map": {"lm_head.weight": "model.safetensors"}}, f
+        )
+    return d
+
+
+def write_vocab_mapping(path, vocab=V, draft_vocab=D, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    draft_ids = torch.randperm(vocab, generator=g)[:draft_vocab].sort().values
+    t2d = torch.zeros(vocab, dtype=torch.bool)
+    t2d[draft_ids] = True
+    d2t = (draft_ids - torch.arange(draft_vocab)).to(torch.int64)
+    torch.save({"t2d": t2d, "d2t": d2t}, path)
+    return path
+
+
+def write_offline_files(d, n=4, seq=16, hidden=H, vocab=V, seed=0):
+    os.makedirs(d, exist_ok=True)
+    g = torch.Generator().manual_seed(seed)
+    for i in range(n):
+        torch.save(
+            {
+                "input_ids": torch.randint(0, vocab, (seq,), generator=g),
+                "loss_mask": torch.ones(seq, dtype=torch.long),
+                # prepared offline features are bf16 (target ran in bf16)
+                "hidden_state": torch.randn(1, seq, hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+                "aux_hidden_state": torch.randn(1, seq, 3 * hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+            },
+            os.path.join(d, f"{i:04d}.ckpt"),
+        )
+    return d
+
+
+def build_hf_target(workdir, hidden=H, layers=8, vocab=V, aux_layer_ids=(1, 3, 4)):
+    """Build a tiny HF Llama target wrapped by the SpecForge HF eagle3 backend."""
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    from specforge.modeling.target import get_eagle3_target_model
+
+    cfg = LlamaConfig(
+        hidden_size=hidden,
+        intermediate_size=2 * hidden,
+        num_hidden_layers=layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=vocab,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(1234)
+    model = LlamaForCausalLM(cfg)
+    target_dir = os.path.join(workdir, "hf_target")
+    model.save_pretrained(target_dir)
+    target = get_eagle3_target_model(
+        pretrained_model_name_or_path=target_dir,
+        backend="hf",
+        torch_dtype=torch.bfloat16,
+        device="cuda",
+    )
+    target.set_aux_hidden_states_layers(list(aux_layer_ids))
+    return target, target_dir, list(aux_layer_ids)
+
+
+def build_eagle3(workdir, ttt=3):
+    """Build (eagle3_model, target_head) sharing one set of weights, on cuda."""
+    from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
+    from specforge.modeling.target import TargetHead
+
+    cfg = write_draft_config(os.path.join(workdir, "draft.json"))
+    target_dir = write_target_head_dir(os.path.join(workdir, "target"))
+    vocab_path = write_vocab_mapping(os.path.join(workdir, "vocab_mapping.pt"))
+
+    draft_config = AutoDraftModelConfig.from_file(cfg)
+    draft_model = AutoEagle3DraftModel.from_config(
+        draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+    ).cuda()
+    draft_model.load_vocab_mapping(vocab_path)
+    draft_model.freeze_embedding()
+    target_head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+    eagle3_model = OnlineEagle3Model(
+        draft_model=draft_model, length=ttt, attention_backend="flex_attention"
+    ).cuda()
+    return eagle3_model, target_head

--- a/tests/test_runtime/test_capture.py
+++ b/tests/test_runtime/test_capture.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""CaptureConfig assertions, incl. the M4 gate test_capture_layer_mismatch_fails (CPU)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.inference.capture import (
+    CaptureConfig,
+    CaptureMismatchError,
+    verify_capture,
+)
+
+H = 8
+DRAFT_V = 16
+TARGET_V = 64
+
+
+def _capture(layer_ids=(10, 15, 20), target_repr="hidden_state", **kw):
+    return CaptureConfig.from_strategy(
+        required_features={"input_ids", "loss_mask", "hidden_state", "target"},
+        aux_hidden_state_layer_ids=layer_ids,
+        target_repr=target_repr,
+        target_hidden_size=H,
+        target_vocab_size=TARGET_V,
+        draft_vocab_size=DRAFT_V,
+        **kw,
+    )
+
+
+def _good_tensors(target_dim=H):
+    return {
+        "input_ids": torch.zeros(1, 4, dtype=torch.long),
+        "loss_mask": torch.ones(1, 4, dtype=torch.long),
+        "hidden_state": torch.randn(1, 4, 3 * H),  # 3 aux layers * H
+        "target": torch.randn(1, 4, target_dim),
+    }
+
+
+class TestCapture(unittest.TestCase):
+    def test_ok(self):
+        verify_capture(
+            _good_tensors(),
+            _capture(),
+            sample_id="s0",
+            recorded_aux_layer_ids=(10, 15, 20),
+        )
+
+    def test_capture_layer_mismatch_fails(self):
+        """Requested aux layers [10,15,20] vs recorded [10,15,21] -> loud failure."""
+        with self.assertRaises(CaptureMismatchError) as ctx:
+            verify_capture(
+                _good_tensors(),
+                _capture(layer_ids=(10, 15, 20)),
+                sample_id="s0",
+                recorded_aux_layer_ids=(10, 15, 21),
+            )
+        self.assertIn("aux-layer id mismatch", str(ctx.exception))
+
+    def test_missing_feature_fails(self):
+        t = _good_tensors()
+        del t["target"]
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(t, _capture(), sample_id="s0")
+
+    def test_aux_width_mismatch_fails(self):
+        t = _good_tensors()
+        t["hidden_state"] = torch.randn(1, 4, 2 * H)  # only 2 layers' worth
+        with self.assertRaises(CaptureMismatchError) as ctx:
+            verify_capture(t, _capture(), sample_id="s0")
+        self.assertIn("aux width", str(ctx.exception))
+
+    def test_target_dim_mismatch_pruned_logits(self):
+        cap = _capture(target_repr="pruned_logits", vocab_map_version="v1")
+        # pruned_logits expects draft_vocab_size on the last dim
+        ok = _good_tensors(target_dim=DRAFT_V)
+        verify_capture(ok, cap, sample_id="s0")
+        bad = _good_tensors(target_dim=TARGET_V)  # full vocab, wrong for pruned
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(bad, cap, sample_id="s0")
+
+    def test_pruned_logits_requires_vocab_map_version(self):
+        cap = _capture(target_repr="pruned_logits")  # no vocab_map_version
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(_good_tensors(target_dim=DRAFT_V), cap, sample_id="s0")
+
+    def test_logits_expects_full_vocab(self):
+        cap = _capture(target_repr="logits")
+        verify_capture(_good_tensors(target_dim=TARGET_V), cap, sample_id="s0")
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(_good_tensors(target_dim=DRAFT_V), cap, sample_id="s0")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_checkpoint_resume.py
+++ b/tests/test_runtime/test_checkpoint_resume.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""M3 gate: checkpoint save -> resume restores weights and step (single rank).
+
+Trains a few offline steps through the new TrainerController, saves a checkpoint,
+reloads the draft state into a fresh model, and asserts the persisted draft
+weights and global step round-trip exactly.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "checkpoint resume requires CUDA")
+class TestCheckpointResume(unittest.TestCase):
+    def test_checkpoint_resume(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29563")
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import TrainBatch
+        from specforge.runtime.training.backend import (
+            FSDPTrainingBackend,
+            ParallelConfig,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+        from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+        TTT, BS, N = 3, 2, 6
+        workdir = tempfile.mkdtemp(prefix="ckpt_resume_")
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        target_dir = fx.write_target_head_dir(os.path.join(workdir, "target"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=N)
+        out_dir = os.path.join(workdir, "out")
+
+        draft_config = AutoDraftModelConfig.from_file(cfg)
+
+        def build_model():
+            dm = AutoEagle3DraftModel.from_config(
+                draft_config,
+                attention_backend="flex_attention",
+                torch_dtype=torch.bfloat16,
+            ).cuda()
+            dm.load_vocab_mapping(vocab_path)
+            dm.freeze_embedding()
+            return OnlineEagle3Model(
+                dm, length=TTT, attention_backend="flex_attention"
+            ).cuda()
+
+        head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+        ds = OfflineEagle3Dataset(
+            sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)), max_len=512
+        )
+        collate = DataCollatorWithPadding()
+
+        def make_batches():
+            out = []
+            for s in range(0, N, BS):
+                data = collate([ds[j] for j in range(s, s + BS)])
+                out.append(
+                    TrainBatch(
+                        sample_ids=[str(j) for j in range(s, s + BS)],
+                        strategy="eagle3",
+                        tensors=dict(data),
+                        metadata={"target_repr": "hidden_state", "ttt_length": TTT},
+                    )
+                )
+            return out
+
+        model = build_model()
+        opt = BF16Optimizer(
+            model.draft_model,
+            lr=1e-3,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.prepare_model(model, wrap=False)  # register module (no FSDP at 1 rank)
+        backend.set_optimizer(opt)
+        strategy = Eagle3TrainStrategy(model, target_head=head)
+        core = TrainerCore(strategy, backend)
+        ctrl = TrainerController(
+            core, run_id="r", output_dir=out_dir, max_steps=3, num_epochs=2
+        )
+        step = ctrl.fit(make_batches())
+        self.assertEqual(step, 3)
+        wv = ctrl.save_checkpoint(step)
+
+        # reload into a fresh model and compare persisted (non-embedding) weights
+        ckpt = torch.load(
+            os.path.join(wv.checkpoint_uri[len("file://") :], "training_state.pt"),
+            map_location="cpu",
+            weights_only=False,
+        )
+        self.assertEqual(ckpt["global_step"], 3)
+        self.assertEqual(ckpt["strategy"], "eagle3")
+
+        fresh = build_model()
+        missing, unexpected = fresh.draft_model.load_state_dict(
+            ckpt["draft_state_dict"], strict=False
+        )
+        self.assertEqual(unexpected, [])  # all persisted keys belong to the draft
+        # every persisted weight must now match the trained model bit-for-bit
+        trained = strategy.checkpoint_state_filter(backend.state_dict())
+        fresh_sd = fresh.draft_model.state_dict()
+        for k, v in trained.items():
+            self.assertTrue(
+                torch.equal(v.cpu(), fresh_sd[k].cpu()), msg=f"weight {k} mismatch"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_contracts.py
+++ b/tests/test_runtime/test_contracts.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""Contract dataclasses + the no-tensor invariant (CPU-only)."""
+
+import dataclasses
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import (
+    FeatureSpec,
+    PromptTask,
+    SampleRef,
+    TrainBatch,
+    assert_no_tensors,
+)
+
+
+class TestContracts(unittest.TestCase):
+    def _sample_ref(self) -> SampleRef:
+        return SampleRef(
+            sample_id="s0",
+            run_id="r0",
+            source_task_id=None,
+            feature_store_uri="mem://x/s0",
+            feature_keys={"input_ids": "s0/input_ids"},
+            feature_specs={
+                "input_ids": FeatureSpec("input_ids", (1, 8), "int64"),
+                "target": FeatureSpec(
+                    "target",
+                    (1, 8, 16),
+                    "bfloat16",
+                    target_repr="hidden_state",
+                    target_meta={"lm_head_key": "lm_head.weight"},
+                ),
+            },
+            strategy="eagle3",
+            num_tokens=8,
+        )
+
+    def test_roundtrip_asdict(self):
+        ref = self._sample_ref()
+        d = dataclasses.asdict(ref)
+        self.assertEqual(d["sample_id"], "s0")
+        self.assertEqual(d["feature_specs"]["target"]["target_repr"], "hidden_state")
+
+    def test_frozen(self):
+        ref = self._sample_ref()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ref.sample_id = "nope"
+
+    def test_assert_no_tensors_passes_on_metadata_records(self):
+        assert_no_tensors(self._sample_ref())
+        assert_no_tensors(
+            PromptTask(
+                task_id="t",
+                run_id="r",
+                source_id="s",
+                payload={"input_ids": [1, 2, 3], "nested": {"a": [4, 5]}},
+                max_length=8,
+            )
+        )
+
+    def test_assert_no_tensors_catches_tensor_in_metadata(self):
+        ref = self._sample_ref()
+        # smuggle a tensor into metadata -> must be caught
+        bad = dataclasses.replace(ref, metadata={"sneaky": torch.zeros(3)})
+        with self.assertRaises(TypeError):
+            assert_no_tensors(bad)
+
+    def test_assert_no_tensors_catches_tensor_in_payload(self):
+        bad = PromptTask(
+            task_id="t",
+            run_id="r",
+            source_id="s",
+            payload={"ids": torch.zeros(3)},
+            max_length=8,
+        )
+        with self.assertRaises(TypeError):
+            assert_no_tensors(bad)
+
+    def test_trainbatch_holds_tensors(self):
+        batch = TrainBatch(
+            sample_ids=["s0"],
+            strategy="eagle3",
+            tensors={"input_ids": torch.zeros(1, 8, dtype=torch.long)},
+            metadata={},
+        )
+        # TrainBatch is the ONLY contract allowed to carry tensors.
+        self.assertIn("input_ids", batch.tensors)
+        with self.assertRaises(TypeError):
+            assert_no_tensors(batch)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_controller_no_tensor.py
+++ b/tests/test_runtime/test_controller_no_tensor.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""M1 gate: the controller carries no tensor across any API (CPU-only)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import FeatureSpec, SampleRef
+from specforge.runtime.control_plane.controller import DataFlowController
+
+
+def _ref(i: int, store_uri="mem://x") -> SampleRef:
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"{store_uri}/s{i}",
+        feature_keys={"input_ids": f"s{i}/input_ids"},
+        feature_specs={"input_ids": FeatureSpec("input_ids", (1, 8), "int64")},
+        strategy="eagle3",
+    )
+
+
+class TestControllerCarriesNoTensor(unittest.TestCase):
+    def test_controller_carries_no_tensor(self):
+        """Online + offline ingest paths reject any tensor payload."""
+        ctrl = DataFlowController("run1")
+
+        # offline refs (metadata only) flow fine
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        self.assertEqual(ctrl.status()["samples_committed"], 2)
+
+        # a SampleRef with a tensor smuggled into metadata must be rejected
+        bad = SampleRef(
+            sample_id="bad",
+            run_id="r",
+            source_task_id=None,
+            feature_store_uri="mem://x/bad",
+            feature_keys={},
+            feature_specs={},
+            strategy="eagle3",
+            metadata={"sneaky": torch.zeros(4)},
+        )
+        with self.assertRaises(TypeError):
+            ctrl.enqueue_offline_refs([bad])
+        with self.assertRaises(TypeError):
+            ctrl.commit_samples("w0", [bad])
+
+        # a prompt carrying a tensor in its payload must be rejected
+        with self.assertRaises(TypeError):
+            ctrl.ingest_prompts([{"payload": {"ids": torch.zeros(3)}}])
+
+    def test_online_offline_converge_at_same_queue(self):
+        ctrl = DataFlowController("run1")
+        ctrl.enqueue_offline_refs([_ref(0)])
+        ctrl.commit_samples("w0", [_ref(1)])  # online path, same queue
+        leased = ctrl.lease_train_refs("t0", 8)
+        self.assertEqual({r.sample_id for r in leased}, {"s0", "s1"})
+        ctrl.ack_train_refs("t0", [r.sample_id for r in leased])
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+    def test_commit_samples_idempotent(self):
+        ctrl = DataFlowController("run1")
+        ctrl.commit_samples("w0", [_ref(0)])
+        ctrl.commit_samples("w0", [_ref(0)])  # at-least-once: dedup on sample_id
+        self.assertEqual(ctrl.status()["samples_committed"], 1)
+        self.assertEqual(ctrl.sample_queue.depth(), 1)
+
+    def test_prompt_lease_and_commit_clears_lease(self):
+        ctrl = DataFlowController("run1")
+        ids = ctrl.ingest_prompts([{"payload": {"text": "hi"}, "max_length": 16}])
+        tasks = ctrl.lease_prompt_tasks("w0", 4)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].task_id, ids[0])
+        ref = _ref(0)
+        ref = SampleRef(**{**ref.__dict__, "source_task_id": ids[0]})
+        ctrl.commit_samples("w0", [ref])
+        self.assertEqual(ctrl.status()["prompts_leased"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_offline_eagle3.py
+++ b/tests/test_runtime/test_equiv_offline_eagle3.py
@@ -1,0 +1,233 @@
+# coding=utf-8
+"""M1 exit gate: offline EAGLE3 through SampleRef -> TrainBatch is bit-exact.
+
+Differential equivalence: the same tiny model + same offline feature files are
+driven through (a) today's offline ``run_forward`` math and (b) the new
+DataFlow path (OfflineManifestReader -> LocalFeatureStore -> FeatureDataLoader ->
+TrainBatch -> Eagle3TrainStrategy.forward_loss). The per-batch weighted loss
+must match bit-for-bit (tol=0) — this is a plumbing gate, not a correctness gate.
+
+GPU-only (the EAGLE3 draft/flex-attention path requires CUDA). Run on the H200
+box via rcli. Uses a synthetic tiny fixture — no model download.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+def _build_distributed_single_rank():
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized():
+        return
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29555")
+    torch.cuda.set_device(0)
+    from specforge.distributed import init_distributed
+
+    init_distributed(timeout=10, tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
+
+
+TINY_DRAFT_CONFIG = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "hidden_act": "silu",
+    "hidden_size": 64,
+    "initializer_range": 0.02,
+    "intermediate_size": 128,
+    "max_position_embeddings": 512,
+    "model_type": "llama",
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "pad_token_id": 0,
+    "rms_norm_eps": 1e-5,
+    "tie_word_embeddings": False,
+    "torch_dtype": "bfloat16",
+    "vocab_size": 256,
+    "draft_vocab_size": 64,
+}
+
+
+def _write_target_head_dir(d, hidden, vocab):
+    """Write a minimal HF-style dir so TargetHead.from_pretrained works."""
+    from safetensors.torch import save_file
+
+    cfg = {
+        "architectures": ["LlamaForCausalLM"],
+        "model_type": "llama",
+        "hidden_size": hidden,
+        "vocab_size": vocab,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "intermediate_size": 128,
+    }
+    with open(os.path.join(d, "config.json"), "w") as f:
+        json.dump(cfg, f)
+    lm_head = torch.randn(vocab, hidden, dtype=torch.float32)
+    save_file({"lm_head.weight": lm_head}, os.path.join(d, "model.safetensors"))
+    with open(os.path.join(d, "model.safetensors.index.json"), "w") as f:
+        json.dump(
+            {"metadata": {}, "weight_map": {"lm_head.weight": "model.safetensors"}}, f
+        )
+
+
+def _write_vocab_mapping(path, vocab, draft_vocab, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    draft_ids = torch.randperm(vocab, generator=g)[:draft_vocab].sort().values
+    t2d = torch.zeros(vocab, dtype=torch.bool)
+    t2d[draft_ids] = True
+    d2t = draft_ids - torch.arange(draft_vocab)
+    torch.save({"t2d": t2d, "d2t": d2t.to(torch.int64)}, path)
+
+
+def _write_offline_files(d, n, seq, hidden, vocab, seed=0):
+    g = torch.Generator().manual_seed(seed)
+    for i in range(n):
+        torch.save(
+            {
+                "input_ids": torch.randint(0, vocab, (seq,), generator=g),
+                "loss_mask": torch.ones(seq, dtype=torch.long),
+                # prepared offline features are bf16 (target ran in bf16)
+                "hidden_state": torch.randn(1, seq, hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+                "aux_hidden_state": torch.randn(1, seq, 3 * hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+            },
+            os.path.join(d, f"{i:04d}.ckpt"),
+        )
+
+
+@unittest.skipUnless(CUDA, "offline EAGLE3 equivalence requires CUDA")
+class TestEquivOfflineEagle3(unittest.TestCase):
+    def test_equiv_offline_eagle3(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        _build_distributed_single_rank()
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.runtime.control_plane import DataFlowController
+        from specforge.runtime.data_plane import (
+            FeatureDataLoader,
+            LocalFeatureStore,
+            OfflineManifestReader,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+
+        H, V, D, SEQ, N, BS, TTT = 64, 256, 64, 16, 4, 2, 3
+
+        workdir = tempfile.mkdtemp(prefix="equiv_offline_")
+        cfg_path = os.path.join(workdir, "draft.json")
+        with open(cfg_path, "w") as f:
+            json.dump(TINY_DRAFT_CONFIG, f)
+        target_dir = os.path.join(workdir, "target")
+        os.makedirs(target_dir)
+        _write_target_head_dir(target_dir, H, V)
+        vocab_path = os.path.join(workdir, "vocab_mapping.pt")
+        _write_vocab_mapping(vocab_path, V, D)
+        feat_dir = os.path.join(workdir, "features")
+        os.makedirs(feat_dir)
+        _write_offline_files(feat_dir, N, SEQ, H, V)
+
+        # one shared model + head used by both paths
+        draft_config = AutoDraftModelConfig.from_file(cfg_path)
+        draft_model = AutoEagle3DraftModel.from_config(
+            draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+        ).cuda()
+        draft_model.load_vocab_mapping(vocab_path)
+        draft_model.freeze_embedding()
+        target_head = TargetHead.from_pretrained(
+            target_dir, lm_head_key="lm_head.weight"
+        )
+        eagle3_model = OnlineEagle3Model(
+            draft_model=draft_model, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+        eagle3_model.eval()
+
+        ploss_decay = 0.8
+
+        @torch.no_grad()
+        def old_path_losses():
+            ds = OfflineEagle3Dataset(
+                sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)),
+                max_len=512,
+            )
+            collate = DataCollatorWithPadding()
+            losses = []
+            for start in range(0, N, BS):
+                if start + BS > N:
+                    break
+                batch = collate([ds[j] for j in range(start, start + BS)])
+                input_ids, target, loss_mask = target_head.preprocess(
+                    batch["input_ids"], batch["target"], batch["loss_mask"]
+                )
+                target = target_head(target.cuda())
+                plosses, _, _, _, _, _, _ = eagle3_model(
+                    input_ids=input_ids.cuda(),
+                    attention_mask=batch["attention_mask"].cuda(),
+                    loss_mask=loss_mask.cuda(),
+                    target=target,
+                    hidden_states=batch["hidden_state"].cuda(),
+                )
+                w = [ploss_decay**i for i in range(len(plosses))]
+                losses.append(
+                    sum(w[i] * plosses[i] for i in range(len(plosses))).item()
+                )
+            return losses
+
+        @torch.no_grad()
+        def new_path_losses():
+            ctrl = DataFlowController("equiv-offline")
+            ctrl.enqueue_offline_refs(
+                OfflineManifestReader(
+                    feat_dir, run_id="equiv-offline", ttt_length=TTT, max_len=512
+                ).read()
+            )
+            store = LocalFeatureStore("equiv")
+            loader = FeatureDataLoader(
+                store,
+                ctrl.sample_queue,
+                batch_size=BS,
+                collate_fn=DataCollatorWithPadding(),
+                per_sample_transform=lambda raw: OfflineEagle3Dataset.process_data(
+                    raw, 512
+                ),
+                drop_last=True,
+            )
+            strategy = Eagle3TrainStrategy(eagle3_model, target_head=target_head)
+            losses = []
+            for batch in loader:
+                out = strategy.forward_loss(batch)
+                losses.append(out.loss.item())
+                ctrl.ack_train_refs("t0", batch.sample_ids)
+            return losses
+
+        old = old_path_losses()
+        new = new_path_losses()
+        self.assertEqual(len(old), len(new))
+        self.assertEqual(len(old), N // BS)
+        for i, (a, b) in enumerate(zip(old, new)):
+            self.assertEqual(a, b, f"batch {i}: old={a} new={b} (must be bit-exact)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_online_eagle3.py
+++ b/tests/test_runtime/test_equiv_online_eagle3.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+"""M2 gate: online EAGLE3 through PromptTask -> SampleRef -> TrainBatch matches.
+
+Old path = legacy online ``run_forward`` (target.generate_eagle3_data -> eagle3
+model). New path = PromptTask -> SGLangAdapter (via RolloutWorker) -> FeatureStore
+-> FeatureDataLoader -> TrainBatch -> Eagle3TrainStrategy. Single rank, batch
+size 1 (so old and new run the identical per-sample target forward): the weighted
+loss must match near-exactly, and the controller never carries a tensor.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "online EAGLE3 equivalence requires CUDA")
+class TestEquivOnlineEagle3(unittest.TestCase):
+    def test_equiv_online_eagle3(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29565")
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.runtime.contracts import assert_no_tensors
+        from specforge.runtime.control_plane import DataFlowController
+        from specforge.runtime.data_plane import FeatureDataLoader, LocalFeatureStore
+        from specforge.runtime.inference.capture import CaptureConfig
+        from specforge.runtime.inference.rollout_worker import RolloutWorker
+        from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+
+        H, V, SEQ, TTT = fx.H, fx.V, 12, 3
+        workdir = tempfile.mkdtemp(prefix="equiv_online_")
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+        eagle3_model.eval()
+
+        torch.manual_seed(11)
+        ids = torch.randint(0, V, (SEQ,)).tolist()
+
+        # --- old online path (batch size 1, tp=1 so no TP sharding) ---
+        @torch.no_grad()
+        def old_loss():
+            input_ids = torch.tensor([ids], device="cuda")
+            attn = torch.ones_like(input_ids)
+            loss_mask = torch.ones_like(input_ids)
+            d = target.generate_eagle3_data(input_ids, attn, loss_mask)
+            plosses, _, _, _, _, _, _ = eagle3_model(
+                input_ids=d.input_ids,
+                attention_mask=d.attention_mask,
+                loss_mask=d.loss_mask,
+                target=d.target,
+                hidden_states=d.hidden_states,
+            )
+            return sum(0.8**i * plosses[i] for i in range(len(plosses))).item()
+
+        # --- new dataflow path ---
+        @torch.no_grad()
+        def new_loss():
+            ctrl = DataFlowController("online")
+            ctrl.ingest_prompts(
+                [{"payload": {"input_ids": ids, "loss_mask": [1] * SEQ}}]
+            )
+            store = LocalFeatureStore("online")
+            adapter = SGLangAdapter(target, device="cuda")
+            capture = CaptureConfig.from_strategy(
+                required_features=Eagle3TrainStrategy.required_features,
+                aux_hidden_state_layer_ids=tuple(aux_ids),
+                target_repr="logits",
+                target_hidden_size=H,
+                target_vocab_size=V,
+            )
+            worker = RolloutWorker(ctrl, store, adapter, capture, run_id="online")
+            worker.start()
+            refs = worker.run_once(max_tasks=4)
+            assert len(refs) == 1
+            # controller holds only metadata
+            assert_no_tensors(ctrl.status())
+            for r in refs:
+                assert_no_tensors(r)
+
+            def cat_collate(feats):
+                return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
+
+            loader = FeatureDataLoader(
+                store,
+                ctrl.sample_queue,
+                batch_size=1,
+                collate_fn=cat_collate,
+            )
+            strategy = Eagle3TrainStrategy(eagle3_model, target_head=None)
+            losses = []
+            for batch in loader:
+                self.assertEqual(batch.metadata["target_repr"], "logits")
+                losses.append(strategy.forward_loss(batch).loss.item())
+            return losses[0]
+
+        old = old_loss()
+        new = new_loss()
+        self.assertAlmostEqual(
+            old, new, places=3, msg=f"online loss: old={old} new={new}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_trainer_split.py
+++ b/tests/test_runtime/test_equiv_trainer_split.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""M3 gate: the trainer-boundary split does not change the math (paired single step).
+
+Old path = legacy ``run_forward`` + ``run_backward_and_update``. New path =
+``Eagle3TrainStrategy`` + ``TrainerCore`` + ``FSDPTrainingBackend``. Two models
+with identical initial weights take one step on the same offline batch; the
+weighted loss must match bit-exactly and the reduced grad-norm near-exactly.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import types
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "trainer-split equivalence requires CUDA")
+class TestEquivTrainerSplit(unittest.TestCase):
+    def test_equiv_trainer_split(self):
+        torch.manual_seed(0)
+        torch.use_deterministic_algorithms(True, warn_only=True)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29562")
+
+        import pathlib
+        import sys
+
+        sys.path.insert(
+            0, str(pathlib.Path(__file__).resolve().parents[2])
+        )  # repo root
+
+        from scripts.train_eagle3 import run_backward_and_update, run_forward
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.data.preprocessing import OfflineEagle3Dataset
+        from specforge.data.utils import DataCollatorWithPadding
+        from specforge.modeling.target import TargetHead
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import TrainBatch
+        from specforge.runtime.training.backend import (
+            FSDPTrainingBackend,
+            ParallelConfig,
+        )
+        from specforge.runtime.training.strategy import Eagle3TrainStrategy
+        from specforge.runtime.training.trainer import TrainerCore
+
+        TTT, BS = 3, 2
+        workdir = tempfile.mkdtemp(prefix="equiv_split_")
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        target_dir = fx.write_target_head_dir(os.path.join(workdir, "target"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=BS)
+
+        draft_config = AutoDraftModelConfig.from_file(cfg)
+
+        def build_model():
+            dm = AutoEagle3DraftModel.from_config(
+                draft_config,
+                attention_backend="flex_attention",
+                torch_dtype=torch.bfloat16,
+            ).cuda()
+            dm.load_vocab_mapping(vocab_path)
+            dm.freeze_embedding()
+            return OnlineEagle3Model(
+                draft_model=dm, length=TTT, attention_backend="flex_attention"
+            ).cuda()
+
+        model_a = build_model()
+        model_b = build_model()
+        # identical initial weights
+        model_b.draft_model.load_state_dict(model_a.draft_model.state_dict())
+        head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+
+        ds = OfflineEagle3Dataset(
+            sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir)), max_len=512
+        )
+        data = DataCollatorWithPadding()([ds[j] for j in range(BS)])
+
+        args = types.SimpleNamespace(
+            is_vlm=False,
+            target_model_backend="hf",
+            shard_target_output=False,
+            draft_accumulation_steps=1,
+            # compact_teacher=False -> run_forward uses the legacy full-logits
+            # teacher path, matching the behavior this equivalence test asserts.
+            compact_teacher=False,
+            compact_teacher_chunk_size=None,
+        )
+
+        # --- old path on model_a ---
+        opt_a = BF16Optimizer(
+            model_a.draft_model,
+            lr=1e-4,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        plosses_a, _, _, _, _, _, _ = run_forward(
+            args, model_a, data, head, is_online=False
+        )
+        loss_old = sum(0.8**i * plosses_a[i] for i in range(len(plosses_a))).item()
+        gn_old = run_backward_and_update(args, plosses_a, opt_a, global_step=1)
+
+        # --- new path on model_b ---
+        opt_b = BF16Optimizer(
+            model_b.draft_model,
+            lr=1e-4,
+            max_grad_norm=0.5,
+            warmup_ratio=0.0,
+            total_steps=10,
+        )
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.set_optimizer(opt_b)
+        strategy = Eagle3TrainStrategy(model_b, target_head=head)
+        core = TrainerCore(strategy, backend, accumulation_steps=1)
+        batch = TrainBatch(
+            sample_ids=["a", "b"],
+            strategy="eagle3",
+            tensors=dict(data),
+            metadata={"target_repr": "hidden_state", "ttt_length": TTT},
+        )
+        rep = core.train_step(batch)
+
+        self.assertAlmostEqual(
+            loss_old, rep.loss, places=4, msg=f"loss: old={loss_old} new={rep.loss}"
+        )
+        self.assertAlmostEqual(
+            float(gn_old.item()),
+            rep.grad_norm,
+            places=3,
+            msg=f"grad_norm: old={gn_old.item()} new={rep.grad_norm}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_extraction_vs_hf_reference.py
+++ b/tests/test_runtime/test_extraction_vs_hf_reference.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""M4 gate: extraction correctness vs an independent HF reference (fp tolerance).
+
+The SGLangAdapter's extracted aux hidden states (at the recorded layer IDs) must
+equal an independent HF ``output_hidden_states=True`` forward at those layers,
+and the target logits must match a direct forward — within a documented bf16
+tolerance. This is the only M4 numerical gate at fp tolerance (different engine),
+NOT bit-exact. Also asserts the capture assertion fires on a layer mismatch.
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+# Documented tolerance: two bf16 forward passes of the same tiny model.
+RTOL, ATOL = 2e-2, 2e-2
+
+
+@unittest.skipUnless(CUDA, "extraction correctness requires CUDA")
+class TestExtractionVsHFReference(unittest.TestCase):
+    def test_extraction_vs_hf_reference(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29564")
+
+        from specforge.runtime.contracts import PromptTask
+        from specforge.runtime.inference.capture import CaptureConfig, verify_capture
+        from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+        H, V, SEQ = fx.H, fx.V, 12
+        workdir = tempfile.mkdtemp(prefix="extract_")
+        target, target_dir, aux_ids = fx.build_hf_target(
+            workdir, hidden=H, layers=8, vocab=V
+        )
+
+        adapter = SGLangAdapter(target, device="cuda")
+        capture = CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=tuple(aux_ids),
+            target_repr="logits",
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+
+        torch.manual_seed(7)
+        ids = torch.randint(0, V, (SEQ,)).tolist()
+        task = PromptTask(
+            task_id="t0",
+            run_id="r",
+            source_id="s",
+            payload={"input_ids": ids, "loss_mask": [1] * SEQ},
+            max_length=SEQ,
+        )
+        feats = adapter.generate_features([task], capture=capture)[0]
+        recorded = feats.pop("__aux_layer_ids__")
+        verify_capture(feats, capture, sample_id="t0", recorded_aux_layer_ids=recorded)
+        self.assertEqual(tuple(recorded), tuple(aux_ids))
+        self.assertEqual(feats["hidden_state"].shape[-1], 3 * H)
+
+        # independent HF reference forward with output_hidden_states
+        input_ids = torch.tensor([ids], device="cuda")
+        ref = target.model(
+            input_ids=input_ids,
+            attention_mask=torch.ones_like(input_ids),
+            output_hidden_states=True,
+            use_cache=False,
+        )
+        # hidden_states[i+1] == output of decoder layer i
+        extracted = feats["hidden_state"].float()
+        for k, layer_id in enumerate(aux_ids):
+            ref_layer = ref.hidden_states[layer_id + 1].float()  # (1, SEQ, H)
+            got = extracted[..., k * H : (k + 1) * H]
+            torch.testing.assert_close(
+                got,
+                ref_layer,
+                rtol=RTOL,
+                atol=ATOL,
+                msg=f"aux layer {layer_id} extraction drift",
+            )
+
+        # target logits match a direct forward (adapter pads next-token; compare
+        # the overlapping positions [0..SEQ-2] against ref logits [1..SEQ-1])
+        adapter_target = feats["target"].float()
+        ref_logits = ref.logits.float()
+        torch.testing.assert_close(
+            adapter_target[:, : SEQ - 1, :],
+            ref_logits[:, 1:SEQ, :],
+            rtol=RTOL,
+            atol=ATOL,
+            msg="target logits drift vs direct lm_head",
+        )
+
+    def test_capture_layer_mismatch_fails(self):
+        """A recorded aux-layer set != requested fails loudly at the boundary."""
+        from specforge.runtime.inference.capture import (
+            CaptureConfig,
+            CaptureMismatchError,
+            verify_capture,
+        )
+
+        cap = CaptureConfig.from_strategy(
+            required_features={"hidden_state", "target", "input_ids", "loss_mask"},
+            aux_hidden_state_layer_ids=(1, 3, 4),
+            target_repr="hidden_state",
+            target_hidden_size=8,
+        )
+        tensors = {
+            "input_ids": torch.zeros(1, 4, dtype=torch.long),
+            "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            "hidden_state": torch.randn(1, 4, 24),
+            "target": torch.randn(1, 4, 8),
+        }
+        with self.assertRaises(CaptureMismatchError):
+            verify_capture(
+                tensors, cap, sample_id="x", recorded_aux_layer_ids=(1, 3, 5)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_feature_dataloader.py
+++ b/tests/test_runtime/test_feature_dataloader.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""FeatureDataLoader: queue + store -> TrainBatch, with injected transform/collate (CPU)."""
+
+import os
+import tempfile
+import unittest
+from dataclasses import replace
+
+import torch
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+def _offline_eagle3_process_data(raw):
+    """Mirror of OfflineEagle3Dataset.process_data (the aux<->target swap)."""
+    max_len = 2048
+    hidden_state = raw["aux_hidden_state"].squeeze(0)[:max_len][None, :]
+    target = raw["hidden_state"].squeeze(0)[:max_len][None, :]
+    input_ids = raw["input_ids"][:max_len][None, :]
+    loss_mask = raw["loss_mask"][:max_len][None, :].clone()
+    loss_mask[0, -1] = 0
+    return {
+        "attention_mask": torch.ones_like(loss_mask, dtype=torch.long),
+        "loss_mask": loss_mask,
+        "target": target,
+        "hidden_state": hidden_state,
+        "input_ids": input_ids,
+    }
+
+
+def _simple_collate(features):
+    keys = features[0].keys()
+    return {k: torch.cat([f[k] for f in features], dim=0) for k in keys}
+
+
+class TestFeatureDataLoader(unittest.TestCase):
+    def _write_offline_files(self, d, n=4, seq=8, h=4, aux=12):
+        for i in range(n):
+            torch.save(
+                {
+                    "input_ids": torch.arange(seq) + i,
+                    "loss_mask": torch.ones(seq, dtype=torch.long),
+                    "hidden_state": torch.randn(1, seq, h),
+                    "aux_hidden_state": torch.randn(1, seq, aux),
+                },
+                os.path.join(d, f"{i:03d}.ckpt"),
+            )
+
+    def test_offline_loader_emits_trainbatch(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=4)
+            # data-plane unit test: drive the loader from the queue primitive
+            # directly (no control plane needed here).
+            q = SampleRefQueue()
+            q.put(OfflineManifestReader(d, run_id="run").read())
+            store = LocalFeatureStore("st")
+            loader = FeatureDataLoader(
+                store,
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            batches = list(loader)
+            self.assertEqual(len(batches), 2)  # 4 samples / batch 2
+            b = batches[0]
+            self.assertEqual(len(b.sample_ids), 2)
+            self.assertEqual(b.tensors["input_ids"].shape, (2, 8))
+            self.assertEqual(b.tensors["target"].shape, (2, 8, 4))
+            self.assertEqual(b.tensors["hidden_state"].shape, (2, 8, 12))
+            # aux<->target swap preserved
+            self.assertEqual(b.metadata["target_repr"], "hidden_state")
+            # all refs acked
+            self.assertEqual(q.in_flight(), 0)
+            self.assertEqual(q.depth(), 0)
+
+    def test_drop_last(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=3)
+            q = SampleRefQueue()
+            q.put(OfflineManifestReader(d, run_id="run").read())
+            store = LocalFeatureStore("st")
+            loader = FeatureDataLoader(
+                store,
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+                drop_last=True,
+            )
+            batches = list(loader)
+            self.assertEqual(len(batches), 1)  # 3 samples, drop the trailing 1
+
+    def test_mixed_target_repr_fails_and_releases_refs(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=2)
+            refs = OfflineManifestReader(d, run_id="run").read()
+            refs[1] = replace(
+                refs[1],
+                metadata={**refs[1].metadata, "target_repr": "logits"},
+            )
+            q = SampleRefQueue()
+            q.put(refs)
+            loader = FeatureDataLoader(
+                LocalFeatureStore("st"),
+                q,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            with self.assertRaises(ValueError):
+                list(loader)
+            self.assertEqual(q.in_flight(), 0)
+            self.assertEqual(q.depth(), 0)
+
+    def test_refs_mode_is_reiterable_across_epochs(self):
+        # offline: a fixed ref set must re-iterate every epoch (no epoch-drain).
+        with tempfile.TemporaryDirectory() as d:
+            self._write_offline_files(d, n=4)
+            refs = OfflineManifestReader(d, run_id="run").read()
+            loader = FeatureDataLoader(
+                LocalFeatureStore("st"),
+                refs=refs,
+                batch_size=2,
+                collate_fn=_simple_collate,
+                per_sample_transform=_offline_eagle3_process_data,
+            )
+            epoch1 = [b.sample_ids for b in loader]
+            epoch2 = [b.sample_ids for b in loader]
+            self.assertEqual(len(epoch1), 2)
+            self.assertEqual(epoch1, epoch2)  # same fixed set each epoch
+
+    def test_requires_exactly_one_source(self):
+        store = LocalFeatureStore("st")
+        with self.assertRaises(ValueError):
+            FeatureDataLoader(store)  # neither queue nor refs
+        with self.assertRaises(ValueError):
+            FeatureDataLoader(store, SampleRefQueue(), refs=[])  # both
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_feature_store.py
+++ b/tests/test_runtime/test_feature_store.py
@@ -1,0 +1,214 @@
+# coding=utf-8
+"""LocalFeatureStore: atomic put, get, idempotent release, abort, file mode (CPU)."""
+
+import logging
+import os
+import tempfile
+import unittest
+
+import torch
+
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+
+class TestLocalFeatureStore(unittest.TestCase):
+    def test_put_returns_ref_with_no_tensors(self):
+        store = LocalFeatureStore("st")
+        tensors = {
+            "input_ids": torch.arange(8).view(1, 8),
+            "hidden_state": torch.randn(1, 8, 4),
+        }
+        ref = store.put(
+            tensors, sample_id="s0", metadata={"run_id": "r", "num_tokens": 8}
+        )
+        self.assertEqual(ref.sample_id, "s0")
+        self.assertTrue(ref.feature_store_uri.startswith("mem://"))
+        self.assertEqual(set(ref.feature_specs), {"input_ids", "hidden_state"})
+        self.assertEqual(ref.feature_specs["hidden_state"].shape, (1, 8, 4))
+        self.assertGreater(ref.estimated_bytes, 0)
+
+    def test_get_returns_tensors_and_handle(self):
+        store = LocalFeatureStore("st")
+        t = torch.randn(1, 4, 2)
+        ref = store.put({"x": t}, sample_id="s0", metadata={})
+        out, handle = store.get(ref)
+        self.assertTrue(torch.equal(out["x"], t))
+        self.assertEqual(handle.sample_id, "s0")
+
+    def test_release_idempotent_and_stale_safe(self):
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h = store.get(ref)
+        store.release(h)
+        store.release(h)  # idempotent: must not raise
+        # re-put bumps generation; old handle release is a no-op
+        ref2 = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h2 = store.get(ref2)
+        store.release(h)  # stale generation -> no-op
+        out, _ = store.get(ref2)
+        self.assertIn("x", out)
+        _ = h2
+
+    def test_release_frees_mem_on_last_lease(self):
+        # mem:// is consume-once: the last release must physically free tensors,
+        # otherwise an online put->get->release loop grows _mem unboundedly.
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        self.assertEqual(store.health()["resident_samples"], 1)
+        _, h = store.get(ref)
+        store.release(h)
+        self.assertEqual(store.health()["resident_samples"], 0)
+        self.assertEqual(store.health()["resident_bytes"], 0)
+        with self.assertRaises(KeyError):
+            store.get(ref)  # consumed -> gone
+
+    def test_release_keeps_mem_while_other_lease_active(self):
+        # refcount: only the LAST lease frees the sample.
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref)
+        _, h2 = store.get(ref)
+        store.release(h1)
+        self.assertEqual(store.health()["resident_samples"], 1)  # h2 still holds it
+        store.release(h2)
+        self.assertEqual(store.health()["resident_samples"], 0)  # last lease -> freed
+
+    def test_online_put_get_release_loop_is_bounded(self):
+        # The regression this fix targets: many unique samples, consumed and
+        # released, must not accumulate in the store.
+        store = LocalFeatureStore("st")
+        for i in range(50):
+            ref = store.put({"x": torch.randn(1, 8)}, sample_id=f"s{i}", metadata={})
+            _, h = store.get(ref)
+            store.release(h)
+        self.assertEqual(store.health()["resident_samples"], 0)
+        self.assertEqual(store.health()["resident_bytes"], 0)
+
+    def test_max_resident_bytes_raises_when_consumer_is_behind(self):
+        # one float32 (1,8) sample = 32 bytes; cap at 40 admits one, rejects two.
+        store = LocalFeatureStore("st", max_resident_bytes=40)
+        ref0 = store.put(
+            {"x": torch.zeros(1, 8, dtype=torch.float32)}, sample_id="s0", metadata={}
+        )
+        with self.assertRaises(MemoryError):
+            store.put(
+                {"x": torch.zeros(1, 8, dtype=torch.float32)},
+                sample_id="s1",
+                metadata={},
+            )
+        # once the first is consumed+released, there is room for the next
+        _, h = store.get(ref0)
+        store.release(h)
+        store.put(
+            {"x": torch.zeros(1, 8, dtype=torch.float32)}, sample_id="s1", metadata={}
+        )
+        self.assertEqual(store.health()["resident_samples"], 1)
+
+    def test_abort_evicts(self):
+        store = LocalFeatureStore("st")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        store.abort("s0", reason="test")
+        with self.assertRaises(KeyError):
+            store.get(ref)
+
+    def test_health(self):
+        store = LocalFeatureStore("st")
+        store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        h = store.health()
+        self.assertEqual(h["resident_samples"], 1)
+        self.assertGreater(h["resident_bytes"], 0)
+
+    def test_estimate_bytes(self):
+        store = LocalFeatureStore("st")
+        ref = store.put(
+            {"x": torch.zeros(1, 10, dtype=torch.float32)}, sample_id="s0", metadata={}
+        )
+        self.assertEqual(store.estimate_bytes(ref.feature_specs), 10 * 4)
+
+    def test_disk_dump_tap(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = LocalFeatureStore("st", dump_dir=d)
+            store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+            self.assertTrue(os.path.exists(os.path.join(d, "s0.ckpt")))
+
+    def test_file_mode_get_matches_offline_format(self):
+        # write an offline-style .ckpt and read it back through the store + reader
+        with tempfile.TemporaryDirectory() as d:
+            raw = {
+                "input_ids": torch.arange(8),
+                "loss_mask": torch.ones(8, dtype=torch.long),
+                "hidden_state": torch.randn(1, 8, 4),
+                "aux_hidden_state": torch.randn(1, 8, 12),
+            }
+            torch.save(raw, os.path.join(d, "000.ckpt"))
+            refs = OfflineManifestReader(d, run_id="off").read()
+            self.assertEqual(len(refs), 1)
+            self.assertTrue(refs[0].feature_store_uri.startswith("file://"))
+            self.assertEqual(set(refs[0].feature_specs), set(raw))
+            self.assertEqual(refs[0].feature_specs["hidden_state"].dtype, "float32")
+            self.assertEqual(refs[0].num_tokens, 8)
+            store = LocalFeatureStore("st")
+            out, handle = store.get(refs[0])
+            self.assertEqual(set(out), set(raw))
+            self.assertTrue(
+                torch.equal(out["aux_hidden_state"], raw["aux_hidden_state"])
+            )
+            store.release(handle)
+
+    def test_offline_reader_rejects_missing_required_key(self):
+        with tempfile.TemporaryDirectory() as d:
+            torch.save({"input_ids": torch.arange(4)}, os.path.join(d, "bad.ckpt"))
+            with self.assertRaises(KeyError):
+                OfflineManifestReader(d, run_id="off").read()
+
+    def test_mem_ref_carries_generation_and_rejects_stale_ref(self):
+        # The mem:// ref carries the generation it was minted for; once a sample
+        # is reclaimed and a new generation is published under the same id, the
+        # stale ref must be rejected rather than silently aliasing fresh data.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        self.assertIn("generation=", ref1.feature_store_uri)
+        _, h = store.get(ref1)
+        store.release(h)  # gen1 reclaimed
+        store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2
+        with self.assertRaises(KeyError):
+            store.get(ref1)  # stale gen1 ref -> rejected
+
+    def test_release_after_reput_while_leased_does_not_leak(self):
+        # Re-put a sample_id while an older generation is still leased, then drop
+        # the newest handle and finally the stale old handle. Freeing is keyed on
+        # the CURRENT generation's last lease, so the current generation must be
+        # freed and nothing leaks.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref1)  # lease on gen1
+        ref2 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2
+        _, h2 = store.get(ref2)  # lease on gen2
+        store.release(h2)  # newest released first (stale gen1 lease still active)
+        store.release(h1)  # stale gen1 handle released last
+        h = store.health()
+        self.assertEqual(h["resident_samples"], 0)
+        self.assertEqual(h["resident_bytes"], 0)
+
+    def test_dump_failure_does_not_abort_publish(self):
+        # The disk dump is a best-effort capture/replay tap; mem is authoritative.
+        # A dump failure must not undo an otherwise successful in-memory publish.
+        class DumpFails(LocalFeatureStore):
+            def _dump(self, sample_id, tensors):
+                raise RuntimeError("disk full")
+
+        with tempfile.TemporaryDirectory() as d:
+            store = DumpFails("st", dump_dir=d)
+            logging.disable(logging.CRITICAL)  # silence the expected warning
+            try:
+                ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+            finally:
+                logging.disable(logging.NOTSET)
+            out, h = store.get(ref)  # mem publish survived
+            self.assertIn("x", out)
+            store.release(h)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_offline_launch_fsdp.py
+++ b/tests/test_runtime/test_offline_launch_fsdp.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+"""Launcher path: FSDP is in the forward path + global_step is optimizer steps.
+
+Exercises build_offline_eagle3_runtime end to end (single rank) with
+accumulation_steps=2, which the equivalence tests (wrap=False) do not cover:
+- the strategy must run forward through the FSDP-wrapped module (Issue 1);
+- fit's global_step counts OPTIMIZER steps, micro_step counts micro-batches (Issue 2).
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "launcher FSDP path requires CUDA")
+class TestOfflineLaunchFSDP(unittest.TestCase):
+    def test_fsdp_in_forward_path_and_optimizer_step_semantics(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29566")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.launch import build_offline_eagle3_runtime
+
+        TTT, ACC, MAX_OPT_STEPS, N = 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="launch_fsdp_")
+        feat_dir = fx.write_offline_files(os.path.join(workdir, "features"), n=N)
+        eagle3_model, target_head = fx.build_eagle3(workdir, ttt=TTT)
+
+        def optimizer_factory(draft_module):
+            return BF16Optimizer(
+                draft_module,
+                lr=1e-3,
+                max_grad_norm=0.5,
+                warmup_ratio=0.0,
+                total_steps=10,
+            )
+
+        trainer, loader = build_offline_eagle3_runtime(
+            hidden_states_path=feat_dir,
+            eagle3_model=eagle3_model,
+            target_head=target_head,
+            optimizer_factory=optimizer_factory,
+            run_id="launch",
+            output_dir=os.path.join(workdir, "out"),
+            ttt_length=TTT,
+            max_len=512,
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=3,
+            max_steps=MAX_OPT_STEPS,
+        )
+
+        # Issue 1: the strategy runs forward through the FSDP-wrapped module
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(
+            module, FSDP, "strategy must hold the FSDP-wrapped module"
+        )
+        self.assertIsNotNone(trainer.core.backend.optimizer)
+
+        step = trainer.fit(loader)
+
+        # Issue 2: global_step == optimizer steps; micro_step == ACC * optimizer steps
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.global_step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+
+        # a checkpoint can be written through the FSDP FULL_STATE_DICT path
+        ckpt = trainer.save_checkpoint(trainer.global_step)
+        self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+        self.assertEqual(ckpt.global_step, MAX_OPT_STEPS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_online_launch.py
+++ b/tests/test_runtime/test_online_launch.py
@@ -1,0 +1,124 @@
+# coding=utf-8
+"""Launcher path (online): build_online_eagle3_runtime end to end, single rank.
+
+Online analog of test_offline_launch_fsdp. Drives a RolloutWorker (HF target,
+no sglang) to materialize SampleRefs into the mem:// store, then trains through
+the queue with FSDP + gradient accumulation. Asserts:
+- rollout produced one ref per prompt and the controller carries no tensors;
+- the strategy runs forward through the FSDP-wrapped module;
+- fit's global_step counts OPTIMIZER steps (micro_step = ACC * optimizer steps).
+
+The old-vs-new bit-exact loss equivalence is covered by test_equiv_online_eagle3.
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "online launcher path requires CUDA")
+class TestOnlineLaunch(unittest.TestCase):
+    def test_online_rollout_then_fsdp_train(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29568")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import assert_no_tensors
+        from specforge.runtime.launch import build_online_eagle3_runtime
+
+        H, V, SEQ, TTT, ACC, MAX_OPT_STEPS, N = fx.H, fx.V, 12, 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="online_launch_")
+
+        # HF target (no sglang) + a fresh eagle3 draft model
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+
+        # N metadata-only prompts (control plane carries no tensors)
+        g = torch.Generator().manual_seed(7)
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": torch.randint(0, V, (SEQ,), generator=g).tolist(),
+                    "loss_mask": [1] * SEQ,
+                }
+            }
+            for _ in range(N)
+        ]
+
+        def optimizer_factory(draft_module):
+            return BF16Optimizer(
+                draft_module,
+                lr=1e-3,
+                max_grad_norm=0.5,
+                warmup_ratio=0.0,
+                total_steps=10,
+            )
+
+        trainer, loader, workers, controller, drive_rollout = (
+            build_online_eagle3_runtime(
+                target_model=target,
+                prompts=prompts,
+                eagle3_model=eagle3_model,
+                optimizer_factory=optimizer_factory,
+                run_id="online-launch",
+                output_dir=os.path.join(workdir, "out"),
+                target_hidden_size=H,
+                target_vocab_size=V,
+                target_repr="logits",
+                aux_hidden_state_layer_ids=tuple(aux_ids),
+                batch_size=1,
+                accumulation_steps=ACC,
+                num_epochs=1,
+                max_steps=MAX_OPT_STEPS,
+            )
+        )
+
+        # Rollout produces exactly one SampleRef per prompt, on the queue.
+        produced = drive_rollout()
+        self.assertEqual(produced, N)
+        self.assertEqual(controller.sample_queue.depth(), N)
+        # control plane carries metadata only
+        assert_no_tensors(controller.status())
+
+        # FSDP must be in the forward path; optimizer exists.
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(
+            module, FSDP, "strategy must hold the FSDP-wrapped module"
+        )
+        self.assertIsNotNone(trainer.core.backend.optimizer)
+
+        step = trainer.fit(loader)
+
+        # global_step counts OPTIMIZER steps; micro_step counts micro-batches.
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.global_step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_rollout_worker.py
+++ b/tests/test_runtime/test_rollout_worker.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+"""RolloutWorker drives PromptTask -> features -> SampleRef commit (CPU, fake source)."""
+
+import unittest
+
+import torch
+
+from specforge.runtime.control_plane import DataFlowController
+from specforge.runtime.data_plane import LocalFeatureStore
+from specforge.runtime.inference.capture import CaptureConfig
+from specforge.runtime.inference.rollout_worker import RolloutWorker
+
+H = 8
+
+
+def _capture(layer_ids=(1, 2, 3)):
+    return CaptureConfig.from_strategy(
+        required_features={
+            "input_ids",
+            "attention_mask",
+            "loss_mask",
+            "hidden_state",
+            "target",
+        },
+        aux_hidden_state_layer_ids=layer_ids,
+        target_repr="logits",
+        target_hidden_size=H,
+        target_vocab_size=32,
+    )
+
+
+class FakeSource:
+    """Stand-in for SGLangAdapter: returns per-sample feature dicts."""
+
+    def __init__(self, seq=4, target_dim=32, aux_layers=3, bad_layers=False):
+        self.seq = seq
+        self.target_dim = target_dim
+        self.aux_layers = aux_layers
+        self.bad_layers = bad_layers
+
+    def generate_features(self, tasks, *, capture):
+        out = []
+        for _ in tasks:
+            feats = {
+                "input_ids": torch.zeros(1, self.seq, dtype=torch.long),
+                "attention_mask": torch.ones(1, self.seq, dtype=torch.long),
+                "loss_mask": torch.ones(1, self.seq, dtype=torch.long),
+                "hidden_state": torch.randn(1, self.seq, self.aux_layers * H),
+                "target": torch.randn(1, self.seq, self.target_dim),
+            }
+            ids = (1, 2, 99) if self.bad_layers else (1, 2, 3)
+            feats["__aux_layer_ids__"] = ids
+            out.append(feats)
+        return out
+
+
+class RaisingSource:
+    def generate_features(self, tasks, *, capture):
+        raise RuntimeError("temporary engine failure")
+
+
+class ShortSource:
+    def generate_features(self, tasks, *, capture):
+        return []
+
+
+class MixedLayerSource(FakeSource):
+    def generate_features(self, tasks, *, capture):
+        out = super().generate_features(tasks, capture=capture)
+        out[-1]["__aux_layer_ids__"] = (1, 2, 99)
+        return out
+
+
+class TestRolloutWorker(unittest.TestCase):
+    def test_run_once_commits_refs(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}, {"payload": {"text": "b"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, FakeSource(), _capture(), run_id="run")
+        w.start()
+        refs = w.run_once(max_tasks=8)
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(ctrl.status()["samples_committed"], 2)
+        self.assertEqual(ctrl.sample_queue.depth(), 2)
+        # features landed in the store, retrievable by ref
+        out, _ = store.get(refs[0])
+        self.assertEqual(
+            set(out),
+            {"input_ids", "attention_mask", "loss_mask", "hidden_state", "target"},
+        )
+        self.assertEqual(w.health()["state"], "ready")
+
+    def test_capture_mismatch_fails_loudly_and_commits_nothing(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(
+            ctrl, store, FakeSource(bad_layers=True), _capture(), run_id="run"
+        )
+        w.start()
+        from specforge.runtime.inference.capture import CaptureMismatchError
+
+        with self.assertRaises(CaptureMismatchError):
+            w.run_once(max_tasks=8)
+        self.assertEqual(ctrl.status()["samples_committed"], 0)
+        self.assertEqual(ctrl.sample_queue.depth(), 0)
+        self.assertEqual(ctrl.status()["prompts_leased"], 0)
+        self.assertEqual(ctrl.status()["prompts_failed"], 1)
+
+    def test_partial_capture_mismatch_releases_all_leases(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}, {"payload": {"text": "bad"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, MixedLayerSource(), _capture(), run_id="run")
+        w.start()
+        from specforge.runtime.inference.capture import CaptureMismatchError
+
+        with self.assertRaises(CaptureMismatchError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["samples_committed"], 1)
+        self.assertEqual(st["queue_depth"], 1)
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_failed"], 1)
+
+    def test_generate_failure_requeues_prompt(self):
+        ctrl = DataFlowController("run")
+        ids = ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, RaisingSource(), _capture(), run_id="run")
+        w.start()
+        with self.assertRaises(RuntimeError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_pending"], 1)
+        self.assertEqual(ctrl.lease_prompt_tasks("w2", 1)[0].task_id, ids[0])
+
+    def test_wrong_feature_count_fails_prompt(self):
+        ctrl = DataFlowController("run")
+        ctrl.ingest_prompts([{"payload": {"text": "a"}}])
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, ShortSource(), _capture(), run_id="run")
+        w.start()
+        with self.assertRaises(ValueError):
+            w.run_once(max_tasks=8)
+        st = ctrl.status()
+        self.assertEqual(st["prompts_leased"], 0)
+        self.assertEqual(st["prompts_failed"], 1)
+
+    def test_no_tasks_returns_empty(self):
+        ctrl = DataFlowController("run")
+        store = LocalFeatureStore("st")
+        w = RolloutWorker(ctrl, store, FakeSource(), _capture(), run_id="run")
+        w.start()
+        self.assertEqual(w.run_once(8), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_sample_ref_queue.py
+++ b/tests/test_runtime/test_sample_ref_queue.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+"""SampleRefQueue lease / ack / fail / depth semantics (CPU-only)."""
+
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+
+
+def _ref(i: int) -> SampleRef:
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://x/s{i}",
+        feature_keys={},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestSampleRefQueue(unittest.TestCase):
+    def test_put_get_ack_depth(self):
+        q = SampleRefQueue()
+        q.put([_ref(0), _ref(1), _ref(2)])
+        self.assertEqual(q.depth(), 3)
+        got = q.get(2)
+        self.assertEqual([r.sample_id for r in got], ["s0", "s1"])
+        self.assertEqual(q.depth(), 1)
+        self.assertEqual(q.in_flight(), 2)
+        q.ack(got)
+        self.assertEqual(q.in_flight(), 0)
+
+    def test_put_is_idempotent_on_sample_id(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        q.put([_ref(0)])  # duplicate sample_id ignored (at-least-once)
+        self.assertEqual(q.depth(), 1)
+
+    def test_fail_retryable_requeues(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        got = q.get(1)
+        q.fail(got, reason="boom", retryable=True)
+        self.assertEqual(q.depth(), 1)
+        again = q.get(1)
+        self.assertEqual(again[0].sample_id, "s0")
+
+    def test_fail_terminal_drops(self):
+        q = SampleRefQueue()
+        q.put([_ref(0)])
+        got = q.get(1)
+        q.fail(got, reason="corrupt", retryable=False)
+        self.assertEqual(q.depth(), 0)
+        self.assertEqual(q.in_flight(), 0)
+
+    def test_get_empty_returns_immediately(self):
+        q = SampleRefQueue()
+        self.assertEqual(q.get(4, timeout_s=0.0), [])
+
+    def test_ack_unknown_is_noop(self):
+        q = SampleRefQueue()
+        q.ack([_ref(99)])  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_seam_fixes.py
+++ b/tests/test_runtime/test_seam_fixes.py
@@ -1,0 +1,195 @@
+# coding=utf-8
+"""CPU tests for do-now seam fixes.
+
+Covered here: durable ack, MetadataStore, TrainLease, partition_key,
+ParallelConfig handles, checkpoint record shape, and DFlash plug-in wiring.
+"""
+
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import SampleRef, TrainBatch
+from specforge.runtime.control_plane import DataFlowController, InMemoryMetadataStore
+from specforge.runtime.training.backend import ParallelConfig, TrainingBackend
+from specforge.runtime.training.strategy import DFlashTrainStrategy
+from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+
+def _ref(i):
+    return SampleRef(
+        sample_id=f"s{i}",
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://x/s{i}",
+        feature_keys={},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestDurableAckTransaction(unittest.TestCase):
+    def test_ack_records_durable_marker(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        leased = ctrl.lease_train_refs("t0", 8)
+        ctrl.ack_train_refs(
+            "t0", [r.sample_id for r in leased], global_step=7, optimizer_durable=True
+        )
+        marker = ctrl.store.durable_marker()
+        self.assertEqual(marker["global_step"], 7)
+        self.assertTrue(marker["optimizer_durable"])
+        self.assertEqual(marker["acked"], {"s0", "s1"})
+        st = ctrl.status()
+        self.assertEqual(st["durable_global_step"], 7)
+        self.assertEqual(st["durable_acked"], 2)
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)  # queue released too
+
+    def test_ack_without_step_still_releases(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0)])
+        leased = ctrl.lease_train_refs("t0", 8)
+        ctrl.ack_train_refs("t0", [r.sample_id for r in leased])  # no global_step
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+
+class TestMetadataStore(unittest.TestCase):
+    def test_commit_dedup(self):
+        s = InMemoryMetadataStore()
+        self.assertTrue(s.commit_sample(_ref(0)))
+        self.assertFalse(s.commit_sample(_ref(0)))  # dup
+        self.assertEqual(s.committed_count(), 1)
+
+
+class TestTrainLease(unittest.TestCase):
+    def test_lease_ack_route_through_controller(self):
+        ctrl = DataFlowController("run")
+        ctrl.enqueue_offline_refs([_ref(0), _ref(1)])
+        lease = ctrl.train_lease("t0")
+        refs = lease.get(8)
+        self.assertEqual({r.sample_id for r in refs}, {"s0", "s1"})
+        lease.ack(refs, global_step=3)
+        self.assertEqual(ctrl.store.durable_marker()["global_step"], 3)
+        self.assertEqual(ctrl.sample_queue.in_flight(), 0)
+
+
+class TestQueuePartitionKey(unittest.TestCase):
+    def test_partition_key_accepted(self):
+        from specforge.runtime.data_plane import SampleRefQueue
+
+        q = SampleRefQueue()
+        q.put([_ref(0)], partition_key="dp0")  # reserved seam, no-op
+        got = q.get(4, timeout_s=0.0, partition_key="dp0")
+        self.assertEqual(len(got), 1)
+
+
+class TestParallelConfigHandles(unittest.TestCase):
+    def test_carries_all_parallel_fields(self):
+        pc = ParallelConfig()
+        for f in (
+            "tp_group",
+            "sp_ulysses_group",
+            "sp_ring_group",
+            "draft_sp_group",
+            "device_mesh",
+            "dp_group",
+            "draft_dp_group",
+        ):
+            self.assertTrue(hasattr(pc, f), f"ParallelConfig missing {f}")
+
+    def test_from_distributed_no_dist(self):
+        pc = ParallelConfig.from_distributed(tp_size=2, sp_ulysses_size=2)
+        self.assertEqual(pc.world_size, 1)  # no dist -> safe defaults
+        self.assertEqual(pc.tp_size, 2)
+        self.assertEqual(pc.sp_size, 2)
+
+
+class _FakeBackend(TrainingBackend):
+    name = "fake"
+
+    def __init__(self, model):
+        self.model = model
+        self.steps = 0
+
+    def prepare_model(self, model):
+        self.module = model
+        return model
+
+    def backward(self, loss):
+        loss.backward()
+
+    def step(self):
+        self.steps += 1
+        return torch.tensor(1.0)
+
+    def state_dict(self):
+        return {"draft_model.w": self.model.w.detach().clone()}
+
+    def load_state_dict(self, state):
+        pass
+
+
+class _FakeDFlashModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.ones(1))
+
+    def forward(self, input_ids, hidden_states, loss_mask):
+        loss = (self.w * hidden_states.float().sum()).abs()
+        acc = torch.tensor(0.5)
+        return loss, acc
+
+
+class TestDFlashSharesLifecycle(unittest.TestCase):
+    def test_dflash_strategy_plugs_into_trainer_core(self):
+        model = _FakeDFlashModel()
+        strat = DFlashTrainStrategy(model)
+        backend = _FakeBackend(model)
+        core = TrainerCore(strat, backend, accumulation_steps=1)
+        batch = TrainBatch(
+            sample_ids=["s0"],
+            strategy="dflash",
+            tensors={
+                "input_ids": torch.zeros(1, 4, dtype=torch.long),
+                "hidden_states": torch.randn(1, 4, 8),
+                "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            },
+            metadata={},
+        )
+        rep = core.train_step(batch)
+        self.assertTrue(rep.optimizer_stepped)  # optimizer stepped via the shared core
+        self.assertEqual(backend.steps, 1)
+        self.assertAlmostEqual(rep.metrics["acc"], 0.5)
+
+    def test_dflash_validate_batch_rejects_missing(self):
+        strat = DFlashTrainStrategy(_FakeDFlashModel())
+        bad = TrainBatch(
+            sample_ids=["s"],
+            strategy="dflash",
+            tensors={"input_ids": torch.zeros(1, 4, dtype=torch.long)},
+            metadata={},
+        )
+        with self.assertRaises(ValueError):
+            strat.forward_loss(bad)
+
+
+class TestCheckpointRecord(unittest.TestCase):
+    def test_save_checkpoint_returns_plain_record(self):
+        model = _FakeDFlashModel()
+        strat = DFlashTrainStrategy(model)
+        backend = _FakeBackend(model)
+        backend.prepare_model(model)
+        core = TrainerCore(strat, backend)
+        with tempfile.TemporaryDirectory() as d:
+            ctrl = TrainerController(core, run_id="r", output_dir=d)
+            ckpt = ctrl.save_checkpoint(10)
+        # weight-version/publish/serving-gate deferred to M7: just a checkpoint record
+        self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+        self.assertEqual(ckpt.global_step, 10)
+        self.assertEqual(ckpt.strategy, "dflash")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_sglang_adapter_batching.py
+++ b/tests/test_runtime/test_sglang_adapter_batching.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+"""SGLangAdapter batches the engine call by sequence length (CPU, fake target)."""
+
+import types
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import PromptTask
+from specforge.runtime.inference.capture import CaptureConfig
+from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+H, V = 4, 16
+
+
+class FakeTarget:
+    """Records each generate_eagle3_data call's batch size; encodes the first
+    token id into hidden_states so per-sample slicing can be verified."""
+
+    aux_hidden_states_layers = [1, 2, 3]
+
+    def __init__(self):
+        self.call_batch_sizes = []
+
+    def generate_eagle3_data(
+        self, input_ids, attention_mask, loss_mask, shard_returns=False
+    ):
+        G, L = input_ids.shape
+        self.call_batch_sizes.append(G)
+        o = types.SimpleNamespace()
+        o.input_ids = input_ids
+        o.attention_mask = attention_mask
+        o.loss_mask = loss_mask.unsqueeze(-1)
+        first_tok = input_ids[:, :1].float()  # (G,1)
+        o.hidden_states = first_tok.unsqueeze(-1).expand(G, L, 3 * H).clone()
+        o.target = torch.zeros(G, L, V)
+        return o
+
+
+class TestAdapterBatching(unittest.TestCase):
+    def _capture(self):
+        return CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=(1, 2, 3),
+            target_repr="logits",
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+
+    def test_groups_by_length_one_call_per_group(self):
+        target = FakeTarget()
+        adapter = SGLangAdapter(target, device="cpu")
+        tasks = [
+            PromptTask("t0", "r", "s", {"input_ids": [10, 11, 12, 13]}, 4),
+            PromptTask("t1", "r", "s", {"input_ids": [20, 21, 22, 23]}, 4),
+            PromptTask("t2", "r", "s", {"input_ids": [30, 31, 32, 33, 34, 35]}, 6),
+        ]
+        feats = adapter.generate_features(tasks, capture=self._capture())
+        # 2 length-groups (len4 x2, len6 x1) -> 2 batched calls, not 3 per-sample
+        self.assertEqual(sorted(target.call_batch_sizes), [1, 2])
+        self.assertEqual(len(feats), 3)
+        # order preserved + correct per-sample mapping (first-token encoding)
+        self.assertEqual(feats[0]["hidden_state"].shape, (1, 4, 3 * H))
+        self.assertEqual(feats[2]["hidden_state"].shape, (1, 6, 3 * H))
+        self.assertEqual(int(feats[0]["hidden_state"][0, 0, 0]), 10)
+        self.assertEqual(int(feats[1]["hidden_state"][0, 0, 0]), 20)
+        self.assertEqual(int(feats[2]["hidden_state"][0, 0, 0]), 30)
+        for f in feats:
+            self.assertEqual(f["__aux_layer_ids__"], (1, 2, 3))
+            self.assertEqual(f["target"].shape[-1], V)
+
+    def test_rejects_unimplemented_target_repr(self):
+        # the online adapter must only advertise reprs it implements
+        adapter = SGLangAdapter(FakeTarget(), device="cpu")
+        cap = CaptureConfig.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=(1, 2, 3),
+            target_repr="hidden_state",  # not implemented online
+            target_hidden_size=H,
+            target_vocab_size=V,
+        )
+        task = PromptTask("t0", "r", "s", {"input_ids": [1, 2, 3, 4]}, 4)
+        with self.assertRaises(NotImplementedError):
+            adapter.generate_features([task], capture=cap)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -1,0 +1,120 @@
+# coding=utf-8
+"""TrainerCore grad-accum + TrainerController fit/checkpoint (CPU)."""
+
+import tempfile
+import unittest
+
+import torch
+import torch.nn as nn
+
+from specforge.runtime.contracts import TrainBatch
+from specforge.runtime.training.backend import TrainingBackend
+from specforge.runtime.training.strategy import DraftTrainStrategy, StepOutput
+from specforge.runtime.training.trainer import (
+    Checkpoint,
+    TrainerController,
+    TrainerCore,
+)
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.ones(1))
+
+
+class FakeStrategy(DraftTrainStrategy):
+    name = "fake"
+    required_features = {"x"}
+
+    def __init__(self):
+        self.model = TinyModel()
+
+    def trainable_module(self):
+        return self.model
+
+    def forward_loss(self, batch: TrainBatch) -> StepOutput:
+        self.validate_batch(batch)
+        loss = (self.model.w * batch.tensors["x"].sum()).abs()
+        return StepOutput(loss=loss, metrics={"accuracy": torch.tensor(0.5)})
+
+
+class FakeBackend(TrainingBackend):
+    name = "fake"
+
+    def __init__(self, model):
+        self.model = model
+        self.steps = 0
+        self.backwards = 0
+
+    def prepare_model(self, model):
+        return model
+
+    def backward(self, loss):
+        self.backwards += 1
+        loss.backward()
+
+    def step(self):
+        self.steps += 1
+        return torch.tensor(1.0)
+
+    def state_dict(self):
+        return {"draft_model.w": self.model.w.detach().clone()}
+
+    def load_state_dict(self, state):
+        pass
+
+
+def _batch():
+    return TrainBatch(
+        sample_ids=["s"], strategy="fake", tensors={"x": torch.ones(2)}, metadata={}
+    )
+
+
+class TestTrainerCore(unittest.TestCase):
+    def test_accumulation_boundary(self):
+        strat = FakeStrategy()
+        backend = FakeBackend(strat.model)
+        core = TrainerCore(strat, backend, accumulation_steps=2)
+        m0 = core.train_step(_batch())
+        self.assertFalse(m0.optimizer_stepped)  # no optimizer step yet
+        self.assertIsNone(m0.grad_norm)
+        self.assertEqual(backend.steps, 0)
+        m1 = core.train_step(_batch())
+        self.assertTrue(m1.optimizer_stepped)  # step on the 2nd micro-batch
+        self.assertIsNotNone(m1.grad_norm)
+        self.assertEqual(backend.steps, 1)
+        self.assertEqual(backend.backwards, 2)
+
+    def test_validate_batch_missing_feature(self):
+        strat = FakeStrategy()
+        bad = TrainBatch(sample_ids=["s"], strategy="fake", tensors={}, metadata={})
+        with self.assertRaises(ValueError):
+            strat.forward_loss(bad)
+
+
+class TestTrainerController(unittest.TestCase):
+    def test_fit_and_checkpoint(self):
+        strat = FakeStrategy()
+        backend = FakeBackend(strat.model)
+        core = TrainerCore(strat, backend, accumulation_steps=1)
+        with tempfile.TemporaryDirectory() as d:
+            ctrl = TrainerController(
+                core,
+                run_id="r",
+                output_dir=d,
+                max_steps=3,
+                num_epochs=5,
+            )
+            data = [_batch() for _ in range(10)]
+            step = ctrl.fit(data)
+            self.assertEqual(step, 3)  # max_steps honored
+            self.assertEqual(backend.steps, 3)
+            ckpt = ctrl.save_checkpoint(step)
+            self.assertIsInstance(ckpt, Checkpoint)
+            self.assertTrue(ckpt.checkpoint_uri.startswith("file://"))
+            self.assertEqual(ckpt.global_step, 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Merges the integrated DataFlow runtime stack into `main`.

The stacked PRs #595–#601 were merged into their parent branches rather than cascading to `main`; only #594 (SGLang import guard) actually reached `main`. As a result `main` currently contains **zero** files under `specforge/runtime/`.

This PR merges the integrated tip (`dataflow-up-7-integration`, which is the #601 merge commit on top of #595–#600) so that `main` actually contains the full `specforge/runtime/` package (contracts, data/control/inference/training planes, launcher, online EAGLE3 launcher) plus its test suite.

## Notes

- Conflict-free merge (verified): 49 files changed, ~+6.4k lines.
- True merge (not fast-forward) — preserves the domino NPU work (#591) already on `main`.
- Equivalent to landing #595–#601 in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)