### PR TITLE
[DataFlow runtime · online] O1.1 — shared cross-process control plane

### DIFF
--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 import os
 import time
-from typing import Iterator, List, Optional
+from typing import Iterator, List, Optional, Set
 
 from specforge.runtime.contracts import SampleRef, assert_no_tensors
 from specforge.runtime.data_plane.disagg_ingest import _ref_from_dict, _ref_to_dict
@@ -192,6 +192,14 @@ class StreamingRefQueue:
     the channel's consumed counter (the producer's backpressure signal); the
     feature-store free already happened in the loader's materialize (get ->
     release) for a consume-once store.
+
+    ``skip_ids`` is the restart contract (O1.1): the channel JSONL is append-only
+    and a restarted consumer re-reads it from offset 0, so without a skip set it
+    would re-train every already-durably-acked sample. The launcher derives this
+    set from the shared durable :class:`MetadataStore` (the samples
+    ``reconcile_on_restart`` reports as released) and passes it here; matching refs
+    are dropped on read and counted as consumed so the producer's backpressure
+    signal (``in_flight_remote``) stays exact across the restart.
     """
 
     def __init__(
@@ -200,26 +208,61 @@ class StreamingRefQueue:
         *,
         poll_s: float = 0.1,
         idle_timeout_s: Optional[float] = None,
+        skip_ids: Optional[Set[str]] = None,
         clock=time.monotonic,
         sleep=time.sleep,
     ) -> None:
         self.channel = channel
         self.poll_s = poll_s
         self.idle_timeout_s = idle_timeout_s
+        self._skip_ids = set(skip_ids) if skip_ids else None
         self._clock = clock
         self._sleep = sleep
         self._buf: List[SampleRef] = []
 
+    def _poll(self) -> "tuple[List[SampleRef], int]":
+        """Poll the channel, dropping already-trained refs (restart skip).
+
+        Returns ``(fresh_refs, raw_count)``. ``raw_count`` is the number of refs
+        the channel actually yielded (skipped or not), so the caller can tell
+        "made progress" from "nothing new" even when every polled ref was skipped.
+        """
+        raw = self.channel.poll()
+        if not self._skip_ids or not raw:
+            return raw, len(raw)
+        fresh: List[SampleRef] = []
+        skipped = 0
+        for ref in raw:
+            if ref.sample_id in self._skip_ids:
+                self._skip_ids.discard(ref.sample_id)
+                skipped += 1
+            else:
+                fresh.append(ref)
+        if skipped:
+            # already durably trained on a prior run: count them consumed so the
+            # producer's in_flight_remote backpressure stays exact across restart.
+            self.channel.mark_consumed(skipped)
+            if not self._skip_ids:
+                # The restart skip-ids are the already-trained FRONT prefix, so once
+                # they are all drained drop back to the zero-overhead fast path
+                # instead of hashing every ref for the rest of a long online run.
+                self._skip_ids = None
+        return fresh, len(raw)
+
     def get(self, n: int, timeout_s: float = 0.0) -> List[SampleRef]:
         last_progress = self._clock()
         while len(self._buf) < n:
-            new = self.channel.poll()
-            if new:
-                self._buf.extend(new)
+            new, raw = self._poll()
+            if raw:
+                # progress on the channel (even if all refs were skipped): buffer
+                # what survived the skip filter and poll again before sleeping.
                 last_progress = self._clock()
+                if new:
+                    self._buf.extend(new)
                 continue
             if self.channel.is_closed():
-                self._buf.extend(self.channel.poll())  # final drain
+                drain, _ = self._poll()
+                self._buf.extend(drain)  # final drain
                 break
             if (
                 self.idle_timeout_s is not None

--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -27,6 +27,10 @@ from typing import List, Optional
 
 from specforge.runtime.contracts import SampleRef
 from specforge.runtime.control_plane import DataFlowController
+from specforge.runtime.control_plane.metadata_store import (
+    MetadataStore,
+    SQLiteMetadataStore,
+)
 from specforge.runtime.data_plane import (
     FeatureDataLoader,
     FeatureStore,
@@ -391,6 +395,28 @@ def _online_cat_collate(feats):
     return {k: torch.cat([f[k] for f in feats], dim=0) for k in feats[0]}
 
 
+def _resolve_metadata_store(
+    metadata_store: Optional[MetadataStore],
+    metadata_db_path: Optional[str],
+) -> Optional[MetadataStore]:
+    """Pick the controller's metadata store for an online disaggregated process.
+
+    O1.1: the producer and consumer run in *separate* processes, so a shared,
+    durable store is what makes commit/dedup/ack cross-process (an in-process
+    ``InMemoryMetadataStore`` per process shares nothing). Pass an explicit
+    ``metadata_store`` (e.g. a future ``RedisMetadataStore`` for multi-node O2),
+    or a ``metadata_db_path`` and both processes open a ``SQLiteMetadataStore``
+    over the same file (enough for single-host O1; SQLite WAL serializes the
+    producer's commits against the consumer's ack transaction). ``None`` keeps the
+    pre-O1.1 behaviour: a private in-process store, control state un-shared.
+    """
+    if metadata_store is not None:
+        return metadata_store
+    if metadata_db_path is not None:
+        return SQLiteMetadataStore(metadata_db_path)
+    return None
+
+
 def build_disagg_online_producer(
     *,
     target_model,
@@ -410,6 +436,8 @@ def build_disagg_online_producer(
     lease: int = 8,
     in_flight_high_watermark: int = 256,
     backpressure_poll_s: float = 0.2,
+    metadata_store: Optional[MetadataStore] = None,
+    metadata_db_path: Optional[str] = None,
     sleep=None,
 ):
     """Producer side of an ONLINE disaggregated run (rollout pool).
@@ -419,6 +447,13 @@ def build_disagg_online_producer(
     :class:`MooncakeFeatureStore`) and the committed SampleRefs are streamed to
     the consumer through a :class:`StreamingRefChannel` instead of an in-process
     queue. The feature tensors never touch a shared mount.
+
+    ``metadata_store`` / ``metadata_db_path`` (O1.1) point the controller at the
+    *shared, durable* metadata store the consumer also opens, so the producer's
+    ``commit_samples`` (dedup, at-least-once) lands in the same store the consumer
+    reconciles against on restart. Omit both for the pre-O1.1 in-process store
+    (commit/ack state stays private to this process). See
+    :func:`_resolve_metadata_store`.
 
     Returns ``(workers, drive_producer)``. ``drive_producer()`` runs the workers
     until the prompt pool drains, publishing refs to the channel and applying
@@ -433,7 +468,10 @@ def build_disagg_online_producer(
     from specforge.runtime.inference.sglang_adapter import SGLangAdapter
 
     sleep = sleep or time.sleep
-    controller = DataFlowController(run_id)
+    controller = DataFlowController(
+        run_id,
+        metadata_store=_resolve_metadata_store(metadata_store, metadata_db_path),
+    )
     controller.ingest_prompts(prompts)
 
     if aux_hidden_state_layer_ids is None:
@@ -503,6 +541,9 @@ def build_disagg_online_consumer(
     sp_ring_size: int = 1,
     collate_fn=None,
     idle_timeout_s: Optional[float] = None,
+    metadata_store: Optional[MetadataStore] = None,
+    metadata_db_path: Optional[str] = None,
+    resume: bool = False,
     logger=None,
     log_interval: int = 50,
 ):
@@ -516,11 +557,41 @@ def build_disagg_online_consumer(
     ``SampleRefQueue``, and the features are fetched cross-node from Mooncake. The
     loader frees each sample on read (consume-once) and acks the channel (the
     producer's backpressure signal).
+
+    ``metadata_store`` / ``metadata_db_path`` (O1.1) point the controller at the
+    *shared, durable* store the producer commits to, so the per-optimizer-step
+    ack transaction (``ack_train_refs``) is recorded against the same committed
+    set the producer wrote — the precondition for a correct restart.
+
+    ``resume=True`` reconciles against that durable store before training: the
+    channel JSONL is append-only and a restarted consumer re-reads it from the
+    start, so ``reconcile_on_restart`` derives the already-durably-trained samples
+    and they are handed to the :class:`StreamingRefQueue` as ``skip_ids`` (dropped
+    on re-read, no duplicate train). The committed-but-unacked tail is *not*
+    skipped, so it is re-trained — that requeue is realized by the channel re-read
+    itself, which is why only the released set matters here. Requires a durable
+    ``metadata_store`` / ``metadata_db_path`` (an in-process store has no history
+    to reconcile).
     """
     from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
 
-    controller = DataFlowController(run_id)
-    queue = StreamingRefQueue(channel, idle_timeout_s=idle_timeout_s)
+    store = _resolve_metadata_store(metadata_store, metadata_db_path)
+    controller = DataFlowController(run_id, metadata_store=store)
+
+    skip_ids = None
+    if resume:
+        if store is None:
+            raise ValueError(
+                "resume=True needs a durable metadata_store/metadata_db_path; an "
+                "in-process store has no committed/ack history to reconcile against"
+            )
+        # Released == durably acked AND optimizer-step committed: the samples
+        # already trained on a prior run. Skip exactly those on the channel
+        # re-read; the committed-unacked tail re-streams and re-trains.
+        reconciled = controller.reconcile_on_restart(feature_store)
+        skip_ids = set(reconciled["released"])
+
+    queue = StreamingRefQueue(channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids)
     loader = FeatureDataLoader(
         feature_store,
         queue,

--- a/tests/test_runtime/test_disagg_online_shared_plane.py
+++ b/tests/test_runtime/test_disagg_online_shared_plane.py
@@ -1,0 +1,213 @@
+# coding=utf-8
+"""O1.1: shared, durable, cross-process control plane for online disaggregation.
+
+The online producer and consumer run in *separate processes*. Before O1.1 each
+built its own in-process ``InMemoryMetadataStore``, so commit / dedup / ack were
+not shared and a restart could not reconcile: the producer held the committed
+set, the consumer held the ack marker, in two different process-local stores.
+These CPU tests prove a shared ``SQLiteMetadataStore`` makes commit/dedup/ack
+cross-process, and that the streaming consumer skips already-trained samples on
+restart instead of re-reading the append-only channel from offset zero.
+
+No GPU / torch needed: this exercises the control plane + streaming queue
+directly (the FSDP training half is the GPU launcher test).
+"""
+
+import os
+import tempfile
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.control_plane.controller import DataFlowController
+from specforge.runtime.control_plane.metadata_store import SQLiteMetadataStore
+from specforge.runtime.data_plane.streaming_ref_channel import (
+    StreamingRefChannel,
+    StreamingRefQueue,
+)
+
+
+def _ref(i: int, run_id: str = "run0") -> SampleRef:
+    """A minimal tensor-free SampleRef (the control plane carries metadata only)."""
+    sid = f"{run_id}:s{i}"
+    return SampleRef(
+        sample_id=sid,
+        run_id=run_id,
+        source_task_id=f"task-{i}",
+        feature_store_uri=f"mem://{run_id}",
+        feature_keys={"hidden_state": f"{sid}/hidden_state"},
+        feature_specs={},
+        strategy="eagle3",
+        metadata={"target_repr": "logits", "num_tokens": 4},
+    )
+
+
+class _RecordingStore:
+    """Minimal FeatureStore stub: records abort() (the reconcile-time free)."""
+
+    def __init__(self) -> None:
+        self.aborted = []
+
+    def abort(self, sample_id: str, reason: str = "") -> None:
+        self.aborted.append(sample_id)
+
+
+def _db() -> str:
+    return os.path.join(tempfile.mkdtemp(prefix="o11_"), "meta.db")
+
+
+class TestSharedControlPlane(unittest.TestCase):
+    def test_commit_and_dedup_cross_process(self):
+        db = _db()
+        # two controllers over ONE db file == two processes sharing the store
+        producer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        consumer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+
+        refs = [_ref(i) for i in range(4)]
+        producer.commit_samples("rollout-0", refs)
+
+        # consumer (separate store instance, same file) sees the producer's commits
+        for r in refs:
+            self.assertTrue(consumer.store.is_committed(r.sample_id))
+            got = consumer.store.get_committed(r.sample_id)
+            self.assertIsNotNone(got)
+            self.assertEqual(got.sample_id, r.sample_id)
+        self.assertEqual(consumer.store.committed_count(), 4)
+
+        # at-least-once dedup: re-committing the same refs adds no duplicate rows
+        producer.commit_samples("rollout-0", refs)
+        self.assertEqual(consumer.store.committed_count(), 4)
+
+    def test_durable_ack_visible_across_process(self):
+        db = _db()
+        producer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        consumer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        refs = [_ref(i) for i in range(3)]
+        producer.commit_samples("rollout-0", refs)
+
+        tid = consumer.register_trainer({"role": "trainer"})
+        consumer.ack_train_refs(
+            tid,
+            [refs[0].sample_id, refs[1].sample_id],
+            global_step=5,
+            optimizer_durable=True,
+        )
+
+        # a fresh controller reopened on the same file sees the durable marker
+        reopened = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        marker = reopened.store.durable_marker()
+        self.assertEqual(marker["acked"], {refs[0].sample_id, refs[1].sample_id})
+        self.assertEqual(marker["global_step"], 5)
+        self.assertTrue(marker["optimizer_durable"])
+
+    def test_reconcile_on_restart_releases_acked_requeues_unacked(self):
+        db = _db()
+        producer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        consumer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        refs = [_ref(i) for i in range(5)]
+        producer.commit_samples("rollout-0", refs)
+        tid = consumer.register_trainer({"role": "trainer"})
+        acked = [refs[0].sample_id, refs[1].sample_id, refs[2].sample_id]
+        consumer.ack_train_refs(tid, acked, global_step=3, optimizer_durable=True)
+
+        # crash + restart: a fresh controller over the same db reconciles
+        restarted = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        fs = _RecordingStore()
+        result = restarted.reconcile_on_restart(fs)
+
+        self.assertEqual(set(result["released"]), set(acked))
+        self.assertEqual(
+            set(result["requeued"]), {refs[3].sample_id, refs[4].sample_id}
+        )
+        # released samples were idempotently freed from the feature store
+        self.assertEqual(set(fs.aborted), set(acked))
+        # the unacked tail is requeued for re-training (no data loss)
+        self.assertEqual(restarted.sample_queue.depth(), 2)
+
+    def test_reconcile_without_optimizer_durable_requeues_all(self):
+        # acked but the optimizer step never durably committed -> replay all (no
+        # sample counted as trained), per the B4 release rule.
+        db = _db()
+        producer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        consumer = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        refs = [_ref(i) for i in range(3)]
+        producer.commit_samples("rollout-0", refs)
+        tid = consumer.register_trainer({"role": "trainer"})
+        consumer.ack_train_refs(
+            tid,
+            [r.sample_id for r in refs],
+            global_step=None,
+            optimizer_durable=False,
+        )
+
+        restarted = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        result = restarted.reconcile_on_restart(_RecordingStore())
+        self.assertEqual(result["released"], [])
+        self.assertEqual(set(result["requeued"]), {r.sample_id for r in refs})
+
+
+class TestStreamingQueueRestartSkip(unittest.TestCase):
+    def _chan_path(self) -> str:
+        return os.path.join(tempfile.mkdtemp(prefix="o11_chan_"), "refs.jsonl")
+
+    def test_skip_ids_drops_trained_refs_on_reread(self):
+        path = self._chan_path()
+        # producer published s0..s4 then closed (the durable channel survives)
+        wchan = StreamingRefChannel(path)
+        refs = [_ref(i) for i in range(5)]
+        wchan.publish_many(refs)
+        wchan.close()
+
+        # restart: s0,s1,s2 were durably trained -> skip them on re-read
+        trained = {refs[0].sample_id, refs[1].sample_id, refs[2].sample_id}
+        rchan = StreamingRefChannel(path)
+        queue = StreamingRefQueue(rchan, poll_s=0.0, skip_ids=trained)
+
+        got = queue.get(2)  # only the untrained tail survives the skip filter
+        self.assertEqual(
+            [r.sample_id for r in got], [refs[3].sample_id, refs[4].sample_id]
+        )
+        queue.ack(got)
+
+        # backpressure stays exact: 3 skipped + 2 acked == 5 consumed, 0 in flight
+        self.assertEqual(wchan.consumed_remote(), 5)
+        self.assertEqual(wchan.in_flight_remote(), 0)
+
+    def test_skip_all_terminates_on_close(self):
+        # every published ref was already trained: the queue must drain to empty
+        # (loop end) once the channel is closed, not spin.
+        path = self._chan_path()
+        wchan = StreamingRefChannel(path)
+        refs = [_ref(i) for i in range(3)]
+        wchan.publish_many(refs)
+        wchan.close()
+
+        queue = StreamingRefQueue(
+            StreamingRefChannel(path),
+            poll_s=0.0,
+            skip_ids={r.sample_id for r in refs},
+        )
+        self.assertEqual(queue.get(1), [])
+        self.assertEqual(wchan.consumed_remote(), 3)  # all counted consumed
+
+    def test_no_skip_ids_is_unchanged(self):
+        # regression: skip_ids=None preserves the pre-O1.1 full-stream behavior
+        path = self._chan_path()
+        wchan = StreamingRefChannel(path)
+        refs = [_ref(i) for i in range(3)]
+        wchan.publish_many(refs)
+        wchan.close()
+
+        queue = StreamingRefQueue(StreamingRefChannel(path), poll_s=0.0)
+        got = []
+        while True:
+            batch = queue.get(1)
+            if not batch:
+                break
+            got.extend(batch)
+            queue.ack(batch)
+        self.assertEqual([r.sample_id for r in got], [r.sample_id for r in refs])
+        self.assertEqual(wchan.consumed_remote(), 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Stage **O1.1** of the online disaggregated training roadmap (#618): a shared, durable, cross-process control plane for the online producer/consumer.

### Problem
The online producer and consumer run in separate processes, but each built its own in-process `InMemoryMetadataStore` — so commit/dedup/ack were never shared, and a restart couldn't reconcile (the producer held the committed set, the consumer held the ack marker, in two separate process-local stores). On restart the consumer also re-read the append-only channel from offset 0, silently re-training already-trained samples.

### Change
- `build_disagg_online_{producer,consumer}` accept `metadata_store` / `metadata_db_path`; both processes share one `SQLiteMetadataStore` (single-host O1 — SQLite WAL serializes the producer's commits against the consumer's ack transaction). New `_resolve_metadata_store` helper. Omitting both keeps the pre-O1.1 private in-process store.
- consumer gains `resume=`: `reconcile_on_restart` derives the already-durably-trained set and hands it to `StreamingRefQueue` as `skip_ids`, so a restarted consumer drops those refs on the channel re-read (no duplicate train); the committed-but-unacked tail re-streams and re-trains.
- `StreamingRefQueue` gains `skip_ids`: drops matching refs on read and counts them consumed so the producer's `in_flight_remote` backpressure stays exact across the restart.

### Tests
`tests/test_runtime/test_disagg_online_shared_plane.py` (CPU): cross-process commit/dedup, durable ack visible across processes, reconcile releases-acked / requeues-unacked (and requeues-all when the optimizer step wasn't durable), and restart-skip. Existing online/streaming tests unchanged.

### Scope / non-goals
SQLite is the single-host O1 tier; a `RedisMetadataStore` for multi-node O2 is a later subclass behind the same `MetadataStore` ABC. The weight-version / staleness machinery is **out of scope** per the roadmap's train-with-decode decision (#618 §1/§8) and is deliberately not in this stack.

Stacked on #622 (`dataflow-up-17-online-disagg`); O1.2 (async loop) stacks on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
