### PR TITLE
[DataFlow runtime · M6 4/4] MooncakeFeatureStore — RDMA fast-path backend

### DIFF
--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -20,6 +20,35 @@ The control plane carries only tensor-free `SampleRef` metadata (the manifest);
 feature tensors travel through the shared store. `build_disagg_eagle3_runtime`
 reuses the exact offline trainer assembly, so results align by construction.
 
+## Backends
+
+The feature transport is selected by `DISAGG_BACKEND` (default `shared_dir`):
+
+| backend | store | shared *data* mount? |
+|---|---|---|
+| `shared_dir` (default) | `SharedDirFeatureStore` (`torch.save` on a POSIX mount) | required |
+| `mooncake` | `MooncakeFeatureStore` (RDMA/TCP network object store) | not needed |
+
+`mooncake` is the M6 **fast path**: producer `put()`s and consumer `get()`s by key
+across nodes peer-to-peer, so feature tensors need no shared *data* mount (only the
+small ref manifest still uses `DISAGG_MANIFEST`). Each object is hard-pinned so
+Mooncake's cache LRU never drops a committed feature. Because a Mooncake object
+lives in the **producer's** memory segment, the producer must stay alive until the
+consumer finishes — the example holds it open until the consumer writes
+`<manifest>.consumed` (or `DISAGG_PRODUCER_HOLD_S` elapses). Enable with:
+
+```bash
+export DISAGG_BACKEND=mooncake
+export MOONCAKE_LOCAL_HOSTNAME=<this-node-ip>
+export MOONCAKE_METADATA_SERVER=<metadata url>
+export MOONCAKE_MASTER_SERVER_ADDR=<master host:port>
+export MOONCAKE_PROTOCOL=tcp   # or rdma
+```
+
+Requires the `mooncake` package and a running Mooncake master/metadata service
+(verify on a Mooncake-enabled GPU host). The contract itself is unit-tested
+backend-agnostically in `tests/test_runtime/test_mooncake_store.py`.
+
 ## Run it (rcli, 2 nodes)
 
 1. Generate offline features on node 0 (any EAGLE3 feature generator), e.g. into

--- a/examples/disagg/run_disagg_eagle3.py
+++ b/examples/disagg/run_disagg_eagle3.py
@@ -18,14 +18,32 @@ feature tensors travel through the shared store. Disaggregation changes *where*
 features live, not their values, so the training curve matches the colocated
 offline baseline.
 
-Role is taken from ``DISAGG_ROLE`` (``producer``/``consumer``); if unset it is
-derived from ``RCLI_NODE_RANK`` (0 -> producer, else consumer). Shared paths +
-auth come from the environment so one wrapper can drive both nodes:
+Backend is selected by ``DISAGG_BACKEND`` (default ``shared_dir``):
 
-    DISAGG_STORE_ROOT=/workspace/disagg_store   # shared mount, both pools
-    DISAGG_MANIFEST=/workspace/disagg_store/refs.json
+* ``shared_dir`` — ``SharedDirFeatureStore`` over a shared POSIX mount.
+* ``mooncake`` — ``MooncakeFeatureStore``, the M6 fast path: a network object
+  store (RDMA/TCP), so the feature tensors need **no shared data mount**. Caveat:
+  a Mooncake object lives in the *producer's* memory segment, so the producer
+  process must stay alive until the consumer has read everything — this example
+  holds the producer open until the consumer writes ``<manifest>.consumed`` (or
+  ``DISAGG_PRODUCER_HOLD_S`` seconds elapse). The small ref manifest + sentinels
+  still travel through ``DISAGG_MANIFEST``.
+
+Role is taken from ``DISAGG_ROLE`` (``producer``/``consumer``/``colocated``); if
+unset it is derived from ``RCLI_NODE_RANK`` (0 -> producer, else consumer).
+Config comes from the environment so one wrapper can drive both nodes:
+
+    DISAGG_MANIFEST=/workspace/disagg_store/refs.json  # small shared control plane
     DISAGG_STORE_ID=eagle3-disagg               # producer/consumer must match
     DISAGG_AUTH_TOKEN=<secret>                   # optional (B9 auth)
+    # backend=shared_dir (default):
+    DISAGG_STORE_ROOT=/workspace/disagg_store    # shared *data* mount
+    # backend=mooncake:
+    DISAGG_BACKEND=mooncake
+    MOONCAKE_LOCAL_HOSTNAME=<this-node-ip>
+    MOONCAKE_METADATA_SERVER=<metadata server url>
+    MOONCAKE_MASTER_SERVER_ADDR=<master host:port>
+    MOONCAKE_PROTOCOL=tcp                         # or "rdma"
 """
 
 import os
@@ -50,6 +68,8 @@ from specforge.runtime.data_plane.disagg_ingest import (
     write_ref_manifest,
 )
 from specforge.runtime.data_plane.disaggregated import AuthPolicy, SharedDirFeatureStore
+from specforge.runtime.data_plane.feature_store import FeatureStore
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
 from specforge.runtime.launch import (
     build_disagg_eagle3_runtime,
     build_offline_eagle3_runtime,
@@ -65,15 +85,61 @@ def _role() -> str:
     return "producer" if os.environ.get("RCLI_NODE_RANK", "0") == "0" else "consumer"
 
 
-def _store(args, *, retain_on_release: bool = False) -> SharedDirFeatureStore:
+def _backend() -> str:
+    return os.environ.get("DISAGG_BACKEND", "shared_dir")
+
+
+def _store(args, *, retain_on_release: bool = False) -> FeatureStore:
     token = os.environ.get("DISAGG_AUTH_TOKEN") or None
+    store_id = os.environ.get("DISAGG_STORE_ID", RUN_ID)
+    if _backend() == "mooncake":
+        # Fast path: producer put()s and consumer get()s by key across nodes over
+        # the Mooncake object store -- no shared *data* mount. store_id namespaces
+        # the keys, so producer and consumer must agree on it (as with shared_dir).
+        return MooncakeFeatureStore(
+            store_id=store_id,
+            setup_kwargs={
+                "local_hostname": os.environ["MOONCAKE_LOCAL_HOSTNAME"],
+                "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
+                "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
+                "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
+            },
+            auth=AuthPolicy(token),
+            credential=token,
+            retain_on_release=retain_on_release,
+        )
     return SharedDirFeatureStore(
         os.environ["DISAGG_STORE_ROOT"],
-        store_id=os.environ.get("DISAGG_STORE_ID", RUN_ID),
+        store_id=store_id,
         auth=AuthPolicy(token),
         credential=token,
         retain_on_release=retain_on_release,
     )
+
+
+def _hold_producer_until_consumed(manifest: str) -> None:
+    """Keep the producer (and its Mooncake memory segment) alive until the
+    consumer signals completion, since a Mooncake object lives in the producing
+    process's segment. shared_dir does not need this (files persist on the mount).
+    """
+    consumed = manifest + ".consumed"
+    hold_s = float(os.environ.get("DISAGG_PRODUCER_HOLD_S", "3600"))
+    deadline = time.monotonic() + hold_s
+    print(
+        f"[producer] mooncake backend: holding segment until {consumed} "
+        f"(<= {hold_s:.0f}s)",
+        flush=True,
+    )
+    while not os.path.exists(consumed):
+        if time.monotonic() > deadline:
+            print(
+                "[producer] hold timed out before consumer signalled; exiting "
+                "(consumer may lose features)",
+                flush=True,
+            )
+            return
+        time.sleep(2)
+    print("[producer] consumer signalled done; releasing segment", flush=True)
 
 
 def run_producer(args) -> None:
@@ -88,11 +154,14 @@ def run_producer(args) -> None:
     )
     write_ref_manifest(refs, manifest)
     open(manifest + ".done", "w").close()  # liveness marker the consumer waits on
+    location = getattr(store, "root", f"mooncake://{store.store_id}")
     print(
-        f"[producer] ingested {len(refs)} samples into {store.root}; "
+        f"[producer] ingested {len(refs)} samples into {location}; "
         f"manifest -> {manifest}",
         flush=True,
     )
+    if _backend() == "mooncake":
+        _hold_producer_until_consumed(manifest)
 
 
 def _build_model_and_optimizer(args):
@@ -196,8 +265,9 @@ def run_consumer(args) -> None:
     # offline ref set is re-iterated across epochs -> retain on release (read-only)
     store = _store(args, retain_on_release=True)
     refs = read_ref_manifest(manifest)
+    location = getattr(store, "root", f"mooncake://{store.store_id}")
     print(
-        f"[consumer] training from {len(refs)} disagg refs in {store.root}", flush=True
+        f"[consumer] training from {len(refs)} disagg refs in {location}", flush=True
     )
 
     trainer, loader = build_disagg_eagle3_runtime(
@@ -222,6 +292,9 @@ def run_consumer(args) -> None:
     )
     trainer.fit(loader)
     destroy_distributed()
+    if _backend() == "mooncake":
+        # release the producer holding its Mooncake segment open (see docstring)
+        open(manifest + ".consumed", "w").close()
 
 
 def main() -> None:

--- a/examples/disagg/run_disagg_eagle3.py
+++ b/examples/disagg/run_disagg_eagle3.py
@@ -275,9 +275,7 @@ def run_consumer(args) -> None:
     store = _store(args, retain_on_release=True)
     refs = read_ref_manifest(manifest)
     location = getattr(store, "root", f"mooncake://{store.store_id}")
-    print(
-        f"[consumer] training from {len(refs)} disagg refs in {location}", flush=True
-    )
+    print(f"[consumer] training from {len(refs)} disagg refs in {location}", flush=True)
 
     trainer, loader = build_disagg_eagle3_runtime(
         feature_store=store,

--- a/examples/disagg/run_disagg_eagle3.py
+++ b/examples/disagg/run_disagg_eagle3.py
@@ -96,14 +96,23 @@ def _store(args, *, retain_on_release: bool = False) -> FeatureStore:
         # Fast path: producer put()s and consumer get()s by key across nodes over
         # the Mooncake object store -- no shared *data* mount. store_id namespaces
         # the keys, so producer and consumer must agree on it (as with shared_dir).
+        setup_kwargs = {
+            "local_hostname": os.environ["MOONCAKE_LOCAL_HOSTNAME"],
+            "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
+            "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
+            "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
+        }
+        # The contributed segment must hold the hard-pinned feature set, so size
+        # it for the workload (default 1 GiB is fine only for tiny sets).
+        for env_key, kw in (
+            ("MOONCAKE_GLOBAL_SEGMENT_SIZE", "global_segment_size"),
+            ("MOONCAKE_LOCAL_BUFFER_SIZE", "local_buffer_size"),
+        ):
+            if os.environ.get(env_key):
+                setup_kwargs[kw] = int(os.environ[env_key])
         return MooncakeFeatureStore(
             store_id=store_id,
-            setup_kwargs={
-                "local_hostname": os.environ["MOONCAKE_LOCAL_HOSTNAME"],
-                "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
-                "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
-                "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
-            },
+            setup_kwargs=setup_kwargs,
             auth=AuthPolicy(token),
             credential=token,
             retain_on_release=retain_on_release,

--- a/examples/disagg/run_qwen2.5_7b_eagle3_disagg.sh
+++ b/examples/disagg/run_qwen2.5_7b_eagle3_disagg.sh
@@ -29,6 +29,17 @@ set -euo pipefail
 export DISAGG_STORE_ROOT DISAGG_MANIFEST
 export DISAGG_STORE_ID="${DISAGG_STORE_ID:-eagle3-disagg}"
 export DISAGG_AUTH_TOKEN="${DISAGG_AUTH_TOKEN:-disagg-secret}"
+
+# --- Optional: Mooncake fast-path backend (network object store, no shared data
+# mount). Uncomment + point at your Mooncake master/metadata to route features
+# over Mooncake instead of $DISAGG_STORE_ROOT. The manifest still uses
+# $DISAGG_MANIFEST, and the producer holds its segment open until the consumer
+# finishes (see run_disagg_eagle3.py). ---
+# export DISAGG_BACKEND=mooncake
+# export MOONCAKE_LOCAL_HOSTNAME="$(hostname -i | awk '{print $1}')"
+# export MOONCAKE_METADATA_SERVER="http://<metadata-host>:8080/metadata"
+# export MOONCAKE_MASTER_SERVER_ADDR="<master-host>:50051"
+# export MOONCAKE_PROTOCOL=tcp   # or "rdma"
 export FLASHINFER_DISABLE_VERSION_CHECK=1
 export HOME=/root HF_HOME=/root/.cache/huggingface TRITON_CACHE_DIR=/root/.triton
 export PYTHONPATH="$SF_HOME:$SF_HOME/scripts:${PYTHONPATH:-}"

--- a/examples/disagg/run_qwen2.5_7b_eagle3_disagg.sh
+++ b/examples/disagg/run_qwen2.5_7b_eagle3_disagg.sh
@@ -40,6 +40,7 @@ export DISAGG_AUTH_TOKEN="${DISAGG_AUTH_TOKEN:-disagg-secret}"
 # export MOONCAKE_METADATA_SERVER="http://<metadata-host>:8080/metadata"
 # export MOONCAKE_MASTER_SERVER_ADDR="<master-host>:50051"
 # export MOONCAKE_PROTOCOL=tcp   # or "rdma"
+# export MOONCAKE_GLOBAL_SEGMENT_SIZE=$((8*1024*1024*1024))  # >= total feature bytes
 export FLASHINFER_DISABLE_VERSION_CHECK=1
 export HOME=/root HF_HOME=/root/.cache/huggingface TRITON_CACHE_DIR=/root/.triton
 export PYTHONPATH="$SF_HOME:$SF_HOME/scripts:${PYTHONPATH:-}"

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -9,6 +9,7 @@ from specforge.runtime.data_plane.feature_store import (
     load_feature_file,
     spec_from_tensor,
 )
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
 from specforge.runtime.data_plane.offline_reader import (
     OfflineManifestReader,
     list_feature_files,
@@ -26,5 +27,6 @@ __all__ = [
     "OfflineManifestReader",
     "list_feature_files",
     "SharedDirFeatureStore",
+    "MooncakeFeatureStore",
     "AuthPolicy",
 ]

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -168,6 +168,14 @@ class MooncakeFeatureStore(FeatureStore):
         self._active_leases: Dict[str, FeatureHandle] = {}
         # samples whose remote remove() failed; retried/force-freed by gc()
         self._release_pending: Dict[str, int] = {}
+        # (sample_id, generation) logically freed in THIS process. Mooncake's
+        # remove() is lease-deferred (an object keeps a short read-lease), so the
+        # bytes can linger after release/abort; this makes the B5 "no
+        # use-after-free" guarantee immediate — get() of a freed ref raises even
+        # while physical reclamation is still pending. Grows with consume-once
+        # frees within a run (empty in retain_on_release/offline mode); a durable
+        # shared index would own this in the online multi-node follow-up.
+        self._freed: set = set()
         self._lock = threading.RLock()
         self._counter = 0
         self._gen_counter = 0
@@ -266,6 +274,15 @@ class MooncakeFeatureStore(FeatureStore):
     ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
         self.auth.check(self._credential)
         sid = sample_ref.sample_id
+        ref_gen = sample_ref.metadata.get("generation")
+        with self._lock:
+            if ref_gen is not None and (sid, int(ref_gen)) in self._freed:
+                # logically freed here; the remote bytes may still linger under
+                # Mooncake's read-lease, but this ref must not resolve (B5)
+                raise KeyError(
+                    f"sample {sid} generation {ref_gen} was released/aborted; "
+                    f"refusing use-after-free"
+                )
         key = self._key(sid)
         if not self._store_exists(key):
             # freed by release/abort, or never written -> never hand back stale
@@ -340,16 +357,22 @@ class MooncakeFeatureStore(FeatureStore):
                 return  # stale lease -> no-op
             if self._still_leased_locked(sid, cur):
                 return
+            self._freed.add((sid, handle.generation))  # immediate logical free
             if self._try_physical_free(sid):
                 self._free_bookkeeping_locked(sid)
             else:
-                # remote free failed -> park for gc() to retry/force-free
+                # remote free deferred (lease) / failed -> gc() retries
                 self._release_pending.setdefault(sid, 0)
 
     def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
         with self._lock:
-            self._try_physical_free(sample_id)
-            self._free_bookkeeping_locked(sample_id)
+            gen = self._generation.get(sample_id)
+            if gen is not None:
+                self._freed.add((sample_id, gen))  # immediate logical free
+            if self._try_physical_free(sample_id):
+                self._free_bookkeeping_locked(sample_id)
+            else:
+                self._release_pending.setdefault(sample_id, 0)
 
     def gc(self, *, now: Optional[float] = None) -> Dict[str, int]:
         now = self._clock() if now is None else now

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -1,0 +1,419 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Mooncake-backed FeatureStore: the M6 *fast path* for disaggregated EAGLE3.
+
+``SharedDirFeatureStore`` (``disaggregated.py``) locked down the disaggregation
+*contract* over a shared POSIX directory. ``MooncakeFeatureStore`` swaps that
+transport for the Mooncake distributed object store (RDMA zero-copy across
+nodes) **behind the exact same FeatureStore API** — the control/training planes
+see nothing new. The producer (rollout/ingest) ``put()``s feature tensors into
+the Mooncake store on one node; the consumer (trainer) ``get()``s them on
+another, peer-to-peer, with no shared filesystem. That is what makes this a
+genuine network object store rather than a shared mount.
+
+Scope (PR-A, the offline path M6 ships): this backend is correct for a single
+consumer process with ``retain_on_release`` for re-iterable epochs and
+whole-store cleanup at run end. The per-sample generation/lease *index* is
+in-process, mirroring ``SharedDirFeatureStore``'s documented single-host
+limitation. A true online multi-node deployment lifts that index into a shared
+metadata service — a separate follow-up, not this PR.
+
+Contract carried from the reference backend:
+
+* **B5 — no use-after-free.** ``get()`` after ``release``/``abort`` raises
+  ``KeyError``; a generation guard rejects a stale ref after a re-``put``;
+  clone-on-fetch is the default.
+* **B9 — auth in disaggregated mode** (shared-secret :class:`AuthPolicy`).
+
+Lifetime: Mooncake's default eviction is approximate-LRU for a KV *cache*, which
+would silently drop a committed-but-unacked feature when the trainer lags hours
+(turning ``get()`` into a ``KeyError`` and violating the controller's
+no-data-loss guarantee). We therefore **hard-pin** every object on ``put`` and
+free it only by explicit ``remove()`` on consume/abort — SpecForge is the sole
+lifetime authority, not Mooncake's LRU. Because ``remove()`` is a real (fallible)
+RPC, ``release()`` parks a failed free in ``_release_pending`` and ``gc()``
+retries up to ``max_release_attempts`` before giving up — the
+``LocalFeatureStore`` reclamation seam that ``SharedDirFeatureStore`` dropped.
+
+Concurrency: ``release``/``abort``/``gc`` hold ``self._lock`` across the
+``remove()`` RPC. The lock is what makes consume-once free race-free against a
+concurrent ``get()`` (it prevents a re-lease between "decide to free" and the
+remote delete), exactly as ``SharedDirFeatureStore`` holds its lock across
+``os.remove``. For the offline single-consumer path this is fine; a high-fanout
+online deployment that wants the ``remove()`` RPC off the critical section needs
+a tombstone-then-free protocol — a follow-up tied to the shared metadata index.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import threading
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import torch
+
+from specforge.runtime.contracts import SCHEMA_VERSION, FeatureHandle, SampleRef
+from specforge.runtime.data_plane.disaggregated import AuthPolicy
+from specforge.runtime.data_plane.feature_store import FeatureStore, spec_from_tensor
+
+logger = logging.getLogger(__name__)
+
+# Defaults for MooncakeDistributedStore.setup(); override via ``setup_kwargs``.
+_MOONCAKE_SETUP_DEFAULTS = {
+    "global_segment_size": 1 << 30,  # 1 GiB per-node segment
+    "local_buffer_size": 1 << 30,
+    "protocol": "tcp",  # bring up on TCP; flip to "rdma" once NICs are verified
+    "rdma_devices": "",
+}
+
+
+class _PinConfig:
+    """Fallback for Mooncake's ``ReplicateConfig`` when the package is absent
+    (local unit tests with an injected store). Mirrors the fields the real
+    config exposes so the injected backend can assert on them."""
+
+    def __init__(
+        self, replica_num: int = 1, with_hard_pin: bool = True, with_soft_pin: bool = False
+    ) -> None:
+        self.replica_num = replica_num
+        self.with_hard_pin = with_hard_pin
+        self.with_soft_pin = with_soft_pin
+
+
+def _build_replicate_config(replica_num: int, hard_pin: bool) -> Any:
+    """Real ``ReplicateConfig`` if mooncake is importable, else a shim."""
+    try:
+        from mooncake.store import ReplicateConfig  # type: ignore
+    except Exception:
+        return _PinConfig(replica_num=replica_num, with_hard_pin=hard_pin)
+    cfg = ReplicateConfig()
+    cfg.replica_num = replica_num
+    cfg.with_hard_pin = hard_pin
+    return cfg
+
+
+def _connect_store(setup_kwargs: Dict[str, Any]) -> Any:
+    """Construct + ``setup()`` a real ``MooncakeDistributedStore``."""
+    try:
+        from mooncake.store import MooncakeDistributedStore  # type: ignore
+    except Exception as e:  # pragma: no cover - exercised only without mooncake
+        raise RuntimeError(
+            "MooncakeFeatureStore requires the 'mooncake' package "
+            "(pip install mooncake-transfer-engine). Pass store=<obj> to inject "
+            "a backend for testing."
+        ) from e
+    store = MooncakeDistributedStore()
+    rc = store.setup(**setup_kwargs)
+    if rc is not None and int(rc) != 0:
+        raise RuntimeError(f"Mooncake setup failed (status {rc}); kwargs={setup_kwargs}")
+    return store
+
+
+class MooncakeFeatureStore(FeatureStore):
+    """A disaggregated :class:`FeatureStore` backed by the Mooncake store.
+
+    One Mooncake object per sample (``{store_id}/{sample_id}``) holds a
+    ``torch.save``'d ``{"generation": int, "tensors": dict}`` blob, hard-pinned so
+    Mooncake's LRU never reclaims a live feature. ``store`` may be injected (any
+    object exposing ``is_exist/put/get/remove`` with the Mooncake signatures) so
+    the contract is unit-testable without a running master.
+    """
+
+    def __init__(
+        self,
+        *,
+        store_id: Optional[str] = None,
+        store: Optional[Any] = None,
+        setup_kwargs: Optional[Dict[str, Any]] = None,
+        auth: Optional[AuthPolicy] = None,
+        credential: Optional[str] = None,
+        max_resident_bytes: Optional[int] = None,
+        max_hold_age_s: Optional[float] = None,
+        retain_on_release: bool = False,
+        max_release_attempts: int = 3,
+        replica_num: int = 1,
+        hard_pin: bool = True,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.auth = auth or AuthPolicy()
+        self._credential = credential
+        self.auth.check(credential)  # attach-time gate (B9)
+        self.store_id = store_id or uuid.uuid4().hex[:8]
+        if store is None:
+            kw = dict(_MOONCAKE_SETUP_DEFAULTS)
+            kw.update(setup_kwargs or {})
+            store = _connect_store(kw)
+        self._store = store
+        self._put_config = _build_replicate_config(replica_num, hard_pin)
+        self.max_resident_bytes = max_resident_bytes
+        self.max_hold_age_s = max_hold_age_s
+        # Offline re-iterable mode: release() must NOT free (multi-epoch); mirrors
+        # SharedDirFeatureStore / LocalFeatureStore file:// no-op release.
+        self.retain_on_release = retain_on_release
+        self.max_release_attempts = max_release_attempts
+        self._clock = clock
+        # in-process liveness index (single-host; see module docstring)
+        self._generation: Dict[str, int] = {}
+        self._put_time: Dict[str, float] = {}
+        self._sample_bytes: Dict[str, int] = {}
+        self._active_leases: Dict[str, FeatureHandle] = {}
+        # samples whose remote remove() failed; retried/force-freed by gc()
+        self._release_pending: Dict[str, int] = {}
+        self._lock = threading.RLock()
+        self._counter = 0
+        self._gen_counter = 0
+        self._stats = {"force_freed": 0, "force_freed_bytes": 0}
+
+    # -- keys --------------------------------------------------------------
+    def _key(self, sample_id: str) -> str:
+        return f"{self.store_id}/{sample_id}"
+
+    # -- store wrappers (status-code aware) --------------------------------
+    def _store_exists(self, key: str) -> bool:
+        return int(self._store.is_exist(key)) == 1
+
+    def _store_put(self, key: str, value: bytes) -> None:
+        rc = self._store.put(key, value, self._put_config)
+        if rc is not None and int(rc) != 0:
+            raise RuntimeError(f"mooncake put failed (status {rc}) for {key}")
+
+    def _store_remove(self, key: str) -> bool:
+        """Best-effort physical free. Returns True on confirmed removal."""
+        try:
+            rc = self._store.remove(key)
+        except Exception:  # pragma: no cover - transient RPC failure
+            return False
+        return rc is None or int(rc) == 0
+
+    # -- write -------------------------------------------------------------
+    def put(
+        self,
+        tensors: Dict[str, torch.Tensor],
+        *,
+        sample_id: str,
+        metadata: Dict[str, Any],
+    ) -> SampleRef:
+        self.auth.check(self._credential)
+        if not tensors:
+            raise ValueError("put requires at least one tensor")
+        staged = {k: v.detach().cpu() for k, v in tensors.items()}
+        specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
+        nbytes = sum(t.numel() * t.element_size() for t in staged.values())
+        with self._lock:
+            if (
+                self.max_resident_bytes is not None
+                and sum(self._sample_bytes.values()) + nbytes > self.max_resident_bytes
+            ):
+                raise MemoryError(
+                    f"MooncakeFeatureStore {self.store_id} over budget "
+                    f"({self.max_resident_bytes} bytes): consumer is behind"
+                )
+            self._gen_counter += 1
+            gen = self._gen_counter
+        buf = io.BytesIO()
+        torch.save({"generation": gen, "tensors": staged}, buf)
+        key = self._key(sample_id)
+        # Overwrite-safe publish: a re-put bumps the generation. remove() first so
+        # the hard-pinned prior blob is released rather than orphaned; if that
+        # remove fails the old (pinned) blob may leak, so surface it loudly.
+        if self._store_exists(key) and not self._store_remove(key):
+            logger.warning(
+                "MooncakeFeatureStore re-put of %s: removing the stale blob failed; "
+                "a hard-pinned object may be orphaned",
+                key,
+            )
+        self._store_put(key, buf.getvalue())
+        with self._lock:
+            self._generation[sample_id] = gen
+            self._put_time[sample_id] = self._clock()
+            self._sample_bytes[sample_id] = nbytes
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=str(metadata.get("run_id", "unknown")),
+            source_task_id=metadata.get("source_task_id"),
+            feature_store_uri=f"mooncake://{self.store_id}/{sample_id}",
+            feature_keys={k: f"{sample_id}/{k}" for k in staged},
+            feature_specs=specs,
+            strategy=metadata.get("strategy", "eagle3"),
+            schema_version=int(metadata.get("schema_version", SCHEMA_VERSION)),
+            target_model_version=str(metadata.get("target_model_version", "unknown")),
+            draft_weight_version=metadata.get("draft_weight_version"),
+            tokenizer_version=str(metadata.get("tokenizer_version", "unknown")),
+            num_tokens=int(metadata.get("num_tokens", 0)),
+            estimated_bytes=nbytes,
+            metadata={
+                **{k: v for k, v in metadata.items() if k != "num_tokens"},
+                "generation": gen,  # travels with the ref for the staleness guard
+            },
+        )
+
+    # -- read --------------------------------------------------------------
+    def get(
+        self,
+        sample_ref: SampleRef,
+        *,
+        device: "torch.device | str" = "cpu",
+        names: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, torch.Tensor], FeatureHandle]:
+        self.auth.check(self._credential)
+        sid = sample_ref.sample_id
+        key = self._key(sid)
+        if not self._store_exists(key):
+            # freed by release/abort, or never written -> never hand back stale
+            raise KeyError(f"sample {sid} not available in store {self.store_id}")
+        value = self._store.get(key)
+        if not value:
+            raise KeyError(f"sample {sid} not available in store {self.store_id}")
+        # weights_only=True: these bytes arrive over the wire from a producer node,
+        # so refuse arbitrary-pickle deserialization (the payload is only an int +
+        # a dict of tensors, all of which the safe unpickler supports).
+        payload = torch.load(io.BytesIO(value), weights_only=True)
+        on_disk_gen = payload.get("generation")
+        on_disk_gen = int(on_disk_gen) if on_disk_gen is not None else None
+        ref_gen = sample_ref.metadata.get("generation", on_disk_gen)
+        if on_disk_gen is not None and ref_gen != on_disk_gen:
+            # re-put after this ref was minted -> stale handle
+            raise KeyError(
+                f"sample {sid} generation {ref_gen} is stale "
+                f"(current {on_disk_gen}); refusing use-after-free"
+            )
+        raw = payload["tensors"]
+        wanted = names or list(sample_ref.feature_keys.keys())
+        out: Dict[str, torch.Tensor] = {}
+        for n in wanted:
+            raw_key = sample_ref.feature_keys.get(n, n)
+            raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
+            if raw_key not in raw:
+                raise KeyError(f"sample {sid} missing key {raw_key!r} for feature {n!r}")
+            # clone-on-fetch (B5): returned tensor is independent of the transport
+            out[n] = raw[raw_key].clone()
+        if str(device) != "cpu":
+            out = {k: v.to(device) for k, v in out.items()}
+        with self._lock:
+            self._counter += 1
+            handle = FeatureHandle(
+                sample_id=sid,
+                generation=on_disk_gen or 0,
+                lease_token=f"{sid}:{self._counter}",
+            )
+            self._active_leases[handle.lease_token] = handle
+        return out, handle
+
+    # -- lifetime ----------------------------------------------------------
+    def _try_physical_free(self, sample_id: str) -> bool:
+        """Remove the remote object. False on a (retryable) RPC failure."""
+        return self._store_remove(self._key(sample_id))
+
+    def _free_bookkeeping_locked(self, sample_id: str) -> int:
+        """Drop in-process tracking for a sample. Returns bytes accounted freed."""
+        nbytes = self._sample_bytes.pop(sample_id, 0)
+        self._generation.pop(sample_id, None)
+        self._put_time.pop(sample_id, None)
+        self._release_pending.pop(sample_id, None)
+        return nbytes
+
+    def _still_leased_locked(self, sample_id: str, generation: Optional[int]) -> bool:
+        # generation-aware: a stale older-generation lease does not pin the
+        # current generation (matches LocalFeatureStore's invariant).
+        return any(
+            h.sample_id == sample_id and h.generation == generation
+            for h in self._active_leases.values()
+        )
+
+    def release(self, handle: FeatureHandle, *, reason: str = "consumed") -> None:
+        with self._lock:
+            self._active_leases.pop(handle.lease_token, None)
+            if self.retain_on_release:
+                return  # offline re-iterable set: keep for the next epoch
+            sid = handle.sample_id
+            cur = self._generation.get(sid)
+            if cur is not None and handle.generation != cur:
+                return  # stale lease -> no-op
+            if self._still_leased_locked(sid, cur):
+                return
+            if self._try_physical_free(sid):
+                self._free_bookkeeping_locked(sid)
+            else:
+                # remote free failed -> park for gc() to retry/force-free
+                self._release_pending.setdefault(sid, 0)
+
+    def abort(self, sample_id: str, *, reason: str = "aborted") -> None:
+        with self._lock:
+            self._try_physical_free(sample_id)
+            self._free_bookkeeping_locked(sample_id)
+
+    def gc(self, *, now: Optional[float] = None) -> Dict[str, int]:
+        now = self._clock() if now is None else now
+        freed = freed_bytes = 0
+        with self._lock:
+            # max-hold sweep: force-free abandoned samples (spare still-leased)
+            if self.max_hold_age_s is not None:
+                stale = [
+                    sid
+                    for sid, t in list(self._put_time.items())
+                    if now - t > self.max_hold_age_s
+                    and not self._still_leased_locked(sid, self._generation.get(sid))
+                ]
+                for sid in stale:
+                    if self._try_physical_free(sid):
+                        freed_bytes += self._free_bookkeeping_locked(sid)
+                        freed += 1
+                    else:
+                        self._release_pending.setdefault(sid, 0)
+            # reconcile release-pending: retry the fallible remote free
+            for sid in list(self._release_pending):
+                if not self._store_exists(self._key(sid)):
+                    freed_bytes += self._free_bookkeeping_locked(sid)
+                    continue
+                attempts = self._release_pending[sid] + 1
+                if self._try_physical_free(sid):
+                    freed_bytes += self._free_bookkeeping_locked(sid)
+                    freed += 1
+                elif attempts >= self.max_release_attempts:
+                    # give up retrying the remote remove; stop tracking it. The
+                    # remote object may leak — surfaced via force_freed stats.
+                    freed_bytes += self._free_bookkeeping_locked(sid)
+                    freed += 1
+                else:
+                    self._release_pending[sid] = attempts
+            self._stats["force_freed"] += freed
+            self._stats["force_freed_bytes"] += freed_bytes
+        return {
+            "force_freed": freed,
+            "force_freed_bytes": freed_bytes,
+            "release_pending": len(self._release_pending),
+        }
+
+    def health(self) -> Dict[str, Any]:
+        with self._lock:
+            now = self._clock()
+            ages = [now - t for t in self._put_time.values()]
+            # NOTE: resident_bytes is an in-process accounting sum, not a live
+            # Mooncake pool-usage query (the Python API exposes only per-key
+            # get_size). A cross-node pool-usage signal is a follow-up.
+            return {
+                "store_id": self.store_id,
+                "backend": "mooncake",
+                "resident_samples": len(self._generation),
+                "active_leases": len(self._active_leases),
+                "resident_bytes": sum(self._sample_bytes.values()),
+                "max_resident_bytes": self.max_resident_bytes,
+                "auth_required": self.auth.required,
+                "release_pending": len(self._release_pending),
+                "oldest_age_s": max(ages) if ages else 0.0,
+                "avg_age_s": (sum(ages) / len(ages)) if ages else 0.0,
+                "force_freed_total": self._stats["force_freed"],
+                "hard_pin": bool(getattr(self._put_config, "with_hard_pin", False)),
+            }
+
+
+__all__ = ["MooncakeFeatureStore"]

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -82,7 +82,10 @@ class _PinConfig:
     config exposes so the injected backend can assert on them."""
 
     def __init__(
-        self, replica_num: int = 1, with_hard_pin: bool = True, with_soft_pin: bool = False
+        self,
+        replica_num: int = 1,
+        with_hard_pin: bool = True,
+        with_soft_pin: bool = False,
     ) -> None:
         self.replica_num = replica_num
         self.with_hard_pin = with_hard_pin
@@ -114,7 +117,9 @@ def _connect_store(setup_kwargs: Dict[str, Any]) -> Any:
     store = MooncakeDistributedStore()
     rc = store.setup(**setup_kwargs)
     if rc is not None and int(rc) != 0:
-        raise RuntimeError(f"Mooncake setup failed (status {rc}); kwargs={setup_kwargs}")
+        raise RuntimeError(
+            f"Mooncake setup failed (status {rc}); kwargs={setup_kwargs}"
+        )
     return store
 
 
@@ -310,7 +315,9 @@ class MooncakeFeatureStore(FeatureStore):
             raw_key = sample_ref.feature_keys.get(n, n)
             raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
             if raw_key not in raw:
-                raise KeyError(f"sample {sid} missing key {raw_key!r} for feature {n!r}")
+                raise KeyError(
+                    f"sample {sid} missing key {raw_key!r} for feature {n!r}"
+                )
             # clone-on-fetch (B5): returned tensor is independent of the transport
             out[n] = raw[raw_key].clone()
         if str(device) != "cpu":

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -25,6 +25,7 @@ class _FakeMooncakeStore:
         self._d = {}
         self.last_config = None
         self.fail_remove = False
+        self.lease_defer = False  # remove() returns ok but keeps bytes (Mooncake lease)
         self.put_calls = 0
         self.remove_calls = 0
 
@@ -44,6 +45,8 @@ class _FakeMooncakeStore:
         self.remove_calls += 1
         if self.fail_remove:
             return -1
+        if self.lease_defer:
+            return 0  # report success but keep the object (lease-deferred free)
         self._d.pop(key, None)
         return 0
 
@@ -112,6 +115,19 @@ class TestMooncakeFeatureStore(unittest.TestCase):
         fs.release(handle)
         with self.assertRaises(KeyError):
             fs.get(ref)
+
+    def test_get_after_release_raises_even_if_remote_lingers(self):
+        # Mooncake's remove() is lease-deferred: it can report success while the
+        # bytes linger under a read-lease. The ref must still not resolve (B5).
+        fake = _FakeMooncakeStore()
+        fake.lease_defer = True
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = fs.get(ref)
+        fs.release(handle)
+        self.assertEqual(fake.is_exist("run0/s0"), 1)  # bytes still physically there
+        with self.assertRaises(KeyError):
+            fs.get(ref)  # but the ref is logically freed -> KeyError
 
     def test_abort_frees(self):
         fs = _store()

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -13,8 +13,8 @@ import unittest
 
 import torch
 
-from specforge.runtime.data_plane.feature_store import LocalFeatureStore
 from specforge.runtime.data_plane.disaggregated import AuthPolicy
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
 from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
 
 
@@ -202,9 +202,7 @@ class TestMooncakeFeatureStore(unittest.TestCase):
 
     def test_release_pending_retry_then_reconcile(self):
         fake = _FakeMooncakeStore()
-        fs = MooncakeFeatureStore(
-            store=fake, store_id="run0", max_release_attempts=3
-        )
+        fs = MooncakeFeatureStore(store=fake, store_id="run0", max_release_attempts=3)
         ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
         _, handle = fs.get(ref)
         fake.fail_remove = True
@@ -221,13 +219,19 @@ class TestMooncakeFeatureStore(unittest.TestCase):
         src = _tensors()
         local = LocalFeatureStore("run0")
         mooncake = _store()
-        lref = local.put({k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta())
-        mref = mooncake.put({k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta())
+        lref = local.put(
+            {k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta()
+        )
+        mref = mooncake.put(
+            {k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta()
+        )
         lout, _ = local.get(lref)
         mout, _ = mooncake.get(mref)
         self.assertEqual(set(lout), set(mout))
         for k in lout:
-            self.assertTrue(torch.equal(lout[k], mout[k]), f"{k} differs local vs mooncake")
+            self.assertTrue(
+                torch.equal(lout[k], mout[k]), f"{k} differs local vs mooncake"
+            )
 
 
 @unittest.skipUnless(
@@ -242,7 +246,11 @@ class TestMooncakeFeatureStoreReal(unittest.TestCase):
     def _setup_kwargs(self):
         import os
 
-        req = ("MOONCAKE_LOCAL_HOSTNAME", "MOONCAKE_METADATA_SERVER", "MOONCAKE_MASTER_SERVER_ADDR")
+        req = (
+            "MOONCAKE_LOCAL_HOSTNAME",
+            "MOONCAKE_METADATA_SERVER",
+            "MOONCAKE_MASTER_SERVER_ADDR",
+        )
         if not all(os.environ.get(k) for k in req):
             self.skipTest(f"set {req} to run the real Mooncake e2e test")
         return {

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -1,0 +1,252 @@
+# coding=utf-8
+"""Contract tests for MooncakeFeatureStore using an in-memory fake backend.
+
+The fake stands in for ``MooncakeDistributedStore`` (the subset of its API the
+backend uses), so the FeatureStore contract — generation guard, clone-on-fetch,
+consume-once free, retain mode, auth, hard-pin, max-hold gc, and the fallible-free
+retry seam — is verified locally without a running Mooncake master. A real
+end-to-end test against ``mooncake`` is gated below on the package import.
+"""
+
+import importlib.util
+import unittest
+
+import torch
+
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.disaggregated import AuthPolicy
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+
+
+class _FakeMooncakeStore:
+    """In-memory stand-in for MooncakeDistributedStore (API subset)."""
+
+    def __init__(self) -> None:
+        self._d = {}
+        self.last_config = None
+        self.fail_remove = False
+        self.put_calls = 0
+        self.remove_calls = 0
+
+    def is_exist(self, key):
+        return 1 if key in self._d else 0
+
+    def put(self, key, value, config=None):
+        self.last_config = config
+        self._d[key] = bytes(value)
+        self.put_calls += 1
+        return 0
+
+    def get(self, key):
+        return self._d.get(key, b"")
+
+    def remove(self, key):
+        self.remove_calls += 1
+        if self.fail_remove:
+            return -1
+        self._d.pop(key, None)
+        return 0
+
+    def get_size(self, key):
+        return len(self._d.get(key, b""))
+
+
+class _FakeClock:
+    def __init__(self, t=0.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, dt):
+        self.t += dt
+
+
+def _tensors():
+    torch.manual_seed(0)
+    return {
+        "hidden_state": torch.randn(4, 8),
+        "target": torch.randn(4, 8),
+        "input_ids": torch.arange(4).unsqueeze(0),
+    }
+
+
+def _meta():
+    return {"run_id": "run0", "num_tokens": 4}
+
+
+def _store(**kw):
+    return MooncakeFeatureStore(store=_FakeMooncakeStore(), store_id="run0", **kw)
+
+
+class TestMooncakeFeatureStore(unittest.TestCase):
+    def test_put_get_roundtrip_bit_exact(self):
+        fs = _store()
+        src = _tensors()
+        ref = fs.put(src, sample_id="s0", metadata=_meta())
+        self.assertTrue(ref.feature_store_uri.startswith("mooncake://"))
+        out, handle = fs.get(ref)
+        for k in src:
+            self.assertTrue(torch.equal(out[k], src[k]), f"{k} not bit-exact")
+        self.assertEqual(handle.sample_id, "s0")
+
+    def test_clone_on_fetch_independent(self):
+        fs = _store()
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        out, _ = fs.get(ref)
+        out["hidden_state"] += 1.0  # mutate the returned copy
+        again, _ = fs.get(ref)
+        self.assertFalse(torch.equal(out["hidden_state"], again["hidden_state"]))
+
+    def test_hard_pin_config_on_put(self):
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0", hard_pin=True)
+        fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        self.assertTrue(getattr(fake.last_config, "with_hard_pin", False))
+        self.assertTrue(fs.health()["hard_pin"])
+
+    def test_get_after_release_raises(self):
+        fs = _store()
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = fs.get(ref)
+        fs.release(handle)
+        with self.assertRaises(KeyError):
+            fs.get(ref)
+
+    def test_abort_frees(self):
+        fs = _store()
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        fs.abort("s0")
+        with self.assertRaises(KeyError):
+            fs.get(ref)
+        self.assertEqual(fs.health()["resident_samples"], 0)
+
+    def test_stale_generation_rejected_after_reput(self):
+        fs = _store()
+        ref1 = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        fs.put(_tensors(), sample_id="s0", metadata=_meta())  # re-put -> new gen
+        with self.assertRaises(KeyError):
+            fs.get(ref1)  # stale ref refused (B5)
+
+    def test_retain_on_release_keeps_data(self):
+        fs = _store(retain_on_release=True)
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = fs.get(ref)
+        fs.release(handle)
+        out, _ = fs.get(ref)  # still available for the next epoch
+        self.assertIn("hidden_state", out)
+
+    def test_consume_once_free_on_last_lease(self):
+        fs = _store()
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, h1 = fs.get(ref)
+        _, h2 = fs.get(ref)
+        fs.release(h1)
+        self.assertEqual(fs.health()["resident_samples"], 1)  # still leased
+        fs.release(h2)
+        with self.assertRaises(KeyError):
+            fs.get(ref)  # freed on last lease
+
+    def test_auth_required_disaggregated(self):
+        auth = AuthPolicy(token="secret")
+        with self.assertRaises(PermissionError):
+            MooncakeFeatureStore(
+                store=_FakeMooncakeStore(), auth=auth, credential="wrong"
+            )
+        fs = MooncakeFeatureStore(
+            store=_FakeMooncakeStore(), store_id="run0", auth=auth, credential="secret"
+        )
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        out, _ = fs.get(ref)
+        self.assertIn("target", out)
+
+    def test_max_resident_bytes_raises_when_behind(self):
+        fs = _store(max_resident_bytes=16)  # far below one sample
+        with self.assertRaises(MemoryError):
+            fs.put(_tensors(), sample_id="s0", metadata=_meta())
+
+    def test_gc_force_frees_past_max_hold(self):
+        clock = _FakeClock()
+        fs = _store(max_hold_age_s=10.0, clock=clock)
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        clock.advance(11.0)
+        res = fs.gc()
+        self.assertEqual(res["force_freed"], 1)
+        with self.assertRaises(KeyError):
+            fs.get(ref)
+
+    def test_gc_spares_leased_even_if_old(self):
+        clock = _FakeClock()
+        fs = _store(max_hold_age_s=10.0, clock=clock)
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, _h = fs.get(ref)  # active lease
+        clock.advance(11.0)
+        res = fs.gc()
+        self.assertEqual(res["force_freed"], 0)  # spared while leased
+
+    def test_release_pending_retry_then_reconcile(self):
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(
+            store=fake, store_id="run0", max_release_attempts=3
+        )
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = fs.get(ref)
+        fake.fail_remove = True
+        fs.release(handle)  # remote free fails -> parked
+        self.assertEqual(fs.health()["release_pending"], 1)
+        fs.gc()  # retry, still failing
+        self.assertEqual(fs.health()["release_pending"], 1)
+        fake.fail_remove = False
+        res = fs.gc()  # now the remove succeeds
+        self.assertEqual(res["force_freed"], 1)
+        self.assertEqual(fs.health()["release_pending"], 0)
+
+    def test_equivalence_with_local_feature_store(self):
+        src = _tensors()
+        local = LocalFeatureStore("run0")
+        mooncake = _store()
+        lref = local.put({k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta())
+        mref = mooncake.put({k: v.clone() for k, v in src.items()}, sample_id="s0", metadata=_meta())
+        lout, _ = local.get(lref)
+        mout, _ = mooncake.get(mref)
+        self.assertEqual(set(lout), set(mout))
+        for k in lout:
+            self.assertTrue(torch.equal(lout[k], mout[k]), f"{k} differs local vs mooncake")
+
+
+@unittest.skipUnless(
+    importlib.util.find_spec("mooncake") is not None,
+    "mooncake package not installed; real end-to-end store test skipped",
+)
+class TestMooncakeFeatureStoreReal(unittest.TestCase):
+    """End-to-end against a real Mooncake master. Requires env:
+    MOONCAKE_LOCAL_HOSTNAME, MOONCAKE_METADATA_SERVER, MOONCAKE_MASTER_SERVER_ADDR.
+    Run on a Mooncake-enabled GPU host."""
+
+    def _setup_kwargs(self):
+        import os
+
+        req = ("MOONCAKE_LOCAL_HOSTNAME", "MOONCAKE_METADATA_SERVER", "MOONCAKE_MASTER_SERVER_ADDR")
+        if not all(os.environ.get(k) for k in req):
+            self.skipTest(f"set {req} to run the real Mooncake e2e test")
+        return {
+            "local_hostname": os.environ["MOONCAKE_LOCAL_HOSTNAME"],
+            "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
+            "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
+            "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
+        }
+
+    def test_real_roundtrip(self):
+        fs = MooncakeFeatureStore(setup_kwargs=self._setup_kwargs())
+        src = _tensors()
+        ref = fs.put(src, sample_id="s0", metadata=_meta())
+        out, handle = fs.get(ref)
+        for k in src:
+            self.assertTrue(torch.equal(out[k], src[k]))
+        fs.release(handle)
+        with self.assertRaises(KeyError):
+            fs.get(ref)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds MooncakeFeatureStore: backs the FeatureStore contract with the Mooncake distributed object store (cross-node RDMA/TCP) behind the unchanged API — hard-pin-on-put, lease-deferred-free tombstone for B5, fallible-free retry. Validated 2-node cross-node on H200. mooncake imported lazily; backend-selectable in the disagg example.

Part of the **DataFlow runtime M5/M6** stacked series (continues #594–#601 / #603). Stacked PRs — **merge bottom-up** (up-9 first). Lint (pre-commit) + runtime CPU test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)