### PR TITLE
[DataFlow runtime · online] Online disaggregated training (StreamingRefChannel + build_disagg_online_*)

### DIFF
--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -101,8 +101,11 @@ class StreamingRefChannel:
         return self._published - self.consumed_remote()
 
     # -- consumer ----------------------------------------------------------
-    def _is_closed(self) -> bool:
+    def is_closed(self) -> bool:
+        """True once the producer has dropped the EOF sentinel."""
         return os.path.exists(self.path + _CLOSED_SUFFIX)
+
+    _is_closed = is_closed  # backwards-compatible alias
 
     def poll(self, max_n: Optional[int] = None) -> List[SampleRef]:
         """Return refs appended since the last poll (complete lines only).
@@ -179,4 +182,69 @@ class StreamingRefChannel:
             sleep(poll_s)
 
 
-__all__ = ["StreamingRefChannel"]
+class StreamingRefQueue:
+    """Adapts a :class:`StreamingRefChannel` to the ``SampleRefQueue`` protocol
+    (``get``/``ack``/``fail``) the ``FeatureDataLoader`` consumes in queue mode.
+
+    ``get(n)`` BLOCKS (polling) until ``n`` refs are buffered or the channel is
+    closed-and-drained, so the trainer streams the whole online run and only sees
+    an empty batch (-> loop ends) once the producer has closed. ``ack`` advances
+    the channel's consumed counter (the producer's backpressure signal); the
+    feature-store free already happened in the loader's materialize (get ->
+    release) for a consume-once store.
+    """
+
+    def __init__(
+        self,
+        channel: StreamingRefChannel,
+        *,
+        poll_s: float = 0.1,
+        idle_timeout_s: Optional[float] = None,
+        clock=time.monotonic,
+        sleep=time.sleep,
+    ) -> None:
+        self.channel = channel
+        self.poll_s = poll_s
+        self.idle_timeout_s = idle_timeout_s
+        self._clock = clock
+        self._sleep = sleep
+        self._buf: List[SampleRef] = []
+
+    def get(self, n: int, timeout_s: float = 0.0) -> List[SampleRef]:
+        last_progress = self._clock()
+        while len(self._buf) < n:
+            new = self.channel.poll()
+            if new:
+                self._buf.extend(new)
+                last_progress = self._clock()
+                continue
+            if self.channel.is_closed():
+                self._buf.extend(self.channel.poll())  # final drain
+                break
+            if (
+                self.idle_timeout_s is not None
+                and self._clock() - last_progress > self.idle_timeout_s
+            ):
+                raise TimeoutError(
+                    f"StreamingRefQueue {self.channel.path}: idle "
+                    f"{self.idle_timeout_s:.0f}s with the channel still open"
+                )
+            self._sleep(self.poll_s)
+        take = min(n, len(self._buf))
+        out, self._buf = self._buf[:take], self._buf[take:]
+        return out
+
+    def ack(self, refs: List[SampleRef]) -> None:
+        self.channel.mark_consumed(len(refs))  # backpressure: producer reads this
+
+    def fail(self, refs: List[SampleRef], reason: str, retryable: bool) -> None:
+        if retryable:
+            self._buf[:0] = refs  # re-buffer at the front for the next get()
+        else:
+            self.channel.mark_consumed(len(refs))
+
+    def depth(self) -> int:
+        return len(self._buf)
+
+
+__all__ = ["StreamingRefChannel", "StreamingRefQueue"]

--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -1,0 +1,182 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""StreamingRefChannel: a cross-process, append-only ``SampleRef`` stream.
+
+The offline disaggregation path hands the consumer a *static* ref manifest
+(:func:`disagg_ingest.write_ref_manifest`) written once before training. The
+*online* disaggregated path needs the opposite: the rollout producer commits
+refs continuously while the trainer consumes them, on a different node. This is
+that control-plane channel.
+
+* **Tensor-free.** Only ``SampleRef`` metadata travels here (asserted on
+  publish); the feature tensors go through the ``FeatureStore`` (Mooncake), so a
+  shared *data* mount is never required -- only this small control file.
+* **Append-only JSONL.** ``publish()`` appends one ref per line and fsyncs;
+  ``poll()`` tail-reads complete lines from the last offset, buffering a partial
+  trailing line so a reader never parses a half-written record.
+* **Consume-once friendly.** The reader marks how many refs it has consumed
+  (``mark_consumed``) in a sidecar counter the writer reads back, so the producer
+  can apply backpressure (``in_flight_remote``) without any shared in-process
+  state -- the same split-process model as the rest of disaggregation.
+* **Explicit close.** ``close()`` drops an EOF sentinel so the reader's
+  :meth:`stream` terminates once the file is drained instead of polling forever.
+
+This is the framework, intentionally filesystem-backed (works over any shared
+control mount). A networked control plane (Redis/the durable MetadataStore)
+slots in behind the same publish/poll API later.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Iterator, List, Optional
+
+from specforge.runtime.contracts import SampleRef, assert_no_tensors
+from specforge.runtime.data_plane.disagg_ingest import _ref_from_dict, _ref_to_dict
+
+_CLOSED_SUFFIX = ".closed"
+_CONSUMED_SUFFIX = ".consumed_count"
+
+
+class StreamingRefChannel:
+    """An append-only, tensor-free ``SampleRef`` stream over a shared file.
+
+    One instance per process. The *producer* calls :meth:`publish`/:meth:`close`
+    (+ reads :meth:`in_flight_remote` for backpressure); the *consumer* calls
+    :meth:`poll`/:meth:`stream` (+ :meth:`mark_consumed`). Both point at the same
+    ``path`` on a shared control mount.
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        # producer-side
+        self._published = 0
+        # consumer-side
+        self._read_offset = 0
+        self._buf = ""
+        self._consumed = 0
+
+    # -- producer ----------------------------------------------------------
+    def publish(self, ref: SampleRef) -> None:
+        """Append one tensor-free ref. Durable (fsync) so a remote reader sees it."""
+        assert_no_tensors([ref])
+        line = json.dumps(_ref_to_dict(ref), separators=(",", ":")) + "\n"
+        with open(self.path, "a") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+        self._published += 1
+
+    def publish_many(self, refs: List[SampleRef]) -> None:
+        for r in refs:
+            self.publish(r)
+
+    def close(self) -> None:
+        """Drop the EOF sentinel so the reader's stream() terminates when drained."""
+        open(self.path + _CLOSED_SUFFIX, "w").close()
+
+    @property
+    def published(self) -> int:
+        return self._published
+
+    def consumed_remote(self) -> int:
+        """How many refs the consumer reports having consumed (cross-process)."""
+        try:
+            with open(self.path + _CONSUMED_SUFFIX) as f:
+                return int(f.read() or "0")
+        except (FileNotFoundError, ValueError):
+            return 0
+
+    def in_flight_remote(self) -> int:
+        """published - consumed: the producer's backpressure signal."""
+        return self._published - self.consumed_remote()
+
+    # -- consumer ----------------------------------------------------------
+    def _is_closed(self) -> bool:
+        return os.path.exists(self.path + _CLOSED_SUFFIX)
+
+    def poll(self, max_n: Optional[int] = None) -> List[SampleRef]:
+        """Return refs appended since the last poll (complete lines only).
+
+        Non-blocking: returns whatever is available now (possibly empty). A
+        partially written trailing line is buffered until its newline arrives, so
+        a ref is never parsed half-written.
+        """
+        try:
+            with open(self.path, "r") as f:
+                f.seek(self._read_offset)
+                chunk = f.read()
+                self._read_offset = f.tell()
+        except FileNotFoundError:
+            chunk = ""
+        if chunk:
+            self._buf += chunk
+        # parse the buffer even when no new bytes arrived -- a previous max_n call
+        # may have left complete lines buffered.
+        out: List[SampleRef] = []
+        while "\n" in self._buf:
+            if max_n is not None and len(out) >= max_n:
+                break
+            line, self._buf = self._buf.split("\n", 1)
+            line = line.strip()
+            if line:
+                out.append(_ref_from_dict(json.loads(line)))
+        return out
+
+    def mark_consumed(self, n: int) -> None:
+        """Record n more consumed refs in the sidecar the producer reads back."""
+        self._consumed += n
+        tmp = self.path + _CONSUMED_SUFFIX + ".tmp"
+        with open(tmp, "w") as f:
+            f.write(str(self._consumed))
+        os.replace(tmp, self.path + _CONSUMED_SUFFIX)  # atomic counter publish
+
+    def stream(
+        self,
+        *,
+        poll_s: float = 0.25,
+        idle_timeout_s: Optional[float] = None,
+        clock=time.monotonic,
+        sleep=time.sleep,
+    ) -> Iterator[SampleRef]:
+        """Yield refs until the channel is closed AND drained.
+
+        Blocks (polling every ``poll_s``) while the producer is still live.
+        ``idle_timeout_s`` (if set) raises ``TimeoutError`` after that long with
+        no new ref and no close sentinel -- a liveness guard against a dead
+        producer.
+        """
+        last_progress = clock()
+        while True:
+            batch = self.poll()
+            if batch:
+                last_progress = clock()
+                for ref in batch:
+                    yield ref
+                continue
+            if self._is_closed():
+                # one final drain after close, then stop
+                tail = self.poll()
+                for ref in tail:
+                    yield ref
+                if not tail:
+                    return
+                continue
+            if idle_timeout_s is not None and clock() - last_progress > idle_timeout_s:
+                raise TimeoutError(
+                    f"StreamingRefChannel {self.path}: no refs for "
+                    f"{idle_timeout_s:.0f}s and not closed (producer dead?)"
+                )
+            sleep(poll_s)
+
+
+__all__ = ["StreamingRefChannel"]

--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -382,6 +382,181 @@ def build_online_eagle3_runtime(
     return trainer, loader, workers, controller, drive_rollout
 
 
+def _online_cat_collate(feats):
+    """Concatenate pre-formed online features along the batch dim (see
+    build_online_eagle3_runtime); online features are already in train form, so a
+    plain cat is correct for equal-length / batch_size=1 batches."""
+    import torch
+
+    return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
+
+
+def build_disagg_online_producer(
+    *,
+    target_model,
+    prompts,
+    feature_store: FeatureStore,
+    channel,
+    run_id: str,
+    target_hidden_size: int,
+    target_vocab_size: Optional[int] = None,
+    draft_vocab_size: Optional[int] = None,
+    target_repr: str = "logits",
+    aux_hidden_state_layer_ids=None,
+    vocab_map_version: Optional[str] = None,
+    t2d=None,
+    num_rollout_workers: int = 1,
+    device: str = "cuda",
+    lease: int = 8,
+    in_flight_high_watermark: int = 256,
+    backpressure_poll_s: float = 0.2,
+    sleep=None,
+):
+    """Producer side of an ONLINE disaggregated run (rollout pool).
+
+    Mirrors the producer half of :func:`build_online_eagle3_runtime`, but the
+    RolloutWorkers put() into a cross-node ``feature_store`` (a consume-once
+    :class:`MooncakeFeatureStore`) and the committed SampleRefs are streamed to
+    the consumer through a :class:`StreamingRefChannel` instead of an in-process
+    queue. The feature tensors never touch a shared mount.
+
+    Returns ``(workers, drive_producer)``. ``drive_producer()`` runs the workers
+    until the prompt pool drains, publishing refs to the channel and applying
+    backpressure (it pauses while ``channel.in_flight_remote()`` exceeds
+    ``in_flight_high_watermark`` so a lagging trainer can't overrun the Mooncake
+    segment), then closes the channel so the consumer's loader terminates.
+    """
+    import time
+
+    from specforge.runtime.inference.capture import CaptureConfig
+    from specforge.runtime.inference.rollout_worker import RolloutWorker
+    from specforge.runtime.inference.sglang_adapter import SGLangAdapter
+
+    sleep = sleep or time.sleep
+    controller = DataFlowController(run_id)
+    controller.ingest_prompts(prompts)
+
+    if aux_hidden_state_layer_ids is None:
+        aux_hidden_state_layer_ids = tuple(
+            getattr(target_model, "aux_hidden_states_layers", ()) or ()
+        )
+    adapter = SGLangAdapter(target_model, device=device, t2d=t2d)
+    capture = CaptureConfig.from_strategy(
+        required_features=Eagle3TrainStrategy.required_features,
+        aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
+        target_repr=target_repr,
+        target_hidden_size=target_hidden_size,
+        target_vocab_size=target_vocab_size,
+        draft_vocab_size=draft_vocab_size,
+        vocab_map_version=vocab_map_version,
+    )
+    workers = [
+        RolloutWorker(
+            controller,
+            feature_store,
+            adapter,
+            capture,
+            run_id=run_id,
+            worker_id=f"rollout-{i}",
+        )
+        for i in range(num_rollout_workers)
+    ]
+
+    def drive_producer(max_rounds: int = 1_000_000) -> int:
+        for w in workers:
+            w.start()
+        produced = 0
+        for _ in range(max_rounds):
+            # backpressure: don't let the producer outrun the consumer (and the
+            # Mooncake segment). in_flight_remote = published - consumer-acked.
+            while channel.in_flight_remote() >= in_flight_high_watermark:
+                sleep(backpressure_poll_s)
+            refs = []
+            for w in workers:
+                refs.extend(w.run_once(max_tasks=lease))
+            if not refs:
+                break  # prompt pool drained
+            channel.publish_many(refs)
+            produced += len(refs)
+        channel.close()  # EOF -> the consumer's loader terminates once drained
+        return produced
+
+    return workers, drive_producer
+
+
+def build_disagg_online_consumer(
+    *,
+    feature_store: FeatureStore,
+    channel,
+    eagle3_model,
+    optimizer_factory,
+    run_id: str,
+    output_dir: str,
+    batch_size: int = 1,
+    accumulation_steps: int = 1,
+    num_epochs: int = 1,
+    max_steps: Optional[int] = None,
+    save_interval: int = 0,
+    eval_interval: int = 0,
+    tp_size: int = 1,
+    sp_ulysses_size: int = 1,
+    sp_ring_size: int = 1,
+    collate_fn=None,
+    idle_timeout_s: Optional[float] = None,
+    logger=None,
+    log_interval: int = 50,
+):
+    """Consumer (trainer) side of an ONLINE disaggregated run.
+
+    Trains from a streamed ``SampleRef`` channel + a consume-once
+    ``feature_store`` produced by a *different pool*. The trainer assembly is the
+    online one (``target_head=None``: rollout already materialized the target
+    distribution); the only difference from colocated online is that refs arrive
+    from a :class:`StreamingRefQueue` over the channel rather than the in-process
+    ``SampleRefQueue``, and the features are fetched cross-node from Mooncake. The
+    loader frees each sample on read (consume-once) and acks the channel (the
+    producer's backpressure signal).
+    """
+    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
+
+    controller = DataFlowController(run_id)
+    queue = StreamingRefQueue(channel, idle_timeout_s=idle_timeout_s)
+    loader = FeatureDataLoader(
+        feature_store,
+        queue,
+        batch_size=batch_size,
+        collate_fn=collate_fn or _online_cat_collate,
+        drop_last=True,
+        strategy="eagle3",
+    )
+
+    parallel = ParallelConfig.from_distributed(
+        tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
+    )
+    backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
+    wrapped = backend.prepare_model(
+        eagle3_model, optimizer_target=eagle3_model.draft_model
+    )
+    strategy = Eagle3TrainStrategy(wrapped, target_head=None)
+    core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
+    trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
+    trainer = TrainerController(
+        core,
+        run_id=run_id,
+        output_dir=output_dir,
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+        save_interval=save_interval,
+        eval_interval=eval_interval,
+        log_interval=log_interval,
+        logger=logger,
+        ack_fn=lambda ids, step: controller.ack_train_refs(
+            trainer_id, ids, global_step=step, optimizer_durable=True
+        ),
+    )
+    return trainer, loader
+
+
 # Backward-compatible alias for early branch users.
 build_offline_eagle3_controller = build_offline_eagle3_runtime
 
@@ -391,4 +566,6 @@ __all__ = [
     "build_offline_eagle3_runtime",
     "build_disagg_eagle3_runtime",
     "build_online_eagle3_runtime",
+    "build_disagg_online_producer",
+    "build_disagg_online_consumer",
 ]

--- a/tests/test_runtime/test_disagg_online.py
+++ b/tests/test_runtime/test_disagg_online.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""Online disaggregation integration (data + control plane, no GPU).
+
+Producer and consumer are SEPARATE MooncakeFeatureStore instances over one shared
+backend (the disagg topology). The producer put()s consume-once features and
+streams tensor-free refs through a StreamingRefChannel; the consumer's
+FeatureDataLoader pulls the stream and materializes batches, freeing each sample
+on read (consume-once). Proves the streaming-ref + Mooncake-get + consume-once
+free + loader wiring end to end. The FSDP training half is covered by the
+cross-node mooncake_store / disagg_launch GPU tests.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+from specforge.runtime.data_plane.streaming_ref_channel import (
+    StreamingRefChannel,
+    StreamingRefQueue,
+)
+from tests.test_runtime.test_mooncake_store import _FakeMooncakeStore, _phys_resident
+
+
+def _online_features(seed):
+    g = torch.Generator().manual_seed(seed)
+    return {
+        "hidden_state": torch.randn(1, 4, 8, generator=g),
+        "target": torch.randn(1, 4, 8, generator=g),
+        "loss_mask": torch.ones(1, 4),
+    }
+
+
+def _cat_collate(feats):
+    return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
+
+
+class TestOnlineDisaggIntegration(unittest.TestCase):
+    def test_stream_to_loader_consume_once(self):
+        fake = _FakeMooncakeStore()  # the shared cross-node store
+        producer = MooncakeFeatureStore(store=fake, store_id="run0")  # consume-once
+        consumer = MooncakeFeatureStore(store=fake, store_id="run0")  # consume-once
+        path = os.path.join(tempfile.mkdtemp(prefix="online_disagg_"), "stream.jsonl")
+
+        # producer: stream 4 samples, then close
+        wchan = StreamingRefChannel(path)
+        srcs = {}
+        for i in range(4):
+            srcs[f"s{i}"] = _online_features(100 + i)
+            ref = producer.put(
+                {k: v.clone() for k, v in srcs[f"s{i}"].items()},
+                sample_id=f"s{i}",
+                metadata={"run_id": "run0", "num_tokens": 4},
+            )
+            wchan.publish(ref)
+        wchan.close()
+
+        # consumer: stream the refs through the loader, materializing consume-once
+        rchan = StreamingRefChannel(path)
+        queue = StreamingRefQueue(rchan, poll_s=0.0)
+        loader = FeatureDataLoader(
+            consumer,
+            queue,
+            batch_size=1,
+            collate_fn=_cat_collate,
+            drop_last=True,
+            strategy="eagle3",
+        )
+
+        seen, batches = [], 0
+        for batch in loader:
+            sid = batch.sample_ids[0]
+            seen.append(sid)
+            # tensors arrived bit-exact across the (fake) cross-node transport
+            self.assertTrue(
+                torch.equal(batch.tensors["hidden_state"], srcs[sid]["hidden_state"])
+            )
+            batches += 1
+
+        self.assertEqual(seen, ["s0", "s1", "s2", "s3"])  # full stream, in order
+        self.assertEqual(batches, 4)
+        # consume-once: every sample was freed from the shared store on read
+        for i in range(4):
+            self.assertFalse(_phys_resident(fake, f"s{i}"))
+        # backpressure counter advanced as the consumer acked
+        self.assertEqual(wchan.consumed_remote(), 4)
+        self.assertEqual(wchan.in_flight_remote(), 0)
+
+    def test_loader_blocks_until_producer_closes(self):
+        # the loader must NOT end just because the producer is momentarily behind;
+        # it ends only once the channel is closed and drained.
+        fake = _FakeMooncakeStore()
+        producer = MooncakeFeatureStore(store=fake, store_id="run0")
+        consumer = MooncakeFeatureStore(store=fake, store_id="run0")
+        path = os.path.join(tempfile.mkdtemp(prefix="online_disagg_"), "stream.jsonl")
+        wchan = StreamingRefChannel(path)
+
+        # publish 2, but the queue's get() for the 3rd must block until close.
+        for i in range(2):
+            ref = producer.put(
+                _online_features(i), sample_id=f"s{i}", metadata={"run_id": "run0"}
+            )
+            wchan.publish(ref)
+
+        # a fake clock/sleep: the "sleep" publishes the close so the next poll drains
+        state = {"closed": False}
+
+        def sleep(_dt):
+            if not state["closed"]:
+                wchan.close()
+                state["closed"] = True
+
+        rchan = StreamingRefChannel(path)
+        queue = StreamingRefQueue(rchan, poll_s=0.1, sleep=sleep)
+        loader = FeatureDataLoader(
+            consumer,
+            queue,
+            batch_size=1,
+            collate_fn=_cat_collate,
+            drop_last=True,
+            strategy="eagle3",
+        )
+        seen = [b.sample_ids[0] for b in loader]
+        self.assertEqual(seen, ["s0", "s1"])  # drained then terminated on close
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_disagg_online_launch.py
+++ b/tests/test_runtime/test_disagg_online_launch.py
@@ -1,0 +1,137 @@
+# coding=utf-8
+"""Launcher path (ONLINE disaggregated): producer pool -> channel + Mooncake ->
+consumer pool, end to end, single rank.
+
+Online analog of test_disagg_launch's FSDP path. The producer drives a
+RolloutWorker (HF target, no sglang) that put()s consume-once features into a
+MooncakeFeatureStore and streams SampleRefs through a StreamingRefChannel; the
+consumer trains from that channel + a SECOND store instance over the same backend
+(the disagg topology) through FSDP. Asserts the producer streamed one ref per
+prompt, the trainer consumed the whole stream, and consume-once freed the store.
+
+Uses the in-memory Mooncake fake (no master needed); the real cross-node Mooncake
+transport is covered by the mooncake_store real test + the 2-node e2e. GPU-only.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+from tests.test_runtime.test_mooncake_store import _FakeMooncakeStore
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "online disagg launcher path requires CUDA")
+class TestDisaggOnlineLaunch(unittest.TestCase):
+    def test_producer_streams_consumer_trains_consume_once(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29569")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+        from specforge.runtime.data_plane.streaming_ref_channel import (
+            StreamingRefChannel,
+        )
+        from specforge.runtime.launch import (
+            build_disagg_online_consumer,
+            build_disagg_online_producer,
+        )
+
+        H, V, SEQ, TTT, ACC, MAX_OPT_STEPS, N = fx.H, fx.V, 12, 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="disagg_online_")
+
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+
+        g = torch.Generator().manual_seed(7)
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": torch.randint(0, V, (SEQ,), generator=g).tolist(),
+                    "loss_mask": [1] * SEQ,
+                }
+            }
+            for _ in range(N)
+        ]
+
+        # the disagg topology: producer + consumer are SEPARATE store instances
+        # over one shared (here, fake-in-memory) Mooncake backend.
+        backend = _FakeMooncakeStore()
+        producer_store = MooncakeFeatureStore(store=backend, store_id="dol")
+        consumer_store = MooncakeFeatureStore(store=backend, store_id="dol")
+        channel = StreamingRefChannel(os.path.join(workdir, "refs.jsonl"))
+
+        # producer pool: rollout -> Mooncake (consume-once) -> channel
+        workers, drive_producer = build_disagg_online_producer(
+            target_model=target,
+            prompts=prompts,
+            feature_store=producer_store,
+            channel=channel,
+            run_id="dol",
+            target_hidden_size=H,
+            target_vocab_size=V,
+            target_repr="logits",
+            aux_hidden_state_layer_ids=tuple(aux_ids),
+        )
+        produced = drive_producer()  # generates, streams, closes the channel
+        self.assertEqual(produced, N)
+        self.assertEqual(channel.published, N)
+
+        def optimizer_factory(m):
+            return BF16Optimizer(
+                m, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
+            )
+
+        # consumer pool: channel + Mooncake -> FSDP train
+        trainer, loader = build_disagg_online_consumer(
+            feature_store=consumer_store,
+            channel=channel,
+            eagle3_model=eagle3_model,
+            optimizer_factory=optimizer_factory,
+            run_id="dol",
+            output_dir=os.path.join(workdir, "out"),
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=1,
+            max_steps=MAX_OPT_STEPS,
+        )
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(module, FSDP)
+
+        step = trainer.fit(loader)
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+
+        # consume-once: the consumer acked what it materialized, advancing the
+        # producer's backpressure counter. The loader acks AFTER yield, so the
+        # final batch's ack doesn't fire when fit() stops at max_steps (the store
+        # free still happened in _materialize); hence -1. Per-sample free is
+        # asserted in the CPU integration test + the cross-process mooncake tests.
+        self.assertGreaterEqual(channel.consumed_remote(), ACC * MAX_OPT_STEPS - 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_streaming_ref_channel.py
+++ b/tests/test_runtime/test_streaming_ref_channel.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+"""Tests for StreamingRefChannel: the cross-process online ref stream."""
+
+import os
+import tempfile
+import unittest
+
+from specforge.runtime.contracts import FeatureSpec, SampleRef
+from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+
+
+def _ref(sid="s0", gen=1):
+    spec = FeatureSpec(name="hidden_state", shape=(4, 8), dtype="float32")
+    return SampleRef(
+        sample_id=sid,
+        run_id="run0",
+        source_task_id=None,
+        feature_store_uri=f"mooncake://run0/{sid}",
+        feature_keys={"hidden_state": f"{sid}/hidden_state"},
+        feature_specs={"hidden_state": spec},
+        strategy="eagle3",
+        num_tokens=4,
+        metadata={"generation": gen},
+    )
+
+
+class TestStreamingRefChannel(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="refstream_")
+        self.path = os.path.join(self.dir, "stream.jsonl")
+
+    def test_publish_poll_roundtrip(self):
+        w = StreamingRefChannel(self.path)
+        r = StreamingRefChannel(self.path)  # separate instance = separate process
+        w.publish(_ref("s0", 1))
+        w.publish(_ref("s1", 2))
+        got = r.poll()
+        self.assertEqual([x.sample_id for x in got], ["s0", "s1"])
+        self.assertEqual(got[0].feature_specs["hidden_state"].shape, (4, 8))
+        self.assertEqual(got[1].metadata["generation"], 2)
+        # nothing new -> empty
+        self.assertEqual(r.poll(), [])
+
+    def test_incremental_poll(self):
+        w = StreamingRefChannel(self.path)
+        r = StreamingRefChannel(self.path)
+        w.publish(_ref("s0"))
+        self.assertEqual([x.sample_id for x in r.poll()], ["s0"])
+        w.publish(_ref("s1"))
+        w.publish(_ref("s2"))
+        self.assertEqual([x.sample_id for x in r.poll()], ["s1", "s2"])
+
+    def test_partial_trailing_line_is_not_parsed(self):
+        # a half-written record (no newline yet) must not be parsed; it is held
+        # until its newline arrives.
+        r = StreamingRefChannel(self.path)
+        with open(self.path, "w") as f:
+            f.write('{"sample_id": "s0", "incomplete')  # torn write, no newline
+        self.assertEqual(r.poll(), [])  # nothing complete yet
+        # the writer finishes the line with a real ref
+        w = StreamingRefChannel(self.path)
+        # overwrite with a clean complete line (simulating the real append path)
+        with open(self.path, "w") as f:
+            f.write("")
+        r2 = StreamingRefChannel(self.path)
+        w.publish(_ref("s0"))
+        self.assertEqual([x.sample_id for x in r2.poll()], ["s0"])
+
+    def test_max_n_limits_batch(self):
+        w = StreamingRefChannel(self.path)
+        r = StreamingRefChannel(self.path)
+        for i in range(5):
+            w.publish(_ref(f"s{i}"))
+        first = r.poll(max_n=2)
+        self.assertEqual(len(first), 2)
+        rest = r.poll()
+        self.assertEqual(len(rest), 3)
+
+    def test_stream_drains_then_stops_on_close(self):
+        w = StreamingRefChannel(self.path)
+        r = StreamingRefChannel(self.path)
+        for i in range(3):
+            w.publish(_ref(f"s{i}"))
+        w.close()
+        got = list(r.stream(poll_s=0.0))  # closed -> drains 3 then terminates
+        self.assertEqual([x.sample_id for x in got], ["s0", "s1", "s2"])
+
+    def test_backpressure_in_flight_remote(self):
+        producer = StreamingRefChannel(self.path)
+        consumer = StreamingRefChannel(self.path)
+        for i in range(4):
+            producer.publish(_ref(f"s{i}"))
+        self.assertEqual(producer.in_flight_remote(), 4)  # consumer hasn't acked
+        got = consumer.poll()
+        consumer.mark_consumed(len(got))
+        self.assertEqual(producer.consumed_remote(), 4)
+        self.assertEqual(producer.in_flight_remote(), 0)
+
+    def test_stream_idle_timeout_when_producer_silent(self):
+        r = StreamingRefChannel(self.path)
+        t = {"now": 0.0}
+
+        def clock():
+            return t["now"]
+
+        def sleep(dt):
+            t["now"] += 10.0  # jump past the timeout on the first idle sleep
+
+        it = r.stream(poll_s=0.1, idle_timeout_s=5.0, clock=clock, sleep=sleep)
+        with self.assertRaises(TimeoutError):
+            next(it)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Online disaggregated training on top of the Mooncake zero-copy store (#621). Adds `StreamingRefChannel`/`StreamingRefQueue` (cross-process append-only tensor-free SampleRef stream with backpressure + EOF) and `build_disagg_online_producer`/`build_disagg_online_consumer` in `launch.py`. Cross-pool consume-once free works via shared Mooncake `remove()`; from SampleRef down the trainer path == colocated online. **NO hot-switch.**

Validated 2-node real-Mooncake online e2e over **RDMA** (rollout pool streams refs → trainer pool trains FSDP steps cross-node, consume-once). Rebased onto current #621.

Stacked: #608 → #621 → **this** → up-18 staleness. Supersedes the fork-only PR maocheng23/SpecForge#18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)