### PR TITLE
[DataFlow runtime · M6 1/4] Disaggregation seam: SharedDirFeatureStore + resharding + auth

### DIFF
--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 """Data plane: large-tensor storage, transfer, and materialization."""
 
+from specforge.runtime.data_plane.disaggregated import (
+    AuthPolicy,
+    SharedDirFeatureStore,
+)
 from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
 from specforge.runtime.data_plane.feature_store import (
     FeatureStore,
@@ -12,7 +16,7 @@ from specforge.runtime.data_plane.offline_reader import (
     OfflineManifestReader,
     list_feature_files,
 )
-from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue, dp_partition
 
 __all__ = [
     "FeatureStore",
@@ -20,7 +24,10 @@ __all__ = [
     "load_feature_file",
     "spec_from_tensor",
     "SampleRefQueue",
+    "dp_partition",
     "FeatureDataLoader",
     "OfflineManifestReader",
     "list_feature_files",
+    "SharedDirFeatureStore",
+    "AuthPolicy",
 ]

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -1,10 +1,7 @@
 # coding=utf-8
 """Data plane: large-tensor storage, transfer, and materialization."""
 
-from specforge.runtime.data_plane.disaggregated import (
-    AuthPolicy,
-    SharedDirFeatureStore,
-)
+from specforge.runtime.data_plane.disaggregated import AuthPolicy, SharedDirFeatureStore
 from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
 from specforge.runtime.data_plane.feature_store import (
     FeatureStore,

--- a/specforge/runtime/data_plane/disaggregated.py
+++ b/specforge/runtime/data_plane/disaggregated.py
@@ -45,11 +45,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import torch
 
-from specforge.runtime.contracts import (
-    SCHEMA_VERSION,
-    FeatureHandle,
-    SampleRef,
-)
+from specforge.runtime.contracts import SCHEMA_VERSION, FeatureHandle, SampleRef
 from specforge.runtime.data_plane.feature_store import (
     FeatureStore,
     load_feature_file,
@@ -258,7 +254,11 @@ class SharedDirFeatureStore(FeatureStore):
                     freed += 1
             self._stats["force_freed"] += freed
             self._stats["force_freed_bytes"] += freed_bytes
-        return {"force_freed": freed, "force_freed_bytes": freed_bytes, "release_pending": 0}
+        return {
+            "force_freed": freed,
+            "force_freed_bytes": freed_bytes,
+            "release_pending": 0,
+        }
 
     def health(self) -> Dict[str, Any]:
         with self._lock:

--- a/specforge/runtime/data_plane/disaggregated.py
+++ b/specforge/runtime/data_plane/disaggregated.py
@@ -6,38 +6,36 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-"""Disaggregated FeatureStore: producer and consumer in different processes.
+"""Disaggregated FeatureStore over a shared directory (M6 seam).
 
-``SharedDirFeatureStore`` is the M6 disaggregation seam. Producer (rollout) and
-consumer (trainer) run as separate processes that share only a directory — the
-control plane still carries nothing but ``SampleRef`` metadata (the URI points at
-the shared store), exactly as in the colocated case. ``get()`` resolves a sample
-from the shared filesystem *and the ref alone*, with no shared in-process state,
-which is what makes it a true cross-process boundary.
+Producer (rollout) and consumer (trainer) run as separate processes that share
+only a directory. The control plane still carries only ``SampleRef`` metadata;
+``get()`` resolves a sample from the ref + filesystem alone, with no shared
+in-process state. A real ``MooncakeFeatureStore`` later swaps the shared-dir
+transport for RDMA behind this same API.
 
-This is the framework, not the fast path. A real ``MooncakeFeatureStore`` swaps
-the shared-dir transport for RDMA zero-copy **behind this same API**; everything
-the control/training planes see is unchanged. What this reference backend exists
-to lock down *now* is the contract the fast backend must honor:
+Scope: this is the CPU-testable *reference* backend that pins the contract, not
+the fast path. The read/data path is genuinely cross-process, but the
+generation/lease index is in-process — so the B5 guarantees below hold for the
+single-host (single-producer) case. True multi-node liveness needs that index
+lifted into a shared/durable metadata store (a later milestone).
 
-* **B5 — no use-after-free.** ``get()`` after ``release``/``abort`` raises
-  loudly (``KeyError``) instead of returning stale data, and a generation guard
-  rejects a stale ref after a re-``put``. Clone-on-fetch is the default, so a
-  consumer never holds a pointer a free could invalidate.
-* **B9 — auth required in disaggregated mode.** A process must present the
-  shared credential to attach to and use the store; a missing/mismatched token
-  is a ``PermissionError``, not a silent open door.
+Contract this backend locks down:
 
-Cross-node note: the per-sample generation/lease *index* here is in-process for
-the single-host case. A true multi-node deployment moves that index to the
-durable metadata store (so liveness survives a process restart); the on-disk
-payload + URI contract is already cross-process.
+* **B5 — no use-after-free.** Each generation is a distinct file
+  (``{sample_id}.g{gen}.ckpt``) published by a single atomic rename, and a
+  re-``put`` removes superseded generations — so a stale ref's file is gone and
+  its ``get()`` raises ``KeyError`` rather than aliasing fresh data. ``release()``
+  is generation-aware (frees only the generation its lease held); clone-on-fetch
+  is the default.
+* **B9 — auth in disaggregated mode.** A missing/mismatched shared credential is
+  a ``PermissionError`` at attach time and on the data path.
 """
 
 from __future__ import annotations
 
-import json
 import os
+import re
 import threading
 import time
 import uuid
@@ -81,6 +79,7 @@ class SharedDirFeatureStore(FeatureStore):
         auth: Optional[AuthPolicy] = None,
         credential: Optional[str] = None,
         max_hold_age_s: Optional[float] = None,
+        retain_on_release: bool = False,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self.auth = auth or AuthPolicy()
@@ -90,6 +89,11 @@ class SharedDirFeatureStore(FeatureStore):
         self.root = os.path.join(root, self.store_id)
         os.makedirs(self.root, exist_ok=True)
         self.max_hold_age_s = max_hold_age_s
+        # Read-only re-iterable mode: an offline-imported feature set is consumed
+        # across multiple epochs, so release() must NOT physically free it (mirrors
+        # LocalFeatureStore's file:// no-op release). Cleanup is whole-store at run
+        # end; consume-once free (retain_on_release=False) is for online rollout.
+        self.retain_on_release = retain_on_release
         self._clock = clock
         # in-process liveness index (generation / put-time / active leases)
         self._generation: Dict[str, int] = {}
@@ -97,15 +101,31 @@ class SharedDirFeatureStore(FeatureStore):
         self._active_leases: Dict[str, FeatureHandle] = {}
         self._lock = threading.RLock()
         self._counter = 0
-        self._gen_counter = 0
         self._stats = {"force_freed": 0, "force_freed_bytes": 0}
 
     # -- paths -------------------------------------------------------------
-    def _data_path(self, sample_id: str) -> str:
-        return os.path.join(self.root, f"{sample_id}.ckpt")
+    # Generation is encoded in the FILENAME ({sid}.g{gen}.ckpt) so a generation
+    # is published with ONE atomic rename — a reader either sees a full
+    # generation file or none, never new data under an old generation's number.
+    _FNAME_RE = re.compile(r"^(?P<sid>.+)\.g(?P<gen>\d+)\.ckpt$")
 
-    def _gen_path(self, sample_id: str) -> str:
-        return os.path.join(self.root, f"{sample_id}.gen")
+    def _data_path(self, sample_id: str, gen: int) -> str:
+        return os.path.join(self.root, f"{sample_id}.g{gen}.ckpt")
+
+    def _disk_gens(self, sample_id: str) -> List[int]:
+        gens: List[int] = []
+        try:
+            for name in os.listdir(self.root):
+                m = self._FNAME_RE.match(name)
+                if m and m.group("sid") == sample_id:
+                    gens.append(int(m.group("gen")))
+        except FileNotFoundError:
+            pass
+        return sorted(gens)
+
+    def _current_gen(self, sample_id: str) -> Optional[int]:
+        gens = self._disk_gens(sample_id)
+        return gens[-1] if gens else None
 
     # -- write -------------------------------------------------------------
     def put(
@@ -121,16 +141,20 @@ class SharedDirFeatureStore(FeatureStore):
         staged = {k: v.detach().cpu() for k, v in tensors.items()}
         specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
         with self._lock:
-            self._gen_counter += 1
-            gen = self._gen_counter
-        # atomic publish: write data + generation sidecar, rename into place
-        data_tmp = self._data_path(sample_id) + f".{uuid.uuid4().hex}.tmp"
-        torch.save(staged, data_tmp)
-        os.replace(data_tmp, self._data_path(sample_id))
-        with open(self._gen_path(sample_id) + ".tmp", "w") as f:
-            json.dump({"generation": gen}, f)
-        os.replace(self._gen_path(sample_id) + ".tmp", self._gen_path(sample_id))
-        with self._lock:
+            # next generation, derived from disk so a re-put across instances is
+            # monotonic; the new file is published with a single atomic rename.
+            gen = (self._current_gen(sample_id) or 0) + 1
+            data_tmp = self._data_path(sample_id, gen) + f".{uuid.uuid4().hex}.tmp"
+            torch.save(staged, data_tmp)
+            os.replace(data_tmp, self._data_path(sample_id, gen))
+            # remove superseded generations so a stale ref's file is gone (its
+            # get() then raises -> no use-after-free on re-put).
+            for old in self._disk_gens(sample_id):
+                if old != gen:
+                    try:
+                        os.remove(self._data_path(sample_id, old))
+                    except FileNotFoundError:
+                        pass
             self._generation[sample_id] = gen
             self._put_time[sample_id] = self._clock()
         nbytes = sum(t.numel() * t.element_size() for t in staged.values())
@@ -164,19 +188,19 @@ class SharedDirFeatureStore(FeatureStore):
     ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
         self.auth.check(self._credential)
         sid = sample_ref.sample_id
-        data_path = self._data_path(sid)
-        if not os.path.exists(data_path):
-            # freed by release/abort, or never written -> never hand back stale
-            raise KeyError(f"sample {sid} not available in store {self.store_id}")
-        on_disk_gen = self._read_gen(sid)
-        ref_gen = sample_ref.metadata.get("generation", on_disk_gen)
-        if on_disk_gen is not None and ref_gen != on_disk_gen:
-            # the sample was re-put after this ref was minted -> stale handle
+        gen = sample_ref.metadata.get("generation")
+        if gen is None:
+            gen = self._current_gen(sid)
+        data_path = self._data_path(sid, gen) if gen is not None else None
+        # A missing file means: freed (release/abort), superseded by a re-put, or
+        # never written. In every case refuse to hand back data (B5: no
+        # use-after-free, no stale generation).
+        if data_path is None or not os.path.exists(data_path):
             raise KeyError(
-                f"sample {sid} generation {ref_gen} is stale "
-                f"(current {on_disk_gen}); refusing use-after-free"
+                f"sample {sid} generation {gen} not available in store {self.store_id} "
+                f"(freed, stale, or never written)"
             )
-        raw = load_feature_file(data_path)
+        raw = load_feature_file(data_path)  # gen and data come from one file
         wanted = names or list(sample_ref.feature_keys.keys())
         out = {}
         for n in wanted:
@@ -192,51 +216,53 @@ class SharedDirFeatureStore(FeatureStore):
             self._counter += 1
             handle = FeatureHandle(
                 sample_id=sid,
-                generation=on_disk_gen or 0,
+                generation=int(gen),
                 lease_token=f"{sid}:{self._counter}",
             )
             self._active_leases[handle.lease_token] = handle
         return out, handle
 
-    def _read_gen(self, sample_id: str) -> Optional[int]:
-        try:
-            with open(self._gen_path(sample_id)) as f:
-                return int(json.load(f)["generation"])
-        except (FileNotFoundError, ValueError, KeyError):
-            return None
-
     # -- lifetime ----------------------------------------------------------
-    def _free_locked(self, sample_id: str) -> int:
-        nbytes = 0
-        data_path = self._data_path(sample_id)
-        if os.path.exists(data_path):
-            nbytes = os.path.getsize(data_path)
-        for p in (data_path, self._gen_path(sample_id)):
-            try:
-                os.remove(p)
-            except FileNotFoundError:
-                pass
-        self._generation.pop(sample_id, None)
-        self._put_time.pop(sample_id, None)
+    def _free_gen_locked(self, sample_id: str, gen: int) -> int:
+        path = self._data_path(sample_id, gen)
+        nbytes = os.path.getsize(path) if os.path.exists(path) else 0
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        if self._generation.get(sample_id) == gen:
+            self._generation.pop(sample_id, None)
+            self._put_time.pop(sample_id, None)
         return nbytes
 
     def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
+        # Free this generation's file once the last lease ON THAT generation
+        # drops. A stale handle (its generation already superseded + removed by a
+        # re-put) frees a file that is already gone -> harmless no-op; it can
+        # never delete the freshly re-put current generation (different filename).
         with self._lock:
             self._active_leases.pop(handle.lease_token, None)
-            cur = self._generation.get(handle.sample_id)
-            if cur is not None and handle.generation != cur:
-                return  # stale -> no-op
-            still_leased = any(
-                h.sample_id == handle.sample_id for h in self._active_leases.values()
-            )
-            if not still_leased:
-                self._free_locked(handle.sample_id)
+            if self.retain_on_release:
+                return  # offline re-iterable set: keep the file for the next epoch
+            sid, gen = handle.sample_id, handle.generation
+            if any(
+                h.sample_id == sid and h.generation == gen
+                for h in self._active_leases.values()
+            ):
+                return  # a lease on this generation still holds it
+            self._free_gen_locked(sid, gen)
 
     def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
         with self._lock:
-            self._free_locked(sample_id)
+            for gen in self._disk_gens(sample_id):
+                self._free_gen_locked(sample_id, gen)
+            self._generation.pop(sample_id, None)
+            self._put_time.pop(sample_id, None)
 
     def gc(self, *, now: Optional[float] = None) -> Dict[str, int]:
+        # Max-hold force-free uses this instance's _put_time (single-host). A
+        # true cross-node sweeper reads the durable index / file mtime; that is
+        # the documented disaggregated follow-up.
         now = self._clock() if now is None else now
         freed = freed_bytes = 0
         with self._lock:
@@ -250,8 +276,10 @@ class SharedDirFeatureStore(FeatureStore):
                     )
                 ]
                 for sid in stale:
-                    freed_bytes += self._free_locked(sid)
-                    freed += 1
+                    gen = self._generation.get(sid)
+                    if gen is not None:
+                        freed_bytes += self._free_gen_locked(sid, gen)
+                        freed += 1
             self._stats["force_freed"] += freed
             self._stats["force_freed_bytes"] += freed_bytes
         return {
@@ -261,26 +289,38 @@ class SharedDirFeatureStore(FeatureStore):
         }
 
     def health(self) -> Dict[str, Any]:
+        # Residency is read from DISK (cross-process truth) and computed OUTSIDE
+        # the lock so a directory stat never serializes the put/get/release path.
+        sids_on_disk = set()
+        resident_bytes = 0
+        try:
+            for name in os.listdir(self.root):
+                m = self._FNAME_RE.match(name)
+                if m:
+                    sids_on_disk.add(m.group("sid"))
+                    try:
+                        resident_bytes += os.path.getsize(os.path.join(self.root, name))
+                    except FileNotFoundError:
+                        pass
+        except FileNotFoundError:
+            pass
         with self._lock:
             now = self._clock()
             ages = [now - t for t in self._put_time.values()]
-            resident = sum(
-                os.path.getsize(self._data_path(s))
-                for s in self._generation
-                if os.path.exists(self._data_path(s))
-            )
-            return {
-                "store_id": self.store_id,
-                "backend": "shared_dir",
-                "root": self.root,
-                "resident_samples": len(self._generation),
-                "active_leases": len(self._active_leases),
-                "resident_bytes": resident,
-                "auth_required": self.auth.required,
-                "oldest_age_s": max(ages) if ages else 0.0,
-                "avg_age_s": (sum(ages) / len(ages)) if ages else 0.0,
-                "force_freed_total": self._stats["force_freed"],
-            }
+            active_leases = len(self._active_leases)
+            force_freed = self._stats["force_freed"]
+        return {
+            "store_id": self.store_id,
+            "backend": "shared_dir",
+            "root": self.root,
+            "resident_samples": len(sids_on_disk),
+            "active_leases": active_leases,
+            "resident_bytes": resident_bytes,
+            "auth_required": self.auth.required,
+            "oldest_age_s": max(ages) if ages else 0.0,
+            "avg_age_s": (sum(ages) / len(ages)) if ages else 0.0,
+            "force_freed_total": force_freed,
+        }
 
 
 __all__ = ["AuthPolicy", "SharedDirFeatureStore"]

--- a/specforge/runtime/data_plane/disaggregated.py
+++ b/specforge/runtime/data_plane/disaggregated.py
@@ -1,0 +1,286 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Disaggregated FeatureStore: producer and consumer in different processes.
+
+``SharedDirFeatureStore`` is the M6 disaggregation seam. Producer (rollout) and
+consumer (trainer) run as separate processes that share only a directory — the
+control plane still carries nothing but ``SampleRef`` metadata (the URI points at
+the shared store), exactly as in the colocated case. ``get()`` resolves a sample
+from the shared filesystem *and the ref alone*, with no shared in-process state,
+which is what makes it a true cross-process boundary.
+
+This is the framework, not the fast path. A real ``MooncakeFeatureStore`` swaps
+the shared-dir transport for RDMA zero-copy **behind this same API**; everything
+the control/training planes see is unchanged. What this reference backend exists
+to lock down *now* is the contract the fast backend must honor:
+
+* **B5 — no use-after-free.** ``get()`` after ``release``/``abort`` raises
+  loudly (``KeyError``) instead of returning stale data, and a generation guard
+  rejects a stale ref after a re-``put``. Clone-on-fetch is the default, so a
+  consumer never holds a pointer a free could invalidate.
+* **B9 — auth required in disaggregated mode.** A process must present the
+  shared credential to attach to and use the store; a missing/mismatched token
+  is a ``PermissionError``, not a silent open door.
+
+Cross-node note: the per-sample generation/lease *index* here is in-process for
+the single-host case. A true multi-node deployment moves that index to the
+durable metadata store (so liveness survives a process restart); the on-disk
+payload + URI contract is already cross-process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+
+from specforge.runtime.contracts import (
+    SCHEMA_VERSION,
+    FeatureHandle,
+    SampleRef,
+)
+from specforge.runtime.data_plane.feature_store import (
+    FeatureStore,
+    load_feature_file,
+    spec_from_tensor,
+)
+
+
+class AuthPolicy:
+    """Shared-secret auth (B9). ``token=None`` means auth disabled (colocated)."""
+
+    def __init__(self, token: Optional[str] = None) -> None:
+        self.token = token
+
+    @property
+    def required(self) -> bool:
+        return self.token is not None
+
+    def check(self, presented: Optional[str]) -> None:
+        if self.required and presented != self.token:
+            raise PermissionError(
+                "disaggregated feature store: auth required and token missing/mismatched"
+            )
+
+
+class SharedDirFeatureStore(FeatureStore):
+    """A disaggregated ``FeatureStore`` backed by a shared directory."""
+
+    def __init__(
+        self,
+        root: str,
+        store_id: Optional[str] = None,
+        *,
+        auth: Optional[AuthPolicy] = None,
+        credential: Optional[str] = None,
+        max_hold_age_s: Optional[float] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.auth = auth or AuthPolicy()
+        self._credential = credential
+        self.auth.check(credential)  # attach-time gate
+        self.store_id = store_id or uuid.uuid4().hex[:8]
+        self.root = os.path.join(root, self.store_id)
+        os.makedirs(self.root, exist_ok=True)
+        self.max_hold_age_s = max_hold_age_s
+        self._clock = clock
+        # in-process liveness index (generation / put-time / active leases)
+        self._generation: Dict[str, int] = {}
+        self._put_time: Dict[str, float] = {}
+        self._active_leases: Dict[str, FeatureHandle] = {}
+        self._lock = threading.RLock()
+        self._counter = 0
+        self._gen_counter = 0
+        self._stats = {"force_freed": 0, "force_freed_bytes": 0}
+
+    # -- paths -------------------------------------------------------------
+    def _data_path(self, sample_id: str) -> str:
+        return os.path.join(self.root, f"{sample_id}.ckpt")
+
+    def _gen_path(self, sample_id: str) -> str:
+        return os.path.join(self.root, f"{sample_id}.gen")
+
+    # -- write -------------------------------------------------------------
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef:
+        self.auth.check(self._credential)
+        if not tensors:
+            raise ValueError("put requires at least one tensor")
+        staged = {k: v.detach().cpu() for k, v in tensors.items()}
+        specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
+        with self._lock:
+            self._gen_counter += 1
+            gen = self._gen_counter
+        # atomic publish: write data + generation sidecar, rename into place
+        data_tmp = self._data_path(sample_id) + f".{uuid.uuid4().hex}.tmp"
+        torch.save(staged, data_tmp)
+        os.replace(data_tmp, self._data_path(sample_id))
+        with open(self._gen_path(sample_id) + ".tmp", "w") as f:
+            json.dump({"generation": gen}, f)
+        os.replace(self._gen_path(sample_id) + ".tmp", self._gen_path(sample_id))
+        with self._lock:
+            self._generation[sample_id] = gen
+            self._put_time[sample_id] = self._clock()
+        nbytes = sum(t.numel() * t.element_size() for t in staged.values())
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=str(metadata.get("run_id", "unknown")),
+            source_task_id=metadata.get("source_task_id"),
+            feature_store_uri=f"disagg://{self.store_id}/{sample_id}",
+            feature_keys={k: f"{sample_id}/{k}" for k in staged},
+            feature_specs=specs,
+            strategy=metadata.get("strategy", "eagle3"),
+            schema_version=int(metadata.get("schema_version", SCHEMA_VERSION)),
+            target_model_version=str(metadata.get("target_model_version", "unknown")),
+            draft_weight_version=metadata.get("draft_weight_version"),
+            tokenizer_version=str(metadata.get("tokenizer_version", "unknown")),
+            num_tokens=int(metadata.get("num_tokens", 0)),
+            estimated_bytes=nbytes,
+            metadata={
+                **{k: v for k, v in metadata.items() if k != "num_tokens"},
+                "generation": gen,  # travels with the ref for the staleness guard
+            },
+        )
+
+    # -- read --------------------------------------------------------------
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        self.auth.check(self._credential)
+        sid = sample_ref.sample_id
+        data_path = self._data_path(sid)
+        if not os.path.exists(data_path):
+            # freed by release/abort, or never written -> never hand back stale
+            raise KeyError(f"sample {sid} not available in store {self.store_id}")
+        on_disk_gen = self._read_gen(sid)
+        ref_gen = sample_ref.metadata.get("generation", on_disk_gen)
+        if on_disk_gen is not None and ref_gen != on_disk_gen:
+            # the sample was re-put after this ref was minted -> stale handle
+            raise KeyError(
+                f"sample {sid} generation {ref_gen} is stale "
+                f"(current {on_disk_gen}); refusing use-after-free"
+            )
+        raw = load_feature_file(data_path)
+        wanted = names or list(sample_ref.feature_keys.keys())
+        out = {}
+        for n in wanted:
+            raw_key = sample_ref.feature_keys.get(n, n)
+            raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
+            if raw_key not in raw:
+                raise KeyError(f"{data_path} missing key {raw_key!r} for feature {n!r}")
+            # clone-on-fetch (B5): the returned tensor is independent of the store
+            out[n] = raw[raw_key].clone()
+        if str(device) != "cpu":
+            out = {k: v.to(device) for k, v in out.items()}
+        with self._lock:
+            self._counter += 1
+            handle = FeatureHandle(
+                sample_id=sid,
+                generation=on_disk_gen or 0,
+                lease_token=f"{sid}:{self._counter}",
+            )
+            self._active_leases[handle.lease_token] = handle
+        return out, handle
+
+    def _read_gen(self, sample_id: str) -> Optional[int]:
+        try:
+            with open(self._gen_path(sample_id)) as f:
+                return int(json.load(f)["generation"])
+        except (FileNotFoundError, ValueError, KeyError):
+            return None
+
+    # -- lifetime ----------------------------------------------------------
+    def _free_locked(self, sample_id: str) -> int:
+        nbytes = 0
+        data_path = self._data_path(sample_id)
+        if os.path.exists(data_path):
+            nbytes = os.path.getsize(data_path)
+        for p in (data_path, self._gen_path(sample_id)):
+            try:
+                os.remove(p)
+            except FileNotFoundError:
+                pass
+        self._generation.pop(sample_id, None)
+        self._put_time.pop(sample_id, None)
+        return nbytes
+
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
+        with self._lock:
+            self._active_leases.pop(handle.lease_token, None)
+            cur = self._generation.get(handle.sample_id)
+            if cur is not None and handle.generation != cur:
+                return  # stale -> no-op
+            still_leased = any(
+                h.sample_id == handle.sample_id for h in self._active_leases.values()
+            )
+            if not still_leased:
+                self._free_locked(handle.sample_id)
+
+    def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
+        with self._lock:
+            self._free_locked(sample_id)
+
+    def gc(self, *, now: Optional[float] = None) -> Dict[str, int]:
+        now = self._clock() if now is None else now
+        freed = freed_bytes = 0
+        with self._lock:
+            if self.max_hold_age_s is not None:
+                stale = [
+                    sid
+                    for sid, t in list(self._put_time.items())
+                    if now - t > self.max_hold_age_s
+                    and not any(
+                        h.sample_id == sid for h in self._active_leases.values()
+                    )
+                ]
+                for sid in stale:
+                    freed_bytes += self._free_locked(sid)
+                    freed += 1
+            self._stats["force_freed"] += freed
+            self._stats["force_freed_bytes"] += freed_bytes
+        return {"force_freed": freed, "force_freed_bytes": freed_bytes, "release_pending": 0}
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            now = self._clock()
+            ages = [now - t for t in self._put_time.values()]
+            resident = sum(
+                os.path.getsize(self._data_path(s))
+                for s in self._generation
+                if os.path.exists(self._data_path(s))
+            )
+            return {
+                "store_id": self.store_id,
+                "backend": "shared_dir",
+                "root": self.root,
+                "resident_samples": len(self._generation),
+                "active_leases": len(self._active_leases),
+                "resident_bytes": resident,
+                "auth_required": self.auth.required,
+                "oldest_age_s": max(ages) if ages else 0.0,
+                "avg_age_s": (sum(ages) / len(ages)) if ages else 0.0,
+                "force_freed_total": self._stats["force_freed"],
+            }
+
+
+__all__ = ["AuthPolicy", "SharedDirFeatureStore"]

--- a/specforge/runtime/data_plane/sample_ref_queue.py
+++ b/specforge/runtime/data_plane/sample_ref_queue.py
@@ -15,12 +15,28 @@ touching callers. Carries no tensors — only ``SampleRef`` metadata.
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 from collections import OrderedDict
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from specforge.runtime.contracts import SampleRef, assert_no_tensors
+
+
+def dp_partition(sample_id: str, num_partitions: int) -> int:
+    """Stable DP-rank assignment for a sample under a given partition count.
+
+    The resharding contract (M6): partitioning is a *consumer* decision computed
+    from a stable key (``sample_id``), NOT pinned by the producer. So the same
+    committed pool re-distributes cleanly when the consumer's DP width changes —
+    a sample produced under one layout is consumable under another. Hash-based so
+    it is balanced and deterministic across ranks/restarts.
+    """
+    if num_partitions <= 1:
+        return 0
+    digest = hashlib.sha1(sample_id.encode("utf-8")).hexdigest()
+    return int(digest, 16) % num_partitions
 
 
 class SampleRefQueue:
@@ -52,20 +68,42 @@ class SampleRefQueue:
         timeout_s: Optional[float] = None,
         *,
         partition_key: Optional[str] = None,
+        partition: Optional[Tuple[int, int]] = None,
     ) -> List[SampleRef]:
+        """Lease up to ``max_refs`` pending refs.
+
+        ``partition=(index, num_partitions)`` restricts the lease to the DP shard
+        a consumer owns under its *current* layout (resharding contract): only
+        refs whose ``dp_partition(sample_id, num_partitions) == index`` are
+        leased, so changing ``num_partitions`` re-distributes the same pool. A
+        partitioned get does not block waiting for a cross-partition match (that
+        would let one shard starve another); it returns whatever its shard has.
+        ``partition_key`` remains the reserved per-DP-rank seam (unused today).
+        """
         deadline = None if timeout_s is None else time.monotonic() + timeout_s
         with self._cv:
             while True:
                 self._reclaim_expired_locked()
                 if self._pending:
                     out: List[SampleRef] = []
-                    for _ in range(max_refs):
-                        if not self._pending:
+                    if partition is None:
+                        for _ in range(max_refs):
+                            if not self._pending:
+                                break
+                            sid, ref = self._pending.popitem(last=False)
+                            self._leased[sid] = (ref, time.monotonic())
+                            out.append(ref)
+                        return out
+                    # partitioned lease: take this shard's matching refs only.
+                    index, num_partitions = partition
+                    for sid in list(self._pending.keys()):
+                        if len(out) >= max_refs:
                             break
-                        sid, ref = self._pending.popitem(last=False)
-                        self._leased[sid] = (ref, time.monotonic())
-                        out.append(ref)
-                    return out
+                        if dp_partition(sid, num_partitions) == index:
+                            ref = self._pending.pop(sid)
+                            self._leased[sid] = (ref, time.monotonic())
+                            out.append(ref)
+                    return out  # may be empty if this shard has nothing pending
                 if deadline is None:
                     return []
                 remaining = deadline - time.monotonic()

--- a/specforge/runtime/data_plane/sample_ref_queue.py
+++ b/specforge/runtime/data_plane/sample_ref_queue.py
@@ -70,46 +70,61 @@ class SampleRefQueue:
         partition_key: Optional[str] = None,
         partition: Optional[Tuple[int, int]] = None,
     ) -> List[SampleRef]:
-        """Lease up to ``max_refs`` pending refs.
+        """Lease up to ``max_refs`` pending refs; block until some arrive or
+        ``timeout_s`` elapses.
 
         ``partition=(index, num_partitions)`` restricts the lease to the DP shard
-        a consumer owns under its *current* layout (resharding contract): only
-        refs whose ``dp_partition(sample_id, num_partitions) == index`` are
-        leased, so changing ``num_partitions`` re-distributes the same pool. A
-        partitioned get does not block waiting for a cross-partition match (that
-        would let one shard starve another); it returns whatever its shard has.
-        ``partition_key`` remains the reserved per-DP-rank seam (unused today).
+        this consumer owns under its *current* layout (resharding contract), so
+        changing ``num_partitions`` re-distributes the same committed pool. See
+        :meth:`_lease_partition_locked` for the (non-blocking) shard semantics.
+
+        ``partition_key`` is a separate, still-reserved seam (a producer-side
+        routing hint); it is accepted and ignored today. ``partition`` is the
+        consumer-side resharding control — the two are unrelated.
         """
         deadline = None if timeout_s is None else time.monotonic() + timeout_s
         with self._cv:
             while True:
                 self._reclaim_expired_locked()
                 if self._pending:
-                    out: List[SampleRef] = []
                     if partition is None:
-                        for _ in range(max_refs):
-                            if not self._pending:
-                                break
-                            sid, ref = self._pending.popitem(last=False)
-                            self._leased[sid] = (ref, time.monotonic())
-                            out.append(ref)
-                        return out
-                    # partitioned lease: take this shard's matching refs only.
-                    index, num_partitions = partition
-                    for sid in list(self._pending.keys()):
-                        if len(out) >= max_refs:
-                            break
-                        if dp_partition(sid, num_partitions) == index:
-                            ref = self._pending.pop(sid)
-                            self._leased[sid] = (ref, time.monotonic())
-                            out.append(ref)
-                    return out  # may be empty if this shard has nothing pending
+                        return self._lease_any_locked(max_refs)
+                    return self._lease_partition_locked(max_refs, partition)
                 if deadline is None:
                     return []
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return []
                 self._cv.wait(timeout=remaining)
+
+    def _lease_any_locked(self, max_refs: int) -> List[SampleRef]:
+        """FIFO-lease up to ``max_refs`` pending refs (no partitioning)."""
+        out: List[SampleRef] = []
+        while self._pending and len(out) < max_refs:
+            sid, ref = self._pending.popitem(last=False)
+            self._leased[sid] = (ref, time.monotonic())
+            out.append(ref)
+        return out
+
+    def _lease_partition_locked(
+        self, max_refs: int, partition: Tuple[int, int]
+    ) -> List[SampleRef]:
+        """Lease only this shard's matching refs (resharding contract).
+
+        Returns whatever this shard has pending — possibly empty — and never
+        blocks waiting for a cross-partition match (that would starve one shard
+        behind another).
+        """
+        index, num_partitions = partition
+        out: List[SampleRef] = []
+        for sid in list(self._pending.keys()):
+            if len(out) >= max_refs:
+                break
+            if dp_partition(sid, num_partitions) == index:
+                ref = self._pending.pop(sid)
+                self._leased[sid] = (ref, time.monotonic())
+                out.append(ref)
+        return out
 
     def ack(self, refs: List[SampleRef]) -> None:
         with self._cv:

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -54,6 +54,38 @@ def build_single_rank_distributed(port="29561"):
     init_distributed(timeout=10, tp_size=1, sp_ulysses_size=1, sp_ring_size=1)
 
 
+def init_rank_distributed(
+    rank,
+    world_size,
+    *,
+    tp_size=1,
+    sp_ulysses_size=1,
+    sp_ring_size=1,
+    port="29571",
+):
+    """Init one rank of a multi-process group (for the M6 >=4-rank tests).
+
+    Each spawned process calls this with its own rank; together they form a
+    world_size group with the requested TP x SP layout. Mirrors the env that
+    torchrun sets, so SpecForge's ``init_distributed`` builds the real TP +
+    Ulysses/Ring SP groups.
+    """
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(rank)
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ["MASTER_PORT"] = port
+    torch.cuda.set_device(rank)
+    from specforge.distributed import init_distributed
+
+    init_distributed(
+        timeout=60,
+        tp_size=tp_size,
+        sp_ulysses_size=sp_ulysses_size,
+        sp_ring_size=sp_ring_size,
+    )
+
+
 def write_draft_config(path):
     with open(path, "w") as f:
         json.dump(TINY_DRAFT_CONFIG, f)

--- a/tests/test_runtime/test_disaggregated.py
+++ b/tests/test_runtime/test_disaggregated.py
@@ -44,6 +44,20 @@ class TestDisaggregatedStore(unittest.TestCase):
         with self.assertRaises(KeyError):
             producer.get(ref)
 
+    def test_consumer_release_of_stale_handle_does_not_free_fresh_reput(self):
+        # finding [1]/[2]: a consumer-only instance releasing a stale handle must
+        # NOT delete the freshly re-put generation's data.
+        producer = SharedDirFeatureStore(self.root, store_id="st")
+        consumer = SharedDirFeatureStore(self.root, store_id="st")
+        ref1 = producer.put({"x": torch.zeros(1, 4)}, sample_id="s0", metadata={})
+        _, h_old = consumer.get(ref1)  # consumer leases gen1
+        ref2 = producer.put(
+            {"x": torch.ones(1, 4)}, sample_id="s0", metadata={}
+        )  # gen2
+        consumer.release(h_old)  # stale gen1 handle; must not touch gen2
+        out, _ = consumer.get(ref2)  # gen2 must still be intact
+        self.assertEqual(out["x"].sum().item(), 4.0)  # ones(1,4) intact
+
     def test_use_after_free_get_raises(self):
         store = SharedDirFeatureStore(self.root)
         ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})

--- a/tests/test_runtime/test_disaggregated.py
+++ b/tests/test_runtime/test_disaggregated.py
@@ -30,7 +30,9 @@ class TestDisaggregatedStore(unittest.TestCase):
         # The consumer resolves the sample from the ref + filesystem alone.
         producer = SharedDirFeatureStore(self.root, store_id="st")
         t = torch.randn(1, 4, 8)
-        ref = producer.put({"hidden_state": t}, sample_id="s0", metadata={"strategy": "eagle3"})
+        ref = producer.put(
+            {"hidden_state": t}, sample_id="s0", metadata={"strategy": "eagle3"}
+        )
         self.assertTrue(ref.feature_store_uri.startswith("disagg://"))
         assert_no_tensors(ref)  # control plane stays metadata-only across the boundary
 
@@ -52,7 +54,9 @@ class TestDisaggregatedStore(unittest.TestCase):
     def test_stale_generation_is_rejected(self):
         store = SharedDirFeatureStore(self.root)
         ref_old = store.put({"x": torch.zeros(1, 4)}, sample_id="s0", metadata={})
-        store.put({"x": torch.ones(1, 4)}, sample_id="s0", metadata={})  # re-put -> gen+1
+        store.put(
+            {"x": torch.ones(1, 4)}, sample_id="s0", metadata={}
+        )  # re-put -> gen+1
         with self.assertRaises(KeyError):  # old handle must not alias new data
             store.get(ref_old)
 

--- a/tests/test_runtime/test_disaggregated.py
+++ b/tests/test_runtime/test_disaggregated.py
@@ -1,0 +1,117 @@
+# coding=utf-8
+"""Disaggregated FeatureStore: cross-process boundary, B5 use-after-free, B9 auth."""
+
+import tempfile
+import unittest
+
+import torch
+
+from specforge.runtime.contracts import assert_no_tensors
+from specforge.runtime.data_plane.disaggregated import AuthPolicy, SharedDirFeatureStore
+
+
+class _FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+class TestDisaggregatedStore(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def test_producer_and_consumer_share_only_the_directory(self):
+        # Two *separate* store instances (= two processes) share only `root`.
+        # The consumer resolves the sample from the ref + filesystem alone.
+        producer = SharedDirFeatureStore(self.root, store_id="st")
+        t = torch.randn(1, 4, 8)
+        ref = producer.put({"hidden_state": t}, sample_id="s0", metadata={"strategy": "eagle3"})
+        self.assertTrue(ref.feature_store_uri.startswith("disagg://"))
+        assert_no_tensors(ref)  # control plane stays metadata-only across the boundary
+
+        consumer = SharedDirFeatureStore(self.root, store_id="st")  # different instance
+        out, handle = consumer.get(ref)
+        self.assertTrue(torch.allclose(out["hidden_state"], t))
+        consumer.release(handle)
+        # after the consumer frees it, it is gone for everyone (shared backend)
+        with self.assertRaises(KeyError):
+            producer.get(ref)
+
+    def test_use_after_free_get_raises(self):
+        store = SharedDirFeatureStore(self.root)
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        store.abort("s0", reason="terminal")
+        with self.assertRaises(KeyError):  # B5: no stale data after free
+            store.get(ref)
+
+    def test_stale_generation_is_rejected(self):
+        store = SharedDirFeatureStore(self.root)
+        ref_old = store.put({"x": torch.zeros(1, 4)}, sample_id="s0", metadata={})
+        store.put({"x": torch.ones(1, 4)}, sample_id="s0", metadata={})  # re-put -> gen+1
+        with self.assertRaises(KeyError):  # old handle must not alias new data
+            store.get(ref_old)
+
+    def test_clone_on_fetch_is_independent(self):
+        store = SharedDirFeatureStore(self.root)
+        ref = store.put({"x": torch.zeros(1, 4)}, sample_id="s0", metadata={})
+        out, h = store.get(ref)
+        out["x"].add_(1.0)  # mutate the fetched copy
+        store.release(h)
+        ref2 = store.put({"x": torch.zeros(1, 4)}, sample_id="s1", metadata={})
+        out2, _ = store.get(ref2)
+        self.assertEqual(out2["x"].sum().item(), 0.0)  # store data untouched
+
+    def test_release_refcounted_last_lease_frees(self):
+        store = SharedDirFeatureStore(self.root)
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref)
+        _, h2 = store.get(ref)
+        store.release(h1)
+        self.assertEqual(store.health()["resident_samples"], 1)  # h2 holds it
+        store.release(h2)
+        with self.assertRaises(KeyError):
+            store.get(ref)
+
+    def test_gc_force_frees_past_max_hold(self):
+        clock = _FakeClock()
+        store = SharedDirFeatureStore(self.root, max_hold_age_s=10.0, clock=clock)
+        store.put({"x": torch.randn(1, 4)}, sample_id="old", metadata={})
+        clock.advance(50.0)
+        report = store.gc()
+        self.assertEqual(report["force_freed"], 1)
+        self.assertEqual(store.health()["resident_samples"], 0)
+
+
+class TestDisaggregatedAuth(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp()
+
+    def test_auth_required_blocks_wrong_credential(self):
+        auth = AuthPolicy("s3cret")
+        # attach-time gate: wrong/missing credential cannot open the store
+        with self.assertRaises(PermissionError):
+            SharedDirFeatureStore(self.root, auth=auth, credential="wrong")
+        with self.assertRaises(PermissionError):
+            SharedDirFeatureStore(self.root, auth=auth, credential=None)
+
+    def test_auth_enforced_on_data_path(self):
+        auth = AuthPolicy("s3cret")
+        store = SharedDirFeatureStore(self.root, auth=auth, credential="s3cret")
+        ref = store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+        out, _ = store.get(ref)
+        self.assertIn("x", out)
+        self.assertTrue(store.health()["auth_required"])
+
+    def test_no_auth_is_open(self):
+        store = SharedDirFeatureStore(self.root)  # colocated default
+        self.assertFalse(store.health()["auth_required"])
+        store.put({"x": torch.randn(1, 4)}, sample_id="s0", metadata={})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_equiv_4rank.py
+++ b/tests/test_runtime/test_equiv_4rank.py
@@ -33,13 +33,12 @@ def _worker(rank, world_size, workdir, results_dir):
         rank, world_size, tp_size=2, sp_ulysses_size=2, sp_ring_size=1, port="29573"
     )
 
+    from scripts.train_eagle3 import run_backward_and_update, run_forward
     from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
     from specforge.data.preprocessing import OfflineEagle3Dataset
     from specforge.data.utils import DataCollatorWithPadding
     from specforge.modeling.target import TargetHead
     from specforge.optimizer import BF16Optimizer
-    from scripts.train_eagle3 import run_backward_and_update, run_forward
-
     from specforge.runtime.contracts import TrainBatch
     from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
     from specforge.runtime.training.strategy import Eagle3TrainStrategy
@@ -78,20 +77,34 @@ def _worker(rank, world_size, workdir, results_dir):
     data = DataCollatorWithPadding()([ds[j] for j in range(BS)])
 
     args = types.SimpleNamespace(
-        is_vlm=False, target_model_backend="hf",
-        shard_target_output=False, draft_accumulation_steps=1,
+        is_vlm=False,
+        target_model_backend="hf",
+        shard_target_output=False,
+        draft_accumulation_steps=1,
     )
 
     # --- legacy path ---
-    opt_a = BF16Optimizer(model_a.draft_model, lr=1e-4, max_grad_norm=0.5,
-                          warmup_ratio=0.0, total_steps=10)
-    plosses_a, _, _, _, _, _, _ = run_forward(args, model_a, data, head, is_online=False)
+    opt_a = BF16Optimizer(
+        model_a.draft_model,
+        lr=1e-4,
+        max_grad_norm=0.5,
+        warmup_ratio=0.0,
+        total_steps=10,
+    )
+    plosses_a, _, _, _, _, _, _ = run_forward(
+        args, model_a, data, head, is_online=False
+    )
     loss_old = sum(0.8**i * plosses_a[i] for i in range(len(plosses_a))).item()
     gn_old = run_backward_and_update(args, plosses_a, opt_a, global_step=1)
 
     # --- new path under the real 4-rank ParallelConfig ---
-    opt_b = BF16Optimizer(model_b.draft_model, lr=1e-4, max_grad_norm=0.5,
-                          warmup_ratio=0.0, total_steps=10)
+    opt_b = BF16Optimizer(
+        model_b.draft_model,
+        lr=1e-4,
+        max_grad_norm=0.5,
+        warmup_ratio=0.0,
+        total_steps=10,
+    )
     pc = ParallelConfig.from_distributed(tp_size=2, sp_ulysses_size=2, sp_ring_size=1)
     backend = FSDPTrainingBackend(pc)
     backend.prepare_model(model_b, wrap=False, optimizer_target=model_b.draft_model)
@@ -99,7 +112,9 @@ def _worker(rank, world_size, workdir, results_dir):
     strategy = Eagle3TrainStrategy(model_b, target_head=head)
     core = TrainerCore(strategy, backend, accumulation_steps=1)
     batch = TrainBatch(
-        sample_ids=["a", "b"], strategy="eagle3", tensors=dict(data),
+        sample_ids=["a", "b"],
+        strategy="eagle3",
+        tensors=dict(data),
         metadata={"target_repr": "hidden_state", "ttt_length": TTT},
     )
     rep = core.train_step(batch)
@@ -151,12 +166,16 @@ class TestEquiv4Rank(unittest.TestCase):
             self.assertEqual(res["sp"], 2)
             # per-rank: new path reproduces legacy loss on the same SP slice
             self.assertAlmostEqual(
-                res["loss_old"], res["loss_new"], places=3,
+                res["loss_old"],
+                res["loss_new"],
+                places=3,
                 msg=f"rank {res['rank']} loss: old={res['loss_old']} new={res['loss_new']}",
             )
             # grad-norm reduction matches (both reduce across the world group)
             self.assertAlmostEqual(
-                res["gn_old"], res["gn_new"], places=2,
+                res["gn_old"],
+                res["gn_new"],
+                places=2,
                 msg=f"rank {res['rank']} grad_norm: old={res['gn_old']} new={res['gn_new']}",
             )
 

--- a/tests/test_runtime/test_equiv_4rank.py
+++ b/tests/test_runtime/test_equiv_4rank.py
@@ -1,0 +1,165 @@
+# coding=utf-8
+"""M6 gate: the trainer split is equivalent under tp>1 & sp>1 (>=4 ranks).
+
+Spawns a 4-process group with TP=2 x SP(ulysses)=2 and, on every rank, runs ONE
+offline EAGLE3 step through both the legacy path (``run_forward`` +
+``run_backward_and_update``) and the new path (``Eagle3TrainStrategy`` +
+``TrainerCore`` + ``FSDPTrainingBackend`` carrying the real 4-rank
+``ParallelConfig``). Both consume the *identical* USP-sharded data for that rank,
+so any divergence is the new path failing to preserve the math under real TP+SP —
+the "scale-out claim met, not FSDP-only" gate.
+
+GPU-only and needs >=4 visible GPUs. Run on the H200 box via rcli.
+"""
+
+import json
+import os
+import tempfile
+import types
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+NGPU = torch.cuda.device_count() if CUDA else 0
+WORLD = 4
+
+
+def _worker(rank, world_size, workdir, results_dir):
+    """One rank: build old+new with identical weights, one step, record result."""
+    from tests.test_runtime import _fixtures as fx
+
+    fx.init_rank_distributed(
+        rank, world_size, tp_size=2, sp_ulysses_size=2, sp_ring_size=1, port="29573"
+    )
+
+    from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
+    from specforge.data.preprocessing import OfflineEagle3Dataset
+    from specforge.data.utils import DataCollatorWithPadding
+    from specforge.modeling.target import TargetHead
+    from specforge.optimizer import BF16Optimizer
+    from scripts.train_eagle3 import run_backward_and_update, run_forward
+
+    from specforge.runtime.contracts import TrainBatch
+    from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
+    from specforge.runtime.training.strategy import Eagle3TrainStrategy
+    from specforge.runtime.training.trainer import TrainerCore
+
+    torch.manual_seed(0)
+    torch.use_deterministic_algorithms(True, warn_only=True)
+
+    TTT, BS = 3, 2
+    cfg = os.path.join(workdir, "draft.json")
+    target_dir = os.path.join(workdir, "target")
+    vocab_path = os.path.join(workdir, "vm.pt")
+    feat_dir = os.path.join(workdir, "features")
+    draft_config = AutoDraftModelConfig.from_file(cfg)
+
+    def build_model():
+        dm = AutoEagle3DraftModel.from_config(
+            draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+        ).cuda()
+        dm.load_vocab_mapping(vocab_path)
+        dm.freeze_embedding()
+        return OnlineEagle3Model(
+            draft_model=dm, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+
+    model_a = build_model()
+    model_b = build_model()
+    model_b.draft_model.load_state_dict(model_a.draft_model.state_dict())  # identical
+    head = TargetHead.from_pretrained(target_dir, lm_head_key="lm_head.weight")
+
+    # USP-sharded offline data: this rank gets its SP slice (the real sp>1 path).
+    files = sorted(os.path.join(feat_dir, f) for f in os.listdir(feat_dir))
+    ds = OfflineEagle3Dataset(
+        files, max_len=512, ttt_length=TTT, use_usp_preprocess=True
+    )
+    data = DataCollatorWithPadding()([ds[j] for j in range(BS)])
+
+    args = types.SimpleNamespace(
+        is_vlm=False, target_model_backend="hf",
+        shard_target_output=False, draft_accumulation_steps=1,
+    )
+
+    # --- legacy path ---
+    opt_a = BF16Optimizer(model_a.draft_model, lr=1e-4, max_grad_norm=0.5,
+                          warmup_ratio=0.0, total_steps=10)
+    plosses_a, _, _, _, _, _, _ = run_forward(args, model_a, data, head, is_online=False)
+    loss_old = sum(0.8**i * plosses_a[i] for i in range(len(plosses_a))).item()
+    gn_old = run_backward_and_update(args, plosses_a, opt_a, global_step=1)
+
+    # --- new path under the real 4-rank ParallelConfig ---
+    opt_b = BF16Optimizer(model_b.draft_model, lr=1e-4, max_grad_norm=0.5,
+                          warmup_ratio=0.0, total_steps=10)
+    pc = ParallelConfig.from_distributed(tp_size=2, sp_ulysses_size=2, sp_ring_size=1)
+    backend = FSDPTrainingBackend(pc)
+    backend.prepare_model(model_b, wrap=False, optimizer_target=model_b.draft_model)
+    backend.set_optimizer(opt_b)
+    strategy = Eagle3TrainStrategy(model_b, target_head=head)
+    core = TrainerCore(strategy, backend, accumulation_steps=1)
+    batch = TrainBatch(
+        sample_ids=["a", "b"], strategy="eagle3", tensors=dict(data),
+        metadata={"target_repr": "hidden_state", "ttt_length": TTT},
+    )
+    rep = core.train_step(batch)
+
+    with open(os.path.join(results_dir, f"rank{rank}.json"), "w") as f:
+        json.dump(
+            {
+                "rank": rank,
+                "world": pc.world_size,
+                "tp": pc.tp_size,
+                "sp": pc.sp_size,
+                "loss_old": loss_old,
+                "loss_new": rep.loss,
+                "gn_old": float(gn_old.item()),
+                "gn_new": rep.grad_norm,
+            },
+            f,
+        )
+
+
+@unittest.skipUnless(CUDA and NGPU >= WORLD, f"requires >={WORLD} GPUs")
+class TestEquiv4Rank(unittest.TestCase):
+    def test_equiv_tp2_sp2(self):
+        import torch.multiprocessing as mp
+
+        workdir = tempfile.mkdtemp(prefix="equiv_4rank_")
+        from tests.test_runtime import _fixtures as fx
+
+        # build shared fixtures once (deterministic, seed-fixed)
+        fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        fx.write_target_head_dir(os.path.join(workdir, "target"))
+        fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        fx.write_offline_files(os.path.join(workdir, "features"), n=8, seq=64)
+
+        results_dir = os.path.join(workdir, "results")
+        os.makedirs(results_dir, exist_ok=True)
+
+        mp.spawn(_worker, args=(WORLD, workdir, results_dir), nprocs=WORLD, join=True)
+
+        results = []
+        for r in range(WORLD):
+            with open(os.path.join(results_dir, f"rank{r}.json")) as f:
+                results.append(json.load(f))
+        self.assertEqual(len(results), WORLD)
+
+        for res in results:
+            self.assertEqual(res["world"], WORLD)
+            self.assertEqual(res["tp"], 2)
+            self.assertEqual(res["sp"], 2)
+            # per-rank: new path reproduces legacy loss on the same SP slice
+            self.assertAlmostEqual(
+                res["loss_old"], res["loss_new"], places=3,
+                msg=f"rank {res['rank']} loss: old={res['loss_old']} new={res['loss_new']}",
+            )
+            # grad-norm reduction matches (both reduce across the world group)
+            self.assertAlmostEqual(
+                res["gn_old"], res["gn_new"], places=2,
+                msg=f"rank {res['rank']} grad_norm: old={res['gn_old']} new={res['gn_new']}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_resharding.py
+++ b/tests/test_runtime/test_resharding.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+"""Resharding contract: consumer re-partitions a stable committed pool (M6).
+
+The numerical correctness of resharding tensors across a different rank layout is
+the GPU gate (``test_equiv_4rank.py``). These CPU tests lock down the *control*
+side: partitioning is a stable, consumer-side function of ``sample_id``, so the
+same pool re-distributes cleanly when the consumer's DP width changes — and no
+sample is leased twice or dropped across a reshard.
+"""
+
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue, dp_partition
+
+
+def _ref(sid):
+    return SampleRef(
+        sample_id=sid,
+        run_id="r",
+        source_task_id=None,
+        feature_store_uri=f"mem://st/{sid}",
+        feature_keys={"x": f"{sid}/x"},
+        feature_specs={},
+        strategy="eagle3",
+    )
+
+
+class TestDpPartition(unittest.TestCase):
+    def test_stable_and_in_range(self):
+        for sid in (f"s{i}" for i in range(100)):
+            p = dp_partition(sid, 4)
+            self.assertEqual(p, dp_partition(sid, 4))  # stable
+            self.assertTrue(0 <= p < 4)
+
+    def test_single_partition_is_zero(self):
+        self.assertEqual(dp_partition("anything", 1), 0)
+
+    def test_roughly_balanced(self):
+        counts = [0, 0, 0, 0]
+        for i in range(4000):
+            counts[dp_partition(f"sample-{i}", 4)] += 1
+        # within ~20% of even (1000 each) — hash balance, not exact
+        for c in counts:
+            self.assertTrue(800 < c < 1200, counts)
+
+
+class TestQueueResharding(unittest.TestCase):
+    def test_two_shards_partition_the_pool_disjointly(self):
+        q = SampleRefQueue()
+        q.put([_ref(f"s{i}") for i in range(50)])
+        shard0 = q.get(100, partition=(0, 2))
+        shard1 = q.get(100, partition=(1, 2))
+        ids0 = {r.sample_id for r in shard0}
+        ids1 = {r.sample_id for r in shard1}
+        self.assertEqual(ids0 & ids1, set())  # disjoint
+        self.assertEqual(ids0 | ids1, {f"s{i}" for i in range(50)})  # complete
+        for sid in ids0:
+            self.assertEqual(dp_partition(sid, 2), 0)
+
+    def test_reshard_to_wider_layout_consumes_remainder_once(self):
+        # Start consuming under width 2 (one shard), then the leftover pool is
+        # consumed under width 3 — every sample is leased exactly once total.
+        q = SampleRefQueue()
+        all_ids = {f"s{i}" for i in range(60)}
+        q.put([_ref(s) for s in all_ids])
+        leased = set()
+
+        first = q.get(100, partition=(0, 2))  # width-2 shard 0
+        leased |= {r.sample_id for r in first}
+        # ... reshard to width 3: the remaining (still-pending) refs go to 3 shards
+        for idx in range(3):
+            got = q.get(100, partition=(idx, 3))
+            new = {r.sample_id for r in got}
+            self.assertEqual(new & leased, set())  # never re-leased
+            leased |= new
+        self.assertEqual(leased, all_ids)  # nothing lost
+        self.assertEqual(q.depth(), 0)
+
+    def test_partitioned_get_does_not_block_on_empty_shard(self):
+        q = SampleRefQueue()
+        q.put([_ref("s0")])  # only sample maps to some partition
+        p = dp_partition("s0", 4)
+        empty_idx = (p + 1) % 4
+        # a shard with no matching ref returns [] immediately, even with timeout
+        self.assertEqual(q.get(10, timeout_s=0.05, partition=(empty_idx, 4)), [])
+        self.assertEqual(len(q.get(10, partition=(p, 4))), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds the M6 disaggregation seam: **SharedDirFeatureStore** + **AuthPolicy** (B9) + **SampleRefQueue** consumer-side resharding (`dp_partition`).

**B5 (no use-after-free)** via a per-generation-file design: each generation is a distinct `{sample_id}.g{gen}.ckpt` published with a single atomic rename; a re-`put` removes superseded generations (so a stale ref's file is gone and its `get()` raises rather than aliasing fresh data); `release()` is generation-aware (frees only the generation its lease held); clone-on-fetch is the default. Generation is derived from disk, so re-`put` is monotonic across instances. `retain_on_release` supports offline re-iterable feature sets.

**Resharding contract:** partitioning is a consumer-side hash of `sample_id` (`dp_partition`), so the same committed pool re-distributes when DP width changes — no sample leased twice or dropped.

Scope: this is the CPU-testable **reference** backend that pins the contract; the RDMA fast path is `MooncakeFeatureStore` (#612). The generation/lease index is in-process (single-host); true multi-node liveness lifts it into a shared metadata store (later milestone). The per-generation B5 correctness was folded in here (from the M6 hardening pass) so the seam lands correct rather than fixed two PRs later.

Part of the **DataFlow runtime M5/M6** stacked series (continues the M1–M4 work in #594–#601 / #603). Stacked PRs — **merge bottom-up** (up-9 first). Lint (pre-commit) + runtime CPU test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
