### PR TITLE
[DataFlow runtime · M6] MooncakeFeatureStore zero-copy transport (put_from/get_into)

### DIFF
--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -123,14 +123,54 @@ def _connect_store(setup_kwargs: Dict[str, Any]) -> Any:
     return store
 
 
+# FeatureSpec.dtype (a string) -> torch dtype, for allocating zero-copy receive
+# tensors from the ref alone (the ref carries shape+dtype, so get() needs no
+# serialized header).
+_TORCH_DTYPES = {
+    "float32": torch.float32,
+    "float64": torch.float64,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "int64": torch.int64,
+    "int32": torch.int32,
+    "int16": torch.int16,
+    "int8": torch.int8,
+    "uint8": torch.uint8,
+    "bool": torch.bool,
+}
+
+
+def _alloc_from_spec(spec) -> torch.Tensor:
+    """A fresh contiguous tensor matching a FeatureSpec (the zero-copy dst)."""
+    dtype = _TORCH_DTYPES.get(spec.dtype)
+    if dtype is None:
+        raise KeyError(f"unsupported feature dtype {spec.dtype!r} for zero-copy get")
+    return torch.empty(tuple(int(d) for d in spec.shape), dtype=dtype)
+
+
+def _nbytes(t: torch.Tensor) -> int:
+    return t.numel() * t.element_size()
+
+
 class MooncakeFeatureStore(FeatureStore):
     """A disaggregated :class:`FeatureStore` backed by the Mooncake store.
 
-    One Mooncake object per sample (``{store_id}/{sample_id}``) holds a
-    ``torch.save``'d ``{"generation": int, "tensors": dict}`` blob, hard-pinned so
-    Mooncake's LRU never reclaims a live feature. ``store`` may be injected (any
-    object exposing ``is_exist/put/get/remove`` with the Mooncake signatures) so
-    the contract is unit-testable without a running master.
+    **Zero-copy transport (default).** One hard-pinned Mooncake object per
+    *tensor*, keyed ``{store_id}/{sample_id}/g{gen}/{name}``. ``put()`` writes each
+    tensor straight from its storage with ``put_from(ptr)``; ``get()`` reads each
+    straight into a tensor allocated from the ref's ``FeatureSpec`` with
+    ``get_into(ptr)``. There is no ``torch.save``/``torch.load`` pickle round-trip
+    on the hot path — shape/dtype travel on the ref, the bytes are the raw tensor
+    buffer. The generation lives in the key (like ``SharedDirFeatureStore``'s
+    filename generation), so a re-put supersedes the old key set and a stale ref's
+    keys are gone -> ``get()`` raises (B5).
+
+    Set ``zero_copy=False`` (or inject a backend without ``put_from``/``get_into``)
+    to fall back to the single-object ``torch.save`` blob path.
+
+    ``store`` may be injected (any object exposing the Mooncake method subset:
+    ``is_exist/remove`` plus either ``put_from``/``get_into`` or ``put``/``get``)
+    so the contract is unit-testable without a running master.
     """
 
     def __init__(
@@ -147,6 +187,7 @@ class MooncakeFeatureStore(FeatureStore):
         max_release_attempts: int = 3,
         replica_num: int = 1,
         hard_pin: bool = True,
+        zero_copy: bool = True,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self.auth = auth or AuthPolicy()
@@ -159,6 +200,16 @@ class MooncakeFeatureStore(FeatureStore):
             store = _connect_store(kw)
         self._store = store
         self._put_config = _build_replicate_config(replica_num, hard_pin)
+        # Zero-copy transport: one Mooncake object per *tensor*, written straight
+        # from the tensor's storage via put_from(ptr) and read straight into a
+        # spec-allocated tensor via get_into(ptr) -- no torch.save/torch.load
+        # pickle round-trip. Falls back to the pickle path if the backend lacks
+        # the raw-buffer API (older mooncake / a fake without it).
+        self._zero_copy = (
+            bool(zero_copy)
+            and callable(getattr(store, "put_from", None))
+            and callable(getattr(store, "get_into", None))
+        )
         self.max_resident_bytes = max_resident_bytes
         self.max_hold_age_s = max_hold_age_s
         # Offline re-iterable mode: release() must NOT free (multi-epoch); mirrors
@@ -170,6 +221,11 @@ class MooncakeFeatureStore(FeatureStore):
         self._generation: Dict[str, int] = {}
         self._put_time: Dict[str, float] = {}
         self._sample_bytes: Dict[str, int] = {}
+        # feature names per resident sample -> the per-tensor keys to remove on
+        # free (zero-copy mode). Cached on both put() (producer) and get()
+        # (consumer) so each side can free the sample it owns/consumed without the
+        # ref in hand at release() time.
+        self._sample_names: Dict[str, List[str]] = {}
         self._active_leases: Dict[str, FeatureHandle] = {}
         # samples whose remote remove() failed; retried/force-freed by gc()
         self._release_pending: Dict[str, int] = {}
@@ -190,6 +246,12 @@ class MooncakeFeatureStore(FeatureStore):
     def _key(self, sample_id: str) -> str:
         return f"{self.store_id}/{sample_id}"
 
+    def _tkey(self, sample_id: str, gen: int, name: str) -> str:
+        # generation lives in the key (like SharedDirFeatureStore's filename gen):
+        # a re-put writes a new-gen key set and removes the old, so a stale ref's
+        # keys are gone -> get() raises (B5), no payload-carried gen needed.
+        return f"{self.store_id}/{sample_id}/g{gen}/{name}"
+
     # -- store wrappers (status-code aware) --------------------------------
     def _store_exists(self, key: str) -> bool:
         return int(self._store.is_exist(key)) == 1
@@ -199,6 +261,52 @@ class MooncakeFeatureStore(FeatureStore):
         if rc is not None and int(rc) != 0:
             raise RuntimeError(f"mooncake put failed (status {rc}) for {key}")
 
+    def _store_put_tensor(self, key: str, t: torch.Tensor) -> None:
+        """Zero-copy publish: DMA straight from the tensor's storage, hard-pinned.
+
+        ``t`` must be contiguous + CPU (caller stages it). No torch.save: the
+        bytes are the raw tensor buffer; shape/dtype travel on the ref's
+        FeatureSpec, so get() needs no header. The source is registered with the
+        transfer engine for the duration of the put -- RDMA transfers it by DMA
+        and rejects an unregistered address (AddressNotRegistered); TCP ignores
+        the registration.
+        """
+        nb = _nbytes(t)
+        try:
+            self._store.register_buffer(t.data_ptr(), nb)
+        except Exception:  # pragma: no cover - some builds auto-register
+            pass
+        try:
+            rc = self._store.put_from(key, t.data_ptr(), nb, self._put_config)
+        finally:
+            try:
+                self._store.unregister_buffer(t.data_ptr())
+            except Exception:  # pragma: no cover
+                pass
+        if rc is not None and int(rc) < 0:
+            raise RuntimeError(f"mooncake put_from failed (status {rc}) for {key}")
+
+    def _store_get_tensor(self, key: str, out: torch.Tensor) -> None:
+        """Zero-copy fetch into a pre-allocated tensor. Raises KeyError if absent.
+
+        The receive buffer is registered with the transfer engine for the get_into
+        (required by the raw-buffer path), then unregistered.
+        """
+        nb = _nbytes(out)
+        try:
+            self._store.register_buffer(out.data_ptr(), nb)
+        except Exception:  # pragma: no cover - some builds auto-register
+            pass
+        try:
+            rc = self._store.get_into(key, out.data_ptr(), nb)
+        finally:
+            try:
+                self._store.unregister_buffer(out.data_ptr())
+            except Exception:  # pragma: no cover
+                pass
+        if rc is None or int(rc) < 0:
+            raise KeyError(f"mooncake get_into failed (status {rc}) for {key}")
+
     def _store_remove(self, key: str) -> bool:
         """Best-effort physical free. Returns True on confirmed removal."""
         try:
@@ -206,6 +314,11 @@ class MooncakeFeatureStore(FeatureStore):
         except Exception:  # pragma: no cover - transient RPC failure
             return False
         return rc is None or int(rc) == 0
+
+    def _tensor_keys(self, sample_id: str, gen: int) -> List[str]:
+        return [
+            self._tkey(sample_id, gen, n) for n in self._sample_names.get(sample_id, [])
+        ]
 
     # -- write -------------------------------------------------------------
     def put(
@@ -218,9 +331,9 @@ class MooncakeFeatureStore(FeatureStore):
         self.auth.check(self._credential)
         if not tensors:
             raise ValueError("put requires at least one tensor")
-        staged = {k: v.detach().cpu() for k, v in tensors.items()}
+        staged = {k: v.detach().cpu().contiguous() for k, v in tensors.items()}
         specs = {k: spec_from_tensor(k, v) for k, v in staged.items()}
-        nbytes = sum(t.numel() * t.element_size() for t in staged.values())
+        nbytes = sum(_nbytes(t) for t in staged.values())
         with self._lock:
             if (
                 self.max_resident_bytes is not None
@@ -232,23 +345,50 @@ class MooncakeFeatureStore(FeatureStore):
                 )
             self._gen_counter += 1
             gen = self._gen_counter
-        buf = io.BytesIO()
-        torch.save({"generation": gen, "tensors": staged}, buf)
-        key = self._key(sample_id)
-        # Overwrite-safe publish: a re-put bumps the generation. remove() first so
-        # the hard-pinned prior blob is released rather than orphaned; if that
-        # remove fails the old (pinned) blob may leak, so surface it loudly.
-        if self._store_exists(key) and not self._store_remove(key):
-            logger.warning(
-                "MooncakeFeatureStore re-put of %s: removing the stale blob failed; "
-                "a hard-pinned object may be orphaned",
-                key,
-            )
-        self._store_put(key, buf.getvalue())
+            prior_gen = self._generation.get(sample_id)
+            prior_names = self._sample_names.get(sample_id, [])
+        if self._zero_copy:
+            # One hard-pinned object per tensor, DMA'd straight from its storage.
+            # staged keeps the source tensors alive across the synchronous puts.
+            for name, t in staged.items():
+                self._store_put_tensor(self._tkey(sample_id, gen, name), t)
+            # Overwrite-safe: drop the prior generation's tensor keys so a stale
+            # ref's keys are gone (its get() then raises -> no use-after-free).
+            if prior_gen is not None and prior_gen != gen:
+                leaked = [
+                    name
+                    for name in prior_names
+                    if not self._store_remove(self._tkey(sample_id, prior_gen, name))
+                ]
+                if leaked:
+                    logger.warning(
+                        "MooncakeFeatureStore re-put of %s gen %s: removing prior "
+                        "generation %s tensors %s failed; hard-pinned objects may be "
+                        "orphaned (and the stale ref stays readable until reclaimed)",
+                        sample_id,
+                        prior_gen,
+                        prior_gen,
+                        leaked,
+                    )
+        else:
+            buf = io.BytesIO()
+            torch.save({"generation": gen, "tensors": staged}, buf)
+            key = self._key(sample_id)
+            # Overwrite-safe publish: a re-put bumps the generation. remove() first
+            # so the hard-pinned prior blob is released rather than orphaned; if
+            # that remove fails the old (pinned) blob may leak, so surface it.
+            if self._store_exists(key) and not self._store_remove(key):
+                logger.warning(
+                    "MooncakeFeatureStore re-put of %s: removing the stale blob "
+                    "failed; a hard-pinned object may be orphaned",
+                    key,
+                )
+            self._store_put(key, buf.getvalue())
         with self._lock:
             self._generation[sample_id] = gen
             self._put_time[sample_id] = self._clock()
             self._sample_bytes[sample_id] = nbytes
+            self._sample_names[sample_id] = list(staged)
         return SampleRef(
             sample_id=sample_id,
             run_id=str(metadata.get("run_id", "unknown")),
@@ -288,9 +428,60 @@ class MooncakeFeatureStore(FeatureStore):
                     f"sample {sid} generation {ref_gen} was released/aborted; "
                     f"refusing use-after-free"
                 )
+        wanted = names or list(sample_ref.feature_keys.keys())
+        if self._zero_copy:
+            out, gen = self._get_zero_copy(sample_ref, wanted)
+        else:
+            out, gen = self._get_pickle(sample_ref, wanted)
+        if str(device) != "cpu":
+            out = {k: v.to(device) for k, v in out.items()}
+        with self._lock:
+            self._counter += 1
+            # Consumer-side cache: a process that only get()s a sample (never
+            # put() it) still needs gen + feature names so its release()/abort()
+            # can free the per-tensor keys. setdefault keeps the producer's own
+            # entries authoritative when producer and consumer are one instance.
+            self._generation.setdefault(sid, gen)
+            self._sample_names.setdefault(sid, list(sample_ref.feature_keys.keys()))
+            handle = FeatureHandle(
+                sample_id=sid,
+                generation=gen,
+                lease_token=f"{sid}:{self._counter}",
+            )
+            self._active_leases[handle.lease_token] = handle
+        return out, handle
+
+    def _get_zero_copy(
+        self, ref: SampleRef, wanted: List[str]
+    ) -> Tuple[Dict[str, torch.Tensor], int]:
+        """Read each feature straight into a spec-allocated tensor (no pickle)."""
+        sid = ref.sample_id
+        gen = ref.metadata.get("generation")
+        if gen is None:
+            raise KeyError(f"sample {sid} ref carries no generation; cannot locate")
+        gen = int(gen)
+        out: Dict[str, torch.Tensor] = {}
+        for n in wanted:
+            spec = ref.feature_specs.get(n)
+            if spec is None:
+                raise KeyError(f"sample {sid} ref has no spec for feature {n!r}")
+            key = self._tkey(sid, gen, n)
+            if not self._store_exists(key):
+                # freed (release/abort), superseded by a re-put, or never written
+                raise KeyError(
+                    f"sample {sid} gen {gen} feature {n!r} not available "
+                    f"(freed, stale, or never written)"
+                )
+            out[n] = _alloc_from_spec(spec)  # fresh -> clone-on-fetch for free (B5)
+            self._store_get_tensor(key, out[n])
+        return out, gen
+
+    def _get_pickle(
+        self, ref: SampleRef, wanted: List[str]
+    ) -> Tuple[Dict[str, torch.Tensor], int]:
+        sid = ref.sample_id
         key = self._key(sid)
         if not self._store_exists(key):
-            # freed by release/abort, or never written -> never hand back stale
             raise KeyError(f"sample {sid} not available in store {self.store_id}")
         value = self._store.get(key)
         if not value:
@@ -301,47 +492,60 @@ class MooncakeFeatureStore(FeatureStore):
         payload = torch.load(io.BytesIO(value), weights_only=True)
         on_disk_gen = payload.get("generation")
         on_disk_gen = int(on_disk_gen) if on_disk_gen is not None else None
-        ref_gen = sample_ref.metadata.get("generation", on_disk_gen)
+        ref_gen = ref.metadata.get("generation", on_disk_gen)
         if on_disk_gen is not None and ref_gen != on_disk_gen:
-            # re-put after this ref was minted -> stale handle
             raise KeyError(
                 f"sample {sid} generation {ref_gen} is stale "
                 f"(current {on_disk_gen}); refusing use-after-free"
             )
         raw = payload["tensors"]
-        wanted = names or list(sample_ref.feature_keys.keys())
         out: Dict[str, torch.Tensor] = {}
         for n in wanted:
-            raw_key = sample_ref.feature_keys.get(n, n)
+            raw_key = ref.feature_keys.get(n, n)
             raw_key = raw_key.split("/")[-1] if "/" in raw_key else raw_key
             if raw_key not in raw:
                 raise KeyError(
                     f"sample {sid} missing key {raw_key!r} for feature {n!r}"
                 )
-            # clone-on-fetch (B5): returned tensor is independent of the transport
-            out[n] = raw[raw_key].clone()
-        if str(device) != "cpu":
-            out = {k: v.to(device) for k, v in out.items()}
-        with self._lock:
-            self._counter += 1
-            handle = FeatureHandle(
-                sample_id=sid,
-                generation=on_disk_gen or 0,
-                lease_token=f"{sid}:{self._counter}",
-            )
-            self._active_leases[handle.lease_token] = handle
-        return out, handle
+            out[n] = raw[raw_key].clone()  # clone-on-fetch (B5)
+        return out, (on_disk_gen or 0)
 
     # -- lifetime ----------------------------------------------------------
     def _try_physical_free(self, sample_id: str) -> bool:
-        """Remove the remote object. False on a (retryable) RPC failure."""
-        return self._store_remove(self._key(sample_id))
+        """Remove the remote object(s). False on a (retryable) RPC failure.
+
+        Zero-copy: one object per tensor, so remove every per-tensor key of the
+        sample's current generation. Pickle: a single object.
+        """
+        if not self._zero_copy:
+            return self._store_remove(self._key(sample_id))
+        gen = self._generation.get(sample_id)
+        if gen is None:
+            return True  # nothing tracked to remove (already freed)
+        ok = True
+        for name in self._sample_names.get(sample_id, []):
+            if not self._store_remove(self._tkey(sample_id, gen, name)):
+                ok = False
+        return ok
+
+    def _sample_exists(self, sample_id: str) -> bool:
+        """True if any object backing the sample's current generation is present."""
+        if not self._zero_copy:
+            return self._store_exists(self._key(sample_id))
+        gen = self._generation.get(sample_id)
+        if gen is None:
+            return False
+        return any(
+            self._store_exists(self._tkey(sample_id, gen, n))
+            for n in self._sample_names.get(sample_id, [])
+        )
 
     def _free_bookkeeping_locked(self, sample_id: str) -> int:
         """Drop in-process tracking for a sample. Returns bytes accounted freed."""
         nbytes = self._sample_bytes.pop(sample_id, 0)
         self._generation.pop(sample_id, None)
         self._put_time.pop(sample_id, None)
+        self._sample_names.pop(sample_id, None)
         self._release_pending.pop(sample_id, None)
         return nbytes
 
@@ -401,7 +605,7 @@ class MooncakeFeatureStore(FeatureStore):
                         self._release_pending.setdefault(sid, 0)
             # reconcile release-pending: retry the fallible remote free
             for sid in list(self._release_pending):
-                if not self._store_exists(self._key(sid)):
+                if not self._sample_exists(sid):
                     freed_bytes += self._free_bookkeeping_locked(sid)
                     continue
                 attempts = self._release_pending[sid] + 1

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -306,6 +306,16 @@ class MooncakeFeatureStore(FeatureStore):
                 pass
         if rc is None or int(rc) < 0:
             raise KeyError(f"mooncake get_into failed (status {rc}) for {key}")
+        # get_into returns the number of bytes read; a full read returns exactly
+        # nb. A short read (0 <= rc < nb) would leave the tail of this freshly
+        # torch.empty'd buffer as uninitialized garbage -- and unlike the pickle
+        # path (torch.load reconstructs whole tensors) the raw-buffer path cannot
+        # otherwise detect under-fill. Reject it rather than hand the trainer
+        # silently-corrupt data (B5: never serve wrong bytes).
+        if int(rc) != nb:
+            raise KeyError(
+                f"mooncake get_into short read for {key}: got {rc} of {nb} bytes"
+            )
 
     def _store_remove(self, key: str) -> bool:
         """Best-effort physical free. Returns True on confirmed removal."""
@@ -314,11 +324,6 @@ class MooncakeFeatureStore(FeatureStore):
         except Exception:  # pragma: no cover - transient RPC failure
             return False
         return rc is None or int(rc) == 0
-
-    def _tensor_keys(self, sample_id: str, gen: int) -> List[str]:
-        return [
-            self._tkey(sample_id, gen, n) for n in self._sample_names.get(sample_id, [])
-        ]
 
     # -- write -------------------------------------------------------------
     def put(

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -364,6 +364,21 @@ class TestMooncakeFeatureStoreZeroCopy(unittest.TestCase):
         with self.assertRaises(KeyError):
             fs.get(ref1)  # gen-1 keys gone -> stale ref refused (B5)
 
+    def test_short_read_is_rejected(self):
+        # A get_into that transfers fewer bytes than the spec-sized receive buffer
+        # (a truncated / partially-written object the backend still reports
+        # present) must raise -- never return a tensor whose uninitialized tail is
+        # silent garbage. get_into returns the byte count, so a short count != nb
+        # is the signal. Simulate by truncating the stored blob.
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        key = "run0/s0/g1/hidden_state"
+        self.assertEqual(len(fake._d[key]), 4 * 8 * 4)  # full 4x8 float32
+        fake._d[key] = fake._d[key][:-4]  # drop 4 bytes -> short read on get_into
+        with self.assertRaises(KeyError):
+            fs.get(ref)
+
 
 def _shared_pair(**consumer_kw):
     """A producer + consumer backed by ONE fake store = the real disagg topology.

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -8,6 +8,7 @@ retry seam — is verified locally without a running Mooncake master. A real
 end-to-end test against ``mooncake`` is gated below on the package import.
 """
 
+import ctypes
 import importlib.util
 import unittest
 
@@ -19,7 +20,13 @@ from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
 
 
 class _FakeMooncakeStore:
-    """In-memory stand-in for MooncakeDistributedStore (API subset)."""
+    """In-memory stand-in for MooncakeDistributedStore (API subset).
+
+    Supports BOTH the zero-copy raw-buffer API (``put_from``/``get_into`` +
+    ``register_buffer``, simulated with ctypes against the real buffer pointers)
+    and the legacy byte API (``put``/``get``), so the contract is exercised on
+    either transport without a running master.
+    """
 
     def __init__(self) -> None:
         self._d = {}
@@ -41,6 +48,27 @@ class _FakeMooncakeStore:
     def get(self, key):
         return self._d.get(key, b"")
 
+    # -- zero-copy raw-buffer API (ctypes-simulated) -----------------------
+    def register_buffer(self, ptr, size):
+        return 0
+
+    def unregister_buffer(self, ptr):
+        return 0
+
+    def put_from(self, key, ptr, size, config=None):
+        self.last_config = config
+        self._d[key] = ctypes.string_at(ptr, size)  # DMA-equivalent read of src
+        self.put_calls += 1
+        return 0
+
+    def get_into(self, key, ptr, size):
+        data = self._d.get(key)
+        if not data:
+            return -1
+        n = min(size, len(data))
+        ctypes.memmove(ptr, data, n)  # DMA-equivalent write into dst
+        return n
+
     def remove(self, key):
         self.remove_calls += 1
         if self.fail_remove:
@@ -52,6 +80,16 @@ class _FakeMooncakeStore:
 
     def get_size(self, key):
         return len(self._d.get(key, b""))
+
+
+def _phys_resident(fake, sid="s0", store_id="run0"):
+    """Transport-agnostic: do the sample's bytes physically exist in the fake?
+
+    pickle: one key ``run0/s0``; zero-copy: ``run0/s0/g{gen}/{name}`` keys.
+    """
+    exact = f"{store_id}/{sid}"
+    prefix = exact + "/"
+    return any(k == exact or k.startswith(prefix) for k in fake._d)
 
 
 class _FakeClock:
@@ -125,7 +163,7 @@ class TestMooncakeFeatureStore(unittest.TestCase):
         ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
         _, handle = fs.get(ref)
         fs.release(handle)
-        self.assertEqual(fake.is_exist("run0/s0"), 1)  # bytes still physically there
+        self.assertTrue(_phys_resident(fake))  # bytes still physically there
         with self.assertRaises(KeyError):
             fs.get(ref)  # but the ref is logically freed -> KeyError
 
@@ -232,6 +270,181 @@ class TestMooncakeFeatureStore(unittest.TestCase):
             self.assertTrue(
                 torch.equal(lout[k], mout[k]), f"{k} differs local vs mooncake"
             )
+
+    def test_abort_raises_even_if_remote_lingers(self):
+        # Mirror of test_get_after_release_raises_even_if_remote_lingers, but for
+        # abort(): Mooncake's remove() is lease-deferred (reports success while the
+        # bytes linger under a read-lease). Within one process the abort tombstone
+        # still makes the ref unresolvable immediately (B5), even though is_exist
+        # is still 1.
+        fake = _FakeMooncakeStore()
+        fake.lease_defer = True
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        fs.abort("s0")
+        self.assertTrue(_phys_resident(fake))  # bytes physically linger
+        with self.assertRaises(KeyError):
+            fs.get(ref)  # logically aborted -> KeyError (no use-after-free)
+
+    def test_reput_with_failed_remove_warns_and_supersedes(self):
+        # Pickle path: re-put when the pre-remove of the prior hard-pinned blob
+        # fails must still publish the new generation (overwriting the single key)
+        # and warn loudly that a pinned blob may be orphaned. The stale ref is then
+        # refused by the generation guard (the overwrite replaced the blob).
+        # (Zero-copy uses distinct per-generation keys, so a failed remove leaves
+        # the stale generation readable -- covered separately below.)
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0", zero_copy=False)
+        ref1 = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        fake.fail_remove = True
+        with self.assertLogs(
+            "specforge.runtime.data_plane.mooncake_store", level="WARNING"
+        ) as cm:
+            ref2 = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        self.assertTrue(
+            any("orphan" in line.lower() for line in cm.output),
+            f"expected an orphan warning, got {cm.output}",
+        )
+        out, _ = fs.get(ref2)  # the new generation is resident + served
+        self.assertIn("hidden_state", out)
+        with self.assertRaises(KeyError):
+            fs.get(ref1)  # the superseded ref is refused (generation guard)
+
+
+class TestMooncakeFeatureStoreZeroCopy(unittest.TestCase):
+    """Zero-copy transport specifics (the default): per-tensor keys, no pickle."""
+
+    def test_zero_copy_is_the_default(self):
+        fs = _store()
+        self.assertTrue(fs._zero_copy)
+
+    def test_falls_back_to_pickle_without_raw_api(self):
+        # a backend that lacks put_from/get_into must transparently use the blob
+        # path (and still round-trip).
+        class _ByteOnly(_FakeMooncakeStore):
+            put_from = None
+            get_into = None
+
+        fs = MooncakeFeatureStore(store=_ByteOnly(), store_id="run0")
+        self.assertFalse(fs._zero_copy)
+        src = _tensors()
+        ref = fs.put(src, sample_id="s0", metadata=_meta())
+        out, _ = fs.get(ref)
+        for k in src:
+            self.assertTrue(torch.equal(out[k], src[k]))
+
+    def test_one_object_per_tensor_with_generation_in_key(self):
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        self.assertEqual(
+            set(fake._d),
+            {"run0/s0/g1/hidden_state", "run0/s0/g1/target", "run0/s0/g1/input_ids"},
+        )
+        # no pickle blob was written under the bare sample key
+        self.assertNotIn("run0/s0", fake._d)
+
+    def test_no_pickle_on_the_wire(self):
+        # the stored bytes are the raw tensor buffer, not a torch.save pickle
+        # (which would begin with the PK zip magic or the pickle protocol byte).
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        blob = fake._d["run0/s0/g1/hidden_state"]
+        self.assertEqual(len(blob), 4 * 8 * 4)  # 4x8 float32, exactly the raw bytes
+        self.assertFalse(blob[:2] == b"PK")  # not a torch.save zip archive
+
+    def test_reput_success_supersedes_old_generation(self):
+        fake = _FakeMooncakeStore()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref1 = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        fs.put(_tensors(), sample_id="s0", metadata=_meta())  # gen 2; gen-1 removed
+        self.assertNotIn("run0/s0/g1/hidden_state", fake._d)
+        self.assertIn("run0/s0/g2/hidden_state", fake._d)
+        with self.assertRaises(KeyError):
+            fs.get(ref1)  # gen-1 keys gone -> stale ref refused (B5)
+
+
+def _shared_pair(**consumer_kw):
+    """A producer + consumer backed by ONE fake store = the real disagg topology.
+
+    Two MooncakeFeatureStore instances (separate in-process generation/lease/freed
+    indices) over a single shared backend, mirroring producer-on-node-0 /
+    consumer-on-node-1. store_id must match so the keys line up.
+    """
+    fake = _FakeMooncakeStore()
+    producer = MooncakeFeatureStore(store=fake, store_id="run0")
+    consumer = MooncakeFeatureStore(store=fake, store_id="run0", **consumer_kw)
+    return fake, producer, consumer
+
+
+class TestMooncakeFeatureStoreCrossProcess(unittest.TestCase):
+    """Cross-instance (disaggregated) contract: the consumer never put(), so it
+    resolves refs purely from the shared backend + the generation carried on the
+    ref, with its own empty in-process index."""
+
+    def test_cross_process_put_then_get_bit_exact(self):
+        fake, producer, consumer = _shared_pair(retain_on_release=True)
+        src = _tensors()
+        ref = producer.put(src, sample_id="s0", metadata=_meta())
+        out, handle = consumer.get(ref)  # separate instance, empty local index
+        for k in src:
+            self.assertTrue(torch.equal(out[k], src[k]), f"{k} not bit-exact")
+        self.assertEqual(handle.sample_id, "s0")
+        # the producer owns the sample; the consumer resolved it cross-instance
+        # from the shared backend + the generation carried on the ref.
+        self.assertEqual(producer.health()["resident_samples"], 1)
+
+    def test_cross_process_stale_generation_rejected(self):
+        # producer re-puts (gen bumps on the shared blob); the consumer's original
+        # ref is stale and must be refused via the on-disk generation guard, even
+        # though the consumer's in-process index never saw either put.
+        fake, producer, consumer = _shared_pair(retain_on_release=True)
+        ref1 = producer.put(_tensors(), sample_id="s0", metadata=_meta())
+        producer.put(_tensors(), sample_id="s0", metadata=_meta())  # re-put -> gen 2
+        with self.assertRaises(KeyError):
+            consumer.get(ref1)
+
+    def test_cross_process_abort_blocks_consumer_get(self):
+        # With a normal (immediate) remove, producer.abort physically deletes the
+        # blob, so a separate consumer's get() raises (B5 holds cross-process via
+        # physical removal, not the per-process tombstone).
+        fake, producer, consumer = _shared_pair(retain_on_release=True)
+        ref = producer.put(_tensors(), sample_id="s0", metadata=_meta())
+        producer.abort("s0")
+        self.assertFalse(_phys_resident(fake))
+        with self.assertRaises(KeyError):
+            consumer.get(ref)
+
+    def test_cross_process_consume_once_free_by_consumer(self):
+        # Consume-once consumer (retain_on_release=False) frees the shared blob on
+        # release; the producer can then no longer resolve the ref.
+        fake, producer, consumer = _shared_pair()  # consumer frees on release
+        ref = producer.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = consumer.get(ref)
+        consumer.release(handle)
+        self.assertFalse(_phys_resident(fake))
+        with self.assertRaises(KeyError):
+            producer.get(ref)
+
+    @unittest.expectedFailure
+    def test_cross_process_abort_under_lease_defer_is_known_gap(self):
+        # KNOWN LIMITATION (deferred to the M7 shared metadata index): under a
+        # lease-deferred remove, producer.abort marks only ITS OWN _freed and the
+        # bytes linger, so a separate consumer (empty _freed) still resolves the
+        # aborted ref -> stale. The cross-process tombstone needs a shared index.
+        # Encoded as expectedFailure so it flips to a hard failure once M7 closes
+        # it (prompting removal of this marker).
+        fake = _FakeMooncakeStore()
+        fake.lease_defer = True
+        producer = MooncakeFeatureStore(store=fake, store_id="run0")
+        consumer = MooncakeFeatureStore(
+            store=fake, store_id="run0", retain_on_release=True
+        )
+        ref = producer.put(_tensors(), sample_id="s0", metadata=_meta())
+        producer.abort("s0")
+        with self.assertRaises(KeyError):
+            consumer.get(ref)  # SHOULD raise; currently returns stale -> xfail
 
 
 @unittest.skipUnless(


### PR DESCRIPTION
Stacks on #612 (`dataflow-up-15-mooncake`). **Merge bottom-up.** First PR of a short series toward **online disaggregated training** (no hot-switch): this one delivers the zero-copy transport; follow-ups add `build_disagg_online_eagle3_runtime` + cross-pool consume-once/backpressure, then a two-axis staleness gate.

## What
Replaces the `torch.save`/`torch.load` pickle round-trip in `MooncakeFeatureStore` with Mooncake's native raw-buffer DMA:

- **One hard-pinned object per tensor**, keyed `{store_id}/{sample_id}/g{gen}/{name}`.
- `put()` writes each tensor straight from its storage via `put_from(ptr, nbytes, ReplicateConfig)`; `get()` reads each straight into a tensor allocated from the ref's `FeatureSpec` via `get_into(ptr, nbytes)`. Shape/dtype travel on the ref → **no serialized header**.
- **Generation in the key** (like `SharedDirFeatureStore`'s filename gen): a re-put supersedes the old key set, so a stale ref's keys are gone → `get()` raises (**B5**).
- **Hard-pin preserved** (`put_from` carries the `ReplicateConfig`).
- **Fallback**: `zero_copy=False` (or a backend without `put_from`/`get_into`) transparently uses the pickle blob path.

Source **and** receive buffers are registered with the transfer engine around the DMA — RDMA rejects an unregistered address (`AddressNotRegistered`, status -800); TCP ignores it.

## Validation (2× H200, cross-node)
- Full contract suite **28 tests green**, including the real gated `TestMooncakeFeatureStoreReal` against a live `mooncake_master` (now exercising the zero-copy path).
- **Cross-node training** (producer `put_from` on node 0 → consumer `get_into` + FSDP on node 1) over **both `tcp` and `rdma`**, end-to-end through `build_disagg_eagle3_runtime`.

## Tests
The in-memory fake now simulates `put_from`/`get_into` via `ctypes`, so the whole contract runs on the zero-copy path. Adds zero-copy specifics (per-tensor keys, no-pickle-on-the-wire, re-put supersede, pickle fallback), cross-process contract tests (producer/consumer as **separate instances** over one backend — the real disagg topology), and `abort`-under-lease-defer / re-put-with-failed-remove edge cases. One `@unittest.expectedFailure` documents the cross-process-abort-under-lease-defer tombstone gap (closes with the shared metadata index follow-up).

> Note: a failed prior-generation remove on re-put leaves the stale generation readable (distinct per-gen keys) and is logged loudly — weaker than the pickle path's overwrite. Re-put is not on the offline path; tightening this is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)