### PR TITLE
[DataFlow runtime · M5 2/4] Control-plane backpressure (watermarks, caps, starvation)

### DIFF
--- a/specforge/runtime/control_plane/__init__.py
+++ b/specforge/runtime/control_plane/__init__.py
@@ -1,10 +1,21 @@
 # coding=utf-8
 """Control plane: metadata-only scheduling, queues, lifecycle, version policy."""
 
+from specforge.runtime.control_plane.backpressure import (
+    BackpressureConfig,
+    BackpressureController,
+)
 from specforge.runtime.control_plane.controller import DataFlowController, TrainLease
 from specforge.runtime.control_plane.metadata_store import (
     InMemoryMetadataStore,
     MetadataStore,
 )
 
-__all__ = ["DataFlowController", "TrainLease", "MetadataStore", "InMemoryMetadataStore"]
+__all__ = [
+    "DataFlowController",
+    "TrainLease",
+    "MetadataStore",
+    "InMemoryMetadataStore",
+    "BackpressureConfig",
+    "BackpressureController",
+]

--- a/specforge/runtime/control_plane/backpressure.py
+++ b/specforge/runtime/control_plane/backpressure.py
@@ -1,0 +1,158 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Backpressure: the control plane's "when to pause rollout" decision.
+
+Ownership (from ``control_plane/backpressure.md``): **the controller decides when
+to pause; the FeatureStore only reports capacity.** This module is the policy. It
+reads capacity through a narrow ``CapacityReporter`` (anything exposing
+``health() -> dict`` — the feature store qualifies, and its health dict carries
+*ints only*, never tensors, so the control plane stays tensor-free). It owns no
+tensors and no scheduling state beyond its own counters.
+
+Phase-1 policy (this file):
+
+* pause prompt leasing when feature bytes cross a **high watermark**; resume only
+  once they fall back below a **low watermark** (hysteresis, so we don't flap);
+* cap in-flight prompt tasks per rollout worker;
+* cap sample refs leased to the trainer per call;
+* count **rollout starvation** (paused, can't produce) and **trainer starvation**
+  (queue empty when the trainer asks) *separately*, because they call for
+  opposite fixes.
+
+Later (not here): adaptive rollout batch size, priority routing for eval samples,
+stale-sample dropping, per-strategy byte budgets, weighted prompt-source
+scheduling.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol
+
+
+class CapacityReporter(Protocol):
+    """Anything that can report data-plane capacity as a flat metadata dict."""
+
+    def health(self) -> Dict[str, Any]: ...
+
+
+@dataclass
+class BackpressureConfig:
+    """Watermarks and caps. All optional; ``None`` disables that lever.
+
+    ``low_watermark_bytes`` must be ``<= high_watermark_bytes`` so the resume
+    threshold sits below the pause threshold (the hysteresis band). If only the
+    high watermark is given, the low defaults to it (degenerate: no hysteresis).
+    """
+
+    high_watermark_bytes: Optional[int] = None
+    low_watermark_bytes: Optional[int] = None
+    max_inflight_prompts_per_worker: Optional[int] = None
+    max_train_lease: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.high_watermark_bytes is not None and self.low_watermark_bytes is None:
+            self.low_watermark_bytes = self.high_watermark_bytes
+        if (
+            self.high_watermark_bytes is not None
+            and self.low_watermark_bytes is not None
+            and self.low_watermark_bytes > self.high_watermark_bytes
+        ):
+            raise ValueError(
+                "low_watermark_bytes must be <= high_watermark_bytes "
+                f"({self.low_watermark_bytes} > {self.high_watermark_bytes})"
+            )
+
+
+class BackpressureController:
+    """Pure policy: decides pause/resume and caps from capacity signals.
+
+    Holds a latched ``_paused`` flag for hysteresis and separate starvation
+    counters. Thread-safe so a rollout-lease thread and a trainer-lease thread
+    can consult it concurrently.
+    """
+
+    def __init__(
+        self,
+        config: Optional[BackpressureConfig] = None,
+        capacity: Optional[CapacityReporter] = None,
+    ) -> None:
+        self.config = config or BackpressureConfig()
+        self.capacity = capacity
+        self._paused = False
+        self._lock = threading.Lock()
+        self._stats = {
+            "rollout_starved": 0,  # asked to lease prompts while paused
+            "trainer_starved": 0,  # asked to lease train refs, queue was empty
+            "pause_transitions": 0,
+            "resume_transitions": 0,
+        }
+
+    # -- the pause decision (hysteresis) -----------------------------------
+    def should_pause_prompts(self) -> bool:
+        """True iff prompt leasing should be paused right now.
+
+        Latches on at the high watermark and off at the low watermark so a store
+        hovering near one threshold does not flap pause/resume every call.
+        """
+        hi = self.config.high_watermark_bytes
+        if hi is None or self.capacity is None:
+            return False
+        resident = int(self.capacity.health().get("resident_bytes", 0))
+        lo = self.config.low_watermark_bytes
+        with self._lock:
+            if not self._paused and resident >= hi:
+                self._paused = True
+                self._stats["pause_transitions"] += 1
+            elif self._paused and resident <= lo:
+                self._paused = False
+                self._stats["resume_transitions"] += 1
+            return self._paused
+
+    # -- caps ---------------------------------------------------------------
+    def cap_prompt_grant(self, worker_inflight: int, requested: int) -> int:
+        """How many prompt tasks may be granted given the worker's in-flight count."""
+        cap = self.config.max_inflight_prompts_per_worker
+        if cap is None:
+            return requested
+        return max(0, min(requested, cap - worker_inflight))
+
+    def cap_train_lease(self, requested: int) -> int:
+        cap = self.config.max_train_lease
+        return requested if cap is None else min(requested, cap)
+
+    # -- starvation accounting ---------------------------------------------
+    def note_rollout_starved(self) -> None:
+        with self._lock:
+            self._stats["rollout_starved"] += 1
+
+    def note_trainer_starved(self) -> None:
+        with self._lock:
+            self._stats["trainer_starved"] += 1
+
+    # -- observability ------------------------------------------------------
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            snap: Dict[str, Any] = {"paused": self._paused, **self._stats}
+        if self.capacity is not None:
+            h = self.capacity.health()
+            resident = int(h.get("resident_bytes", 0))
+            snap["resident_bytes"] = resident
+            snap["max_resident_bytes"] = h.get("max_resident_bytes")
+            hi = self.config.high_watermark_bytes
+            snap["free_to_high_watermark_bytes"] = (
+                max(0, hi - resident) if hi is not None else None
+            )
+            snap["avg_feature_age_s"] = h.get("avg_age_s")
+            snap["oldest_feature_age_s"] = h.get("oldest_age_s")
+        return snap
+
+
+__all__ = ["CapacityReporter", "BackpressureConfig", "BackpressureController"]

--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -30,6 +30,7 @@ from collections import OrderedDict, deque
 from typing import Any, Deque, Dict, List, Optional
 
 from specforge.runtime.contracts import PromptTask, SampleRef, assert_no_tensors
+from specforge.runtime.control_plane.backpressure import BackpressureController
 from specforge.runtime.control_plane.metadata_store import (
     InMemoryMetadataStore,
     MetadataStore,
@@ -80,10 +81,15 @@ class DataFlowController:
         *,
         sample_queue: Optional[SampleRefQueue] = None,
         metadata_store: Optional[MetadataStore] = None,
+        backpressure: Optional[BackpressureController] = None,
     ) -> None:
         self.run_id = run_id
         self.sample_queue = sample_queue or SampleRefQueue()
         self.store = metadata_store or InMemoryMetadataStore()
+        # Optional backpressure policy. None = never pause / no caps (M1-M4
+        # behavior). The controller owns the pause decision; the policy only
+        # reads capacity (FeatureStore.health) — no tensors cross this seam.
+        self.backpressure = backpressure
         self._prompts: "OrderedDict[str, PromptTask]" = OrderedDict()
         self._prompt_pending: Deque[str] = deque()
         self._prompt_leased: Dict[str, str] = {}  # task_id -> worker_id
@@ -139,9 +145,22 @@ class DataFlowController:
         return task_ids
 
     def lease_prompt_tasks(self, worker_id: str, max_tasks: int) -> List[PromptTask]:
+        # Backpressure: pause leasing entirely above the high watermark (a paused
+        # rollout that asks for work is "rollout starvation" — logged distinctly
+        # from trainer starvation). Consult the policy *outside* the controller
+        # lock; it takes the store lock internally.
+        if self.backpressure is not None and self.backpressure.should_pause_prompts():
+            self.backpressure.note_rollout_starved()
+            return []
         out: List[PromptTask] = []
         with self._lock:
-            for _ in range(max_tasks):
+            grant = max_tasks
+            if self.backpressure is not None:
+                inflight = sum(
+                    1 for w in self._prompt_leased.values() if w == worker_id
+                )
+                grant = self.backpressure.cap_prompt_grant(inflight, max_tasks)
+            for _ in range(grant):
                 if not self._prompt_pending:
                     break
                 task_id = self._prompt_pending.popleft()
@@ -203,7 +222,14 @@ class DataFlowController:
     def lease_train_refs(
         self, trainer_id: str, max_refs: int, timeout_s: Optional[float] = None
     ) -> List[SampleRef]:
-        return self.sample_queue.get(max_refs, timeout_s=timeout_s)
+        if self.backpressure is not None:
+            max_refs = self.backpressure.cap_train_lease(max_refs)
+        refs = self.sample_queue.get(max_refs, timeout_s=timeout_s)
+        # Empty lease == trainer outran rollout (or rollout is paused). Logged as
+        # trainer starvation — the opposite condition from rollout starvation.
+        if not refs and self.backpressure is not None:
+            self.backpressure.note_trainer_starved()
+        return refs
 
     def ack_train_refs(
         self,
@@ -251,20 +277,28 @@ class DataFlowController:
             workers = len(self._workers)
             trainers = len(self._trainers)
         marker = self.store.durable_marker()
-        return {
+        committed = self.store.committed_count()
+        acked = len(marker["acked"])
+        status = {
             "run_id": self.run_id,
             "prompts": prompts,
             "prompts_pending": pending,
             "prompts_leased": leased,
             "prompts_failed": failed,
-            "samples_committed": self.store.committed_count(),
+            "samples_committed": committed,
+            # train_backlog = samples produced but not yet acked-as-trained: the
+            # count-based "trainer behind rollout" signal for backpressure.
+            "train_backlog": committed - acked,
             "queue_depth": self.sample_queue.depth(),
             "queue_in_flight": self.sample_queue.in_flight(),
             "rollout_workers": workers,
             "trainers": trainers,
             "durable_global_step": marker["global_step"],
-            "durable_acked": len(marker["acked"]),
+            "durable_acked": acked,
         }
+        if self.backpressure is not None:
+            status["backpressure"] = self.backpressure.snapshot()
+        return status
 
 
 __all__ = ["DataFlowController", "TrainLease"]

--- a/tests/test_runtime/test_backpressure.py
+++ b/tests/test_runtime/test_backpressure.py
@@ -1,0 +1,147 @@
+# coding=utf-8
+"""Backpressure policy + its wiring into DataFlowController (CPU, no torch)."""
+
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.control_plane.backpressure import (
+    BackpressureConfig,
+    BackpressureController,
+)
+from specforge.runtime.control_plane.controller import DataFlowController
+
+
+class _FakeCapacity:
+    """Minimal CapacityReporter: a mutable health dict, ints only (no tensors)."""
+
+    def __init__(self) -> None:
+        self.resident_bytes = 0
+        self.max_resident_bytes = None
+        self.avg_age_s = 0.0
+        self.oldest_age_s = 0.0
+
+    def health(self):
+        return {
+            "resident_bytes": self.resident_bytes,
+            "max_resident_bytes": self.max_resident_bytes,
+            "avg_age_s": self.avg_age_s,
+            "oldest_age_s": self.oldest_age_s,
+        }
+
+
+def _ref(sid: str) -> SampleRef:
+    return SampleRef(
+        sample_id=sid,
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://st/{sid}",
+        feature_keys={"x": f"{sid}/x"},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestBackpressurePolicy(unittest.TestCase):
+    def test_config_rejects_low_above_high(self):
+        with self.assertRaises(ValueError):
+            BackpressureConfig(high_watermark_bytes=100, low_watermark_bytes=200)
+
+    def test_no_config_never_pauses(self):
+        bp = BackpressureController()  # empty config, no capacity
+        self.assertFalse(bp.should_pause_prompts())
+
+    def test_hysteresis_pause_and_resume(self):
+        cap = _FakeCapacity()
+        bp = BackpressureController(
+            BackpressureConfig(high_watermark_bytes=100, low_watermark_bytes=50),
+            capacity=cap,
+        )
+        cap.resident_bytes = 40
+        self.assertFalse(bp.should_pause_prompts())  # below high
+        cap.resident_bytes = 100
+        self.assertTrue(bp.should_pause_prompts())  # hit high -> pause
+        cap.resident_bytes = 70  # between low and high: still paused (latched)
+        self.assertTrue(bp.should_pause_prompts())
+        cap.resident_bytes = 50  # at/below low -> resume
+        self.assertFalse(bp.should_pause_prompts())
+        snap = bp.snapshot()
+        self.assertEqual(snap["pause_transitions"], 1)
+        self.assertEqual(snap["resume_transitions"], 1)
+
+    def test_cap_prompt_grant(self):
+        bp = BackpressureController(
+            BackpressureConfig(max_inflight_prompts_per_worker=4)
+        )
+        self.assertEqual(bp.cap_prompt_grant(worker_inflight=1, requested=10), 3)
+        self.assertEqual(bp.cap_prompt_grant(worker_inflight=4, requested=10), 0)
+        self.assertEqual(bp.cap_prompt_grant(worker_inflight=5, requested=10), 0)
+
+    def test_cap_train_lease(self):
+        bp = BackpressureController(BackpressureConfig(max_train_lease=2))
+        self.assertEqual(bp.cap_train_lease(10), 2)
+        self.assertEqual(bp.cap_train_lease(1), 1)
+
+
+class TestBackpressureInController(unittest.TestCase):
+    def test_paused_rollout_gets_no_prompts_and_counts_starvation(self):
+        cap = _FakeCapacity()
+        bp = BackpressureController(
+            BackpressureConfig(high_watermark_bytes=100, low_watermark_bytes=50),
+            capacity=cap,
+        )
+        ctrl = DataFlowController("run", backpressure=bp)
+        ctrl.ingest_prompts([{"task_id": f"t{i}", "payload": {}} for i in range(5)])
+        cap.resident_bytes = 100  # over high watermark
+        granted = ctrl.lease_prompt_tasks("w0", 5)
+        self.assertEqual(granted, [])
+        self.assertEqual(ctrl.status()["backpressure"]["rollout_starved"], 1)
+        # drains below low watermark -> resumes
+        cap.resident_bytes = 10
+        granted = ctrl.lease_prompt_tasks("w0", 5)
+        self.assertEqual(len(granted), 5)
+
+    def test_per_worker_inflight_cap(self):
+        bp = BackpressureController(
+            BackpressureConfig(max_inflight_prompts_per_worker=2)
+        )
+        ctrl = DataFlowController("run", backpressure=bp)
+        ctrl.ingest_prompts([{"task_id": f"t{i}", "payload": {}} for i in range(5)])
+        first = ctrl.lease_prompt_tasks("w0", 5)
+        self.assertEqual(len(first), 2)  # capped at 2 in-flight
+        second = ctrl.lease_prompt_tasks("w0", 5)
+        self.assertEqual(len(second), 0)  # still 2 in-flight, no headroom
+        # a different worker has its own budget
+        other = ctrl.lease_prompt_tasks("w1", 5)
+        self.assertEqual(len(other), 2)
+
+    def test_trainer_starvation_counted_on_empty_lease(self):
+        bp = BackpressureController(BackpressureConfig(max_train_lease=4))
+        ctrl = DataFlowController("run", backpressure=bp)
+        out = ctrl.lease_train_refs("trainer", 8)  # queue empty
+        self.assertEqual(out, [])
+        self.assertEqual(ctrl.status()["backpressure"]["trainer_starved"], 1)
+
+    def test_train_lease_capped(self):
+        bp = BackpressureController(BackpressureConfig(max_train_lease=2))
+        ctrl = DataFlowController("run", backpressure=bp)
+        ctrl.enqueue_offline_refs([_ref(f"s{i}") for i in range(5)])
+        out = ctrl.lease_train_refs("trainer", 8)
+        self.assertEqual(len(out), 2)  # capped
+
+    def test_train_backlog_signal(self):
+        ctrl = DataFlowController("run")  # no backpressure needed for this signal
+        ctrl.enqueue_offline_refs([_ref(f"s{i}") for i in range(3)])
+        self.assertEqual(ctrl.status()["train_backlog"], 3)
+        refs = ctrl.lease_train_refs("trainer", 3)
+        ctrl.ack_train_refs("trainer", [r.sample_id for r in refs], global_step=1)
+        self.assertEqual(ctrl.status()["train_backlog"], 0)
+
+    def test_no_backpressure_is_unchanged_behavior(self):
+        ctrl = DataFlowController("run")  # M1-M4 behavior
+        ctrl.ingest_prompts([{"task_id": f"t{i}", "payload": {}} for i in range(5)])
+        self.assertEqual(len(ctrl.lease_prompt_tasks("w0", 10)), 5)
+        self.assertNotIn("backpressure", ctrl.status())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds BackpressureController (hysteresis high/low watermarks, per-worker inflight caps, train-lease caps, separate rollout/trainer starvation) wired optionally into DataFlowController.

Part of the **DataFlow runtime M5/M6** stacked series (continues the M1–M4 work in #594–#601 / #603). Stacked PRs — **merge bottom-up** (up-9 first). Lint (pre-commit) + runtime CPU test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)