### PR TITLE
[DataFlow runtime · M6 3/4] M5/M6 adversarial-review hardening

### DIFF
--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -293,7 +293,12 @@ class DataFlowController:
         """
         marker = self.store.durable_marker()
         acked = marker["acked"]
-        step_committed = marker["global_step"] is not None
+        # Release eligibility is gated on the optimizer-durable marker, NOT on a
+        # global_step scalar that the ack API leaves None by default — otherwise a
+        # durable ack with global_step omitted would force every acked sample to
+        # replay (duplicate train). (Coarse: optimizer_durable is a run-level
+        # flag; a per-sample durability column is the future refinement.)
+        step_committed = bool(marker["optimizer_durable"])
         requeued: List[str] = []
         released: List[str] = []
         for sid in self.store.all_committed_ids():

--- a/specforge/runtime/control_plane/metadata_store.py
+++ b/specforge/runtime/control_plane/metadata_store.py
@@ -188,6 +188,9 @@ class SQLiteMetadataStore(MetadataStore):
         self.path = path
         self._conn = sqlite3.connect(path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")  # durable + concurrent reads
+        self._conn.execute(
+            "PRAGMA synchronous=FULL"
+        )  # ack survives power loss, not just process crash
         self._lock = threading.RLock()
         with self._lock:
             self._conn.execute(
@@ -231,7 +234,10 @@ class SQLiteMetadataStore(MetadataStore):
 
     def all_committed_ids(self) -> List[str]:
         with self._lock:
-            rows = self._conn.execute("SELECT sample_id FROM committed").fetchall()
+            # rowid order == commit (insertion) order, matching InMemory's dict.
+            rows = self._conn.execute(
+                "SELECT sample_id FROM committed ORDER BY rowid"
+            ).fetchall()
         return [r[0] for r in rows]
 
     def record_train_ack(

--- a/specforge/runtime/data_plane/feature_store.py
+++ b/specforge/runtime/data_plane/feature_store.py
@@ -356,7 +356,9 @@ class LocalFeatureStore(FeatureStore):
         self, ref: SampleRef, wanted: List[str]
     ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
         # The resident read and the lease registration share one lock so a
-        # concurrent abort() cannot reclaim the sample between them.
+        # concurrent gc()/abort() cannot free the sample between the existence
+        # check and the lease being recorded (otherwise max-hold gc could free a
+        # just-read sample whose lease was not yet visible).
         expected_generation = _mem_uri_generation(ref.feature_store_uri)
         with self._lock:
             if ref.sample_id not in self._mem:
@@ -406,28 +408,36 @@ class LocalFeatureStore(FeatureStore):
 
     # -- lifetime ----------------------------------------------------------
     def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
-        # mem:// samples are consume-once: when the LAST lease on the current
-        # generation is released, free the tensors. This is what bounds online
-        # residency — release() owns physical free here, so the consumer never
-        # needs to know the backend's memory policy. file:// samples never enter
-        # _mem, so the pops below are harmless no-ops and offline ref sets stay
-        # re-iterable across epochs. Idempotent + stale-generation safe.
+        # mem:// samples are consume-once: free the *current* resident generation
+        # once the last lease ON THAT generation drops. Freeing is keyed on the
+        # current generation via ``_still_leased_locked(sid, cur)`` — not on the
+        # released handle's own generation — so a sample re-put while an older
+        # lease is still outstanding (gen N held, gen N+1 leased+released, then the
+        # stale gen-N handle released) is still freed: the gen-N+1 lease was the
+        # last on the current generation. The reverse hazard — a stale release
+        # freeing a freshly re-put-but-never-consumed sample — is closed by the
+        # ``handle.generation != cur`` guard: to possess a handle for the current
+        # generation you must have got() it, so a never-leased re-put can only be
+        # targeted by an older-generation handle, which this guard turns into a
+        # no-op. file:// samples never enter _mem, so this is a harmless no-op for
+        # them. Idempotent + stale-safe.
+        sid = handle.sample_id
         with self._lock:
             self._active_leases.pop(handle.lease_token, None)
-            cur = self._generation.get(handle.sample_id)
+            cur = self._generation.get(sid)
             if cur is not None and handle.generation != cur:
                 return  # stale handle (sample was re-put) -> no-op
             # Count only leases on the CURRENT generation. A sample re-put while
             # an older generation is still leased gets a fresh generation, so the
             # stale older-gen lease must not keep the current generation pinned —
             # otherwise the last current-gen release would leak it.
-            if self._still_leased_locked(handle.sample_id, cur):
+            if self._still_leased_locked(sid, cur):
                 return  # another (current-gen) lease still holds it
             # Last current-gen lease dropped -> free. A fallible backend
             # (Mooncake) parks it release-pending for gc() to retry; local frees
             # synchronously.
-            if not self._try_physical_free(handle.sample_id):
-                self._release_pending.setdefault(handle.sample_id, 0)
+            if not self._try_physical_free(sid):
+                self._release_pending.setdefault(sid, 0)
 
     def _try_physical_free(self, sample_id: str) -> bool:
         """Physically free a sample. Returns True on success.
@@ -493,9 +503,13 @@ class LocalFeatureStore(FeatureStore):
                 self._release_pending.pop(sid, None)
                 continue
             attempts = self._release_pending[sid] + 1
+            # Bytes the sample is holding now; counted if this retry frees it.
+            # _try_physical_free drops the tensors, so capture the size first.
+            sample_bytes = _tensors_bytes(self._mem.get(sid, {}))
             if self._try_physical_free(sid):
                 self._release_pending.pop(sid, None)
                 freed += 1
+                freed_bytes += sample_bytes
             elif attempts >= self.max_release_attempts:
                 freed_bytes += self._free_sample_locked(sid)  # final force-free
                 freed += 1

--- a/tests/test_runtime/test_equiv_4rank.py
+++ b/tests/test_runtime/test_equiv_4rank.py
@@ -9,7 +9,12 @@ offline EAGLE3 step through both the legacy path (``run_forward`` +
 so any divergence is the new path failing to preserve the math under real TP+SP —
 the "scale-out claim met, not FSDP-only" gate.
 
-GPU-only and needs >=4 visible GPUs. Run on the H200 box via rcli.
+GPU-only; needs >=4 visible GPUs AND flash-attn **v2** (the Ulysses/USP attention
+path resolves flash-attn v2 varlen kernels in ``llama3_eagle`` — there is no SP
+fallback). The cached ``sglang:dev`` image used for the other gates ships
+flash-attn **v4**, whose API differs, so SpecForge's USP path is non-functional
+there and this test skips. Run on a training image with flash-attn v2. Validated
+up to the USP-engages point on 8xH200; full numerical assertion needs v2.
 """
 
 import json
@@ -23,6 +28,20 @@ import torch
 CUDA = torch.cuda.is_available()
 NGPU = torch.cuda.device_count() if CUDA else 0
 WORLD = 4
+
+
+def _has_usp_flash_attn() -> bool:
+    # Authoritative check: the USP attention path resolves flash-attn *v2* varlen
+    # kernels in llama3_eagle. Probe that exact symbol — it is None when flash-attn
+    # is absent OR when an API-incompatible major version is installed (e.g. the
+    # cached sglang:dev image ships flash-attn v4, whose API differs, so SpecForge's
+    # USP path is non-functional there). A bare `import flash_attn` is NOT enough.
+    try:
+        from specforge.modeling.draft.llama3_eagle import _std_flash_unpad_input
+
+        return _std_flash_unpad_input is not None
+    except Exception:
+        return False
 
 
 def _worker(rank, world_size, workdir, results_dir):
@@ -55,13 +74,17 @@ def _worker(rank, world_size, workdir, results_dir):
     draft_config = AutoDraftModelConfig.from_file(cfg)
 
     def build_model():
+        # attention_backend="usp" so the forward actually exercises Ulysses SP
+        # (UspAdapter + SeqAllToAll cross-rank attention), matching production
+        # when sp>1; flex_attention would silently run per-rank-local attention
+        # and the use_usp_preprocess-sharded data would shape-mismatch.
         dm = AutoEagle3DraftModel.from_config(
-            draft_config, attention_backend="flex_attention", torch_dtype=torch.bfloat16
+            draft_config, attention_backend="usp", torch_dtype=torch.bfloat16
         ).cuda()
         dm.load_vocab_mapping(vocab_path)
         dm.freeze_embedding()
         return OnlineEagle3Model(
-            draft_model=dm, length=TTT, attention_backend="flex_attention"
+            draft_model=dm, length=TTT, attention_backend="usp"
         ).cuda()
 
     model_a = build_model()
@@ -135,7 +158,10 @@ def _worker(rank, world_size, workdir, results_dir):
         )
 
 
-@unittest.skipUnless(CUDA and NGPU >= WORLD, f"requires >={WORLD} GPUs")
+@unittest.skipUnless(
+    CUDA and NGPU >= WORLD and _has_usp_flash_attn(),
+    f"requires >={WORLD} GPUs and flash-attn v2 (USP/Ulysses attention path)",
+)
 class TestEquiv4Rank(unittest.TestCase):
     def test_equiv_tp2_sp2(self):
         import torch.multiprocessing as mp

--- a/tests/test_runtime/test_feature_store.py
+++ b/tests/test_runtime/test_feature_store.py
@@ -276,6 +276,32 @@ class TestFeatureStoreGC(unittest.TestCase):
         self.assertEqual(store.gc()["force_freed"], 0)
         self.assertEqual(store.health()["resident_samples"], 1)
 
+    def test_release_after_reput_while_leased_does_not_leak(self):
+        # Regression for the consume-once leak: re-put a sample_id while an older
+        # lease is still outstanding, then release the newest handle and finally
+        # the stale old handle. The current generation MUST be freed.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref1)  # lease on gen1
+        ref2 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2
+        _, h2 = store.get(ref2)  # lease on gen2
+        store.release(h2)  # newest released first (h1/gen1 still active)
+        store.release(h1)  # stale gen1 handle released last
+        h = store.health()
+        self.assertEqual(h["resident_samples"], 0)  # was leaking before the fix
+        self.assertEqual(h["resident_bytes"], 0)
+
+    def test_stale_release_does_not_free_unconsumed_reput(self):
+        # The reverse guard: a stale double-release must NOT free a freshly
+        # re-put sample that nobody has consumed (leased) yet.
+        store = LocalFeatureStore("st")
+        ref1 = store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})
+        _, h1 = store.get(ref1)
+        store.release(h1)  # frees gen1
+        store.put({"x": torch.randn(1, 8)}, sample_id="s0", metadata={})  # gen2, no get
+        store.release(h1)  # stale double-release of the gen1 handle
+        self.assertEqual(store.health()["resident_samples"], 1)  # gen2 preserved
+
     def test_release_pending_reconciled_by_gc(self):
         # A backend whose physical free fails parks the sample release-pending;
         # gc() retries within the bounded window, then force-frees.

--- a/tests/test_runtime/test_recovery.py
+++ b/tests/test_runtime/test_recovery.py
@@ -152,6 +152,29 @@ class TestRestartReconciliation(unittest.TestCase):
         self.assertEqual(report["released"], [])
         store2.close()
 
+    def test_durable_ack_without_global_step_still_releases(self):
+        # A durable ack (optimizer_durable=True) with global_step omitted must
+        # still release the acked samples on restart — not replay them.
+        store = SQLiteMetadataStore(self.path)
+        ctrl = DataFlowController(
+            "run", sample_queue=SampleRefQueue(), metadata_store=store
+        )
+        ctrl.commit_samples("w0", [_ref(f"s{i}") for i in range(2)])
+        ctrl.lease_train_refs("trainer", 2)
+        store.record_train_ack(["s0", "s1"], global_step=None, optimizer_durable=True)
+        store.close()
+
+        store2 = SQLiteMetadataStore(self.path)
+        ctrl2 = DataFlowController(
+            "run", sample_queue=SampleRefQueue(), metadata_store=store2
+        )
+        report = ctrl2.reconcile_on_restart()
+        self.assertEqual(
+            set(report["released"]), {"s0", "s1"}
+        )  # released, not replayed
+        self.assertEqual(report["requeued"], [])
+        store2.close()
+
     def test_reconcile_is_idempotent(self):
         # Reconciling twice on a fresh (post-crash) queue must not double-enqueue;
         # queue.put is idempotent on sample_id.


### PR DESCRIPTION
**M5/M6 adversarial-review hardening (LocalFeatureStore + control plane).**

- **LocalFeatureStore:** `gc()` counts `freed_bytes` on a successful release-pending retry; lease registered under the existence-check lock; `release()` cleanup.
- **SQLiteMetadataStore:** `synchronous=FULL`; `all_committed_ids` `ORDER BY rowid`.
- **Controller:** `reconcile_on_restart` gates release on `optimizer_durable` (not `global_step is not None`).
- **test_equiv_4rank:** `attention_backend='usp'` + flash-attn skip guard.
- Regression tests in `test_feature_store` / `test_recovery`.

The **SharedDirFeatureStore per-generation B5 rewrite** that was previously bundled in this PR now lives in **#609** alongside the store it hardens. (Hot-update / weight-version-control intentionally NOT included.)

Part of the **DataFlow runtime M5/M6** stacked series (continues the M1–M4 work in #594–#601 / #603). Stacked PRs — **merge bottom-up** (up-9 first). Lint (pre-commit) + runtime CPU test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
