### PR TITLE
[DataFlow runtime] DFlash end-to-end on the composable launch (offline + online)

### DIFF
--- a/specforge/runtime/inference/dflash_adapter.py
+++ b/specforge/runtime/inference/dflash_adapter.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DFlashAdapter: the DFlash counterpart of SGLangAdapter.
+
+Wraps a ``DFlashTargetModel`` (sglang / hf, both expose ``generate_dflash_data``)
+and returns per-sample feature dicts for the DataFlow rollout. DFlash's schema is
+``{input_ids, hidden_states, loss_mask}`` — note ``hidden_states`` is the
+concatenated target capture layers, and there is NO ``target`` distribution / no
+vocab projection (DFlash trains on hard real-token labels), so unlike
+``SGLangAdapter`` there is no ``_project_target`` / ``t2d`` step.
+
+``verify_capture`` (run by the RolloutWorker before any store write) keys its
+eagle3-specific aux/target checks on the feature names ``"hidden_state"`` /
+``"target"``, which DFlash does not emit, so those checks self-skip; the
+recorded-aux-layer check is skipped too because the RolloutWorker reads it via
+``feats.pop("__aux_layer_ids__", None)`` and DFlash simply omits the key.
+
+Imports SpecForge model code transitively (via the target backend), so it is
+imported by rollout entry points, not at package load.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import torch
+
+from specforge.runtime.contracts import PromptTask
+from specforge.runtime.inference.capture import CaptureConfig
+
+
+def _as_2d_long(values, device) -> torch.Tensor:
+    t = torch.as_tensor(values, dtype=torch.long, device=device)
+    if t.ndim == 1:
+        t = t.unsqueeze(0)
+    return t
+
+
+class DFlashAdapter:
+    """Adapter over a SpecForge ``DFlashTargetModel`` (any ``generate_dflash_data``)."""
+
+    SUPPORTED_FEATURE_NAMES = {"input_ids", "hidden_states", "loss_mask"}
+
+    def __init__(
+        self,
+        target_model,
+        *,
+        device: str = "cuda",
+        t2d: Optional[torch.Tensor] = None,  # unused (DFlash has no vocab map); kept
+    ) -> None:  # for a uniform make_adapter(target_model, *, device, t2d) signature
+        self.target_model = target_model
+        self.device = device
+        self._healthy = True
+
+    def generate_features(
+        self, tasks: List[PromptTask], *, capture: CaptureConfig
+    ) -> List[Dict[str, Any]]:
+        """Extract per-sample DFlash features, batching equal-length prompts.
+
+        Mirrors SGLangAdapter's length-grouped batching, but calls
+        ``generate_dflash_data`` and emits the DFlash schema. The target must have
+        had ``set_capture_layers`` called so ``hidden_states`` width matches the
+        draft's ``len(target_layer_ids) * hidden_size``.
+        """
+        out: List[Optional[Dict[str, Any]]] = [None] * len(tasks)
+
+        groups: Dict[int, List[int]] = {}
+        for i, task in enumerate(tasks):
+            groups.setdefault(len(task.payload["input_ids"]), []).append(i)
+
+        for _length, idxs in groups.items():
+            input_ids = torch.stack(
+                [
+                    _as_2d_long(tasks[i].payload["input_ids"], self.device)[0]
+                    for i in idxs
+                ],
+                dim=0,
+            )  # (G, L)
+            length = input_ids.shape[1]
+            loss_mask = torch.stack(
+                [
+                    (
+                        _as_2d_long(tasks[i].payload["loss_mask"], self.device)[0]
+                        if "loss_mask" in tasks[i].payload
+                        else torch.ones(length, dtype=torch.long, device=self.device)
+                    )
+                    for i in idxs
+                ],
+                dim=0,
+            )
+            attention_mask = torch.ones_like(input_ids)
+            data = self.target_model.generate_dflash_data(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                loss_mask=loss_mask,
+            )
+            for j, gi in enumerate(idxs):
+                out[gi] = {
+                    "input_ids": data.input_ids[j : j + 1],
+                    "hidden_states": data.hidden_states[j : j + 1],
+                    "loss_mask": data.loss_mask[j : j + 1],
+                    # DFlash emits no eagle3 aux/target features. The recorded
+                    # aux-layer check in verify_capture is skipped for free: the
+                    # RolloutWorker reads it via feats.pop("__aux_layer_ids__", None),
+                    # so an absent key is identical to an explicit None.
+                }
+        return out
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "healthy": self._healthy,
+            "backend": getattr(self.target_model, "backend", "unknown"),
+        }
+
+
+__all__ = ["DFlashAdapter"]

--- a/specforge/runtime/training/registry.py
+++ b/specforge/runtime/training/registry.py
@@ -153,6 +153,118 @@ register_strategy(
 )
 
 
+# --- DFlash -----------------------------------------------------------------
+# DFlash uses its own feature schema ('hidden_states' = the concatenated target
+# capture layers, NO eagle3 aux/target swap, NO target distribution / vocab map).
+# Offline: the reader reuses OfflineManifestReader with dflash feature_keys; the
+# transform slices to max_len (no swap); the collate pads + emits {input_ids,
+# hidden_states, loss_mask}. Online: a DFlashAdapter wraps generate_dflash_data
+# and emits the same schema. The DFlashTrainStrategy already drops into the
+# unchanged TrainerCore/Backend/Loader.
+
+from specforge.runtime.training.strategy import DFlashTrainStrategy
+
+
+def _dflash_offline_reader(hidden_states_path, *, run_id, ttt_length, max_len):
+    from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+    # OfflineManifestReader is schema-agnostic; only its EAGLE3 defaults
+    # (feature_keys/strategy/target_repr) must be overridden. DFlash has no target
+    # distribution, so target_repr=None (only stored in ref metadata).
+    return OfflineManifestReader(
+        hidden_states_path,
+        run_id=run_id,
+        ttt_length=ttt_length,
+        max_len=max_len,
+        strategy="dflash",
+        feature_keys=("input_ids", "loss_mask", "hidden_states"),
+        target_repr=None,
+    )
+
+
+def _dflash_process_data(raw, max_len):
+    """Offline DFlash per-sample normalization.
+
+    Slices to ``max_len`` and restores a leading batch dim. NO eagle3-style
+    aux->input / hidden->target swap and NO last-position loss zeroing (the online
+    DFlash path does neither), so offline matches online training.
+    """
+    input_ids = raw["input_ids"][:max_len]
+    loss_mask = raw["loss_mask"][:max_len]
+    hidden_states = raw["hidden_states"]
+    if hidden_states.dim() == 3:  # stored as [1, seq, W]; drop the saved batch dim
+        hidden_states = hidden_states.squeeze(0)
+    hidden_states = hidden_states[:max_len]
+    return {
+        "input_ids": input_ids[None, :],
+        "loss_mask": loss_mask[None, :],
+        "hidden_states": hidden_states[None, :, :],
+    }
+
+
+def _dflash_offline_transform(max_len):
+    return lambda raw: _dflash_process_data(raw, max_len)
+
+
+def _dflash_offline_collate():
+    """Right-pad ragged samples to the batch max length and concat along batch.
+
+    DataCollatorWithPadding is eagle3-specific (hardwires attention_mask + the
+    hidden_state/target keys), so DFlash uses this minimal collate. loss_mask is
+    zero-padded, so padded positions contribute no loss. (Single-rank; no SP
+    sharding multiple — sequence-parallel offline DFlash is a follow-up.)
+    """
+
+    def collate(feats):
+        maxlen = max(f["input_ids"].shape[-1] for f in feats)
+
+        def pad2d(t):  # [1, n] -> [1, maxlen]
+            n = t.shape[-1]
+            if n == maxlen:
+                return t
+            return torch.cat([t, t.new_zeros(t.shape[0], maxlen - n)], dim=-1)
+
+        def pad3d(t):  # [1, n, W] -> [1, maxlen, W]
+            n = t.shape[1]
+            if n == maxlen:
+                return t
+            return torch.cat(
+                [t, t.new_zeros(t.shape[0], maxlen - n, t.shape[2])], dim=1
+            )
+
+        return {
+            "input_ids": torch.cat([pad2d(f["input_ids"]) for f in feats], dim=0),
+            "loss_mask": torch.cat([pad2d(f["loss_mask"]) for f in feats], dim=0),
+            "hidden_states": torch.cat(
+                [pad3d(f["hidden_states"]) for f in feats], dim=0
+            ),
+        }
+
+    return collate
+
+
+def _dflash_adapter(target_model, *, device="cuda", t2d=None):
+    from specforge.runtime.inference.dflash_adapter import DFlashAdapter
+
+    return DFlashAdapter(target_model, device=device, t2d=t2d)
+
+
+register_strategy(
+    StrategySpec(
+        name="dflash",
+        required_features=frozenset(DFlashTrainStrategy.required_features),
+        make_strategy=lambda wrapped, *, target_head=None: DFlashTrainStrategy(wrapped),
+        uses_target_head=False,
+        make_offline_reader=_dflash_offline_reader,
+        make_offline_transform=_dflash_offline_transform,
+        make_offline_collate=_dflash_offline_collate,
+        make_online_collate=lambda: concat_collate,
+        make_adapter=_dflash_adapter,
+        supports_online=True,
+    )
+)
+
+
 __all__ = [
     "StrategySpec",
     "concat_collate",

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -200,3 +200,103 @@ def build_eagle3(workdir, ttt=3):
         draft_model=draft_model, length=ttt, attention_backend="flex_attention"
     ).cuda()
     return eagle3_model, target_head
+
+
+# --- DFlash fixtures ---------------------------------------------------------
+# DFlash has its OWN feature schema: 'hidden_states' = concat of the target
+# capture layers (NO eagle3 aux/target swap, NO target distribution). For a
+# single draft layer the capture set is one layer, so width == hidden_size.
+
+
+def write_offline_files_dflash(d, n=4, seq=32, hidden=H, vocab=V, seed=0):
+    """Write synthetic DFlash offline .ckpt files: {input_ids, loss_mask, hidden_states}.
+
+    No production dumper for DFlash exists yet (prepare_hidden_states.py is the
+    EAGLE3 dumper), so the offline DataFlow path is exercised with synthetic files.
+    loss_mask is all-ones with seq >= 2*block_size so anchor sampling succeeds;
+    hidden_states is bf16 (uniform dtype across files for the loader's spec check).
+    """
+    os.makedirs(d, exist_ok=True)
+    g = torch.Generator().manual_seed(seed)
+    for i in range(n):
+        torch.save(
+            {
+                "input_ids": torch.randint(0, vocab, (seq,), generator=g),
+                "loss_mask": torch.ones(seq, dtype=torch.long),
+                # width == len(target_layer_ids)*hidden; single draft layer -> hidden
+                "hidden_states": torch.randn(1, seq, hidden, generator=g).to(
+                    torch.bfloat16
+                ),
+            },
+            os.path.join(d, f"{i:04d}.ckpt"),
+        )
+    return d
+
+
+def build_dflash(
+    workdir,
+    *,
+    hidden=H,
+    vocab=V,
+    target_layers=4,
+    draft_layers=1,
+    block_size=4,
+    num_anchors=8,
+    mask_token_id=0,
+    attention_backend="sdpa",
+):
+    """Build a tiny OnlineDFlashModel on cuda, mirroring scripts/train_dflash.build_models.
+
+    Returns (dflash_model, hidden_states_width, target_dir, target_layer_ids).
+    target_dir holds the saved tiny Qwen3 target (load it as an HF DFlash target for
+    the ONLINE path); target_layer_ids are the capture layers (== set_capture_layers).
+    For draft_layers=1 the capture set is one target layer so width == hidden.
+    """
+    from transformers import AutoConfig, Qwen3Config, Qwen3ForCausalLM
+
+    from specforge.core.dflash import OnlineDFlashModel
+    from specforge.modeling.draft.dflash import DFlashDraftModel
+    from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
+
+    # tiny Qwen3 target saved to disk (draft config is derived from it, as in train_dflash)
+    tcfg = Qwen3Config(
+        hidden_size=hidden,
+        intermediate_size=2 * hidden,
+        num_hidden_layers=target_layers,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=vocab,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+    )
+    torch.manual_seed(1234)
+    target_dir = os.path.join(workdir, "dflash_target")
+    Qwen3ForCausalLM(tcfg).save_pretrained(target_dir)
+
+    draft_config = AutoConfig.from_pretrained(target_dir)
+    draft_config.num_hidden_layers = draft_layers
+    draft_config.block_size = block_size
+    draft_config.num_target_layers = target_layers
+    draft_config.dflash_config = {"mask_token_id": mask_token_id}
+    draft_config._attn_implementation = attention_backend
+
+    draft_model = DFlashDraftModel(draft_config).to(device="cuda", dtype=torch.bfloat16)
+    draft_model.mask_token_id = mask_token_id
+
+    target_components = TargetEmbeddingsAndHead.from_pretrained(
+        target_dir, lm_head_key="lm_head.weight", device="cuda", dtype=torch.bfloat16
+    )
+
+    dflash_model = OnlineDFlashModel(
+        draft_model=draft_model,
+        target_lm_head=target_components.lm_head,
+        target_embed_tokens=target_components.embed_tokens,
+        block_size=draft_model.block_size,
+        mask_token_id=mask_token_id,
+        attention_backend=attention_backend,
+        num_anchors=num_anchors,
+        loss_type="dflash",
+    ).cuda()
+    width = len(draft_model.target_layer_ids) * hidden
+    return dflash_model, width, target_dir, list(draft_model.target_layer_ids)

--- a/tests/test_runtime/test_dflash_launch.py
+++ b/tests/test_runtime/test_dflash_launch.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+"""Launcher path (DFlash, offline): build_offline_runtime(strategy="dflash") end to end.
+
+Proves the strategy-parameterized launch layer trains a DIFFERENT model family
+(DFlash: block-parallel, scalar loss, no target distribution) through the SAME
+runtime spine (FeatureDataLoader -> _assemble_trainer -> FSDP -> DFlashTrainStrategy)
+with zero new builder — only a StrategySpec entry. Synthetic offline features
+(no DFlash dumper exists yet). GPU-only; run on the H200 box via rcli.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "DFlash launcher FSDP path requires CUDA")
+class TestDFlashOfflineLaunch(unittest.TestCase):
+    def test_offline_dflash_trains_through_fsdp(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29567")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.launch import build_offline_runtime
+
+        HIDDEN, SEQ, N, MAX_OPT_STEPS = 64, 32, 4, 2
+        workdir = tempfile.mkdtemp(prefix="dflash_launch_")
+        feat_dir = fx.write_offline_files_dflash(
+            os.path.join(workdir, "features"), n=N, seq=SEQ, hidden=HIDDEN
+        )
+        dflash_model, width, _target_dir, _layers = fx.build_dflash(
+            workdir,
+            hidden=HIDDEN,
+            block_size=4,
+            num_anchors=8,
+            attention_backend="sdpa",
+        )
+        # single draft layer -> one capture layer -> width == hidden
+        self.assertEqual(width, HIDDEN)
+
+        def optimizer_factory(draft_module):
+            return BF16Optimizer(
+                draft_module,
+                lr=1e-3,
+                max_grad_norm=0.5,
+                warmup_ratio=0.0,
+                total_steps=10,
+            )
+
+        logs = []
+        trainer, loader = build_offline_runtime(
+            strategy="dflash",
+            hidden_states_path=feat_dir,
+            eagle3_model=dflash_model,  # legacy param name = "the composite draft model"
+            target_head=None,  # DFlash owns its own (frozen) head
+            optimizer_factory=optimizer_factory,
+            run_id="dflash-offline",
+            output_dir=os.path.join(workdir, "out"),
+            max_len=SEQ,
+            batch_size=1,
+            num_epochs=3,
+            max_steps=MAX_OPT_STEPS,
+            log_interval=1,
+            logger=lambda metrics, step: logs.append((step, metrics)),
+        )
+
+        # the strategy holds the FSDP-wrapped DFlash model
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(module, FSDP)
+
+        step = trainer.fit(loader)
+
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertTrue(logs, "trainer logged no metrics")
+        # loss must have been finite: NaN/inf loss would corrupt the params via AdamW
+        self.assertTrue(
+            all(torch.isfinite(p).all() for p in module.parameters()),
+            "draft params became non-finite — loss was NaN/inf?",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_dflash_online_launch.py
+++ b/tests/test_runtime/test_dflash_online_launch.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+"""Launcher path (DFlash, online): build_online_runtime(strategy="dflash") end to end.
+
+Online analog of test_dflash_launch: drives a RolloutWorker with the new
+DFlashAdapter (HF DFlash target, no sglang) calling generate_dflash_data to
+materialize {input_ids, hidden_states, loss_mask} SampleRefs into the mem:// store,
+then trains through the queue with FSDP. Proves the strategy-parameterized rollout
+assembler (spec.make_adapter + strategy tag) drives a non-eagle3 model. GPU-only.
+"""
+
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+@unittest.skipUnless(CUDA, "DFlash online launcher path requires CUDA")
+class TestDFlashOnlineLaunch(unittest.TestCase):
+    def test_online_rollout_then_fsdp_train(self):
+        torch.manual_seed(0)
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29570")
+
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge.modeling.target.dflash_target_model import (
+            get_dflash_target_model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import assert_no_tensors
+        from specforge.runtime.launch import build_online_runtime
+
+        HIDDEN, V, SEQ, ACC, MAX_OPT_STEPS, N = 64, fx.V, 16, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="dflash_online_")
+
+        # trainable DFlash model + the saved tiny Qwen3 target it derived from
+        dflash_model, width, target_dir, layers = fx.build_dflash(
+            workdir,
+            hidden=HIDDEN,
+            vocab=V,
+            block_size=4,
+            num_anchors=8,
+            attention_backend="sdpa",
+        )
+        self.assertEqual(width, HIDDEN)
+
+        # HF DFlash target (no sglang) capturing the same layers the draft expects
+        target = get_dflash_target_model(
+            pretrained_model_name_or_path=target_dir,
+            backend="hf",
+            torch_dtype=torch.bfloat16,
+            device="cuda",
+        )
+        target.set_capture_layers(layers)
+
+        g = torch.Generator().manual_seed(7)
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": torch.randint(0, V, (SEQ,), generator=g).tolist(),
+                    "loss_mask": [1] * SEQ,
+                }
+            }
+            for _ in range(N)
+        ]
+
+        def optimizer_factory(draft_module):
+            return BF16Optimizer(
+                draft_module,
+                lr=1e-3,
+                max_grad_norm=0.5,
+                warmup_ratio=0.0,
+                total_steps=10,
+            )
+
+        trainer, loader, workers, controller, drive_rollout = build_online_runtime(
+            strategy="dflash",
+            target_model=target,
+            prompts=prompts,
+            eagle3_model=dflash_model,  # legacy param name = the composite draft model
+            optimizer_factory=optimizer_factory,
+            run_id="dflash-online",
+            output_dir=os.path.join(workdir, "out"),
+            target_hidden_size=HIDDEN,  # benign for DFlash (no target distribution)
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=1,
+            max_steps=MAX_OPT_STEPS,
+        )
+
+        # the DFlashAdapter produced one SampleRef per prompt, control plane tensor-free
+        produced = drive_rollout()
+        self.assertEqual(produced, N)
+        self.assertEqual(controller.sample_queue.depth(), N)
+        assert_no_tensors(controller.status())
+
+        module = trainer.core.strategy.trainable_module()
+        self.assertIsInstance(module, FSDP)
+
+        step = trainer.fit(loader)
+
+        self.assertEqual(step, MAX_OPT_STEPS)
+        self.assertEqual(trainer.micro_step, ACC * MAX_OPT_STEPS)
+        self.assertTrue(
+            all(torch.isfinite(p).all() for p in module.parameters()),
+            "draft params became non-finite — loss was NaN/inf?",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_strategy_registry.py
+++ b/tests/test_runtime/test_strategy_registry.py
@@ -16,12 +16,34 @@ import unittest
 
 from specforge.runtime import launch
 from specforge.runtime.training.registry import available_strategies, resolve_strategy
-from specforge.runtime.training.strategy import Eagle3TrainStrategy
+from specforge.runtime.training.strategy import DFlashTrainStrategy, Eagle3TrainStrategy
 
 
 class TestStrategyRegistry(unittest.TestCase):
-    def test_eagle3_registered(self):
+    def test_builtins_registered(self):
         self.assertIn("eagle3", available_strategies())
+        self.assertIn("dflash", available_strategies())
+
+    def test_dflash_fully_wired(self):
+        spec = resolve_strategy("dflash")
+        self.assertEqual(
+            spec.required_features, frozenset(DFlashTrainStrategy.required_features)
+        )
+        # offline (reader/transform/collate) + online (adapter) both wired
+        self.assertIsNotNone(spec.make_offline_reader)
+        self.assertIsNotNone(spec.make_offline_transform)
+        self.assertIsNotNone(spec.make_offline_collate)
+        self.assertIsNotNone(spec.make_adapter)
+        self.assertTrue(spec.supports_online)
+        # DFlash owns its own (frozen) head -> builders pass target_head=None
+        self.assertFalse(spec.uses_target_head)
+
+        class _M:
+            draft_model = object()
+
+        self.assertIsInstance(
+            spec.make_strategy(_M(), target_head=None), DFlashTrainStrategy
+        )
 
     def test_required_features_track_the_strategy_class(self):
         # The registry's required_features is the single source of truth wired


### PR DESCRIPTION
## What
DFlash trains end-to-end (offline + online) through the composable launch from the parent PR — via **a `StrategySpec` entry + a `DFlashAdapter`, with ZERO `launch.py` changes**.

## Changes
- `registry.py`: dflash spec — offline reader (`OfflineManifestReader` with dflash `feature_keys`, no aux/target swap), per-sample transform, padding collate; online via `DFlashAdapter`; `supports_online=True`.
- **`specforge/runtime/inference/dflash_adapter.py`** (new): wraps `generate_dflash_data`, emits `{input_ids, hidden_states, loss_mask}`. `verify_capture` self-skips the eagle3 aux/target checks (different feature names + `__aux_layer_ids__=None`).
- `tests/_fixtures.py`: `write_offline_files_dflash` + `build_dflash` (tiny Qwen3 target → DFlash draft + `TargetEmbeddingsAndHead` → `OnlineDFlashModel`).
- `tests/test_dflash_launch.py` + `test_dflash_online_launch.py` (new, GPU): offline and online dflash train end-to-end through FSDP.

## Note
DFlash is online-only in production today (no offline dumper exists — `prepare_hidden_states.py` is eagle3-only), so the offline path is exercised with synthetic fixtures while online is its real workflow.

## Testing
Part of the **197 tests OK** suite run at the stack tip (sci-h200 / H200).

Stacked on the composable-launch PR. **Part 2/3.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
