### PR TITLE
[DataFlow runtime · online] O1.2 — named builder + interleaved async loop

### DIFF
--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -28,6 +28,7 @@ from typing import List, Optional
 from specforge.runtime.contracts import SampleRef
 from specforge.runtime.control_plane import DataFlowController
 from specforge.runtime.control_plane.metadata_store import (
+    InMemoryMetadataStore,
     MetadataStore,
     SQLiteMetadataStore,
 )
@@ -455,11 +456,16 @@ def build_disagg_online_producer(
     (commit/ack state stays private to this process). See
     :func:`_resolve_metadata_store`.
 
-    Returns ``(workers, drive_producer)``. ``drive_producer()`` runs the workers
-    until the prompt pool drains, publishing refs to the channel and applying
-    backpressure (it pauses while ``channel.in_flight_remote()`` exceeds
+    Returns ``(workers, drive_producer)``. ``drive_producer(should_stop=...)`` runs
+    the workers until the prompt pool drains, publishing refs to the channel and
+    applying backpressure (it pauses while ``channel.in_flight_remote()`` exceeds
     ``in_flight_high_watermark`` so a lagging trainer can't overrun the Mooncake
     segment), then closes the channel so the consumer's loader terminates.
+    ``should_stop`` (a zero-arg predicate) lets a caller wind the producer down
+    early — e.g. the interleaved driver sets it once the trainer hits ``max_steps``
+    so the producer doesn't block forever on the watermark after the consumer
+    stops draining (O1.2). The channel is always closed on exit so the consumer
+    never hangs on a finished producer.
     """
     import time
 
@@ -500,24 +506,30 @@ def build_disagg_online_producer(
         for i in range(num_rollout_workers)
     ]
 
-    def drive_producer(max_rounds: int = 1_000_000) -> int:
+    def drive_producer(max_rounds: int = 1_000_000, should_stop=None) -> int:
         for w in workers:
             w.start()
         produced = 0
-        for _ in range(max_rounds):
-            # backpressure: don't let the producer outrun the consumer (and the
-            # Mooncake segment). in_flight_remote = published - consumer-acked.
-            while channel.in_flight_remote() >= in_flight_high_watermark:
-                sleep(backpressure_poll_s)
-            refs = []
-            for w in workers:
-                refs.extend(w.run_once(max_tasks=lease))
-            if not refs:
-                break  # prompt pool drained
-            channel.publish_many(refs)
-            produced += len(refs)
-        channel.close()  # EOF -> the consumer's loader terminates once drained
-        return produced
+        try:
+            for _ in range(max_rounds):
+                if should_stop is not None and should_stop():
+                    break  # caller asked us to wind down (e.g. trainer finished)
+                # backpressure: don't let the producer outrun the consumer (and
+                # the Mooncake segment). in_flight = published - consumer-acked.
+                while channel.in_flight_remote() >= in_flight_high_watermark:
+                    if should_stop is not None and should_stop():
+                        return produced  # don't block on the watermark forever
+                    sleep(backpressure_poll_s)
+                refs = []
+                for w in workers:
+                    refs.extend(w.run_once(max_tasks=lease))
+                if not refs:
+                    break  # prompt pool drained
+                channel.publish_many(refs)
+                produced += len(refs)
+            return produced
+        finally:
+            channel.close()  # EOF -> the consumer's loader terminates once drained
 
     return workers, drive_producer
 
@@ -628,6 +640,226 @@ def build_disagg_online_consumer(
     return trainer, loader
 
 
+def run_disagg_online_interleaved(
+    *,
+    trainer,
+    loader,
+    drive_producer,
+    channel,
+    producer_max_rounds: int = 1_000_000,
+    join_timeout_s: Optional[float] = 30.0,
+) -> int:
+    """Run an online producer and the trainer CONCURRENTLY (O1.2).
+
+    Replaces the synchronous drain-then-fit shape (generate the whole prompt
+    pool, *then* train) with a live loop: the producer streams refs on a
+    background thread while ``trainer.fit`` consumes them on this thread. The
+    consumer's :class:`StreamingRefQueue` blocks until the channel is
+    closed-and-drained, so the trainer tracks the producer instead of ending the
+    instant the stream is momentarily empty.
+
+    Shutdown is symmetric and hang-free:
+
+    * trainer finishes first (e.g. ``max_steps``) -> ``should_stop`` is set, so
+      the producer stops generating instead of blocking on the in-flight
+      watermark after the consumer quit draining;
+    * producer finishes first (prompts drained) -> it closes the channel, so the
+      loader drains the tail and ``fit`` returns;
+    * producer raises -> the channel is closed (``drive_producer``'s ``finally``)
+      so the consumer cannot hang, and the exception is re-raised here once
+      ``fit`` has unwound.
+
+    Returns the trainer's final optimizer step. Single process, in-process
+    generator stub — no Ray, no live SGLang server (those are O1.3 / O2).
+    """
+    import threading
+
+    stop = threading.Event()
+    err: dict = {}
+
+    def _produce() -> None:
+        try:
+            drive_producer(producer_max_rounds, should_stop=stop.is_set)
+        except BaseException as exc:  # surfaced to the main thread below
+            err["exc"] = exc
+            channel.close()  # never leave the consumer blocked on a dead producer
+
+    thread = threading.Thread(
+        target=_produce, name="disagg-online-producer", daemon=True
+    )
+    thread.start()
+    trainer_exc: Optional[BaseException] = None
+    try:
+        step = trainer.fit(loader)
+    except BaseException as exc:  # noqa: BLE001 - re-raised below, chained w/ producer
+        trainer_exc = exc
+    finally:
+        stop.set()  # trainer done (or failed) -> tell the producer to wind down
+        thread.join(timeout=join_timeout_s)
+
+    producer_exc = err.get("exc")
+    if thread.is_alive():
+        # The producer overran join_timeout_s and is still running: a daemon thread
+        # that would keep publishing into a store no consumer drains. Fail loudly
+        # instead of returning "success" with a leaked, still-live producer.
+        msg = (
+            f"disagg online producer did not wind down within {join_timeout_s}s of "
+            "trainer exit (still alive); abandoning it would leak an active rollout"
+        )
+        if trainer_exc is not None:
+            raise RuntimeError(msg) from trainer_exc
+        raise RuntimeError(msg)
+    # A producer failure closes the channel, which is usually what makes trainer.fit
+    # fail downstream, so surface the producer exception as the root cause and chain
+    # the trainer error so neither is silently lost.
+    if producer_exc is not None:
+        if trainer_exc is not None:
+            raise producer_exc from trainer_exc
+        raise producer_exc
+    if trainer_exc is not None:
+        raise trainer_exc
+    return step
+
+
+def build_disagg_online_eagle3_runtime(
+    *,
+    target_model,
+    prompts,
+    eagle3_model,
+    optimizer_factory,
+    feature_store: FeatureStore,
+    run_id: str,
+    output_dir: str,
+    target_hidden_size: int,
+    channel=None,
+    ref_channel_path: Optional[str] = None,
+    target_vocab_size: Optional[int] = None,
+    draft_vocab_size: Optional[int] = None,
+    target_repr: str = "logits",
+    aux_hidden_state_layer_ids=None,
+    vocab_map_version: Optional[str] = None,
+    t2d=None,
+    num_rollout_workers: int = 1,
+    device: str = "cuda",
+    lease: int = 8,
+    in_flight_high_watermark: int = 256,
+    batch_size: int = 1,
+    accumulation_steps: int = 1,
+    num_epochs: int = 1,
+    max_steps: Optional[int] = None,
+    save_interval: int = 0,
+    eval_interval: int = 0,
+    tp_size: int = 1,
+    sp_ulysses_size: int = 1,
+    sp_ring_size: int = 1,
+    collate_fn=None,
+    idle_timeout_s: Optional[float] = None,
+    metadata_store: Optional[MetadataStore] = None,
+    metadata_db_path: Optional[str] = None,
+    resume: bool = False,
+    join_timeout_s: Optional[float] = 30.0,
+    logger=None,
+    log_interval: int = 50,
+):
+    """One-process online disaggregated EAGLE3 runtime (O1.2).
+
+    The single named builder the roadmap calls for: it wires the producer
+    (rollout pool, in-process ``generate_eagle3_data`` stub via ``SGLangAdapter``)
+    and the consumer (FSDP trainer) over ONE shared metadata store, ONE
+    consume-once ``feature_store``, and ONE streaming-ref channel (two
+    :class:`StreamingRefChannel` views over the same path — the proven
+    producer/consumer split), and returns ``(trainer, loader, run)``. Calling
+    ``run()`` drives both concurrently (:func:`run_disagg_online_interleaved`) —
+    the live loop that replaces drain-then-fit. No live SGLang server and no Ray
+    yet (O1.3 / O2); this proves the data + control paths live with a stubbed
+    generator.
+
+    Pass a ``channel`` or a ``ref_channel_path`` (a ``StreamingRefChannel`` is
+    built over it). The metadata store defaults to a shared in-process store
+    (enough for one process); pass ``metadata_store`` / ``metadata_db_path`` for a
+    durable, restart-reconcilable run (``resume=True`` then skips already-trained
+    refs on the channel re-read).
+    """
+    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+
+    if channel is not None:
+        producer_channel = channel
+        path = channel.path
+    elif ref_channel_path is not None:
+        path = ref_channel_path
+        producer_channel = StreamingRefChannel(path)
+    else:
+        raise ValueError("provide either `channel` or `ref_channel_path`")
+    # The producer writes / the consumer reads through SEPARATE channel views over
+    # the same path (each holds its own read/write offset) — the same split the
+    # cross-process disagg path uses, here colocated in one process.
+    consumer_channel = StreamingRefChannel(path)
+
+    # One process: share a single metadata store instance across both halves so
+    # the producer's commits and the consumer's acks land in the same store.
+    # (A metadata_db_path instead opens one SQLite connection per half over the
+    # same file — durable, and what a restart-reconcilable run needs.)
+    shared_store = metadata_store
+    if shared_store is None and metadata_db_path is None:
+        shared_store = InMemoryMetadataStore()
+
+    _workers, drive_producer = build_disagg_online_producer(
+        target_model=target_model,
+        prompts=prompts,
+        feature_store=feature_store,
+        channel=producer_channel,
+        run_id=run_id,
+        target_hidden_size=target_hidden_size,
+        target_vocab_size=target_vocab_size,
+        draft_vocab_size=draft_vocab_size,
+        target_repr=target_repr,
+        aux_hidden_state_layer_ids=aux_hidden_state_layer_ids,
+        vocab_map_version=vocab_map_version,
+        t2d=t2d,
+        num_rollout_workers=num_rollout_workers,
+        device=device,
+        lease=lease,
+        in_flight_high_watermark=in_flight_high_watermark,
+        metadata_store=shared_store,
+        metadata_db_path=metadata_db_path,
+    )
+    trainer, loader = build_disagg_online_consumer(
+        feature_store=feature_store,
+        channel=consumer_channel,
+        eagle3_model=eagle3_model,
+        optimizer_factory=optimizer_factory,
+        run_id=run_id,
+        output_dir=output_dir,
+        batch_size=batch_size,
+        accumulation_steps=accumulation_steps,
+        num_epochs=num_epochs,
+        max_steps=max_steps,
+        save_interval=save_interval,
+        eval_interval=eval_interval,
+        tp_size=tp_size,
+        sp_ulysses_size=sp_ulysses_size,
+        sp_ring_size=sp_ring_size,
+        collate_fn=collate_fn,
+        idle_timeout_s=idle_timeout_s,
+        metadata_store=shared_store,
+        metadata_db_path=metadata_db_path,
+        resume=resume,
+        logger=logger,
+        log_interval=log_interval,
+    )
+
+    def run() -> int:
+        return run_disagg_online_interleaved(
+            trainer=trainer,
+            loader=loader,
+            drive_producer=drive_producer,
+            channel=producer_channel,
+            join_timeout_s=join_timeout_s,
+        )
+
+    return trainer, loader, run
+
+
 # Backward-compatible alias for early branch users.
 build_offline_eagle3_controller = build_offline_eagle3_runtime
 
@@ -639,4 +871,6 @@ __all__ = [
     "build_online_eagle3_runtime",
     "build_disagg_online_producer",
     "build_disagg_online_consumer",
+    "build_disagg_online_eagle3_runtime",
+    "run_disagg_online_interleaved",
 ]

--- a/tests/test_runtime/test_disagg_online_interleave.py
+++ b/tests/test_runtime/test_disagg_online_interleave.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+"""O1.2: run_disagg_online_interleaved — producer + trainer run concurrently.
+
+Before O1.2 the colocated online path was drain-then-fit: generate the whole
+prompt pool, *then* train. These CPU tests exercise the interleaved driver with
+fakes — a real StreamingRefChannel pair, a fake producer-drive that mimics the
+real ``drive_producer`` contract (publish + honor should_stop + close in
+finally), and a fake trainer that drains a StreamingRefQueue — to prove the three
+shutdown paths:
+
+  * full drain then terminate (producer finishes first, closes, loader drains),
+  * trainer stops first (cooperative producer wind-down, no hang),
+  * producer raises (consumer unblocks + the exception propagates).
+
+No torch / GPU here; the FSDP training half is the GPU launcher test.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.streaming_ref_channel import (
+    StreamingRefChannel,
+    StreamingRefQueue,
+)
+from specforge.runtime.launch import run_disagg_online_interleaved
+
+
+def _ref(i: int) -> SampleRef:
+    sid = f"run0:s{i}"
+    return SampleRef(
+        sample_id=sid,
+        run_id="run0",
+        source_task_id=f"t{i}",
+        feature_store_uri="mem://run0",
+        feature_keys={},
+        feature_specs={},
+        strategy="eagle3",
+        metadata={"target_repr": "logits"},
+    )
+
+
+def _fake_producer(channel, n, *, per_round_sleep=0.0):
+    """Mimics drive_producer's contract: publish up to n refs (one per round),
+    honor should_stop, and close the channel in finally so the consumer can never
+    hang on a finished/dead producer."""
+    state = {"produced": 0}
+
+    def drive(max_rounds=1_000_000, should_stop=None):
+        try:
+            for i in range(min(n, max_rounds)):
+                if should_stop is not None and should_stop():
+                    break
+                channel.publish(_ref(i))
+                state["produced"] += 1
+                if per_round_sleep:
+                    time.sleep(per_round_sleep)
+            return state["produced"]
+        finally:
+            channel.close()
+
+    return drive, state
+
+
+class _FakeTrainer:
+    """Drains a StreamingRefQueue (the 'loader') one ref at a time, up to
+    max_steps; records what it consumed. Stands in for TrainerController.fit."""
+
+    def __init__(self, max_steps=None):
+        self.max_steps = max_steps
+        self.consumed = []
+
+    def fit(self, queue):
+        while self.max_steps is None or len(self.consumed) < self.max_steps:
+            refs = queue.get(1)
+            if not refs:
+                break  # channel closed and drained
+            self.consumed.extend(r.sample_id for r in refs)
+        return len(self.consumed)
+
+
+class TestInterleavedDriver(unittest.TestCase):
+    def _channels(self):
+        path = os.path.join(tempfile.mkdtemp(prefix="o12_"), "refs.jsonl")
+        # producer + consumer views over the same path (the proven disagg split)
+        return StreamingRefChannel(path), StreamingRefChannel(path)
+
+    def test_full_drain_then_terminate(self):
+        prod_ch, cons_ch = self._channels()
+        drive, state = _fake_producer(prod_ch, 5, per_round_sleep=0.002)
+        trainer = _FakeTrainer()
+        loader = StreamingRefQueue(cons_ch, poll_s=0.005)
+
+        step = run_disagg_online_interleaved(
+            trainer=trainer,
+            loader=loader,
+            drive_producer=drive,
+            channel=prod_ch,
+        )
+        self.assertEqual(step, 5)
+        self.assertEqual(trainer.consumed, [f"run0:s{i}" for i in range(5)])
+        self.assertEqual(state["produced"], 5)
+        self.assertTrue(prod_ch.is_closed())
+
+    def test_trainer_stops_first_winds_producer_down(self):
+        prod_ch, cons_ch = self._channels()
+        # producer would publish up to 200 (one per ~3ms); the trainer stops at 3,
+        # so the cooperative should_stop must wind the producer down well short.
+        drive, state = _fake_producer(prod_ch, 200, per_round_sleep=0.003)
+        trainer = _FakeTrainer(max_steps=3)
+        loader = StreamingRefQueue(cons_ch, poll_s=0.002)
+
+        step = run_disagg_online_interleaved(
+            trainer=trainer,
+            loader=loader,
+            drive_producer=drive,
+            channel=prod_ch,
+            join_timeout_s=5.0,
+        )
+        self.assertEqual(step, 3)
+        self.assertEqual(len(trainer.consumed), 3)
+        self.assertLess(state["produced"], 200)  # producer did NOT run all rounds
+
+    def test_producer_exception_propagates_and_unblocks_consumer(self):
+        prod_ch, cons_ch = self._channels()
+
+        def drive(max_rounds=1_000_000, should_stop=None):
+            try:
+                prod_ch.publish(_ref(0))
+                prod_ch.publish(_ref(1))
+                raise RuntimeError("rollout boom")
+            finally:
+                prod_ch.close()  # the real drive_producer also closes in finally
+
+        trainer = _FakeTrainer()
+        loader = StreamingRefQueue(cons_ch, poll_s=0.005)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            run_disagg_online_interleaved(
+                trainer=trainer,
+                loader=loader,
+                drive_producer=drive,
+                channel=prod_ch,
+                join_timeout_s=5.0,
+            )
+        self.assertIn("rollout boom", str(ctx.exception))
+        # the consumer still drained what was published before the crash (no hang)
+        self.assertEqual(trainer.consumed, ["run0:s0", "run0:s1"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_disagg_online_launch.py
+++ b/tests/test_runtime/test_disagg_online_launch.py
@@ -132,6 +132,86 @@ class TestDisaggOnlineLaunch(unittest.TestCase):
         # asserted in the CPU integration test + the cross-process mooncake tests.
         self.assertGreaterEqual(channel.consumed_remote(), ACC * MAX_OPT_STEPS - 1)
 
+    def test_named_runtime_interleaved_run(self):
+        # O1.2: the single named builder wires producer + consumer over a shared
+        # store/channel/feature-store and run() drives them CONCURRENTLY (the live
+        # loop that replaces drain-then-fit), with the in-process generator stub.
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29571")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+        from specforge.runtime.launch import build_disagg_online_eagle3_runtime
+
+        H, V, SEQ, TTT, ACC, MAX_OPT_STEPS, N = fx.H, fx.V, 12, 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="disagg_online_named_")
+
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+
+        g = torch.Generator().manual_seed(7)
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": torch.randint(0, V, (SEQ,), generator=g).tolist(),
+                    "loss_mask": [1] * SEQ,
+                }
+            }
+            for _ in range(N)
+        ]
+
+        # one process, one consume-once store shared by producer + consumer
+        store = MooncakeFeatureStore(store=_FakeMooncakeStore(), store_id="doln")
+
+        def optimizer_factory(m):
+            return BF16Optimizer(
+                m, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
+            )
+
+        trainer, loader, run = build_disagg_online_eagle3_runtime(
+            target_model=target,
+            prompts=prompts,
+            eagle3_model=eagle3_model,
+            optimizer_factory=optimizer_factory,
+            feature_store=store,
+            run_id="doln",
+            output_dir=os.path.join(workdir, "out"),
+            target_hidden_size=H,
+            target_vocab_size=V,
+            target_repr="logits",
+            aux_hidden_state_layer_ids=tuple(aux_ids),
+            ref_channel_path=os.path.join(workdir, "refs.jsonl"),
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=1,
+            max_steps=MAX_OPT_STEPS,
+        )
+        self.assertIsInstance(trainer.core.strategy.trainable_module(), FSDP)
+
+        step = run()  # producer thread streams while the trainer trains
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Stage **O1.2** of the online roadmap (#618): the named single-process runtime builder and the interleaved async loop that replaces drain-then-fit. **Stacked on O1.1 (#624)** — review/merge that first; the diff here is against the O1.1 branch.

### Problem
The colocated online path was drain-then-fit: generate the *whole* prompt pool, then train. (Root cause: the in-process `SampleRefQueue.get` is non-blocking, so the loader ended the instant the queue was momentarily empty.)

### Change
- `run_disagg_online_interleaved`: the producer streams refs on a daemon thread while `trainer.fit` consumes on the main thread (`StreamingRefQueue` blocks until closed-and-drained, so the trainer tracks the producer). Symmetric, hang-free shutdown:
  - trainer finishes first (e.g. `max_steps`) → a cooperative `should_stop` winds the producer down instead of blocking on the in-flight watermark after the consumer stops draining;
  - producer finishes first → closes the channel, the loader drains the tail;
  - producer raises → channel closed in `finally` (consumer can't hang) + the exception re-raised on the main thread.
- `build_disagg_online_eagle3_runtime`: the named single-process builder from the roadmap; composes producer + consumer over one shared metadata store, one consume-once feature store, and a producer/consumer `StreamingRefChannel` pair, returning `(trainer, loader, run)`. Uses the in-process `generate_eagle3_data` stub — **no live SGLang server and no Ray** (those are O1.3 / O2).
- `drive_producer` gains a cooperative `should_stop` predicate + a `finally`-close so it never strands the consumer.

### Tests
`tests/test_runtime/test_disagg_online_interleave.py` (CPU): the three shutdown paths (full-drain-then-terminate, trainer-stops-first cooperative wind-down, producer-exception propagation + consumer unblock). A GPU end-to-end test for the named builder's interleaved `run()` is added to `test_disagg_online_launch.py`.

### Next
O1.3 — live SGLang-server hidden-state capture (the roadmap's gating risk; needs a GPU + the capture spike first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
