### PR TITLE
fix(dflash): use mask_token_id from dflash_config

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -430,6 +430,10 @@ def main():
 
     if args.mask_token_id is not None:
         mask_token_id = args.mask_token_id
+    elif (
+        dflash_config := getattr(draft_model.config, "dflash_config", {})
+    ) and dflash_config.get("mask_token_id") is not None:
+        mask_token_id = dflash_config["mask_token_id"]
     elif tokenizer.mask_token_id is not None:
         mask_token_id = tokenizer.mask_token_id
     else:

--- a/scripts/train_domino.py
+++ b/scripts/train_domino.py
@@ -501,6 +501,10 @@ def main():
 
     if args.mask_token_id is not None:
         mask_token_id = args.mask_token_id
+    elif (
+        dflash_config := getattr(draft_model.config, "dflash_config", {})
+    ) and dflash_config.get("mask_token_id") is not None:
+        mask_token_id = dflash_config["mask_token_id"]
     elif tokenizer.mask_token_id is not None:
         mask_token_id = tokenizer.mask_token_id
     else:


### PR DESCRIPTION
## Motivation

Fixes #500.

The `mask_token_id` defined in `draft_config.dflash_config` was not used during DFlash/Domino training. When `--mask-token-id` was not provided, the training scripts fell back to `tokenizer.mask_token_id` or generated a new mask token, which silently ignored the value configured in the draft config.

## Modifications

- Update `scripts/train_dflash.py` to use `draft_model.config.dflash_config["mask_token_id"]` when `--mask-token-id` is not provided.
- Apply the same logic to `scripts/train_domino.py`.
- Keep `--mask-token-id` as the highest-priority override.
- Preserve the existing tokenizer fallback behavior when no mask token is configured.

The resulting priority order is:

1. `--mask-token-id`
2. `draft_config.dflash_config["mask_token_id"]`
3. `tokenizer.mask_token_id`
4. newly added `<|MASK|>` token fallback

## Related Issues

Fixes #500.

## Accuracy Test

Not run. This change only updates configuration selection logic for `mask_token_id`.

## Benchmark & Profiling

Not run. No performance-impacting code path was changed.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.