### PR TITLE
docs: reconciled SpecForge architecture plan (DataFlow runtime + domain layer)

### DIFF
--- a/docs/redesign-draft-legacy.md
+++ b/docs/redesign-draft-legacy.md
@@ -1,0 +1,1511 @@
+<!-- SUPERSEDED -->
+> **Superseded by `plan.md`** (the reconciled SpecForge Architecture Plan). This is the
+> original "redesign-from-scratch" draft, kept for its detailed component sketches
+> (CheckpointManager, Evaluator, Pydantic config, MLA draft, SGLang export, train-with-decode).
+> Where this draft and `plan.md` disagree (notably the "no Mooncake" stance), `plan.md` wins.
+
+# SpecForge Redesign Plan
+
+> **Status**: Draft (train-with-decode promoted to Phase 5)
+> **Last updated**: 2026-05-31
+
+---
+
+## 1. Context
+
+SpecForge trains speculative decoding draft models (EAGLE3, DFlash) aligned with SGLang
+serving. It works well for single-cluster torchrun workflows, but has accumulated structural
+debt that makes it hard to add new architectures, new training modes, and production tooling.
+
+TorchSpec (a sibling project) solves many of these gaps via Ray + Mooncake disaggregation,
+but at the cost of heavy dependencies and operational complexity. This plan takes a different
+approach: **keep SpecForge's simple torchrun-native design, but restructure internals so
+new capabilities compose cleanly.**
+
+### What we keep verbatim
+
+- `specforge/core/loss.py` — Triton `LogSoftmaxLoss` and `_compute_loss`.
+- `specforge/optimizer.py` — `BF16Optimizer` (FP32 master weights + AdamW + grad clip).
+- `specforge/lr_scheduler.py` — `CosineAnnealingWarmupLR` and the `TwoStageScheduler` family.
+- `specforge/tracker.py` — `Tracker` ABC + `TRACKER_REGISTRY` (wandb/tensorboard/swanlab/mlflow).
+- `specforge/distributed.py` — `init_distributed`, device meshes, yunchang USP integration.
+- `specforge/core/eagle3_adapters.py` — `BackendAdapter` / `StepState` / `UspAdapter`.
+- SGLang target backend code in `specforge/modeling/target/sglang_backend/`.
+- All 30+ existing draft model configs.
+
+### What we throw away
+
+- `scripts/train_eagle3.py` and `scripts/train_dflash.py` as god scripts (become thin shims).
+- Hardcoded `_model_mapping` / `_config_mapping` dicts in `specforge/modeling/auto.py`.
+- `configs/deepseek-v3-671b-eagle3.json` that claims `model_type: llama` for a DeepSeek target.
+- The argparse-flags + per-arch JSON config split.
+- `QwenVLOnlineEagle3Model` (VLM handled by target engine + data pipeline, not a separate model class).
+
+### Workloads in scope
+
+These are the concrete training workflows the redesign must support. All four share the same
+trainer / strategy / draft surface; they differ only in which `HiddenStateStream` and
+`TargetEngine` get composed at the top.
+
+| # | Workload | Description | Engine | Stream |
+|---|---|---|---|---|
+| W1 | **Offline** | Pre-computed hidden states from disk; trainer runs DP-only | none (`TargetHead` for logits) | `OfflineStream` |
+| W2 | **In-process online** | Target on the same GPUs as draft (TP-collective); current default | `SGLangEagle3TargetModel` / `HFEagle3TargetModel` / `CustomEagle3TargetModel` | `OnlineStream` |
+| W3 | **Disaggregated online** | Target on a separate SGLang server cluster; trainer talks HTTP | `SGLangServerEngine` | `RemoteStream` |
+| W4 | **Train-with-decode** *(new in this revision — promoted from Phase 6)* | One long-lived SGLang server simultaneously **(a)** generates training data via prefill+aux and **(b)** serves real spec-decoding traffic. Trainer pushes draft weights into the same server every N steps so production traffic immediately benefits. | `SGLangServerEngine` (decode mode + weight push) | `OnlineStream` over static jsonl, or new `ServingTrafficStream` over a serving-traffic buffer |
+
+W4 is what makes the no-Ray bet non-trivial: TorchSpec gets W4 "for free" because every
+SglEngine actor already supports both modes. SpecForge needs to add three things explicitly
+— `TargetEngine.update_draft_weights`, a decode-mode flag on `SGLangServerEngine`, and a
+periodic weight-sync hook in `Trainer` — but **no actor topology change**: it stays one
+torchrun-native trainer process talking HTTP to one always-on SGLang server. See §4.10.
+
+---
+
+## 2. Current State Gap Analysis
+
+This section grounds the design in what is concretely wrong or missing in the current
+codebase. Two flavors of gap: **(A) missing capabilities** — things the design assumes but
+no code exists for; **(B) structural problems** — code that exists but the shape is wrong.
+
+### 2.1 Missing capabilities
+
+| Gap | Evidence in current tree | Fixed by |
+|---|---|---|
+| **MLA-aware EAGLE3 draft** | Zero references to `DeepseekV3Config` / `Eagle3Deepseek*` outside test data. `configs/deepseek-v3-671b-eagle3.json` is a *Llama* draft mislabeled as DeepSeek (`model_type: "llama"`, `architectures: ["LlamaForCausalLMEagle3"]`). | Phase 1 #2 — port `deepseek_eagle.py` from TorchSpec, register via `@register_draft`. |
+| **Backbone-agnostic DFlash** | `DFlashDraftModel` extends `Qwen3PreTrainedModel`; uses `Qwen3MLP`, `Qwen3DFlashAttention`, `Qwen3RMSNorm` directly (`specforge/modeling/draft/dflash.py:212`). All DFlash configs are Qwen3-only. | Phase 6 #25 — parameterize MLP/Norm/RoPE; add `llama_dflash.py`. |
+| **Remote / disaggregated target** | `modeling/target/sglang_backend/` only does in-process SGLang (target loaded on same node as trainer). No HTTP client. Online mode for 671B targets is infeasible. | Phase 4 #17 — `SGLangServerEngine` over HTTP. |
+| **Eval during training (proper)** | No `EvalCache`, no `simulated_acc_len`, no per-position-accuracy aggregation, no best-checkpoint tracking — grep is clean. | Phase 2 #9 — `Evaluator` + `EvalCache`. |
+| **Checkpoint rotation / best tracking** | `train_eagle3.py:552:def save_checkpoints(...)` just writes every N steps. No `max_checkpoints`, no `best_checkpointed_iteration.txt`, no `meta.json`. | Phase 2 #8 — `CheckpointManager`. |
+| **Resume that actually advances the stream** | No `stream.seek()`. Current `--resume` reloads weights but the dataloader yields from sample 0, silently re-training on the prefix. | §4.2 trainer pseudo-code + Phase 2 #5 — `HiddenStateStream.seek()`. |
+| **Correct gradient accumulation** | Zero `no_sync()` calls anywhere in the codebase. FSDP all-reduces on every micro-step, defeating the point of `--accumulation-steps`. | Phase 2 #10 — `model.no_sync()` on non-sync micro-steps. |
+| **Plugin registry for drafts** | Hardcoded `_model_mapping = {LlamaConfig: LlamaForCausalLMEagle3}` (`specforge/modeling/auto.py:35`). Code already has TODO: "should support lazy model mapping via registry". | Phase 1 #1 — `@register_draft` decorator. |
+| **Train-with-decode (W4)** | No `update_draft_weights` on any target abstraction. `SGLangEagle3TargetModel.from_pretrained` hardcodes `disable_cuda_graph=True` (training-data-gen only); no notion of a long-lived dual-purpose server. No serving-traffic stream — `core/eagle3.py` only knows about static jsonl batches. No periodic weight push from trainer. | Phase 5 #21–#24 — `update_draft_weights` on `TargetEngine`, decode-mode flag on `SGLangServerEngine`, `ServingTrafficStream`, `Trainer._maybe_sync_draft_weights`. See §4.10. |
+| **SGLang export with MLA weight map** | No `export/to_sglang.py`. MLA draft weights (`q_a_proj`, `kv_a_proj_with_mqa`, `kv_b_proj`) need explicit rename to whatever SGLang's spec-decoder loader expects. | Phase 3 #15 + `docs/export_weight_map_mla.md`. |
+| **FSDP2 readiness** | `apply_fsdp` is FSDP1-only, inlined in scripts. No seam for FSDP2 swap. Locks the trainer to a pattern that composes poorly with `torch.compile`. | §4.9 — versioned `apply_fsdp` seam in Phase 2 (FSDP2 impl deferred to Phase 7 #31). |
+| **Pydantic config + CLI** | `specforge/args.py` is 219 lines of argparse; architecture lives in JSON (`--draft-model-config`); training flags live in CLI. Two sources of truth, no validation. | Phase 3 #13/14 — one validated YAML per run. |
+| **VLM unification** | Separate `QwenVLOnlineEagle3Model` class for VLM targets — parallel hierarchy that doesn't fit the abstraction. | Phase 4 #19 — typed `MediaInputs` in `TargetEngine`. |
+
+### 2.2 Structural / workflow problems
+
+Code exists for these, but the shape is wrong: duplication, missing abstractions,
+maintenance debt that compounds with each new arch.
+
+| Problem | Concrete evidence | Fixed by |
+|---|---|---|
+| **God-script duplication** | `train_eagle3.py` = 1012 lines / 60 `add_argument`s; `train_dflash.py` = 562 lines / 44 `add_argument`s. Same argparse, same distributed init, same checkpoint save, same logging — copy-pasted twice. Total ~1574 lines across two top-level scripts. | Phase 2 #6 — single `Trainer`, strategy dispatch. Reduces to one ~70-line loop + strategy classes. |
+| **Target-model duplication in modeling/** | `modeling/target/eagle3_target_model.py` (873 lines) and `modeling/target/dflash_target_model.py` (315 lines) are parallel hierarchies with no shared base. | Phase 2 #4 — single `TargetEngine` ABC; three concrete impls. |
+| **Online ≠ class, offline ≠ class** | `core/eagle3.py` is the "online" wrapper (606 lines); offline is a different path through `OfflineEagle3Dataset` + `TargetHead`. The trainer must branch by mode. | Phase 2 #5 — both become `HiddenStateStream` implementations. Trainer takes one iterator regardless. |
+| **Arch dispatch by 4-file shotgun** | Adding a new arch today touches `modeling/auto.py:35`, `modeling/auto.py:88`, `modeling/auto.py:134`, plus `modeling/draft/__init__.py`. | Phase 1 #1 — one file, one decorator. |
+| **30 hand-maintained shell scripts** | `examples/run_*_online.sh` × 30. Defaults drift between them; new features need 30 edits. | Phase 3 #14 — 30 YAML files derived from one schema; shell scripts collapse to `specforge train --config ...`. |
+| **No data prefetch overlap** | `core/eagle3.py` runs target forward synchronously inside the training step. Draft backward blocks on target forward. | Phase 2 #5 — `OnlineStream.prefetch_factor` overlaps producer and consumer. |
+| **Misleading config in repo** | `configs/deepseek-v3-671b-eagle3.json` declares `model_type: "llama"` for a DeepSeek target — silently wrong if read as "MLA Eagle3 for V3." | §4.7 — rename to `..._llama_draft.json`, add real MLA config, deprecation warning. |
+| **No numerical-equivalence gate for refactors** | Nothing prevents Phase 2's `Trainer` extraction from quietly changing loss curves. | §10.1 — `atol/rtol` gate at fixed steps on every PR touching `core/`, `training/`, `models/drafts/`. |
+| **No FSDP all-reduce verification** | No profiler check that accumulation actually skips sync. `--accumulation-steps` flag exists but the sync isn't suppressed (no `no_sync()`) — same number of all-reduces as without accumulation. | §10.3 — one-time profiler check; one all-reduce per `optimizer.step()`. |
+| **`Eagle3DraftModel.backbone()` ABC return shape** | Returns `Tensor`; KV cache mutates `past_key_values` in place (HF `DynamicCache` pattern). DFlash respects this. A naive MLA port that returns `(out, k, v)` would break the ABC. | §4.7 — explicit "use `DynamicCache.update`, return `Tensor`" rule for MLA. |
+
+### 2.3 The two highest-leverage chunks
+
+If only two things ship this quarter, do these:
+
+**Chunk 1 — Phase 1 (Week 1-2): `@register_draft` + MLA draft + Kimi-K2.5 TP/SP smoke test.**
+Unblocks the actual feature ask (DFlash + MLA Eagle3 on SGLang). Additive — old
+`_model_mapping` dicts stay as a fallback. ~3 new files, ~10 lines of edits to `auto.py`.
+The TP/SP smoke test (§4.7) is the de-risking step that turns Kimi-K2.5 from "should
+work" into a verified deliverable.
+
+**Chunk 2 — Phase 2 (Week 3-6): `TargetEngine` + `HiddenStateStream` + `Trainer` together.**
+These ship as a unit. Extracting one without the others either leaves the trainer talking
+directly to target models (Phase 4 has to undo it) or leaves the stream abstraction
+without a consumer (can't be tested end-to-end). The Phase 2 acceptance gate is that the
+legacy shells, now calling new internals, match the old loss curves to numerical-
+equivalence tolerance (§10.1). Pass that, and Phase 4 becomes drop-in plugins
+(`SGLangServerEngine`, `RemoteStream`) without re-plumbing.
+
+Everything else (export tool, CLI, VLM cleanup, FSDP2, WSD, Mooncake) is debt cleanup
+that compounds — important but not blocking the stated goal.
+
+---
+
+## 3. Design Principles
+
+1. **One trainer, many drafts, many targets.** Config-driven dispatch via a plugin registry.
+   New arch = new file, not a new script.
+
+2. **The target is an interface, not a process.** Same trainer whether the target is in-process
+   HF, a separate SGLang server, or a remote cluster.
+
+3. **Three data modes behind one abstraction.** Offline-cached, online-local, online-remote —
+   all consumed via the same `HiddenStateStream` iterator. But respect the asymmetry: online
+   streams own GPU resources and backpressure; offline streams are pure readers.
+
+4. **Strategies, not forks.** EAGLE3 (TTT unroll) and DFlash (block-causal) are two
+   `DraftTrainStrategy` implementations sharing the trainer.
+
+5. **Keep what works.** Don't rewrite battle-tested code for symmetry.
+
+---
+
+## 4. Target Architecture
+
+### 4.1 Module layout
+
+```
+specforge/
+├── config/                          # Structured configuration
+│   ├── schema.py                    # Pydantic models (Config, ModelConfig, DatasetConfig, ...)
+│   ├── loader.py                    # YAML load + merge + CLI override + validation
+│   └── draft_configs/               # Draft model JSONs (moved from top-level configs/)
+│       ├── llama3_8b_eagle3.json
+│       ├── qwen3_8b_eagle3.json
+│       ├── qwen3_8b_eagle3_mla.json       # NEW
+│       ├── kimi_k25_eagle3_mla.json       # NEW
+│       ├── deepseek_v3_671b_eagle3.json   # NEW — real MLA config
+│       └── ...
+│
+├── core/                            # Core algorithms (preserved)
+│   ├── eagle3.py                    # Eagle3Model (renamed from OnlineEagle3Model)
+│   ├── dflash.py                    # DFlashModel (renamed from OnlineDFlashModel)
+│   ├── loss.py                      # Triton LogSoftmaxLoss (UNCHANGED)
+│   └── adapters.py                  # BackendAdapter / UspAdapter (UNCHANGED)
+│
+├── models/
+│   ├── drafts/                      # Draft model plugin registry (see §4.2 for the registry + naming contract)
+│   │   ├── __init__.py              # DRAFT_REGISTRY + @register_draft decorator
+│   │   ├── base.py                  # Eagle3DraftModel ABC (from modeling/draft/base.py)
+│   │   ├── <model>_<strategy>.py    # one file per arch — ${model_name}_${strategy}
+│   │   │                            #   e.g. llama_eagle3, deepseek_eagle3, qwen3_dflash
+│   │   └── auto.py                  # AutoEagle3DraftModel (registry-backed, no hardcoded dicts)
+│   │
+│   └── targets/                     # Target engine abstraction
+│       ├── base.py                  # TargetEngine ABC + TargetOutput dataclass
+│       ├── hf_engine.py             # In-process HF target (lazy import)
+│       ├── sglang_engine.py         # In-process SGLang target (lazy import)
+│       ├── sglang_server_engine.py  # SGLang-as-service over HTTP (NEW)
+│       ├── custom_engine.py         # Custom TP backend (existing custom_backend/)
+│       └── target_head.py           # TargetHead for offline logits (existing)
+│
+├── data/
+│   ├── streams/                     # HiddenStateStream abstraction
+│   │   ├── base.py                  # HiddenStateStream protocol
+│   │   ├── online.py               # In-process target generates hidden states
+│   │   ├── offline.py              # Pre-computed hidden states from disk
+│   │   └── remote.py               # Target on separate SGLang server (NEW)
+│   ├── template.py                  # TEMPLATE_REGISTRY (UNCHANGED)
+│   ├── parse.py                     # Parsers + KimiK25Parser, MiniMaxParser (NEW)
+│   ├── preprocessing.py             # build_eagle3_dataset etc. (UNCHANGED)
+│   ├── collator.py                  # DataCollatorWithPadding (extracted from utils.py)
+│   └── cache.py                     # Tokenization cache + eval cache (NEW)
+│
+├── training/
+│   ├── trainer.py                   # Trainer: unified training loop
+│   ├── strategies/
+│   │   ├── __init__.py              # DraftTrainStrategy protocol
+│   │   ├── eagle3_ttt.py            # Eagle3 TTT unroll + forward-KL
+│   │   └── dflash_block.py          # DFlash block-causal + anchor sampling
+│   ├── optimizer.py                 # BF16Optimizer (UNCHANGED)
+│   ├── lr_scheduler.py              # CosineWarmup + WSD scheduler (NEW)
+│   ├── checkpoint.py                # CheckpointManager (NEW)
+│   ├── fsdp.py                      # apply_fsdp (FSDP1 SHARD_GRAD_OP + future FSDP2)
+│   └── distributed.py               # init_distributed etc. (moved from specforge/distributed.py)
+│
+├── eval/                            # Evaluation system (NEW)
+│   ├── evaluator.py                 # Evaluator: eval loop + metric aggregation
+│   ├── cache.py                     # EvalCache: MD5-keyed disk cache
+│   └── metrics.py                   # simulated_acc_len, avg_loss, avg_acc
+│
+├── export/                          # Model export tools (NEW)
+│   ├── to_hf.py                     # FSDP checkpoint → HF format + vocab pruning
+│   └── to_sglang.py                 # Checkpoint → SGLang spec-decoder layout
+│
+├── tracker.py                       # UNCHANGED
+├── utils.py                         # UNCHANGED
+│
+├── cli.py                           # `specforge train|prepare|export|eval` (NEW)
+└── __init__.py
+
+scripts/
+├── legacy/                          # Old scripts as thin shims
+│   ├── train_eagle3.py
+│   └── train_dflash.py
+├── prepare_data.py                  # UNCHANGED
+├── prepare_hidden_states.py         # UNCHANGED
+└── regenerate_train_data.py         # UNCHANGED
+```
+
+### 4.2 Key abstractions
+
+#### Draft model registry
+
+This is the single source of truth for the `models/drafts/` layout sketched in §4.1.
+One file per architecture, named `${model_name}_${strategy}` (strategy ∈ `eagle3`,
+`dflash`, `domino`, `dspark`) — e.g. `llama_eagle3.py`, `deepseek_eagle3.py`,
+`qwen3_dflash.py`; the registry key matches the filename stem.
+
+```python
+# models/drafts/__init__.py
+DRAFT_REGISTRY: dict[str, type] = {}
+
+def register_draft(name: str):
+    """Decorator. New arch = new file + @register_draft("deepseek_v3_eagle3")."""
+    def wrapper(cls):
+        DRAFT_REGISTRY[name] = cls
+        return cls
+    return wrapper
+
+# models/drafts/llama_eagle3.py
+@register_draft("llama_eagle3")
+class LlamaForCausalLMEagle3(Eagle3DraftModel):
+    ...
+
+# models/drafts/deepseek_eagle3.py — MLA (NEW)
+@register_draft("deepseek_v3_eagle3")
+class Eagle3DeepseekV2ForCausalLM(Eagle3DraftModel):
+    config_class = DeepseekV3Config
+    ...
+
+# models/drafts/qwen3_dflash.py — DFlash (existing)
+@register_draft("qwen3_dflash")
+class DFlashDraftModel(Eagle3DraftModel):
+    ...
+```
+
+The `Eagle3DraftModel` ABC is preserved exactly as-is. Its interface is already well-designed:
+
+```python
+class Eagle3DraftModel(PreTrainedModel, ABC):
+    def embed_input_ids(self, input_ids: Tensor) -> Tensor: ...
+    def project_hidden_states(self, hidden_states: Tensor) -> Tensor: ...
+    def backbone(self, input_embeds, hidden_states, cache_hidden,
+                 attention_mask, position_ids, past_key_values=None,
+                 use_cache=True) -> Tensor: ...
+    def compute_logits(self, hidden_states: Tensor) -> Tensor: ...
+    # Concrete: load_embedding, freeze_embedding, load_vocab_mapping, t2d/d2t
+```
+
+`AutoDraftModelConfig.from_file()` is updated to look up `DRAFT_REGISTRY` first, fall back to
+HF config type dispatch for backward compatibility.
+
+#### Target engine
+
+```python
+# models/targets/base.py
+@dataclass
+class TargetOutput:
+    aux_hidden_states: torch.Tensor  # [batch, seq, hidden * num_aux_layers] — raw concat (NOT projected)
+    target_logits: torch.Tensor      # [batch, seq, vocab] — pre-softmax logits in draft vocab space
+    loss_mask: torch.Tensor          # [batch, seq]
+    input_ids: torch.Tensor          # [batch, seq]
+    attention_mask: torch.Tensor     # [batch, seq]
+    last_hidden_states: Optional[torch.Tensor] = None
+
+class TargetEngine(ABC):
+    @abstractmethod
+    def generate_train_data(
+        self,
+        input_ids: Tensor,
+        attention_mask: Tensor,
+        loss_mask: Tensor,
+        media: Optional[MediaInputs] = None,   # typed VLM payload (pixel_values, image_grid_thw, ...)
+    ) -> TargetOutput: ...
+
+    @property
+    @abstractmethod
+    def aux_layer_ids(self) -> list[int]: ...
+
+    def set_aux_hidden_states_layers(self, layers: list[int]) -> None: ...
+```
+
+Naming:
+- `target_logits` (not `target`) — the previous overload of "target" with "target model" was confusing.
+- `aux_hidden_states` — raw concatenated multi-layer hidden states from the target.
+  The projection (3·hidden → hidden) **stays inside the draft model** (`project_hidden_states`),
+  so streams and engines never need to know the draft's hidden_size.
+
+This is a rename + mild generalization of the existing `Eagle3TargetModel` +
+`Eagle3TargetOutput`. The existing SGLang/HF/Custom implementations become concrete engines
+with no API changes. VLM is handled via `**media_kwargs` — no separate model class needed.
+
+Lazy imports ensure SGLang is never imported unless `backend="sglang"`:
+
+```python
+def get_target_engine(backend: str, **kwargs) -> TargetEngine:
+    if backend == "sglang":
+        from specforge.models.targets.sglang_engine import SGLangTargetEngine
+        return SGLangTargetEngine(**kwargs)
+    elif backend == "sglang_server":
+        from specforge.models.targets.sglang_server_engine import SGLangServerEngine
+        return SGLangServerEngine(**kwargs)
+    elif backend == "hf":
+        from specforge.models.targets.hf_engine import HFTargetEngine
+        return HFTargetEngine(**kwargs)
+    elif backend == "custom":
+        from specforge.models.targets.custom_engine import CustomTargetEngine
+        return CustomTargetEngine(**kwargs)
+    raise ValueError(f"Unknown target backend: {backend}")
+```
+
+#### HiddenStateStream
+
+```python
+# data/streams/base.py
+class HiddenStateStream(ABC):
+    """Produces TrainBatch instances for the draft trainer."""
+
+    def setup(self, draft_config) -> None:
+        """Inform stream of draft requirements (aux layers, vocab mapping, etc.)."""
+        pass
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[TrainBatch]: ...
+
+    def seek(self, step: int) -> None:
+        """Resume from step N. Required for checkpoint resume to behave correctly.
+
+        Default behavior (provided by base class): advance the iterator by `step`
+        batches. Implementations with random-access storage (e.g. OfflineStream)
+        should override to seek directly without consuming.
+        """
+
+    def teardown(self) -> None:
+        """Release GPU / network resources."""
+        pass
+
+@dataclass
+class TrainBatch:
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    target_logits: torch.Tensor     # target logits on draft vocab (pre-softmax)
+    loss_mask: torch.Tensor
+    aux_hidden_states: torch.Tensor # raw concat of target aux layers — draft projects internally
+    position_ids: Optional[torch.Tensor] = None
+```
+
+Three implementations:
+
+| Stream | Source | GPU cost | Notes |
+|--------|--------|----------|-------|
+| `OnlineStream` | In-process `TargetEngine` | High (target on same GPUs) | Current "online" mode; supports `prefetch_factor` to overlap target inference with draft training |
+| `OfflineStream` | Pre-computed .pt files | None | Current "offline" mode; overrides `seek()` for O(1) resume |
+| `RemoteStream` | SGLang server over HTTP | None locally | NEW — target on separate node(s); supports `prefetch_factor` and request batching |
+
+`OnlineStream` owns the target engine lifecycle and handles TP→DP batch sharding
+(currently done manually in `train_eagle3.py:get_dp_data_shard_from_tp`). Exposes
+`prefetch_factor: int = 2` so the next batch's target forward overlaps the current
+batch's draft backward.
+
+`OfflineStream` wraps the existing `OfflineEagle3Dataset` + `TargetHead` path. Overrides
+`seek()` to jump directly to a sample index without iterating intermediate files.
+
+`RemoteStream` sends tokenized batches to an SGLang server, receives hidden states back.
+This covers the "671B target on dedicated GPUs" case without Ray/Mooncake. Should also
+expose `prefetch_factor` (network roundtrip dominates without it) and a `max_in_flight`
+bound so back-pressure is explicit.
+
+#### DraftTrainStrategy
+
+```python
+# training/strategies/__init__.py
+class DraftTrainStrategy(ABC):
+    """Encapsulates one training algorithm's forward + loss computation."""
+
+    @abstractmethod
+    def forward_and_loss(
+        self,
+        draft_model: Eagle3DraftModel,
+        batch: TrainBatch,
+    ) -> tuple[torch.Tensor, dict[str, float]]:
+        """Returns (loss, metrics_dict). Target data is already in batch."""
+        ...
+
+    @abstractmethod
+    def build_model(self, draft_model, **kwargs) -> nn.Module:
+        """Wrap draft_model in the strategy-specific training wrapper."""
+        ...
+
+    def fsdp_wrap_policy(self) -> Optional[Callable]:
+        """Optional: return an FSDP auto-wrap policy tailored to this strategy's wrapper.
+
+        The trainer applies this if non-None; otherwise falls back to a default
+        transformer-block wrap policy. Lets strategies declare wrapping intent
+        instead of the trainer second-guessing.
+        """
+        return None
+```
+
+Two implementations:
+
+- **`Eagle3TTTStrategy`**: wraps draft in `Eagle3Model` (current `core/eagle3.py`), runs
+  TTT unroll, forward-KL loss via `LogSoftmaxLoss`. The existing `Eagle3Model.forward()`
+  signature maps directly.
+
+- **`DFlashBlockStrategy`**: wraps draft in `DFlashModel` (current `core/dflash.py`), does
+  anchor sampling + block-causal CE. The existing `OnlineDFlashModel.forward()` maps directly.
+
+The strategy does NOT touch the target engine — batch already contains materialized tensors.
+This is a hard boundary.
+
+#### Trainer
+
+```python
+# training/trainer.py
+class Trainer:
+    def __init__(self, config: Config):
+        self.config = config
+        self.strategy = self._build_strategy()
+        self.checkpoint_mgr = CheckpointManager(config.training)
+        self.evaluator = Evaluator(config.eval) if config.eval.enabled else None
+        self.tracker = create_tracker(config.logging)
+
+    def train(self):
+        # 1. Distributed setup
+        init_distributed(...)
+
+        # 2. Build draft model from registry
+        draft_config = AutoDraftModelConfig.from_file(self.config.model.draft_model_config)
+        draft_model = DRAFT_REGISTRY[draft_config.architectures[0]].from_config(draft_config)
+
+        # 3. Build strategy-specific wrapper
+        model = self.strategy.build_model(draft_model, ...)
+
+        # 4. Apply FSDP (strategy may override wrap policy)
+        model = apply_fsdp(
+            model,
+            self.config.training,
+            wrap_policy=self.strategy.fsdp_wrap_policy(),
+        )
+
+        # 5. Build optimizer
+        optimizer = BF16Optimizer(model, ...)
+
+        # 6. Build data stream
+        stream = self._build_stream()
+        stream.setup(draft_config)
+
+        # 7. Resume if needed — note: stream.seek() is required for correctness.
+        #    enumerate(stream, start=start_step) only changes the counter; without
+        #    seek(), the stream still yields batch 0 first, silently re-training on it.
+        start_step = 0
+        if self.config.training.resume:
+            start_step = self.checkpoint_mgr.load(model, optimizer)
+            stream.seek(start_step)
+
+        # 8. Training loop
+        accum = self.config.training.accumulation_steps
+        for step, batch in enumerate(stream, start=start_step):
+            if step >= self.config.training.max_steps:
+                break
+
+            # Forward + loss (strategy-specific)
+            loss, metrics = self.strategy.forward_and_loss(model, batch)
+            scaled_loss = loss / accum
+
+            # Skip gradient sync on all but the final micro-step of an accumulation
+            # window. With FSDP this is the difference between one all-reduce per
+            # micro-batch and one per optimizer step — non-trivial on large models.
+            is_sync_step = ((step + 1) % accum == 0)
+            sync_ctx = nullcontext() if is_sync_step else model.no_sync()
+            with sync_ctx:
+                scaled_loss.backward()
+
+            if is_sync_step:
+                optimizer.step()
+
+            # Logging
+            if (step + 1) % self.config.training.log_interval == 0:
+                self.tracker.log(metrics, step=step)
+
+            # Eval
+            if self.evaluator and (step + 1) % self.config.eval.interval == 0:
+                eval_metrics = self.evaluator.run(
+                    lambda b: self.strategy.forward_and_loss(model, b),
+                    self._eval_stream,
+                )
+                self.checkpoint_mgr.update_best(step, eval_metrics)
+                self.tracker.log(eval_metrics, step=step)
+
+            # Save
+            if (step + 1) % self.config.training.save_interval == 0:
+                self.checkpoint_mgr.save(step, model, optimizer)
+
+        stream.teardown()
+        self.tracker.close()
+```
+
+This is ~70 lines of logic. Everything else is behind interfaces.
+
+Two non-obvious correctness points the pseudo-code makes explicit:
+
+1. **Resume requires `stream.seek(start_step)`.** Without it, `enumerate(stream, start=N)`
+   only relabels the counter — the iterator still yields batch 0 first, so resume
+   silently re-trains on the prefix.
+
+2. **Gradient accumulation needs `model.no_sync()` on non-sync steps.** Otherwise FSDP
+   all-reduces on every micro-batch, defeating the point of accumulation.
+
+### 4.3 Checkpoint manager
+
+```python
+# training/checkpoint.py
+class CheckpointManager:
+    def __init__(self, config: TrainingConfig):
+        self.checkpoint_dir = Path(config.checkpoint_dir)
+        self.max_checkpoints = config.max_checkpoints    # 0 = keep all
+        self.best_score = -float("inf")
+
+    def save(self, step: int, model, optimizer, meta: dict = None):
+        """Save model + optimizer + LR state + RNG + meta.json."""
+        step_dir = self.checkpoint_dir / f"iter_{step + 1:07d}"
+        # torch.distributed.checkpoint.save for model, optimizer
+        # rank-0: rng.pt, meta.json (step, timestamp, global_step, world_size)
+        self._update_latest(step + 1)
+        self._rotate()
+
+    def load(self, model, optimizer=None, continual=False) -> int:
+        """Load latest or specified checkpoint. Returns start_step."""
+        step_id = self._read_latest()
+        # torch.distributed.checkpoint.load
+        # If continual: skip optimizer/LR/RNG, only restore weights + rebuild FP32 master
+        return step_id
+
+    def update_best(self, step: int, eval_metrics: dict):
+        """Track best checkpoint by simulated_acc_len."""
+        score = eval_metrics.get("simulated_acc_len", eval_metrics.get("avg_acc", 0))
+        if score > self.best_score:
+            self.best_score = score
+            self._write_best(step + 1, eval_metrics)
+
+    def _rotate(self):
+        """Keep only max_checkpoints newest iter_* directories."""
+        if self.max_checkpoints <= 0:
+            return
+        dirs = sorted(self.checkpoint_dir.glob("iter_*"))
+        for d in dirs[:-self.max_checkpoints]:
+            shutil.rmtree(d)
+
+    def _update_latest(self, step_id: int):
+        (self.checkpoint_dir / "latest_checkpointed_iteration.txt").write_text(str(step_id))
+
+    def _write_best(self, step_id: int, metrics: dict):
+        (self.checkpoint_dir / "best_checkpointed_iteration.txt").write_text(str(step_id))
+        (self.checkpoint_dir / "best_meta.json").write_text(json.dumps(metrics, indent=2))
+```
+
+### 4.4 Evaluation system
+
+```python
+# eval/evaluator.py
+class Evaluator:
+    def __init__(self, config: EvalConfig):
+        self.cache = EvalCache(config.cache_dir)
+        self.micro_batch_size = config.micro_batch_size
+
+    def run(self, forward_fn, eval_stream: HiddenStateStream) -> dict:
+        """Run full eval pass, return aggregated metrics.
+
+        Per-position accuracy must be averaged *across all batches first*, then fed
+        into the geometric sum. Treating each batch's per-position vector as if it
+        were positions makes simulated_acc_len batch-size-dependent.
+        """
+        total_loss_x_tokens = 0.0
+        total_tokens = 0
+        # Sum and count per draft position (TTT step), aggregated across the whole pass.
+        per_pos_acc_sum: Optional[torch.Tensor] = None       # shape [ttt_length]
+        per_pos_acc_count: Optional[torch.Tensor] = None     # shape [ttt_length]
+
+        for batch in self._iter_micro_batches(eval_stream):
+            with torch.no_grad():
+                loss, metrics = forward_fn(batch)
+            total_loss_x_tokens += metrics["loss"] * metrics["num_tokens"]
+            total_tokens += metrics["num_tokens"]
+
+            ppa = metrics.get("per_position_acc")        # [ttt_length], weighted by num_tokens
+            ppc = metrics.get("per_position_count")      # [ttt_length], token counts per position
+            if ppa is not None:
+                if per_pos_acc_sum is None:
+                    per_pos_acc_sum = torch.zeros_like(ppa)
+                    per_pos_acc_count = torch.zeros_like(ppc)
+                per_pos_acc_sum += ppa * ppc             # accumulate weighted sum
+                per_pos_acc_count += ppc
+
+        # Aggregate first, then geometric-sum.
+        per_position_acc = (per_pos_acc_sum / per_pos_acc_count.clamp_min(1)).tolist()
+        return {
+            "eval/avg_loss": total_loss_x_tokens / max(total_tokens, 1),
+            "eval/avg_acc": float(per_position_acc[0]) if per_position_acc else 0.0,
+            "eval/simulated_acc_len": self._simulated_acc_len(per_position_acc),
+        }
+
+    @staticmethod
+    def _simulated_acc_len(per_position_acc: list[float]) -> float:
+        """E[accepted tokens] = acc_0 + acc_0*acc_1 + acc_0*acc_1*acc_2 + ...
+
+        `per_position_acc` is the *aggregated* per-position accuracy across the full
+        eval set, length = ttt_length. Not a list of per-batch vectors.
+        """
+        cumulative = 1.0
+        total = 0.0
+        for acc in per_position_acc:
+            cumulative *= acc
+            total += cumulative
+        return total
+
+# eval/cache.py
+class EvalCache:
+    """Disk cache for pre-computed eval hidden states.
+
+    Cache key must cover everything that would change the cached tensors:
+    eval data, target model identity & revision, tokenizer, chat template,
+    aux layer ids, and sequence length. Missing any of these silently serves
+    stale data after a target swap or template change.
+    """
+
+    def __init__(self, cache_dir: str):
+        self.cache_dir = Path(cache_dir)
+
+    def cache_key(
+        self,
+        eval_path: str,
+        target_path: str,
+        target_revision: str,
+        tokenizer_path: str,
+        chat_template: str,
+        aux_layer_ids: list[int],
+        max_seq_len: int,
+    ) -> str:
+        content = "|".join([
+            eval_path,
+            target_path,
+            target_revision or "",
+            tokenizer_path,
+            chat_template,
+            ",".join(map(str, aux_layer_ids)),
+            str(max_seq_len),
+        ])
+        return hashlib.md5(content.encode()).hexdigest()[:12]
+
+    def try_load(self, key: str) -> Optional[list]:
+        path = self.cache_dir / "eval_cache" / key
+        if path.exists():
+            return [torch.load(f) for f in sorted(path.glob("rank_*.pt"))]
+        return None
+
+    def save(self, key: str, rank: int, data: list):
+        path = self.cache_dir / "eval_cache" / key
+        path.mkdir(parents=True, exist_ok=True)
+        torch.save(data, path / f"rank_{rank:04d}.pt")
+```
+
+Note: `data/cache.py` (tokenization cache) and `eval/cache.py` (eval hidden-state cache)
+are deliberately separate — they key on different things and live at different lifecycle
+points. Don't merge them.
+
+### 4.5 Structured config
+
+```python
+# config/schema.py
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+
+class ModelConfig(BaseModel):
+    target_model_path: str
+    draft_model_config: str               # path to JSON
+    target_backend: Literal["sglang", "hf", "custom", "sglang_server"] = "sglang"
+    trust_remote_code: bool = False
+    embedding_key: str = "model.embed_tokens.weight"
+    lm_head_key: str = "lm_head.weight"
+    is_vlm: bool = False
+
+class DatasetConfig(BaseModel):
+    train_data_path: str
+    eval_data_path: str = ""
+    train_hidden_states_path: str = ""    # non-empty = offline mode
+    chat_template: str = "llama3"
+    max_length: int = 2048
+    train_only_last_turn: bool = False
+    num_proc: int = 8
+
+class TrainingConfig(BaseModel):
+    strategy: Literal["eagle3", "dflash"] = "eagle3"
+    num_epochs: int = 1
+    max_steps: int = 10000
+    batch_size: int = 1
+    learning_rate: float = 3e-4
+    warmup_ratio: float = 0.015
+    max_grad_norm: float = 0.5
+    accumulation_steps: int = 1
+    ttt_length: int = 7                   # Eagle3-specific
+    block_size: int = 16                  # DFlash-specific
+    num_anchors: int = 512                # DFlash-specific
+    loss_decay_gamma: Optional[float] = None
+    attention_backend: Literal["sdpa", "flex_attention", "fa", "usp"] = "sdpa"
+    fsdp_strategy: Literal["NO_SHARD", "SHARD_GRAD_OP", "FULL_SHARD", "HYBRID_SHARD"] = "SHARD_GRAD_OP"
+    fsdp_version: Literal[1, 2] = 1       # 2 = FSDP2 (PT 2.4+); see §4.9
+    compile_model: bool = False
+    tp_size: int = 1
+    sp_ulysses_size: int = 1
+    sp_ring_size: int = 1
+    save_interval: int = 500
+    log_interval: int = 10
+    max_checkpoints: int = 5              # 0 = keep all
+    checkpoint_dir: str = "checkpoints"
+    resume: bool = False
+    seed: int = 42
+
+class EvalConfig(BaseModel):
+    enabled: bool = False
+    interval: int = 500
+    micro_batch_size: int = 4
+    cache_dir: str = "eval_cache"
+
+class LRConfig(BaseModel):
+    decay_style: Literal["cosine", "WSD"] = "cosine"
+    wsd_decay_steps: int = 0
+    wsd_decay_style: Literal["linear", "cosine", "exponential"] = "cosine"
+
+class LoggingConfig(BaseModel):
+    report_to: Literal["wandb", "tensorboard", "swanlab", "mlflow", "none"] = "wandb"
+    wandb_project: str = "specforge"
+    wandb_run_name: str = ""
+
+class SGLangConfig(BaseModel):
+    attention_backend: str = "flashinfer"
+    # ... other SGLang server args
+
+class Config(BaseModel):
+    model: ModelConfig
+    dataset: DatasetConfig
+    training: TrainingConfig = Field(default_factory=TrainingConfig)
+    eval: EvalConfig = Field(default_factory=EvalConfig)
+    lr: LRConfig = Field(default_factory=LRConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    sglang: SGLangConfig = Field(default_factory=SGLangConfig)
+    output_dir: str = "output"
+    cache_dir: str = "cache"
+```
+
+YAML example for MLA Eagle3 training:
+
+```yaml
+model:
+  target_model_path: Qwen/Qwen3-8B
+  draft_model_config: specforge/config/draft_configs/qwen3_8b_eagle3_mla.json
+  target_backend: sglang
+
+dataset:
+  train_data_path: data/train.jsonl
+  eval_data_path: data/eval.jsonl
+  chat_template: qwen3
+  max_length: 4096
+
+training:
+  strategy: eagle3
+  max_steps: 20000
+  batch_size: 2
+  learning_rate: 3e-4
+  ttt_length: 7
+  attention_backend: flex_attention
+  accumulation_steps: 2
+  tp_size: 4
+  max_checkpoints: 3
+
+eval:
+  enabled: true
+  interval: 1000
+
+output_dir: runs/qwen3_8b_mla_eagle3
+```
+
+CLI override: `specforge train --config config.yaml --training.learning_rate=1e-4`
+
+### 4.6 WSD learning rate scheduler
+
+> **Deferred to Phase 6** (was Phase 2 in the original draft). Cosine warmup is sufficient
+> for typical draft training runs; WSD is most useful for continued pretraining and long
+> stable-phase runs, which aren't on the immediate roadmap.
+
+Add to `specforge/training/lr_scheduler.py`:
+
+```python
+class WSDScheduler(_LRScheduler):
+    """Warmup → Stable → Decay schedule.
+
+    Stable phase holds max LR until (total_steps - wsd_decay_steps).
+    Decay phase applies linear/cosine/exponential decay to min_lr.
+    """
+    def __init__(self, optimizer, total_steps, warmup_steps, min_lr=0.0,
+                 wsd_decay_steps=0, wsd_decay_style="cosine", last_epoch=-1):
+        ...
+```
+
+Wired via `LRConfig.decay_style == "WSD"` in the trainer.
+
+### 4.7 MLA Eagle3 draft model
+
+Port from TorchSpec's `deepseek_eagle.py`. Key design decisions:
+
+**KV cache in TTT context**: During Eagle3 TTT unroll, cache expanded K/V (not compressed
+latent). This matches TorchSpec's approach and avoids requiring MLA-specific cache logic in
+`core/eagle3.py`. The MLA compression only happens during projection (forward pass), not in
+the cache.
+
+**Cache integration**: use the HF `DynamicCache` pattern (mutate `past_key_values` in place
+via `past_key_values.update(k, v, layer_idx, cache_kwargs)`) — same as the existing
+`DFlashDraftModel` and `Eagle3DraftModel.backbone()` ABC, which returns `Tensor` (hidden
+states) and never a `(Tensor, k, v)` tuple. Returning a tuple would break the base ABC.
+
+```python
+# models/drafts/deepseek_eagle3.py
+@register_draft("deepseek_v3_eagle3")
+class Eagle3DeepseekV2ForCausalLM(Eagle3DraftModel):
+    config_class = DeepseekV3Config
+
+    class DeepSeekMLAAttention(nn.Module):
+        """MLA attention with Q/KV LoRA, decoupled RoPE."""
+        def __init__(self, config: DeepseekV3Config):
+            # Q path: q_a_proj → RMSNorm → q_b_proj (if q_lora_rank)
+            # KV path: kv_a_proj_with_mqa → split(kv_compressed, k_rope_raw)
+            #        → kv_a_layernorm → kv_b_proj → split(k_nope, value)
+            # RoPE: interleaved rotation on qk_rope_head_dim slice only
+            # o_proj: num_heads * v_head_dim → hidden_size
+            ...
+
+        def forward(self, hidden_states, past_key_values=None,
+                    attention_mask=None, position_ids=None, cache_position=None,
+                    use_cache=False):
+            # 1. Project Q (with optional LoRA)
+            # 2. Project KV (compressed → expand via kv_b_proj)
+            # 3. Split k_nope from kv_b_proj, k_rope_raw from kv_a_proj
+            # 4. Apply interleaved RoPE to q_rope and k_rope slices
+            # 5. Expand k_rope (MQA → MHA) across heads
+            # 6. Concat [k_nope, k_rope] → full expanded key
+            # 7. If use_cache and past_key_values is not None:
+            #        k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
+            # 8. Attention (SDPA or FlexAttention)
+            # 9. Return attn_output  — k/v stored in the mutable DynamicCache
+            ...
+```
+
+Config fields consumed from `DeepseekV3Config`:
+- `q_lora_rank` — Q low-rank dim (None = dense Q)
+- `kv_lora_rank` — KV compressed dim
+- `qk_nope_head_dim` — per-head key dim without RoPE
+- `qk_rope_head_dim` — per-head key dim with RoPE
+- `v_head_dim` — per-head value dim (may differ from key dim)
+- `rope_scaling` — YaRN parameters
+
+**Memory budget for expanded TTT cache**. Per token per draft layer:
+
+    key_bytes_per_token   = num_heads * (qk_nope_head_dim + qk_rope_head_dim) * dtype_size
+    value_bytes_per_token = num_heads * v_head_dim                            * dtype_size
+
+For DeepSeek-V3 numbers (128 heads, 128 nope + 64 rope, 128 v_dim, bf16 = 2B):
+- per token: 128*(128+64)*2 = 49 152 B key + 128*128*2 = 32 768 B value ≈ 80 KB
+- at seq=4096, ttt=7, one draft layer, one sample: ~2.3 GB
+- the draft typically has 1 layer, so this scales with `batch_size` not with `num_layers`
+
+So per-GPU peak from the TTT cache ≈ `batch_per_gpu * 2.3 GB`. Bound `batch_size`
+accordingly, or revisit the compressed-cache option if this blocks longer-context training.
+
+**TP/SP for MLA — validate before Phase 1 sign-off**. MLA has asymmetric per-head dims
+(`qk_nope`, `qk_rope`, `v_head_dim`) — Yunchang USP and any TP slicing assume per-head
+homogeneity in places. A small smoke test on Kimi-K2.5 with `tp_size=2`,
+`sp_ulysses_size=2` is on the Phase 1 critical path, not a Phase 4 concern.
+
+**Migration for the old `configs/deepseek-v3-671b-eagle3.json`**. That file declares
+`model_type: "llama"` and trains a Llama-style draft against a DeepSeek target — it's not
+an MLA draft despite the filename. Phase 1 plan:
+- Move it to `specforge/config/draft_configs/deepseek_v3_671b_eagle3_llama_draft.json`
+  (preserves backward compat for anyone training against it).
+- Add the new MLA config at `specforge/config/draft_configs/deepseek_v3_671b_eagle3.json`.
+- Emit a one-time deprecation warning when the old path is loaded.
+
+### 4.8 SGLang export tool
+
+```python
+# export/to_sglang.py
+def export_to_sglang(checkpoint_dir: str, output_dir: str, target_model_path: str,
+                     prune_vocab: bool = False, prune_dataset: str = None):
+    """Convert FSDP training checkpoint to SGLang-loadable spec-decoder format.
+
+    Handles:
+    - FSDP state dict → flat state dict
+    - Weight key renaming (training names → SGLang spec-decoder expected names)
+    - MLA weight naming: q_a_proj, kv_a_proj_with_mqa, kv_b_proj etc.
+    - Optional vocab pruning based on dataset token frequency
+    - Config generation (draft config JSON + tokenizer copy)
+    """
+    ...
+```
+
+**Weight-name compatibility is the riskiest single piece of the rewrite** — it's silent
+when it goes wrong (loader picks up zeros for missing keys, or refuses to load). Before
+Phase 3 starts, produce an explicit two-column map per draft arch:
+
+| Trainer key | SGLang spec-decoder loader key |
+|---|---|
+| `model.layers.{i}.self_attn.q_a_proj.weight` | _e.g._ `draft_model.layers.{i}.self_attn.q_a_proj.weight` |
+| `model.layers.{i}.self_attn.q_a_layernorm.weight` | ... |
+| `model.layers.{i}.self_attn.q_b_proj.weight` | ... |
+| `model.layers.{i}.self_attn.kv_a_proj_with_mqa.weight` | ... |
+| `model.layers.{i}.self_attn.kv_a_layernorm.weight` | ... |
+| `model.layers.{i}.self_attn.kv_b_proj.weight` | ... |
+| `model.layers.{i}.self_attn.o_proj.weight` | ... |
+| `model.embed_tokens.weight` | ... |
+| `lm_head.weight` | ... |
+| `t2d`, `d2t` (vocab mapping) | ... |
+
+Filling the RHS column requires reading SGLang's current spec-decoding draft loader (the
+`Eagle3*` or `LightseekSpec*` loader, whichever is current in sgl-project/sglang) and
+should be a documented artifact (`docs/export_weight_map_mla.md`), not implicit in code.
+
+### 4.9 FSDP seam (FSDP1 now, FSDP2-ready)
+
+The plan ships on FSDP1 (`SHARD_GRAD_OP`) but `apply_fsdp` is a stable seam from day one,
+gated by `TrainingConfig.fsdp_version`:
+
+```python
+# training/fsdp.py
+def apply_fsdp(model, training_config, wrap_policy=None):
+    if training_config.fsdp_version == 1:
+        return _apply_fsdp1(model, training_config, wrap_policy)
+    elif training_config.fsdp_version == 2:
+        return _apply_fsdp2(model, training_config, wrap_policy)
+    raise ValueError(...)
+```
+
+Rationale: FSDP2 (PT 2.4+) composes much better with `torch.compile` and per-parameter
+sharding (`fully_shard` on individual submodules). The compute-friendly default for the
+next 12 months is FSDP2. Pinning to FSDP1 in the Trainer interface means rewriting again
+once `compile_model: True` becomes the norm. Implementing `_apply_fsdp2` is deferred to
+Phase 7 #31 — the seam is what matters now.
+
+### 4.10 Train-with-decode mode (Phase 5)
+
+W4 from §1 ("Workloads in scope") is a real workload: the same long-lived SGLang server
+simultaneously generates training data and serves real spec-decoding traffic, with the
+trainer pushing freshly-trained draft weights into that server every N steps. The TorchSpec
+implementation does this via Ray actors (`SglEngine.update_weights_from_disk` +
+`controller/loop._maybe_sync_draft_weights`). SpecForge gets the same workload by extending
+the existing `TargetEngine` / `Stream` / `Trainer` interfaces — **no Ray, no Mooncake**.
+
+Three new primitives, all additive to Phase 4 abstractions:
+
+#### (a) `TargetEngine.update_draft_weights` — weight push API
+
+```python
+# models/targets/base.py
+class TargetEngine(ABC):
+    def update_draft_weights(
+        self,
+        weights_path: str | os.PathLike,
+        *,
+        blocking: bool = True,
+        load_format: Literal["pt", "safetensors"] = "safetensors",
+    ) -> dict[str, Any]:
+        """Push new draft weights into a long-lived serving target.
+
+        Default impl raises NotImplementedError. In-process engines (sglang/hf/custom)
+        do not need this — they're torn down with the trainer. Implemented by
+        `SGLangServerEngine`, which forwards to SGLang's
+        `/update_weights_from_disk` endpoint (already present in sglang ≥0.4).
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support live draft weight updates")
+```
+
+`SGLangServerEngine` adds:
+
+```python
+class SGLangServerEngine(TargetEngine):
+    def update_draft_weights(self, weights_path, *, blocking=True, load_format="safetensors"):
+        return self._post_json(
+            "/update_weights_from_disk",
+            {"model_path": str(weights_path), "load_format": load_format},
+        )
+
+    def serving_metrics(self) -> dict[str, float]:
+        """Pull serving-side acceptance rate / queue depth from SGLang.
+
+        Mapped to wandb keys like serving/spec_accept_rate, serving/spec_accept_length.
+        """
+        return self._get_json("/spec_decoding_stats")
+```
+
+The shared filesystem assumption is the same one TorchSpec already lives with: trainer
+saves to a path readable by the SGLang server (NFS, or rank-0 saves and broadcasts the
+path; the server reads from that path).
+
+#### (b) `ServingTrafficStream` — train on real serving prompts (optional)
+
+For pure W4 you can keep using static jsonl with `OnlineStream`/`RemoteStream` — the
+training data has nothing to do with the serving traffic, just the engine is shared. But
+**true on-policy training** wants to sample prompts from real serving traffic. New stream:
+
+```python
+# data/streams/serving_traffic.py
+class ServingTrafficStream(RemoteStream):
+    """RemoteStream variant that pulls prompts from a serving-traffic buffer
+    instead of a static dataset.
+
+    Buffer backends in scope:
+    - file: jsonl tail (simplest; rotated by serving)
+    - redis: list with LPUSH (serving) / BRPOP (this stream)
+    - kafka: topic with consumer group
+
+    Out of scope: anything that requires Ray.
+    """
+    def __init__(
+        self,
+        buffer_uri: str,           # "file:///var/log/sgl/prompts.jsonl"
+                                   # "redis://host:6379/0/serving_prompts"
+        target_engine: SGLangServerEngine,
+        sample_rate: float = 1.0,  # PII-safe rate limiting
+        cold_start_jsonl: Optional[str] = None,  # bootstrap when buffer is empty
+        **kwargs,
+    ): ...
+```
+
+The privacy / PII / sample-rate decisions live with whoever runs the serving cluster,
+**not in the trainer**. Stream just consumes whatever it's pointed at.
+
+#### (c) `Trainer._maybe_sync_draft_weights` — periodic push hook
+
+```python
+# training/trainer.py — addition to the loop in §4.2
+class Trainer:
+    def _maybe_sync_draft_weights(self, step: int) -> None:
+        """Save draft state and call target_engine.update_draft_weights.
+
+        Mirrors TorchSpec's _maybe_sync_draft_weights (controller/loop.py:42-73)
+        but stays in-trainer. No Ray needed because there's exactly one engine
+        to update (one trainer ↔ one serving SGLang).
+        """
+        cfg = self.config.weight_sync
+        if not cfg.enabled or self._target_engine is None:
+            return
+        if (step + 1) % cfg.interval != 0:
+            return
+
+        with rank_0_priority():
+            tmp = Path(cfg.tmp_dir or self.config.checkpoint_dir) / "draft_weight_sync"
+            tmp.mkdir(parents=True, exist_ok=True)
+            self._save_draft_for_serving(tmp)        # FSDP full-state -> safetensors
+
+        # Only rank 0 actually issues the HTTP call; barrier so other ranks wait.
+        if dist.get_rank() == 0:
+            self._target_engine.update_draft_weights(tmp, load_format="safetensors")
+        dist.barrier()
+```
+
+Wired into the existing `_maybe_log / _maybe_eval / _maybe_save` chain. ~30 LOC.
+
+#### (d) Decode-mode `SGLangServerEngine` — server-side config
+
+The serving SGLang must be launched with both prefill+aux capture (for training data
+generation) **and** spec decoding (for serving traffic) enabled simultaneously. This is
+already supported by sglang ≥0.4 via the `--enable-aux-hidden-states` +
+`--enable-spec-training-mooncake=False` (we don't need mooncake) +
+`--enable-cuda-graph=True` combination. `SGLangServerEngine` gets a `decode_mode: bool`
+config flag that simply governs which set of server-args gets validated; it doesn't
+launch the server itself (operations responsibility).
+
+#### Acceptance-rate as a first-class metric
+
+In W1-W3 the relevant metric is `simulated_acc_len` (computed offline from logged
+per-position accuracy). In W4, the **real serving acceptance rate** is available from
+the same SGLang server. The `Trainer.train()` loop calls `target_engine.serving_metrics()`
+on the same cadence as eval and merges into the tracker dict:
+
+```python
+if self.config.weight_sync.report_serving_metrics and step % self.config.eval.interval == 0:
+    sm = self._target_engine.serving_metrics()
+    self.tracker.log({
+        "serving/spec_accept_rate": sm["accept_rate"],
+        "serving/spec_accept_length": sm["accept_length"],
+    }, step=step)
+```
+
+**Why this is sufficient (no Ray, no Mooncake)**:
+
+- One trainer ↔ one server is a hard scope boundary (§8 non-goal). The dispatcher /
+  multi-engine load balancing that TorchSpec's `AsyncInferenceManager` provides isn't
+  needed at this scope.
+- Weight push is HTTP `/update_weights_from_disk`; SGLang already implements this for
+  serving updates, no new server work.
+- Training data path stays identical to W2/W3 — `RemoteStream` /
+  `ServingTrafficStream` produce `TrainBatch` exactly the same way.
+- The trainer has no idea decode mode is on. It just pushes weights and reads metrics.
+
+If profiling later shows that the HTTP weight-push latency itself is a problem (saving +
+loading 100MB-1GB of weights every 500 steps), the optimization is to upgrade
+`update_draft_weights` to accept an in-memory state_dict + zero-copy transfer, again
+without changing the trainer. Same shape as the L2 transport upgrade discussed in §6.
+
+---
+
+## 5. Feature List (Prioritized)
+
+**Ordering note (from review):** the original draft put the unified `Trainer` in Phase 2
+and the `TargetEngine` / `HiddenStateStream` abstractions in Phase 4. That meant Phase 2
+would build the trainer against the *old* `Eagle3TargetModel`/`DFlashTargetModel`
+interface and then Phase 4 would re-plumb it. Reordered so the interfaces (and a single
+in-process implementation of each) land in Phase 2 alongside the trainer; Phase 4 then
+adds new implementations (`SGLangServerEngine`, `RemoteStream`) of stable interfaces
+rather than re-plumbing.
+
+### Phase 1: MLA Draft + Registry (Week 1-2)
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 1 | Draft plugin registry (`@register_draft`) | Every new arch today touches 4 files. This is the single biggest extensibility blocker. | S |
+| 2 | MLA Eagle3 draft (`Eagle3DeepseekV2ForCausalLM`) | The gap for DeepSeek-V3 / Kimi-K2. Port from TorchSpec. Includes MLA-aware KV cache handling via HF `DynamicCache` (no ABC break). | M |
+| 3 | MLA draft configs | `qwen3_8b_eagle3_mla.json`, `kimi_k25_eagle3_mla.json`, `deepseek_v3_671b_eagle3.json` (real MLA, not Llama pretending). | S |
+| 3a | **MLA + TP/SP smoke test** | Validate Yunchang USP and TP slicing on Kimi-K2.5 with asymmetric MLA head dims before declaring Phase 1 done. | S |
+
+**Deliverable**: Train an MLA Eagle3 draft for Qwen3-8B / Kimi-K2.5 using existing `train_eagle3.py`.
+Existing scripts unchanged — registry lives alongside the old `_model_mapping` dicts.
+
+### Phase 2: Interfaces + Trainer + Eval + Checkpoints (Week 3-6)
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 4 | `TargetEngine` protocol + in-process impls | Define the interface up front so the trainer is built against it from day 1. Adapt existing `Eagle3TargetModel` / `DFlashTargetModel` as the initial concrete impls. | M |
+| 5 | `HiddenStateStream` protocol + `OnlineStream` + `OfflineStream` | Same reason — stable abstraction before trainer code is written. `RemoteStream` deferred to Phase 4. | M |
+| 6 | `Trainer` class + `DraftTrainStrategy` protocol | Collapse `train_eagle3.py` and `train_dflash.py`. Stop the script-per-arch sprawl. Trainer consumes `TrainBatch` only — no direct target-model calls. | M |
+| 7 | `Eagle3TTTStrategy` + `DFlashBlockStrategy` | Extract from existing scripts into strategy implementations. Each declares its own `fsdp_wrap_policy()`. | M |
+| 8 | `CheckpointManager` | Rotation (`max_checkpoints`), best tracking, `latest_checkpointed_iteration.txt`, `meta.json`. Must integrate with `stream.seek()` on resume. | S |
+| 9 | `Evaluator` + `EvalCache` | Online eval during training: `simulated_acc_len`, `avg_loss`, `avg_acc`. Per-position acc aggregated across batches before geometric sum. Cache key covers eval/target/tokenizer/template/aux/seqlen. | M |
+| 10 | Gradient accumulation correctness | `model.no_sync()` on non-sync micro-steps, explicit `zero_grad`, `accumulation_steps` in config. Verify by step-time profiling. | S |
+| 11 | `target_layer_ids` as first-class contract | EAGLE3 hardcodes 3 aux layers; DFlash uses a list. Generalize so every draft declares what it needs and the stream materializes accordingly. | S |
+| 12 | FSDP seam (FSDP1 default, FSDP2-ready) | `apply_fsdp` dispatches on `fsdp_version`. FSDP2 impl deferred — but the seam is stable now so the trainer doesn't get rewritten when FSDP2 lands. | S |
+
+**Deliverable**: `Trainer` (no CLI yet — legacy scripts call into it) works for both Eagle3
+and DFlash, using the new interfaces with single in-process target/stream impls. Eval
+metrics logged during training. Best checkpoint auto-saved. Numerical equivalence (§10)
+checked against the pre-refactor scripts.
+
+### Phase 3: Config + Export (Week 7-8)
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 13 | Pydantic config schema | Replace argparse + JSON split with one validated YAML per run. | S-M |
+| 14 | CLI (`specforge train\|prepare\|export\|eval`) | Single entry point. Legacy scripts now become shims that build a `Config` and call `Trainer`. | S |
+| 15 | SGLang export tool | Checkpoint → SGLang spec-decoder layout. **Weight-name map (§4.8) is a documented artifact, finalized before this phase starts.** | M |
+| 16 | HF export tool + vocab pruning | FSDP checkpoint → HF format. Optional vocab pruning by dataset frequency. | S-M |
+
+**Deliverable**: Complete train → eval → export → serve pipeline in one tool. Old MLA
+draft trained in Phase 1 successfully loads in a SGLang server.
+
+### Phase 4: Remote Target + VLM + Parsers (Week 9-11)
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 17 | `SGLangServerEngine` | Target as HTTP service. Unlocks online training against 671B targets on separate GPUs. New impl of the Phase-2 `TargetEngine` interface. | M-H |
+| 18 | `RemoteStream` | Stream backend that talks to `SGLangServerEngine`. `prefetch_factor` + `max_in_flight` back-pressure. | M |
+| 19 | VLM unification | Delete `QwenVLOnlineEagle3Model`. VLM handled via typed `MediaInputs` in `TargetEngine` + data pipeline. | M |
+| 20 | Additional parsers | `KimiK25Parser`, `MiniMaxParser` from TorchSpec. | S |
+
+**Deliverable**: Train Eagle3 for DeepSeek-V3 with the target running on a separate SGLang
+server cluster.
+
+### Phase 5: Train-with-decode (Week 12-14)
+
+W4 from §1 — promoted from Phase 6 because it's a real workload, not a future option. All
+features build on the Phase 4 `SGLangServerEngine` + `RemoteStream` foundation; **no
+trainer / strategy / draft changes**.
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 21 | `TargetEngine.update_draft_weights` | Weight push API on the ABC; default raises NotImplementedError. `SGLangServerEngine` impl forwards to SGLang's `/update_weights_from_disk`. | S |
+| 22 | Decode-mode `SGLangServerEngine` | `decode_mode: bool` config + `serving_metrics()` endpoint. Validates that the server was launched with prefill+aux **and** spec decoding both enabled. | S-M |
+| 23 | `Trainer._maybe_sync_draft_weights` | Periodic push hook in the main loop. ~30 LOC. Save draft state on rank 0 → engine.update_draft_weights → barrier. | S |
+| 24 | `ServingTrafficStream` | Optional stream that pulls prompts from a serving-traffic buffer (file / Redis / Kafka). Subclass of `RemoteStream`; cold-start fallback to a static jsonl. | M |
+| 24a | Acceptance-rate metrics | Trainer reads `serving/spec_accept_rate` + `serving/spec_accept_length` from the engine and logs alongside `eval/simulated_acc_len`. Closes the gap between offline proxy and production reality. | S |
+
+**Deliverable**: A long-lived SGLang server simultaneously serves real spec-decoding
+traffic and produces training data; the trainer pushes draft weights every N steps and
+production acceptance rate trends up over the run, monotonically across `weight_sync_interval`.
+End-to-end smoke test: 1k-step run on a small target, acceptance-rate slope > 0.
+
+### Phase 6: Polish (Week 15-16)
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 25 | Backbone-agnostic DFlash | Factor `DFlashDraftModel` so MLP/Norm/RoPE are parameterized. Currently hardcoded to Qwen3. | S-M |
+| 26 | `torch.compile` support | Optional `compile_model` flag for draft model compilation. | S |
+| 27 | `defer_tokenization` + dynamic loss mask | Tokenize at fetch time, not preprocessing time. Enables dynamic loss masking. | M |
+| 28 | Tokenization disk cache | Cache tokenized datasets keyed by data path + template + max_length. | S |
+| 29 | WSD learning rate scheduler | Warmup-Stable-Decay. Useful for long runs / continued pretraining; defer unless a concrete need surfaces. | S |
+| 30 | Remove legacy `scripts/legacy/` shims | After two minor releases with `DeprecationWarning`. Concrete target: SpecForge 0.X. | S |
+
+### Phase 7: Optional / Future
+
+| # | Feature | Why | Effort |
+|---|---------|-----|--------|
+| 31 | FSDP2 implementation | Fill in `_apply_fsdp2` behind the Phase-2 seam. Required if `torch.compile` becomes default. | M |
+| 32 | Mooncake streaming backend | GPU↔GPU tensor transport for multi-node disaggregation. Only if profiling shows HTTP/gRPC is the bottleneck (T1 trigger, §6). | H |
+| 33 | In-memory `update_draft_weights` | Bypass save-to-disk in W4 weight sync; transfer state_dict directly over a binary channel. Only if 100MB-1GB / N-step push becomes a measurable slowdown. | M |
+| 34 | Multi-job inference pool sharing | Single SGLang cluster amortized across ≥5 concurrent training jobs (T2 trigger, §6). At this point the actor topology becomes worth the complexity. | H |
+| 35 | FA4 attention backend | FlashAttention 4 support for draft attention. | S-M |
+
+---
+
+## 6. Tradeoffs Worth Flagging
+
+### Ray + Mooncake vs HTTP/gRPC
+
+TorchSpec gets a lot from Ray + Mooncake, but they're large dependencies with significant
+operational complexity. For SpecForge, start with HTTP/gRPC to a SGLang server for cross-node
+training — this covers most use cases (target on dedicated GPUs, trainer on others) at a
+fraction of the surface area.
+
+**Train-with-decode (W4) is in scope without Ray.** The TorchSpec value-add from actor
+topology is concentrated in *multi-job inference pool sharing* and *zero-overhead async
+producer-consumer pipelines*. For one-trainer-↔-one-server (which is W4's scope per §8),
+HTTP `/update_weights_from_disk` plus a `ServingTrafficStream` over a Redis/Kafka/file
+buffer is sufficient. See §4.10. Ray actor topology only starts paying off at the T2
+trigger below.
+
+**Triggers that would force a re-evaluation:**
+
+- **T1 — transport bottleneck**: profile shows `last_hidden_states` over JSON/HTTP
+  consumes >30% of step time, with target ≥70B. Response: upgrade `RemoteStream`
+  transport to a binary protocol (gRPC + protobuf, or Mooncake-as-transport).
+  **L1/L3 unchanged.** This is feature #32 in Phase 7.
+
+- **T2 — multi-job inference pool sharing**: ≥5 concurrent training jobs hammering the
+  same 671B target, each tearing the engine up/down is wasteful. Response: introduce
+  Ray actor pool with `AsyncInferenceManager`-style dispatcher. This is the only
+  trigger that genuinely justifies adopting Ray; until then, complexity is pure cost.
+  Feature #34 in Phase 7.
+
+- **T3 — Mooncake transport**: only meaningful after T1; even then, evaluate gRPC
+  binary first. Mooncake's RDMA edge matters for >100GB/s aggregate, which neither W3
+  nor W4 typically hit. Feature #32 in Phase 7.
+
+The bet: 90% of the time we're in W1-W3 territory and the refactor's interface boundaries
+do real work. W4 lands in Phase 5 with ~200 LOC of additive code on those boundaries.
+TorchSpec's full topology is reserved for the day T2 actually fires.
+
+### Plugin registry vs HF AutoModel pattern
+
+HF's "drop in a config JSON" is a nice affordance. Keep both: decorator registry is primary
+for dispatch, HF type dispatch as fallback for configs that specify a known `transformers`
+config class. `AutoDraftModelConfig.from_file()` checks `DRAFT_REGISTRY` by architecture name
+first, falls back to config type mapping.
+
+### Strategy pattern is an indirection
+
+If only EAGLE3 and DFlash ever exist, two scripts are fine. The bet is that Medusa, MTP, or
+hybrid variants will want the same trainer infrastructure — if so, strategies pay off fast.
+If not, the cost is one extra level of dispatch that doesn't hurt readability.
+
+### Pydantic vs OmegaConf
+
+Pydantic gives better validation and serialization. OmegaConf gives effortless YAML merge +
+CLI override (`--training.lr=1e-4`). Options:
+1. **Pydantic + custom CLI overlay** (parse `--key=value` args, `model_validate` from merged dict) — our choice.
+2. OmegaConf + dataclass (TorchSpec's approach).
+3. Pydantic + typer/click for CLI.
+
+We go with (1) because SpecForge already uses Pydantic (`ChatTemplate`) and validation
+matters more than merge ergonomics at this stage. The CLI overlay is ~30 lines of code.
+
+### MLA cache: compressed vs expanded
+
+Two options for KV cache during Eagle3 TTT unroll:
+- **Compressed**: Cache `kv_compressed` (low-rank) + `k_rope_raw`. Saves memory but requires
+  MLA-specific cache logic in `core/eagle3.py`.
+- **Expanded**: Cache full `(K, V)` after projection. More memory but `core/eagle3.py` is
+  architecture-agnostic.
+
+We choose **expanded** (matching TorchSpec). The TTT unroll is typically 5-7 steps with
+short sequences — memory savings from compressed cache are marginal, and keeping
+`core/eagle3.py` architecture-agnostic is worth more.
+
+---
+
+## 7. Migration Path
+
+Each phase ships independently and can be validated without breaking existing users.
+
+### Phase 1 plan
+
+1. Add `models/drafts/__init__.py` with `DRAFT_REGISTRY` and `@register_draft`.
+2. Move `LlamaForCausalLMEagle3` to `models/drafts/llama_eagle3.py`, decorate with
+   `@register_draft("LlamaForCausalLMEagle3")`.
+3. Port `deepseek_eagle.py` from TorchSpec → `models/drafts/deepseek_eagle3.py`, decorate
+   with `@register_draft("Eagle3DeepseekV2ForCausalLM")`.
+4. Update `AutoDraftModelConfig.from_file()` to check `DRAFT_REGISTRY` first.
+5. Update `AutoEagle3DraftModel.from_config()` to check `DRAFT_REGISTRY` first.
+6. Add MLA draft configs (`qwen3_8b_eagle3_mla.json`, `kimi_k25_eagle3_mla.json`).
+7. Keep old `_model_mapping` / `_config_mapping` as fallback — remove later.
+8. Test: train MLA Eagle3 draft using existing `train_eagle3.py` — zero changes to script.
+
+### Phase 2 plan
+
+1. Define `TargetEngine` protocol in `models/targets/base.py`.
+2. Adapt existing `SGLangEagle3TargetModel` → `SGLangTargetEngine` (in-process).
+3. Adapt existing `HFEagle3TargetModel` → `HFTargetEngine`.
+4. Adapt existing `CustomEagle3TargetModel` → `CustomTargetEngine`.
+5. Define `HiddenStateStream` protocol + `OnlineStream` + `OfflineStream`. `seek()` method
+   required for resume correctness. `OnlineStream` exposes `prefetch_factor`.
+6. Create `training/trainer.py` with the `Trainer` class. Trainer consumes `TrainBatch`
+   only, never a target model directly.
+7. Extract `Eagle3TTTStrategy` from `train_eagle3.py` logic. Implement `fsdp_wrap_policy()`.
+8. Extract `DFlashBlockStrategy` from `train_dflash.py` logic. Implement `fsdp_wrap_policy()`.
+9. Add the `apply_fsdp` seam dispatching on `fsdp_version` (FSDP1 only for now).
+10. Implement `CheckpointManager` — `save` / `load` / `update_best` / `_rotate`.
+11. Implement `Evaluator` (per-position acc aggregation across batches) + `EvalCache`
+    (full-key MD5).
+12. Move old scripts to `scripts/legacy/`, create shims that instantiate `Trainer`.
+13. **Numerical equivalence test (§10)**: legacy shim must match the pre-refactor script's
+    loss curve to within tolerance on a fixed seed at steps 100/500/1000. Gate.
+
+### Phase 3 plan
+
+1. Define `config/schema.py` with Pydantic models (Literal-typed enums).
+2. Implement `config/loader.py` (YAML load + CLI override).
+3. Implement `cli.py` (`specforge train|prepare|export|eval`).
+4. Finalize the SGLang weight-name map (`docs/export_weight_map_mla.md`) by reading the
+   current SGLang spec-decoding loader. Block #5 on this.
+5. Implement `export/to_sglang.py` and `export/to_hf.py`.
+6. Mechanically migrate existing JSON configs to YAML with the new schema.
+7. Test: `specforge train --config x.yaml` end-to-end. MLA draft from Phase 1 successfully
+   loads in a SGLang server with non-trivial acceptance rate.
+
+### Phase 4 plan
+
+1. Implement `SGLangServerEngine` (HTTP client to SGLang server). Reuses the Phase-2
+   `TargetEngine` interface — no trainer changes.
+2. Implement `RemoteStream` (`prefetch_factor`, `max_in_flight`). Reuses the Phase-2
+   `HiddenStateStream` interface — no trainer changes.
+3. Add typed `MediaInputs` to `TargetEngine.generate_train_data`.
+4. Delete `QwenVLOnlineEagle3Model`; wire VLM through `MediaInputs` + data pipeline.
+5. Port `KimiK25Parser`, `MiniMaxParser` from TorchSpec.
+6. Test: online training with SGLang server on separate node; results within tolerance of
+   in-process training (same target weights).
+
+### Phase 5 plan
+
+1. Add `update_draft_weights(weights_path, *, blocking, load_format)` to `TargetEngine`
+   ABC with `NotImplementedError` default.
+2. Implement `SGLangServerEngine.update_draft_weights` → POST `/update_weights_from_disk`.
+   Implement `serving_metrics()` → GET `/spec_decoding_stats`.
+3. Add `decode_mode: bool` to `SGLangServerEngine`. Validate that the operator's server
+   was launched with prefill+aux **and** spec decoding both enabled (warn loudly otherwise).
+4. Add `Trainer._maybe_sync_draft_weights(step)` hook between `_maybe_eval` and
+   `_maybe_save`. Save FSDP full-state on rank 0 → call engine update on rank 0 → barrier.
+5. Implement `ServingTrafficStream(RemoteStream)` with file/Redis/Kafka buffer backends
+   and a cold-start jsonl fallback. PII / sample-rate are operator concerns, not
+   trainer concerns.
+6. Wire `serving/spec_accept_rate` and `serving/spec_accept_length` through the existing
+   `Tracker` (every `eval_interval` steps).
+7. **End-to-end test**: 1k-step run with a small target (Qwen3-8B) co-located with a
+   spec-decoding load generator. Acceptance-rate slope across `weight_sync_interval`
+   buckets must be > 0; final acceptance rate must exceed cold-start by ≥ X%
+   (X TBD — set baseline from Phase 4 numbers).
+8. **Weight-sync correctness test (§10.5)**: before/after a sync, the served draft's
+   token-level outputs match the trainer's draft on a 32-prompt fixed eval set within
+   acceptance-rate tolerance.
+
+---
+
+## 8. Non-Goals (Explicit)
+
+- **No Ray dependency.** SpecForge stays torchrun-native, including for train-with-decode (W4).
+- **No Mooncake in Phase 1-6.** HTTP/gRPC to SGLang is sufficient for both disaggregated
+  training (W3) and train-with-decode (W4). Mooncake is gated behind T1/T3 in §6.
+- **No vLLM target backend.** SGLang is primary; HF is the reference. Adding vLLM is possible
+  via the `TargetEngine` interface but not prioritized.
+- **No multi-engine load balancing / multi-job inference pool sharing.** Exactly **one**
+  target engine instance per training job — including in train-with-decode (one trainer
+  ↔ one server). Scaling within a single engine is via SGLang's own scaling (multiple
+  TP workers, replicas behind a single endpoint). Multi-job sharing is gated behind T2
+  in §6 and lands as Phase 7 #34.
+- **No on-policy serving-prompt mining without a buffer.** `ServingTrafficStream` reads
+  from an external buffer (Redis/Kafka/file) populated by the serving cluster; SpecForge
+  does **not** intercept inflight serving requests directly.
+
+---
+
+## 9. Success Criteria
+
+| Phase | Criterion |
+|-------|-----------|
+| 1 | MLA Eagle3 draft trains on Qwen3-8B and converges to comparable loss as Llama draft. Kimi-K2.5 TP/SP smoke test passes. |
+| 2 | Legacy shims (using new `Trainer` internally) match pre-refactor scripts to numerical-equivalence tolerance (§10). Eval metrics agree with manual eval. |
+| 3 | `specforge train --config x.yaml` end-to-end. MLA draft from Phase 1 loads in SGLang and produces non-trivial acceptance rate. |
+| 4 | Online training with 671B target on separate SGLang server; per-step loss within tolerance of in-process baseline using identical target weights. |
+| 5 | **Train-with-decode**: 1k-step run; one long-lived SGLang server simultaneously serves spec-decoding traffic and produces training data; trainer pushes draft weights every `weight_sync_interval`; serving acceptance rate trends up monotonically across sync buckets. Weight-sync correctness gate §10.5 passes. |
+| 6 | DFlash on Llama backbone; tokenization cache cuts data prep time by >50%; legacy shims removed. |
+
+---
+
+## 10. Testing Strategy (gating, not optional)
+
+Every phase that changes the training path must pass a numerical-equivalence gate against
+the immediately prior commit. Treat these as CI requirements, not nice-to-haves —
+behavior-preserving refactors are the most common place silent regressions hide.
+
+### 10.1 Numerical-equivalence gate (Phase 2, 4 critical)
+
+For a fixed seed and a fixed micro-batch sequence (3 batches × 4 samples is enough), the
+new code path must match the old:
+
+| Metric | Tolerance | Steps to check |
+|---|---|---|
+| Per-step training loss | `atol=1e-4, rtol=1e-4` (BF16 master copy) | 0, 1, 100, 500, 1000 |
+| Per-position eval acc (vector of length `ttt_length`) | `atol=1e-3` | end of eval at step 1000 |
+| `simulated_acc_len` | `atol=1e-3` | end of eval at step 1000 |
+| Model state dict (selected keys) | `atol=1e-4` | after step 100 |
+
+The gate run uses: Llama Eagle3 draft, Qwen3-8B target, offline mode, sharegpt eval slice.
+Cheap enough to run on every PR that touches `core/`, `training/`, or `models/drafts/`.
+
+### 10.2 Smoke tests (every phase)
+
+- One config per draft arch (`llama_eagle3`, `deepseek_v3_eagle3`, `qwen3_dflash`) trains
+  for 20 steps without crashing under TP=1, TP=2, and TP=2+SP=2.
+- Checkpoint save + resume produces the same loss curve as no-resume (validates
+  `stream.seek()`).
+- Eval cache miss + hit produce identical metrics (validates the cache key set).
+
+### 10.3 Distributed correctness (Phase 1 + 2)
+
+- MLA + Yunchang USP with `qk_nope_head_dim != qk_rope_head_dim != v_head_dim` on
+  Kimi-K2.5. This is the Phase 1 risk item and must be on the critical path, not the
+  Phase 4 wishlist.
+- Gradient accumulation: confirm one `all_reduce` per `optimizer.step()`, not per
+  `backward()`. Use a NCCL communicator log or `torch.profiler` once.
+
+### 10.4 Export-loop test (Phase 3)
+
+- Train MLA draft for 100 steps, export to SGLang, load in SGLang server, run 32 generation
+  requests. Acceptance rate > 0 (i.e. the loader actually consumed the weights, not zeros).
+  This catches weight-name-map regressions at the integration boundary.
+
+### 10.5 Weight-sync correctness gate (Phase 5)
+
+Every PR that touches `Trainer._maybe_sync_draft_weights`, `SGLangServerEngine.update_draft_weights`,
+or the FSDP-state-save path must pass a parity gate:
+
+| Step | Action | Pass condition |
+|---|---|---|
+| 1 | Train 50 steps; capture trainer-side draft state (full FSDP state dict, broadcast to rank 0). | — |
+| 2 | Call `Trainer._maybe_sync_draft_weights(50)`. | Engine returns 200; serving SGLang reports `update_weights/success=True`. |
+| 3 | Run 32 fixed-seed prompts through both: (a) trainer's local draft (offline-style forward), (b) the now-updated serving SGLang. | Logits agree to `atol=1e-2, rtol=1e-2` (allowing for kernel diffs between training and serving stacks). |
+| 4 | Compare serving acceptance rate over 256 prompts before vs after sync. | Acceptance rate **non-decreasing**; if 50 training steps moved the loss meaningfully, acceptance rate strictly increases. |
+
+The gate fails if any of: (i) the HTTP push silently 200-no-ops, (ii) the serving stack
+loaded a corrupt or partial state dict, (iii) FSDP state-dict gather missed a parameter.
+This is the train-with-decode analog of the §10.4 export-loop test.
+
+### 10.6 Long-run weight-sync soak (Phase 5, optional)
+
+- 1k-step run with `weight_sync_interval=100`. Bucket serving acceptance rate by
+  100-step windows; the slope across buckets must be monotonically non-decreasing
+  (allowing one regression bucket per 10 — to absorb rare unlucky prompt batches).
+- Watches for: (a) silent weight push failures (acceptance rate would plateau),
+  (b) draft drift due to incorrect FSDP gather, (c) serving-side OOM that quietly
+  rolls back to old weights.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,56 @@
+# SpecForge Roadmap
+
+The consolidated, phase-by-phase roadmap behind [`../../plan.md`](../../plan.md) (the reconciled
+architecture). It **folds in** the former online-disaggregation roadmap PR (#618) so there is one
+roadmap home. Each track doc gives, per phase: **Goal / Target state / Implementation
+(files + symbols) / Tests / Done-when**.
+
+## Standing decisions (apply across all tracks)
+- **Substrate is canonical.** `SampleRef` (metadata, control plane; `assert_no_tensors`) +
+  `FeatureStore` (tensors: Local/SharedDir/Mooncake) + `FeatureDataLoader` → `TrainBatch`. There is
+  **no separate `HiddenStateStream`** source of truth — the loader *is* the stream; online/offline/
+  disaggregated vary only in (ref source + `FeatureStore`), shielded from training.
+- **Frozen target, no weight sync.** "Train-with-decode" = a **frozen** target streams hidden
+  states over a **fixed** prompt set; the draft is not in the generation loop. Weight-sync /
+  hot draft-update / weight-version registry / staleness gate / on-policy are **out of scope**;
+  `draft_weight_version` is kept **only as provenance**.
+- **Ray is OPEN.** A *candidate* for the O2 scale-out orchestration layer — likely needed for
+  multi-node N-producer/M-trainer scale-out — but **not committed and not a non-goal**. See the
+  decision gate in [online-disaggregation.md](./online-disaggregation.md) §O2.
+- **Keep the runtime training seam** (`TrainerCore` / `DraftTrainStrategy` / `TrainingBackend` +
+  `StepContext`); a domain `Trainer` + managers *wrap* it, they do not replace it.
+
+## Tracks
+| Track | Doc | Scope |
+|---|---|---|
+| Domain / architecture | [domain-refactor.md](./domain-refactor.md) | Strategy/registry, `TargetEngine`, domain `Trainer` + managers, drafts registry, config/CLI/export |
+| Online disaggregation | [online-disaggregation.md](./online-disaggregation.md) | Live frozen-target generation, cross-process control plane, scale-out (Ray = open), hardening |
+| Eval & breadth | [eval-and-breadth.md](./eval-and-breadth.md) | Acceptance-length eval harness; new algorithms = a `StrategySpec` + loss |
+
+## Phase status at a glance
+| Phase | Track | Size | Status |
+|---|---|---|---|
+| A — Composable launch | domain | L | **done / in review** (#627/#628/#629) |
+| O1.1 — Shared cross-process control plane | online | M | in review (~#624) |
+| O1.2 — Async streaming loop + one-process builder | online | M | in review (~#625) |
+| B — Domain abstractions (`TargetEngine` + `Trainer`) | domain | L | next |
+| O1.3 — Live SGLang-server hidden-state capture | online | L | next (🔴 spike gates it) |
+| E1 — Acceptance-length eval harness | eval | M | next |
+| C — Colocated lightweight path | domain | M | later |
+| D — Training managers (no_sync / resume / ckpt / eval) | domain | L | later |
+| E — Composition & run surface (drafts registry, config/CLI, export) | domain | L | later |
+| O2 — Scale-out orchestration (Ray = open) | online | L | later |
+| O3 — Hardening (RDMA pool, restart, observability) | online | L | later |
+| E2 — Algorithm breadth (MTP/…) | eval | L | later |
+
+## Dependencies (cross-track)
+```
+domain:  A(done) ─┬─▶ B ─┬─▶ C
+                  │       └─▶ D ─▶ E
+                  └─▶ B.TargetEngine ─────────────┐
+online:  O1.1(review) ─▶ O1.2(review) ─▶ O1.3 ◀───┘ ─▶ O2(Ray=open) ─▶ O3
+eval:    E1 ─▶ E2          (parallel / orthogonal to both tracks)
+```
+- Domain **B** (`TargetEngine`) unblocks online **O1.3** (a real `SGLangServerEngine` capture
+  backend), so it is the highest-leverage next domain step.
+- **E1**'s `Evaluator` is the same one domain **D** wires into the trainer loop — build once.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -30,7 +30,7 @@ roadmap home. Each track doc gives, per phase: **Goal / Target state / Implement
 ## Phase status at a glance
 | Phase | Track | Size | Status |
 |---|---|---|---|
-| A — Composable launch | domain | L | **done / in review** (#627/#628/#629) |
+| A — Composable launch | domain | L | **in review** (#627/#628/#629) |
 | O1.1 — Shared cross-process control plane | online | M | in review (~#624) |
 | O1.2 — Async streaming loop + one-process builder | online | M | in review (~#625) |
 | B — Domain abstractions (`TargetEngine` + `Trainer`) | domain | L | next |
@@ -45,7 +45,7 @@ roadmap home. Each track doc gives, per phase: **Goal / Target state / Implement
 
 ## Dependencies (cross-track)
 ```
-domain:  A(done) ─┬─▶ B ─┬─▶ C
+domain:  A(rev.) ─┬─▶ B ─┬─▶ C
                   │       └─▶ D ─▶ E
                   └─▶ B.TargetEngine ─────────────┐
 online:  O1.1(review) ─▶ O1.2(review) ─▶ O1.3 ◀───┘ ─▶ O2(Ray=open) ─▶ O3

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -17,8 +17,17 @@ roadmap home. Each track doc gives, per phase: **Goal / Target state / Implement
 - **Ray is OPEN.** A *candidate* for the O2 scale-out orchestration layer — likely needed for
   multi-node N-producer/M-trainer scale-out — but **not committed and not a non-goal**. See the
   decision gate in [online-disaggregation.md](./online-disaggregation.md) §O2.
-- **Keep the runtime training seam** (`TrainerCore` / `DraftTrainStrategy` / `TrainingBackend` +
-  `StepContext`); a domain `Trainer` + managers *wrap* it, they do not replace it.
+- **Preserve the training seam** (`TrainerCore` / `DraftTrainStrategy` / `TrainingBackend` +
+  `StepContext`); a domain `Trainer` + managers *wrap* it, they do not replace it. It is relocated
+  **intact** (not rewritten) from `runtime/training` to top-level `training/` in the move-only
+  step `E0` — see [domain-refactor.md](./domain-refactor.md).
+- **One implementation home per concern; `runtime/` is substrate-only.** `runtime/` holds only the
+  DataFlow spine (`control_plane` + `data_plane` + `contracts`). All training-execution code lives
+  in top-level `training/`, all rollout/capture-execution code in top-level `inference/`, and
+  `modeling/` holds model definitions only (no orchestration, no capture factory). **New code is
+  born in its final home** — the Phase-D managers land directly in `training/`, never deeper in
+  `runtime/`; the existing seam and target engine are relocated once, in `E0`. There is **no facade
+  package**.
 
 ## Tracks
 | Track | Doc | Scope |
@@ -38,6 +47,7 @@ roadmap home. Each track doc gives, per phase: **Goal / Target state / Implement
 | E1 — Acceptance-length eval harness | eval | M | next |
 | C — Colocated lightweight path | domain | M | later |
 | D — Training managers (no_sync / resume / ckpt / eval) | domain | L | later |
+| E0 — Layout consolidation (move-only: seam + target engine → top-level homes) | domain | M | later (front of E) |
 | E — Composition & run surface (drafts registry, config/CLI, export) | domain | L | later |
 | O2 — Scale-out orchestration (Ray = open) | online | L | later |
 | O3 — Hardening (RDMA pool, restart, observability) | online | L | later |
@@ -46,7 +56,7 @@ roadmap home. Each track doc gives, per phase: **Goal / Target state / Implement
 ## Dependencies (cross-track)
 ```
 domain:  A(rev.) ─┬─▶ B ─┬─▶ C
-                  │       └─▶ D ─▶ E
+                  │       └─▶ D ─▶ E0 ─▶ E
                   └─▶ B.TargetEngine ─────────────┐
 online:  O1.1(review) ─▶ O1.2(review) ─▶ O1.3 ◀───┘ ─▶ O2(Ray=open) ─▶ O3
 eval:    E1 ─▶ E2          (parallel / orthogonal to both tracks)

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -1,0 +1,214 @@
+# Domain / Architecture Refactor Track
+
+This is the **domain/architecture** track — making the runtime support multiple
+draft algorithms (eagle3 / dflash / domino / future) and a real product surface,
+*orthogonal* to the online-disaggregation scale-out work in
+[./online-disaggregation.md](./online-disaggregation.md). It builds on the
+canonical substrate (SampleRef + FeatureStore + FeatureDataLoader → TrainBatch),
+keeps the runtime training seam (`TrainerCore` / `DraftTrainStrategy` /
+`TrainingBackend` + `StepContext`) and only *wraps* it with domain objects. The
+online target is FROZEN — there is **no** weight-sync, no `HiddenStateStream`
+source of truth, and `draft_weight_version` survives only as provenance metadata.
+Sibling tracks: [./online-disaggregation.md](./online-disaggregation.md),
+[./eval-and-breadth.md](./eval-and-breadth.md). Top-level plan:
+[../../plan.md](../../plan.md) (the detailed §4.2–4.8 sketches this track lands
+incrementally are mirrored in [../redesign-draft-legacy.md](../redesign-draft-legacy.md)).
+
+**Dependency order:** A (done) → B → {C, D} → E. B's `TargetEngine` extraction
+also unblocks the online O1.3 multi-backend producer in
+[./online-disaggregation.md](./online-disaggregation.md).
+
+---
+
+### A — Composable launch · size L · GPU · status: done (in review, PRs #627/#628/#629)
+- **Goal** One strategy-parameterized launch path so adding an algorithm is a
+  registry entry, not a new `build_*` family — and so a schedule-dependent loss
+  (domino) flows through the same `TrainerCore`.
+- **Target state** `eagle3`, `dflash`, `domino` all run end-to-end (offline +
+  online) through a single set of topology builders that take `strategy=` and
+  resolve a `StrategySpec`. `launch.py` grows as `topologies + one spec per
+  model`, never `topologies × models`.
+- **Implementation** (landed)
+  - `training/registry.py` — `StrategySpec` dataclass + `register_strategy` /
+    `resolve_strategy` / `available_strategies`; one entry each for `eagle3`,
+    `dflash`, `domino`. Each spec carries `make_strategy`, `required_features`,
+    the offline reader/transform/collate triple + `offline_target_repr`, the
+    online collate (`concat_collate`), and `make_adapter` (None ⇒ default
+    `SGLangAdapter`).
+  - `launch.py` — `_assemble_trainer` / `_offline_io` / `_assemble_rollout_workers`
+    plus topology builders `build_offline_runtime`, `build_disagg_offline_runtime`,
+    `build_online_runtime`, `build_disagg_online_{producer,consumer,runtime}`;
+    every one resolves the spec. Legacy `build_*_eagle3_*` names are kept as
+    aliases.
+  - `training/strategy.py` — `DraftTrainStrategy` ABC + `Eagle3TrainStrategy`,
+    `DFlashTrainStrategy`, `DominoTrainStrategy`; `StepContext`
+    (`global_step` / `total_steps`) is threaded into `forward_loss` so domino's
+    `_lambda_base` decay reads the schedule without ad-hoc kwargs on the model
+    forward.
+  - `inference/dflash_adapter.py` — `DFlashAdapter` over `generate_dflash_data`,
+    emitting the `{input_ids, hidden_states, loss_mask}` schema (no
+    `_project_target` / `t2d`); domino reuses it.
+- **Tests / gates** `tests/test_runtime/` incl. `test_dflash_launch.py`,
+  `test_dflash_online_launch.py`; full suite **197 tests/test_runtime green on
+  H200**.
+- **Done when** All three strategies run offline + online via the one parameterized
+  path with the suite green (DONE; in review).
+
+---
+
+### B — Domain abstractions · size L · GPU · status: next
+- **Goal** De-EAGLE3 the target boundary and give the runtime a domain `Trainer`
+  that *wraps* (does not replace) the runtime controller, so the architecture
+  reads in product terms while the seam stays intact.
+- **Target state** A backend-agnostic `TargetEngine` ABC sits where the
+  EAGLE3-named `Eagle3TargetModel` is today; `hf` / `sglang` / `sglang_server` /
+  `custom` are interchangeable backends behind it. A domain `Trainer` is the
+  caller-facing object; under it the `TrainerController` / `TrainerCore` /
+  `DraftTrainStrategy` / `TrainingBackend` seam is byte-for-byte unchanged. The
+  `FeatureSource` Protocol in `rollout_worker.py` stays the worker's only
+  contract. **No `HiddenStateStream`** — `FeatureDataLoader` over
+  SampleRef+FeatureStore *is* the stream.
+- **Implementation**
+  1. Extract `TargetEngine` (ABC) from
+     `specforge/modeling/target/eagle3_target_model.py:79` (`Eagle3TargetModel`).
+     De-EAGLE3 the names: the ABC's extraction method becomes a generic
+     `generate_features(...)`-style capture call with EAGLE3 specifics
+     (`generate_eagle3_data`, `aux_hidden_states_layers`,
+     `set_aux_hidden_states_layers`) moved into an `Eagle3TargetEngine` subclass;
+     `DFlashTargetModel` (`dflash_target_model.py:33`, `set_capture_layers`)
+     becomes a sibling subclass. Keep `get_eagle3_target_model(backend=...)`
+     working as a thin shim during migration, then rename to a generic factory.
+  2. Add an explicit `backend` attribute on each engine (today `SGLangAdapter.health`
+     / `DFlashAdapter.health` read `getattr(target_model, "backend", "unknown")`
+     — make it real), and add the `sglang_server` backend branch to the factory
+     (currently only `sglang` / `hf` / `custom`).
+  3. Keep the adapters (`SGLangAdapter`, `DFlashAdapter`) as the
+     `FeatureSource` implementations over the engine; nothing in
+     `rollout_worker.py` changes — its `FeatureSource` Protocol
+     (`generate_features(tasks, *, capture)`) is already the seam.
+  4. Introduce a domain `Trainer` (new `training/` module) that composes
+     `resolve_strategy` → `FSDPTrainingBackend` → `TrainerCore` →
+     `TrainerController` (exactly what `launch._assemble_trainer` wires today)
+     behind one object, and calls `.fit()`. The controller/core seam is wrapped,
+     not edited.
+- **Tests / gates** **Byte-identical batches and loss vs the pre-refactor run**
+  for all three strategies (snapshot the first-N `TrainBatch.tensors` digests +
+  per-step loss before refactor, assert equality after). `tests/test_runtime/`
+  stays green; add a `TargetEngine` backend-parity test (hf vs sglang produce the
+  same captured features on a fixed prompt set).
+- **Done when** The EAGLE3 name no longer appears in the target ABC or the
+  trainer-facing API, `sglang_server` is selectable, and the byte-identical gate
+  passes.
+
+---
+
+### C — Colocated lightweight path · size M · CPU · status: later
+- **Goal** Make colocated runs (W1/W2) pay nothing for the disagg control plane,
+  on the *same* code path — not a fork.
+- **Target state** One canonical path. For colocated, the control plane is
+  opt-in / no-op: `LocalFeatureStore` over `mem://`, no SQLite metadata store, no
+  lease / ack / backpressure. Online / offline / disagg differ only in (ref
+  source + FeatureStore), shielded from training.
+- **Implementation**
+  - `control_plane/` — make the metadata store (`metadata_store.py`), leasing
+    (`controller.py`), and backpressure (`backpressure.py`) selectable as no-op
+    implementations rather than required collaborators. Drive the choice from a
+    `DeploymentMode` (`contracts.py` already defines
+    `local_colocated` / `dataflow_colocated` / `disaggregated`).
+  - `launch.py` — in the colocated builders, pass the no-op control plane and the
+    `mem://` `LocalFeatureStore` (`data_plane/feature_store.py`); the
+    `TrainerController.ack_fn` is `None` (already supported — the loader is
+    assumed to ack) so the durable ack transaction is skipped.
+  - Keep the trainer/loader code identical between colocated and disagg.
+- **Tests / gates** A **colocated == disagg numerical-equivalence gate**: same
+  seed + fixed prompt set produce identical loss curves whether run through the
+  no-op colocated control plane or the full disagg control plane.
+- **Done when** Colocated runs with zero SQLite/lease/ack/backpressure overhead
+  and the equivalence gate is green.
+
+---
+
+### D — Training managers · size L · GPU · status: later
+- **Goal** Bring the training loop up to production parity: real grad
+  accumulation, full resume, checkpoint lifecycle, and an evaluator — the pieces
+  `runtime/training` does not have yet.
+- **Target state**
+  - **Grad accumulation with `no_sync()`.** Today `runtime/training` has ZERO of
+    this: `TrainerCore` honors `accumulation_steps` for the optimizer boundary,
+    but `FSDPTrainingBackend.backward` is a bare `loss.backward()`, so FSDP
+    all-reduces gradients **every micro-step**. Add `no_sync()` over the
+    non-boundary micro-steps so the reduction fires once per optimizer step.
+  - **Full resume.** `TrainerController.save_checkpoint` persists only
+    `draft_state_dict` + step/epoch; `FSDPTrainingBackend.load_state_dict` only
+    half-loads the optimizer. Add optimizer + LR-scheduler + RNG state to the
+    saved/loaded state so a resumed run is bit-continuous.
+  - **CheckpointManager** — rotation (keep-last-N), `best` (by eval metric) and
+    `latest` symlinks; owns the `output_dir` layout the controller writes today.
+  - **Evaluator** — `simulated_acc_len` and per-position acceptance, with
+    per-position accuracy aggregated **before** the geometric sum (the eagle3
+    `acces` / `acc_corrects` / `acc_denoms` already flow through
+    `StepOutput.metrics`; `TrainerController.evaluate` currently just means
+    scalar metrics, which is wrong for acc-len).
+- **Implementation**
+  - `training/backend.py` — `FSDPTrainingBackend.backward(loss, *, is_boundary)`
+    wrapping `self.module.no_sync()` on non-boundary micro-steps; extend
+    `state_dict` / `load_state_dict` to round-trip optimizer + scheduler + RNG.
+  - `training/trainer.py` — `TrainerCore` passes the boundary flag into
+    `backward`; `TrainerController` gains scheduler stepping and a real
+    `evaluate` that aggregates per-position correct/denom across batches before
+    computing acc-len. Replace the inline `save_checkpoint` body with a
+    `CheckpointManager`.
+  - New `training/checkpoint.py` (`CheckpointManager`) and `eval/evaluator.py`
+    (`Evaluator`) — see [../../plan.md](../../plan.md) §4 (`training/checkpoint.py`,
+    `eval/evaluator.py`, `eval/cache.py`).
+- **Tests / gates** `tests/test_runtime/test_checkpoint_resume.py` extended to
+  assert loss-curve continuity across a save→resume boundary (optimizer + RNG);
+  a `no_sync` gate asserting one all-reduce per optimizer step (and identical
+  grads to per-step reduction); an evaluator test asserting per-position
+  aggregation precedes the geometric sum.
+- **Done when** A run can be killed and resumed bit-continuously, accumulation
+  reduces once per optimizer step, checkpoints rotate with best/latest, and the
+  evaluator reports correct `simulated_acc_len`.
+
+---
+
+### E — Composition & run surface · size L · GPU · status: later
+- **Goal** A real product surface: a draft-architecture registry (separate axis
+  from the strategy registry), MLA Eagle3, a typed config + CLI, and exporters.
+- **Target state**
+  - **`DRAFT_REGISTRY` / `@register_draft`** for draft *architecture* classes
+    (`models/drafts/`), a **distinct axis** from the per-algorithm strategy
+    registry. Today there is neither: draft model classes live ungoverned in
+    `specforge/modeling/draft/` (`base.py`, `dflash.py`, `llama3_eagle.py`,
+    `flex_attention.py`) and `StrategySpec` lives in `training/registry.py`.
+    Converge today's `StrategySpec` into a `training/strategies/` package so the
+    two registries (architecture vs algorithm) are cleanly separate.
+  - **MLA Eagle3 draft** — an MLA-attention draft architecture registered via
+    `@register_draft`.
+  - **Pydantic config + `specforge` CLI** — a typed run config (Pydantic is
+    already a dep in `pyproject.toml`) replacing the argparse-style launch knobs;
+    a console-script entry point that builds the config and calls the domain
+    `Trainer` (from B).
+  - **Exporters** — `export/to_sglang` (with a documented MLA weight-name map)
+    and `export/to_hf`.
+- **Implementation**
+  - `models/drafts/__init__.py` (new) — `DRAFT_REGISTRY` + `register_draft`
+    decorator; register the existing eagle3 / dflash drafts and the new MLA
+    eagle3 draft. See [../../plan.md](../../plan.md) §4.2 (`models/drafts/…`).
+  - `training/strategies/` (new package) — move the `StrategySpec` registry here;
+    keep `register_strategy` / `resolve_strategy` import-compatible.
+  - `config/schema.py` (new) — Pydantic config; `specforge` CLI entry in
+    `pyproject.toml` `[project.scripts]`. See [../../plan.md](../../plan.md)
+    §4.6 (`config/schema.py`).
+  - `export/to_sglang.py`, `export/to_hf.py` (new) — exporters + the MLA
+    weight-name map. See [../../plan.md](../../plan.md) §4 (`export/to_sglang.py`).
+  - Detailed sketches for all of the above are in
+    [../redesign-draft-legacy.md](../redesign-draft-legacy.md) (legacy redesign
+    draft §4.2–4.8).
+- **Tests / gates** A round-trip export test (train → `to_sglang` → load in
+  sglang serving → speculative decode runs); a `to_hf` load test; an MLA-eagle3
+  draft training smoke test; a CLI/config test (config parses → builds the same
+  `Trainer` the programmatic path does).
+- **Done when** A user trains via `specforge <config>`, registers a new draft
+  architecture with `@register_draft`, trains an MLA Eagle3 draft, and exports a
+  checkpoint that loads in both sglang and HF.

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -125,11 +125,23 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
     `TrainerController.ack_fn` is `None` (already supported — the loader is
     assumed to ack) so the durable ack transaction is skipped.
   - Keep the trainer/loader code identical between colocated and disagg.
+- **Scope note (as landed, #636)** The no-op axis is the *(metadata store +
+  durable-ack transaction)* — the pieces with real I/O/txn cost. Prompt leasing
+  and the in-process `SampleRefQueue` bookkeeping stay shared across modes
+  (single-process lock-guarded dict/deque ops, no I/O; forking them per mode
+  would reintroduce the divergence this phase removes), and backpressure was
+  already opt-in (`None` default) everywhere. Consequences of a store that
+  retains nothing are documented on `NoOpMetadataStore` (`status()` counts read
+  0; no `TrainLease` ref reconstruction). `deployment_mode` is selectable on the
+  offline builder; the colocated ONLINE builder stays pinned to
+  `local_colocated` because its rank-private queue is fed by commit dedup — a
+  shared durable store there belongs to the disagg online builders.
 - **Tests / gates** A **colocated == disagg numerical-equivalence gate**: same
-  seed + fixed prompt set produce identical loss curves whether run through the
-  no-op colocated control plane or the full disagg control plane.
-- **Done when** Colocated runs with zero SQLite/lease/ack/backpressure overhead
-  and the equivalence gate is green.
+  seed + fixed feature set produce bit-identical loss curves through the one
+  builder (`build_offline_runtime(deployment_mode=...)`), no-op colocated plane
+  vs full disagg plane over SQLite, with the durable ack marker asserted.
+- **Done when** Colocated runs with zero metadata-store/durable-ack overhead
+  (leasing/backpressure per the scope note) and the equivalence gate is green.
 
 ---
 
@@ -145,8 +157,15 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
     non-boundary micro-steps so the reduction fires once per optimizer step.
   - **Full resume.** `TrainerController.save_checkpoint` persists only
     `draft_state_dict` + step/epoch; `FSDPTrainingBackend.load_state_dict` only
-    half-loads the optimizer. Add optimizer + LR-scheduler + RNG state to the
-    saved/loaded state so a resumed run is bit-continuous.
+    half-loads the optimizer. Add optimizer + LR-scheduler + RNG state — per
+    rank (they are FSDP-shard-local) — plus the mid-epoch data position, and a
+    seek()-equivalent on the offline stream, so a resumed run continues on the
+    same data with the same state. *Continuity precision (as landed, #637):*
+    draft weights restore bit-for-bit and the data stream repositions exactly;
+    the loss curve is tolerance-continuous, not bit-exact, because
+    `BF16Optimizer` rebuilds its fp32 master from the persisted bf16 weights
+    (matches the legacy trainer; persisting the master would change the
+    optimizer itself and is out of scope here).
   - **CheckpointManager** — rotation (keep-last-N), `best` (by eval metric) and
     `latest` symlinks; owns the `output_dir` layout the controller writes today.
   - **Evaluator** — `simulated_acc_len` and per-position acceptance, with
@@ -171,9 +190,11 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
   a `no_sync` gate asserting one all-reduce per optimizer step (and identical
   grads to per-step reduction); an evaluator test asserting per-position
   aggregation precedes the geometric sum.
-- **Done when** A run can be killed and resumed bit-continuously, accumulation
-  reduces once per optimizer step, checkpoints rotate with best/latest, and the
-  evaluator reports correct `simulated_acc_len`.
+- **Done when** A run can be killed and resumed continuously (weights + data
+  position exact; loss within the documented bf16 fp32-master tolerance) at the
+  same world size, accumulation reduces once per optimizer step, checkpoints
+  rotate with best/latest surviving restarts, and the evaluator reports correct
+  `simulated_acc_len` with all metrics DP-reduced.
 
 ---
 

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -14,13 +14,13 @@ Sibling tracks: [./online-disaggregation.md](./online-disaggregation.md),
 [../../plan.md](../../plan.md) (the detailed §4.2–4.8 sketches this track lands
 incrementally are mirrored in [../redesign-draft-legacy.md](../redesign-draft-legacy.md)).
 
-**Dependency order:** A (done) → B → {C, D} → E. B's `TargetEngine` extraction
-also unblocks the online O1.3 multi-backend producer in
+**Dependency order:** A (in review) → B → {C, D}; D → E (C is parallel — not a prerequisite of
+E). B's `TargetEngine` extraction also unblocks the online O1.3 multi-backend producer in
 [./online-disaggregation.md](./online-disaggregation.md).
 
 ---
 
-### A — Composable launch · size L · GPU · status: done (in review, PRs #627/#628/#629)
+### A — Composable launch · size L · GPU · status: in review (PRs #627/#628/#629, validated)
 - **Goal** One strategy-parameterized launch path so adding an algorithm is a
   registry entry, not a new `build_*` family — and so a schedule-dependent loss
   (domino) flows through the same `TrainerCore`.
@@ -52,7 +52,7 @@ also unblocks the online O1.3 multi-backend producer in
   `test_dflash_online_launch.py`; full suite **197 tests/test_runtime green on
   H200**.
 - **Done when** All three strategies run offline + online via the one parameterized
-  path with the suite green (DONE; in review).
+  path with the suite green (validated, in review).
 
 ---
 
@@ -81,7 +81,11 @@ also unblocks the online O1.3 multi-backend producer in
   2. Add an explicit `backend` attribute on each engine (today `SGLangAdapter.health`
      / `DFlashAdapter.health` read `getattr(target_model, "backend", "unknown")`
      — make it real), and add the `sglang_server` backend branch to the factory
-     (currently only `sglang` / `hf` / `custom`).
+     (currently only `sglang` / `hf` / `custom`). The *depth* of this `sglang_server`
+     branch is informed by the O1.3 capture spike (see
+     [online-disaggregation.md](./online-disaggregation.md) §O1.3): the de-EAGLE3
+     extraction (step 1) and the domain `Trainer` carry no engine risk and can land
+     regardless of the spike's outcome — only the live-server capture backend does.
   3. Keep the adapters (`SGLangAdapter`, `DFlashAdapter`) as the
      `FeatureSource` implementations over the engine; nothing in
      `rollout_worker.py` changes — its `FeatureSource` Protocol

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -14,9 +14,10 @@ Sibling tracks: [./online-disaggregation.md](./online-disaggregation.md),
 [../../plan.md](../../plan.md) (the detailed §4.2–4.8 sketches this track lands
 incrementally are mirrored in [../redesign-draft-legacy.md](../redesign-draft-legacy.md)).
 
-**Dependency order:** A (in review) → B → {C, D}; D → E (C is parallel — not a prerequisite of
-E). B's `TargetEngine` extraction also unblocks the online O1.3 multi-backend producer in
-[./online-disaggregation.md](./online-disaggregation.md).
+**Dependency order:** A (in review) → B → {C, D}; D → E0 → E (C is parallel — not a prerequisite
+of E). `E0` is a move-only layout consolidation (zero functional change) that runs at the front of
+E so E's composition work lands in the final layout. B's `TargetEngine` extraction also unblocks
+the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-disaggregation.md).
 
 ---
 
@@ -176,17 +177,63 @@ E). B's `TargetEngine` extraction also unblocks the online O1.3 multi-backend pr
 
 ---
 
-### E — Composition & run surface · size L · GPU · status: later
-- **Goal** A real product surface: a draft-architecture registry (separate axis
-  from the strategy registry), MLA Eagle3, a typed config + CLI, and exporters.
+### E0 — Layout consolidation (move-only) · size M · CPU · status: later (front of E)
+- **Goal** Collapse the scattered execution code into **one implementation home per concern** with
+  **zero functional change**, so E's composition work is written in the final layout rather than
+  re-moved afterward. This is the §2.3 target tree in [../../plan.md](../../plan.md): `runtime/` =
+  substrate only; top-level `training/` and `inference/` are the single execution homes; `modeling/`
+  is model definitions only; no facade package.
+- **Target state** `runtime/` contains only `contracts.py` + `control_plane/` + `data_plane/`.
+  Every training symbol resolves from top-level `training/`, every rollout/capture symbol from
+  top-level `inference/`.
+- **Implementation** — pure `git mv` + import fixes, one reviewable **rename-only** diff:
+
+  | From (today) | To (consolidated) |
+  |---|---|
+  | `runtime/training/trainer.py` (`TrainerCore`+`TrainerController`) | `training/controller.py` (kept as one file — not split) |
+  | `runtime/training/backend.py` | `training/backend.py` |
+  | `runtime/training/strategy.py` | `training/strategies/base.py` |
+  | `runtime/training/registry.py` | `training/strategies/registry.py` |
+  | `specforge/training/trainer.py` (B3 domain `Trainer`) | stays `training/trainer.py` |
+  | `modeling/target/base.py` · `factory.py` | `inference/target_engine/base.py` · `factory.py` |
+  | `modeling/target/{eagle3,dflash}_target_model.py` | `inference/target_engine/` (relocated as-is; **collapsed to per-backend engines in E, not here**) |
+  | `modeling/target/sglang_backend/capture.py` | `inference/target_engine/sglang_capture_backend.py` |
+  | `runtime/inference/rollout_worker.py` · `capture.py` | `inference/rollout_worker.py` · `capture.py` |
+  | `runtime/inference/{sglang,dflash}_adapter.py` | `inference/adapters/{eagle3,dflash}.py` |
+  | `runtime/launch.py` | `launch.py` (top-level; topology assembly only) |
+  | `modeling/target/{target_head.py, custom_backend/}` | **stays** in `modeling/target/` (model defs) |
+
+  Keep import shims at the old module paths for one release (re-export from the new location) so
+  in-flight branches and legacy scripts don't break.
+- **Tests / gates** The full `tests/test_runtime` suite stays green **unchanged** (only import paths
+  move); the Phase-B byte-identical gate (`test_phase_b_gate.py`) still passes bit-for-bit — a
+  move-only change must not alter a single tensor or loss value.
+- **Done when** `runtime/` is substrate-only (`contracts.py` + `control_plane/` + `data_plane/`);
+  every training/inference symbol resolves from its top-level home; suite + B-gate green; no
+  functional diff.
+
+---
+
+### E — Composition & run surface · size L · GPU · status: later (after E0)
+- **Goal** A real product surface, built **on the consolidated layout from `E0`**: a
+  draft-architecture registry (separate axis from the strategy registry), the (algorithm × backend)
+  target-engine collapse, MLA Eagle3, a typed config + CLI, and exporters.
 - **Target state**
   - **`DRAFT_REGISTRY` / `@register_draft`** for draft *architecture* classes
-    (`models/drafts/`), a **distinct axis** from the per-algorithm strategy
+    (`modeling/draft/`), a **distinct axis** from the per-algorithm strategy
     registry. Today there is neither: draft model classes live ungoverned in
     `specforge/modeling/draft/` (`base.py`, `dflash.py`, `llama3_eagle.py`,
-    `flex_attention.py`) and `StrategySpec` lives in `training/registry.py`.
-    Converge today's `StrategySpec` into a `training/strategies/` package so the
-    two registries (architecture vs algorithm) are cleanly separate.
+    `flex_attention.py`). Add a `modeling/draft/registry.py`; the strategy registry stays in
+    top-level `training/strategies/` (relocated in `E0`) so the two registries (architecture vs
+    algorithm) are cleanly separate.
+  - **Collapse the (algorithm × backend) engine matrix** in `inference/target_engine/`: the
+    per-algorithm files relocated by `E0` converge into per-backend generic engines
+    (`hf.py` / `sglang.py` / `custom.py`) parameterized by a per-algorithm `CaptureSpec` /
+    capture-policy, so adding an algorithm is a spec, not a class-per-backend. NB the SGLang side
+    merges cleanly (shared backend; only `wrap_eagle3_logits` + returned fields + shaping differ),
+    but the **HF side is a real code difference** (eagle3 = forward hooks on 3 aux layers + concat +
+    logits; dflash = `output_hidden_states=True` + layer select, no logits) — so it MUST be a policy
+    object, not a data table.
   - **MLA Eagle3 draft** — an MLA-attention draft architecture registered via
     `@register_draft`.
   - **Pydantic config + `specforge` CLI** — a typed run config (Pydantic is
@@ -196,11 +243,14 @@ E). B's `TargetEngine` extraction also unblocks the online O1.3 multi-backend pr
   - **Exporters** — `export/to_sglang` (with a documented MLA weight-name map)
     and `export/to_hf`.
 - **Implementation**
-  - `models/drafts/__init__.py` (new) — `DRAFT_REGISTRY` + `register_draft`
+  - `modeling/draft/registry.py` (new) — `DRAFT_REGISTRY` + `register_draft`
     decorator; register the existing eagle3 / dflash drafts and the new MLA
-    eagle3 draft. See [../../plan.md](../../plan.md) §4.2 (`models/drafts/…`).
-  - `training/strategies/` (new package) — move the `StrategySpec` registry here;
-    keep `register_strategy` / `resolve_strategy` import-compatible.
+    eagle3 draft. See [../../plan.md](../../plan.md) §4.2.
+  - `inference/target_engine/` — collapse the `eagle3.py` / `dflash.py` per-algorithm files
+    (relocated in `E0`) into `hf.py` / `sglang.py` / `custom.py` + a per-algorithm `CaptureSpec`;
+    `sglang_server.py` is filled by online O1.3.
+  - `training/strategies/` (relocated in `E0`) — finalize the `StrategySpec` registry + the
+    per-algorithm specs; keep `register_strategy` / `resolve_strategy` import-compatible.
   - `config/schema.py` (new) — Pydantic config; `specforge` CLI entry in
     `pyproject.toml` `[project.scripts]`. See [../../plan.md](../../plan.md)
     §4.6 (`config/schema.py`).
@@ -215,4 +265,4 @@ E). B's `TargetEngine` extraction also unblocks the online O1.3 multi-backend pr
   `Trainer` the programmatic path does).
 - **Done when** A user trains via `specforge <config>`, registers a new draft
   architecture with `@register_draft`, trains an MLA Eagle3 draft, and exports a
-  checkpoint that loads in both sglang and HF.
+  checkpoint that loads in both sglang and HF — all from the consolidated layout.

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -57,7 +57,7 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
 
 ---
 
-### B — Domain abstractions · size L · GPU · status: next
+### B — Domain abstractions · size L · GPU · status: in review (PRs #631/#632/#633/#635, validated)
 - **Goal** De-EAGLE3 the target boundary and give the runtime a domain `Trainer`
   that *wraps* (does not replace) the runtime controller, so the architecture
   reads in product terms while the seam stays intact.
@@ -107,7 +107,7 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
 
 ---
 
-### C — Colocated lightweight path · size M · CPU · status: later
+### C — Colocated lightweight path · size M · CPU · status: in review (PR #636, validated)
 - **Goal** Make colocated runs (W1/W2) pay nothing for the disagg control plane,
   on the *same* code path — not a fork.
 - **Target state** One canonical path. For colocated, the control plane is
@@ -145,7 +145,7 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
 
 ---
 
-### D — Training managers · size L · GPU · status: later
+### D — Training managers · size L · GPU · status: in review (PR #637, validated)
 - **Goal** Bring the training loop up to production parity: real grad
   accumulation, full resume, checkpoint lifecycle, and an evaluator — the pieces
   `runtime/training` does not have yet.
@@ -198,7 +198,7 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
 
 ---
 
-### E0 — Layout consolidation (move-only) · size M · CPU · status: later (front of E)
+### E0 — Layout consolidation (move-only) · size M · CPU · status: in review
 - **Goal** Collapse the scattered execution code into **one implementation home per concern** with
   **zero functional change**, so E's composition work is written in the final layout rather than
   re-moved afterward. This is the §2.3 target tree in [../../plan.md](../../plan.md): `runtime/` =

--- a/docs/roadmap/domain-refactor.md
+++ b/docs/roadmap/domain-refactor.md
@@ -256,7 +256,8 @@ the online O1.3 multi-backend producer in [./online-disaggregation.md](./online-
     logits; dflash = `output_hidden_states=True` + layer select, no logits) — so it MUST be a policy
     object, not a data table.
   - **MLA Eagle3 draft** — an MLA-attention draft architecture registered via
-    `@register_draft`.
+    `@register_draft`. *(The draft itself landed early as PR #640 on the Auto* mapping;
+    E re-registers it through `@register_draft`.)*
   - **Pydantic config + `specforge` CLI** — a typed run config (Pydantic is
     already a dep in `pyproject.toml`) replacing the argparse-style launch knobs;
     a console-script entry point that builds the config and calls the domain

--- a/docs/roadmap/eval-and-breadth.md
+++ b/docs/roadmap/eval-and-breadth.md
@@ -14,7 +14,7 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
 
 ---
 
-### E1 — Acceptance-length eval harness · size M · GPU · status: next
+### E1 — Acceptance-length eval harness · size M · GPU · status: in review
 - **Goal** Produce a correct, cache-backed `simulated_acc_len` / `avg_loss` / `avg_acc` eval
   pass that is batch-size-independent and tracks the best checkpoint. This is the same
   `Evaluator` the domain refactor's Phase D wires into the domain `Trainer` — see Phase D in
@@ -72,6 +72,13 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
 - **Done when** `evaluate` returns the three metrics from a single full-pass aggregation, the
   batch-size-invariance gate is green, the cache hits on an unchanged tuple and misses on any
   changed field, and the controller restores the best checkpoint by `eval/simulated_acc_len`.
+- **Landed split (July 2026):** the Evaluator (aggregate-before-geometric-sum, token-weighted
+  loss AND token-weighted scalar accuracy, DP-reduced, batch-size-invariance gates) and durable
+  best-checkpoint tracking landed with domain-refactor Phase D (#637); `EvalConfig` + `EvalCache`
+  (injective JSON-encoded key, atomic-rename produce-once) landed as the E1 PR. One scope note:
+  the launch builders still take a pre-produced `hidden_states_path`, so the cache is consumed
+  programmatically (`EvalCache.for_config` + `get_or_produce`) until Phase E's typed config + CLI
+  own eval-data production and wire it in front.
 
 ---
 

--- a/docs/roadmap/eval-and-breadth.md
+++ b/docs/roadmap/eval-and-breadth.md
@@ -107,7 +107,7 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
      and `supports_online`. If a data path isn't wired yet, leave that factory `None` — the builder
      raises an actionable `NotImplementedError` instead of silently feeding EAGLE3-shaped features.
   3. **Optionally, a draft architecture** under the draft-model package
-     (`specforge/modeling/draft/` today, `specforge/models/drafts/` after domain Phase E —
+     (`specforge/modeling/draft/`; domain Phase E adds a `registry.py` there —
      alongside `dflash.py` / `llama3_eagle.py`) — only if the algorithm needs a network the existing draft
      models don't provide. Medusa heads or MTP heads would live here; an algorithm that reuses an
      existing draft body (as Domino reuses DFlash's draft with a different head/loss) needs **no**

--- a/docs/roadmap/eval-and-breadth.md
+++ b/docs/roadmap/eval-and-breadth.md
@@ -34,7 +34,8 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
     per-position **sum/count** tensors that `Eagle3TrainStrategy.forward_loss` already emits
     (`acc_corrects`, `acc_denoms` in `StepOutput.metrics`) — do **not** reduce them to scalars in
     the eval path.
-  - Add `specforge/runtime/eval/evaluator.py` with `Evaluator` + `EvalConfig`, following the
+  - Add `specforge/eval/evaluator.py` (top-level domain layer, per plan.md §2.3 — **not** under
+    `runtime/`) with `Evaluator` + `EvalConfig`, following the
     sketch in ../../docs/redesign-draft-legacy.md (§4.4 Evaluation system). It consumes a
     `forward_fn` (a thin wrapper over `TrainerCore.eval_step`) and an eval stream that is a plain
     `FeatureDataLoader` over SampleRef+FeatureStore — there is no separate eval source of truth.
@@ -47,7 +48,7 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
   - Emit `{eval/avg_loss, eval/avg_acc, eval/simulated_acc_len}`; `avg_loss` is
     token-weighted (`Σ loss·num_tokens / Σ num_tokens`), `avg_acc` is the position-0 aggregated
     accuracy.
-  - Add `specforge/runtime/eval/cache.py` with `EvalCache`. Key on
+  - Add `specforge/eval/cache.py` with `EvalCache`. Key on
     **eval-data path + target path + target revision + tokenizer path + chat template +
     aux-layer ids + max seqlen** (§4.4 `cache_key`). Missing any field silently serves stale
     tensors after a target swap or template change. Keep this **separate** from the tokenization
@@ -105,8 +106,9 @@ Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan 
      `offline_target_repr`), `make_online_collate`, `make_adapter` (None ⇒ default `SGLangAdapter`),
      and `supports_online`. If a data path isn't wired yet, leave that factory `None` — the builder
      raises an actionable `NotImplementedError` instead of silently feeding EAGLE3-shaped features.
-  3. **Optionally, a draft architecture** under `specforge/modeling/draft/` (alongside
-     `dflash.py` / `llama3_eagle.py`) — only if the algorithm needs a network the existing draft
+  3. **Optionally, a draft architecture** under the draft-model package
+     (`specforge/modeling/draft/` today, `specforge/models/drafts/` after domain Phase E —
+     alongside `dflash.py` / `llama3_eagle.py`) — only if the algorithm needs a network the existing draft
      models don't provide. Medusa heads or MTP heads would live here; an algorithm that reuses an
      existing draft body (as Domino reuses DFlash's draft with a different head/loss) needs **no**
      new arch file.

--- a/docs/roadmap/eval-and-breadth.md
+++ b/docs/roadmap/eval-and-breadth.md
@@ -1,0 +1,129 @@
+# Eval + Algorithm-Breadth Track
+
+This track runs **parallel and orthogonal** to the domain refactor (./domain-refactor.md)
+and the online/disagg work (./online-disaggregation.md): it is where DeepSpec's edge actually
+shows up — a trustworthy acceptance-length number and a low-cost path to new draft algorithms.
+It has **no Ray and no weight-sync content** by construction: the eval target is the same
+**frozen** online/offline target the rest of the system uses (see the weight-sync-out-of-scope
+decision in ../../plan.md), so there is nothing to re-sync and no staleness to model. Both
+phases build directly on the canonical Substrate (SampleRef + FeatureStore + FeatureDataLoader)
+and the runtime training seam (`TrainerCore` / `DraftTrainStrategy` / `StrategySpec`) rather than
+replacing any of it.
+
+Sibling tracks: ./domain-refactor.md · ./online-disaggregation.md · root plan ../../plan.md.
+
+---
+
+### E1 — Acceptance-length eval harness · size M · GPU · status: next
+- **Goal** Produce a correct, cache-backed `simulated_acc_len` / `avg_loss` / `avg_acc` eval
+  pass that is batch-size-independent and tracks the best checkpoint. This is the same
+  `Evaluator` the domain refactor's Phase D wires into the domain `Trainer` — see Phase D in
+  ./domain-refactor.md and cross-link back here.
+- **Target state** Calling eval over any `FeatureDataLoader` stream yields per-position accuracy
+  aggregated across the **whole** eval pass *before* the geometric sum; the number does not move
+  when you change micro-batch size; repeat runs over an unchanged (eval-data, target, revision,
+  tokenizer, template, aux-layers, seqlen) tuple hit an on-disk cache instead of recomputing
+  hidden states; the controller records and can restore the best checkpoint by
+  `eval/simulated_acc_len`.
+- **Implementation**
+  - **Fix the existing bug first.** `specforge/runtime/training/trainer.py::TrainerController.evaluate`
+    today means per-batch scalars: `TrainerCore._result` collapses the per-position vectors
+    (`acces`, `acceptance_rates`, `plosses`) to a single `_scalar` per batch, then `evaluate`
+    averages those scalars across batches. That destroys per-position structure and makes any
+    acceptance-length derived from it batch-size-dependent. The harness must aggregate the raw
+    per-position **sum/count** tensors that `Eagle3TrainStrategy.forward_loss` already emits
+    (`acc_corrects`, `acc_denoms` in `StepOutput.metrics`) — do **not** reduce them to scalars in
+    the eval path.
+  - Add `specforge/runtime/eval/evaluator.py` with `Evaluator` + `EvalConfig`, following the
+    sketch in ../../docs/redesign-draft-legacy.md (§4.4 Evaluation system). It consumes a
+    `forward_fn` (a thin wrapper over `TrainerCore.eval_step`) and an eval stream that is a plain
+    `FeatureDataLoader` over SampleRef+FeatureStore — there is no separate eval source of truth.
+  - Aggregation contract (the load-bearing bit): keep running `per_pos_acc_sum` and
+    `per_pos_acc_count`, each shape `[ttt_length]`, accumulated over **all** micro-batches; only
+    after the full pass compute `per_position_acc = sum / count.clamp_min(1)` and feed *that*
+    single aggregated vector into the geometric sum
+    `acc_0 + acc_0·acc_1 + acc_0·acc_1·acc_2 + …`. The common bug — treating each batch's
+    per-position vector as if it were positions — is explicitly what this ordering prevents.
+  - Emit `{eval/avg_loss, eval/avg_acc, eval/simulated_acc_len}`; `avg_loss` is
+    token-weighted (`Σ loss·num_tokens / Σ num_tokens`), `avg_acc` is the position-0 aggregated
+    accuracy.
+  - Add `specforge/runtime/eval/cache.py` with `EvalCache`. Key on
+    **eval-data path + target path + target revision + tokenizer path + chat template +
+    aux-layer ids + max seqlen** (§4.4 `cache_key`). Missing any field silently serves stale
+    tensors after a target swap or template change. Keep this **separate** from the tokenization
+    cache (`data/cache.py`) — different keys, different lifecycle; do not merge.
+  - Best-checkpoint tracking: have `TrainerController` (trainer.py) keep `best_metric` /
+    `best_checkpoint_uri` keyed on `eval/simulated_acc_len`, updated in the eval hook of `fit`,
+    and persist a `best` pointer next to the step checkpoints written by `save_checkpoint`.
+  - Strategy-agnostic by construction: EAGLE3 supplies per-position vectors; DFlash/Domino supply
+    a single-position `accuracy`, which is the `ttt_length=1` degenerate case of the same
+    aggregation (geometric sum of one term). No branching in the evaluator.
+- **Tests / gates**
+  - **Batch-size invariance gate:** the same fixed eval set produces identical
+    `simulated_acc_len` at micro-batch sizes 1, 4, 16 (the regression that proves the
+    aggregate-before-geometric-sum ordering).
+  - Geometric-sum unit test on a hand-computed per-position vector.
+  - `EvalCache` key test: flipping any one keyed field (target revision, template, aux layers,
+    seqlen, tokenizer) changes the key; a clean re-run with all fields equal is a cache hit.
+  - colocated==disagg equivalence: eval metrics match within tolerance whether the stream is a
+    `LocalFeatureStore` (mem://) colocated loader or a disagg FeatureStore (reuses the track-wide
+    numerical-equivalence gate).
+- **Done when** `evaluate` returns the three metrics from a single full-pass aggregation, the
+  batch-size-invariance gate is green, the cache hits on an unchanged tuple and misses on any
+  changed field, and the controller restores the best checkpoint by `eval/simulated_acc_len`.
+
+---
+
+### E2 — Algorithm breadth · size L · GPU · status: later
+- **Goal** Make "add a new speculative-decoding algorithm" a small, well-bounded contribution:
+  a `DraftTrainStrategy` + a `StrategySpec` entry (+ optionally a draft arch), reusing the entire
+  runtime spine. The first new targets are **MTP** and **Medusa**.
+- **Target state** dflash and domino are **already landed** through the strategy registry
+  (Phase A) — see `Eagle3TrainStrategy` / `DFlashTrainStrategy` / `DominoTrainStrategy` in
+  `specforge/runtime/training/strategy.py` and their three `register_strategy(...)` entries in
+  `specforge/runtime/training/registry.py`. Because of that, breadth is no longer "write a new
+  `build_*_runtime` family" — it is "add a `StrategySpec` + a loss." Adding MTP or Medusa touches
+  only the strategy class, one registry entry, and (if its draft network is new) one file under
+  the draft model package.
+- **Implementation** — what a new algorithm **must add**:
+  1. **A `DraftTrainStrategy` subclass** in `specforge/runtime/training/strategy.py` (or a sibling
+     module imported there). It must set `name`, `required_features`, implement
+     `trainable_module()` and `forward_loss(batch, ctx) -> StepOutput`, and — if its persisted
+     weights are a subset of the wrapped module — `checkpoint_state_filter`. `forward_loss` returns
+     `StepOutput(loss, metrics)`; put per-position `acc_corrects`/`acc_denoms` (or a single
+     `accuracy`) in `metrics` so the E1 `Evaluator` works unchanged. Only read `StepContext` if the
+     loss depends on *where in training* you are (Domino's decayed `lambda_base` is the existing
+     precedent — every other strategy ignores `ctx`).
+       - *MTP*: multi-token-prediction heads → emit per-position accuracy like EAGLE3 (TTT-style),
+         reuse the `ploss_decay`-style weighting.
+       - *Medusa*: independent per-head losses over a shared trunk → a single combined loss; per-head
+         accuracy can be reported as the per-position vector E1 already aggregates.
+  2. **One `StrategySpec` entry** via `register_strategy(...)` in `registry.py`, declaring:
+     `make_strategy`, `required_features` (frozenset, drives `CaptureConfig.from_strategy` +
+     loader validation), `uses_target_head`, the offline data path
+     (`make_offline_reader` / `make_offline_transform` / `make_offline_collate` /
+     `offline_target_repr`), `make_online_collate`, `make_adapter` (None ⇒ default `SGLangAdapter`),
+     and `supports_online`. If a data path isn't wired yet, leave that factory `None` — the builder
+     raises an actionable `NotImplementedError` instead of silently feeding EAGLE3-shaped features.
+  3. **Optionally, a draft architecture** under `specforge/modeling/draft/` (alongside
+     `dflash.py` / `llama3_eagle.py`) — only if the algorithm needs a network the existing draft
+     models don't provide. Medusa heads or MTP heads would live here; an algorithm that reuses an
+     existing draft body (as Domino reuses DFlash's draft with a different head/loss) needs **no**
+     new arch file.
+- **What it reuses (unchanged):** `TrainerCore` / `TrainerController` (trainer.py),
+  `FSDPTrainingBackend` (backend.py), `FeatureDataLoader` + FeatureStore (Substrate), checkpointing,
+  the online capture adapters, and the E1 `Evaluator`. The topology builders stay
+  `topologies + one spec per model` rather than `topologies × models` — the model is the
+  `strategy=` parameter resolved through `resolve_strategy`.
+- **Tests / gates**
+  - A new strategy registers and resolves: `resolve_strategy("mtp")` / `available_strategies()`
+    includes it; `required_features` round-trips through loader validation.
+  - `forward_loss` emits metrics in the shape E1 consumes (per-position sum/count or a scalar
+    `accuracy`); E1 produces a finite `simulated_acc_len` for the new strategy with no evaluator
+    changes.
+  - Offline↔online schema parity for the new strategy where both paths exist (same
+    `required_features`, equivalent collate output).
+  - `NotImplementedError` is raised (not a wrong-feature run) when an unwired data path is invoked.
+- **Done when** at least one new algorithm (MTP **or** Medusa) is registered as a `StrategySpec`,
+  trains through the unchanged `TrainerCore`, is evaluated by the unchanged E1 `Evaluator`, and the
+  only files touched are its strategy class, its registry entry, and (if needed) one draft arch file.

--- a/docs/roadmap/online-disaggregation.md
+++ b/docs/roadmap/online-disaggregation.md
@@ -1,0 +1,263 @@
+# Online Disaggregation Roadmap
+
+Live disaggregated training: a rollout pool runs the **frozen target** model autoregressively
+over a fixed prompt set and streams its hidden states across the network into a separate trainer
+pool. This folds PR #618's online roadmap into the consolidated tree and applies the shared
+decisions: **train-with-decode only** (the online target is frozen, so the streamed data is
+independent of draft weights — there is no staleness and nothing to re-sync, and the whole
+weight-sync / hot-update / on-policy axis is dropped here, kept only as the explicit out-of-scope
+note below); and **Ray is OPEN/undecided** for the O2 scale-out layer — presented as a candidate
+with a decision gate against a lighter torchrun/`rcli` alternative, not as a commitment.
+
+Substrate is canonical and shared with the sibling docs: `SampleRef` (control plane, tensor-free)
++ `FeatureStore` (tensors: Local / SharedDir / Mooncake) + `FeatureDataLoader` → `TrainBatch`.
+There is no separate hidden-state stream source of truth — `FeatureDataLoader` over
+`SampleRef` + `FeatureStore` *is* the stream; online/offline/disagg vary only in the ref source +
+the `FeatureStore` backend, shielded from training. See [domain-refactor](./domain-refactor.md)
+for the domain `Trainer`/managers that wrap the runtime training seam and for Phase B's
+`TargetEngine` that O1.3 depends on, [eval-and-breadth](./eval-and-breadth.md) for the orthogonal
+eval/algorithm track, and the top-level [plan](../../plan.md).
+
+---
+
+## What we keep (do not rebuild)
+
+The data plane is competitive — arguably ahead of the comparables on rigor (three backends behind
+one contract, contract-tested, with a durability seam). The gap is the **orchestration +
+live-engine + async control loop**. Reuse, do not rewrite:
+
+- **Data plane** — `MooncakeFeatureStore` zero-copy (`data_plane/mooncake_store.py`) with hard-pin
+  replication and per-generation key sets; `LocalFeatureStore` / `SharedDirFeatureStore` behind the
+  same `FeatureStore` contract (`data_plane/feature_store.py`).
+- **Control-plane vocabulary** — `SampleRef` (tensor-free; `assert_no_tensors` in `contracts.py`);
+  `SampleRefQueue` with lease/ack and the reserved partition seam (`data_plane/sample_ref_queue.py`);
+  `DataFlowController` commit/lease/ack + `reconcile_on_restart` (`control_plane/controller.py`);
+  the `MetadataStore` ABC with `InMemoryMetadataStore` / `SQLiteMetadataStore`
+  (`control_plane/metadata_store.py`).
+- **Streaming seam** — `StreamingRefChannel` / `StreamingRefQueue`
+  (`data_plane/streaming_ref_channel.py`) already carry committed refs cross-process with
+  in-flight accounting and a close-and-drain protocol.
+- **Trainer seam** — `TrainerCore` / `DraftTrainStrategy` / `TrainingBackend` + `StepContext`
+  (`training/`), wrapped (not replaced) by the domain `Trainer`.
+
+## Comparables (from #618)
+
+| Axis | SpecForge (today) | TorchSpec | DeepSpec |
+|---|---|---|---|
+| Data plane (Mooncake zero-copy, tensor-free metadata) | **At parity / cleaner** — 3 backends, one contract, contract-tested, durability seam | `EagleMooncakeStore` (per-tensor keys) | disk cache, no streaming |
+| Orchestration / scale-out | **GAP** — library + composable builders, controller in-process | Ray actors + placement groups + async controllers + `EnginePool` | single 8-GPU node, no Ray |
+| Live generation (train-with-decode) | **GAP** — in-process generator stub today; no server | live autoregressive rollout streaming | offline regen-to-disk |
+| Cross-pool backpressure | policy exists, off by default | pool-byte feedback + capacity await | n/a |
+| Online weight sync / staleness | n/a — out of scope (frozen target) | **also absent** (not needed) | absent |
+| Fault tolerance | `reconcile_on_restart` + checkpoint resume | checkpoint resume (≈ parity) | n/a |
+
+**Read:** the data plane is at or ahead of parity; the competitive gap is orchestration + the
+live engine + the async control loop. DeepSpec's separate edge (breadth + eval) is orthogonal and
+lives in [eval-and-breadth](./eval-and-breadth.md).
+
+---
+
+### O1.1 — Shared cross-process control plane · size M · CPU · status: in-review
+- **Goal** Producer and consumer attach to **one** durable control plane instead of each building
+  its own `InMemoryMetadataStore`, so commit/lease/ack/dedup and restart-reconcile work across
+  processes (~PR #624 / up-19).
+- **Target state** A separate producer and consumer share commit/lease/ack via a durable store;
+  the "single-host in-process index" caveat is gone for the shared-store path; `reconcile_on_restart`
+  is wired into the launcher and `resume=True` re-streams the committed-but-unacked tail.
+- **Implementation**
+  - `control_plane/metadata_store.py` — `SQLiteMetadataStore` is the end-to-end dev/single-host
+    durable tier behind the existing `MetadataStore` ABC; a thin `RedisMetadataStore` is a later
+    subclass behind the same interface (chosen at O2 if multi-node demands it).
+  - `data_plane/sample_ref_queue.py` — `SampleRefQueue` operates over the shared store rather than
+    purely in-process.
+  - `control_plane/controller.py` — `DataFlowController(metadata_store=...)`; the producer's
+    `commit_samples` and the consumer's `lease_train_refs` / `ack_train_refs` land in the same
+    durable store; `reconcile_on_restart` resolves committed-but-unacked refs on attach.
+  - `launch.py` — `build_disagg_online_producer` / `build_disagg_online_consumer` already accept
+    `metadata_store` / `metadata_db_path` (O1.1 wiring); `_resolve_metadata_store` points both
+    halves at the same durable path, and the consumer's `resume=True` reconciles before training.
+- **Tests / gates** Two controllers over one store: producer commits, consumer leases/acks across
+  processes; restart reconcile hands already-trained ids back as `skip_ids` and re-streams the tail;
+  at-least-once dedup. `tests/test_runtime/test_disagg_online_launch.py`,
+  `tests/test_runtime/test_disagg_online.py`.
+- **Done when** A separate producer and consumer share commit/lease/ack via the durable store, and
+  the single-host-in-process-index caveat is removed for the shared-store path.
+
+### O1.2 — Async streaming loop + one-process builder · size M · CPU / small-GPU · status: in-review
+- **Goal** Replace synchronous drain-then-fit with an async streaming loop, using the **existing
+  in-process generator** as a stub so this milestone carries no engine risk (~PR #625 / up-20).
+- **Target state** End-to-end live 1+1 run with in-process generation: producer pulls prompts →
+  generates → `put` + commit ref; consumer leases → `get` → trains → acks at the optimizer step;
+  a bounded sample pool throttles via the channel's in-flight watermark.
+- **Implementation**
+  - `launch.py` — the composable builders already exist today:
+    `build_disagg_online_producer` returns `(workers, drive_producer)`;
+    `build_disagg_online_consumer` returns `(trainer, loader)`;
+    `run_disagg_online_interleaved` runs the producer on a background thread while `trainer.fit`
+    consumes on the main thread, with symmetric hang-free shutdown (trainer-done sets `should_stop`;
+    producer-done closes the channel; producer-raise closes the channel then re-raises).
+    `build_disagg_online_runtime` (aliased `build_disagg_online_eagle3_runtime`) composes the two
+    halves and dispatches to `run_disagg_online_interleaved`.
+  - The producer's `drive_producer(should_stop=...)` applies channel backpressure (pauses while
+    `channel.in_flight_remote()` exceeds `in_flight_high_watermark`) and closes the channel on exit.
+  - In-process generator stub: `SGLangAdapter.generate_features` over the SpecForge
+    `Eagle3TargetModel.generate_eagle3_data` path (`inference/sglang_adapter.py`), driven by
+    `RolloutWorker` (`inference/rollout_worker.py`).
+- **Tests / gates** Tiny-model 1+1 online run: trainer consumes a **streamed** (not precomputed)
+  ref set; metrics align with the offline baseline on the same prompts/seed. Interleaved
+  shutdown is hang-free in all three orderings. `tests/test_runtime/test_disagg_online_launch.py`,
+  `tests/test_runtime/test_streaming_ref_channel.py`.
+- **Done when** An end-to-end live 1+1 run drives training from an in-process generator over the
+  streaming channel, with no precomputed features.
+
+### O1.3 — Live SGLang-server hidden-state capture · size L · GPU + engine · status: next
+> 🔴 **GATING RISK — run the capture spike first.** The unknown is how far
+> `Eagle3TargetModel.generate_eagle3_data` is from server-backed capture. The spike is the
+> difference between O1.3 being days vs. a quarter; SpecForge is SGLang's own project so reuse is
+> plausible (TorchSpec needed an SGLang codebase patch). Run it before/with O1.1.
+- **Goal** Replace the in-process generator with a real SGLang **server** emitting aux + final
+  hidden states straight into `MooncakeFeatureStore`.
+- **Target state** A live SGLang server feeds training with **zero** precomputed features: server
+  generates → hidden states land in the store → consumer trains; acceptance metrics match the
+  offline baseline.
+- **Implementation**
+  - Depends on [domain-refactor](./domain-refactor.md) Phase B's `TargetEngine` abstraction
+    (`SGLangServerEngine`) — O1.3 is the online consumer of that engine.
+  - `inference/sglang_adapter.py` — a server-backed `FeatureSource` (launch/attach an SGLang
+    server) alongside the existing in-process `SGLangAdapter`; the capture hook is engine-side,
+    writing aux + final hidden states to the `FeatureStore`. Reuse the `CaptureConfig` /
+    `verify_capture` contract (`inference/capture.py`) so an aux-layer-id / width / target-dim
+    mismatch fails loudly. See `inference/sglang_patch_inventory.md` for the patch surface.
+  - `inference/rollout_worker.py` — the producer uses the server-backed source; committed
+    `SampleRef`s flow through the same `StreamingRefChannel`.
+- **Tests / gates** (gated GPU) Server generates → hidden states resident in the store → consumer
+  trains; capture verification passes; acceptance vs. offline. `tests/test_runtime/test_mooncake_store.py`
+  for the store path.
+- **Done when** A live SGLang server feeds training with zero precomputed features and acceptance
+  metrics match the in-process / offline baseline.
+
+### O2 — Scale-out orchestration (Ray = OPEN) · size L · infra · status: later
+- **Goal** Move from 1+1 to N producers + M trainers with per-DP-rank leasing, cross-pool
+  backpressure, and a managed streaming-pool lifetime — and **decide** the orchestration layer.
+- **Target state** Independent N producers and M trainers scale without re-leasing or dropping
+  samples; a slow trainer throttles the producer (bounded memory, not OOM); the online
+  `MooncakeFeatureStore` bugs that become reachable at scale are closed; the orchestration layer is
+  chosen against an explicit gate.
+
+#### Orchestration: Ray candidate vs. lighter alternative (decision gate)
+
+Ray is a **candidate** for the scale-out orchestration layer, not a commitment and not a non-goal.
+It is likely necessary for multi-node N-producer/M-trainer scale-out and high-bandwidth
+isolated-pool runs (its actor/placement model maps cleanly onto independent rollout and trainer
+pools with separate GPU counts/sharding, matching the comparables' shape). The lighter alternative
+is **torchrun + the existing `rcli` multi-node launch** driving the already-composable
+`build_disagg_online_producer` / `build_disagg_online_consumer` builders across nodes, with the
+shared durable `MetadataStore` (O1.1) as the only cross-process coordination point — no actor
+framework.
+
+- **Trade-off** Ray buys dynamic placement, actor restart/health, and a uniform multi-pool control
+  surface, at the cost of a heavy runtime dependency, a new failure surface, and packaging/operability
+  overhead on the GPU boxes. torchrun + `rcli` keeps the dependency surface minimal and reuses the
+  existing launch path, but leaves placement, fan-out, and restart as bespoke launcher logic.
+- **Decision gate — adopt Ray only if** the N+M / multi-node runs demonstrably need *dynamic*
+  placement or per-actor restart that the static torchrun + `rcli` + shared-store path cannot
+  deliver (e.g. heterogeneous pool sizes that must reshard at runtime, or actor-level fault recovery
+  that bash-level relaunch cannot meet the availability target for). If a static launch over the
+  shared store carries N+M with acceptable restart behaviour, stay on the lighter path. Re-evaluate
+  at the first true multi-node scale-out run.
+
+#### dp_partition leasing
+- **Implementation** `data_plane/sample_ref_queue.py` — the partition seam exists today:
+  `dp_partition(sample_id, num_partitions)` computes a stable DP-rank assignment, and
+  `lease(..., partition=(index, num_partitions))` restricts a lease to a DP shard via
+  `_lease_partition_locked`. The reserved `partition_key` producer-side routing hint is
+  accepted-and-ignored today; turn on per-DP-rank leasing so every sample is leased exactly once
+  across a reshard. `control_plane/controller.py` gains multi-trainer lease dispatch.
+- **Tests / gates** N+M run; every sample leased exactly once across a reshard; no double-train;
+  changing `num_partitions` re-distributes the same committed pool without re-leasing or dropping.
+
+#### Cross-pool backpressure
+- **Implementation** `control_plane/backpressure.py` exists and is **off by default**:
+  `BackpressureController` with `should_pause_prompts` / `cap_prompt_grant` / `cap_train_lease` and a
+  high/low watermark `BackpressureConfig`. Wire the controller into the dispatch loop so it returns
+  pool-size feedback and blocks granting when the pool is full; the producer throttles instead of
+  OOM-ing the store. `control_plane/controller.py` reports capacity.
+- **Tests / gates** A slow trainer makes the producer throttle (bounded store memory) rather than
+  OOM.
+
+#### Streaming-pool lifetime + known online MooncakeFeatureStore bugs
+- **Implementation** `data_plane/mooncake_store.py` — add consume-then-GC / TTL lifetime for the
+  streaming pool, and close the two online-only bugs that become reachable at scale, both of which
+  the shared metadata index (O1.1) unblocks:
+  - **release-pending re-put gc-clobber** — a re-put bumps the per-sample generation and removes the
+    prior key set; a parked failed-free in `_release_pending` plus `gc()` can clobber the fresh
+    blob. Needs a tombstone-then-free protocol tied to the shared index.
+  - **cross-process abort tombstone** — under a lease-deferred remove, `producer.abort` marks only
+    its own `_freed`, so the bytes linger and a *separate* consumer (empty `_freed`) still resolves
+    the aborted ref → stale. This is the `expectedFailure`
+    `test_cross_process_abort_under_lease_defer_is_known_gap` in
+    `tests/test_runtime/test_mooncake_store.py:445`; flip it to a hard assertion once the shared
+    index lands.
+- **Tests / gates** Re-put-while-pending no longer deletes the fresh blob; cross-process abort
+  blocks a separate consumer (the `expectedFailure` becomes a real assertion); consume-once
+  streaming is correct cross-process.
+- **Done when** N producers and M trainers scale without re-leasing/dropping; trainer-behind-rollout
+  is a bounded-memory backpressure signal; the streaming-pool bugs are closed; the orchestration
+  decision gate has been evaluated against a real N+M run.
+
+### O3 — Hardening · size L · infra · status: later
+- **Goal** Make the live disaggregated path production-operable.
+- **Target state** RDMA path runs without per-op buffer churn; actor/process restart and health are
+  handled; the run is observable.
+- **Implementation**
+  - RDMA buffer-pool registration in `data_plane/mooncake_store.py` — replace the per-op
+    `register_buffer` / `unregister_buffer` around `_store_put_tensor` / `_store_get_tensor` with a
+    registered pool before flipping `DEFAULT` `protocol` from `tcp` to `rdma`.
+  - Actor / process restart + health: restart the rollout/trainer/controller processes (under
+    whichever orchestration O2 selects) with `reconcile_on_restart` driving recovery from the shared
+    store; health endpoints on `RolloutWorker.health` / `SGLangAdapter.health`.
+  - Observability: pool depth, in-flight, lease/ack rates, backpressure snapshots
+    (`BackpressureController.snapshot`), capture-verification counts.
+- **Tests / gates** Kill-and-restore a producer/trainer mid-run and confirm no lost or
+  double-trained samples; RDMA path registers buffers once; metrics emitted.
+- **Done when** The live disaggregated run survives a process restart with no data loss and runs the
+  RDMA path with one-time buffer registration.
+
+---
+
+## Provenance, not weight sync
+
+`draft_weight_version` is retained **only as provenance metadata** on each committed sample — it is
+recorded by `RolloutWorker._put_metadata` / `_offline_metadata` (`inference/rollout_worker.py`),
+threaded through `contracts.py`, the metadata store, the controller, and every `FeatureStore`
+backend's metadata round-trip. It exists for debugging/audit. There is **no** staleness gate, no
+version registry, and no consumer-side check keyed on it. Because the online target is frozen, the
+streamed hidden states are independent of draft weights.
+
+## Dependency graph
+
+```
+                          capture spike (gates O1.3)
+                                   │
+O1.1 ──▶ O1.2 ──▶ O1.3 ──▶ O2 ──▶ O3
+ │                  │
+ │                  └─ depends on domain Phase B TargetEngine (SGLangServerEngine)
+ │
+ └─ shared MetadataStore unblocks the O2 online-store bug fixes (re-put gc-clobber,
+    cross-process abort tombstone)
+
+eval-and-breadth track ── independent (orthogonal to disaggregation)
+```
+
+## Explicitly out of scope
+
+- **Draft-weight sync, weight-version registry, hot draft-update, staleness gate,
+  `WeightPublisher` / `WeightVersion` / serving accept-length gate / `ServingTrafficStream` /
+  serving-traffic capture** — not needed for train-with-decode. The online target is frozen; the
+  draft is not in the generation loop; the data is independent of draft weights, so there is no
+  staleness and nothing to re-sync. `draft_weight_version` survives as provenance only (above).
+- **True on-policy / draft-coupled training** (draft proposes → target verifies → train on realized
+  acceptance, requiring live draft-weight sync) — a separate research bet, not addressed here. No
+  public framework ships it.
+- **Elastic / dynamic engine scaling at runtime** — engines are fixed at init; the comparables do
+  the same.

--- a/docs/roadmap/online-disaggregation.md
+++ b/docs/roadmap/online-disaggregation.md
@@ -110,7 +110,7 @@ lives in [eval-and-breadth](./eval-and-breadth.md).
 - **Done when** An end-to-end live 1+1 run drives training from an in-process generator over the
   streaming channel, with no precomputed features.
 
-### O1.3 — Live SGLang-server hidden-state capture · size L · GPU + engine · status: next
+### O1.3 — Live SGLang-server hidden-state capture · size L · GPU + engine · status: in review (PR #641, reforward transport; spike findings + upstream proposal in ./o13-capture-spike.md)
 > 🔴 **GATING RISK — run the capture spike first.** The unknown is how far
 > `Eagle3TargetModel.generate_eagle3_data` is from server-backed capture. The spike is the
 > difference between O1.3 being days vs. a quarter; SpecForge is SGLang's own project so reuse is

--- a/docs/roadmap/online-disaggregation.md
+++ b/docs/roadmap/online-disaggregation.md
@@ -60,7 +60,7 @@ lives in [eval-and-breadth](./eval-and-breadth.md).
 ### O1.1 — Shared cross-process control plane · size M · CPU · status: in-review
 - **Goal** Producer and consumer attach to **one** durable control plane instead of each building
   its own `InMemoryMetadataStore`, so commit/lease/ack/dedup and restart-reconcile work across
-  processes (~PR #624 / up-19).
+  processes (~PR #624).
 - **Target state** A separate producer and consumer share commit/lease/ack via a durable store;
   the "single-host in-process index" caveat is gone for the shared-store path; `reconcile_on_restart`
   is wired into the launcher and `resume=True` re-streams the committed-but-unacked tail.
@@ -85,7 +85,7 @@ lives in [eval-and-breadth](./eval-and-breadth.md).
 
 ### O1.2 — Async streaming loop + one-process builder · size M · CPU / small-GPU · status: in-review
 - **Goal** Replace synchronous drain-then-fit with an async streaming loop, using the **existing
-  in-process generator** as a stub so this milestone carries no engine risk (~PR #625 / up-20).
+  in-process generator** as a stub so this milestone carries no engine risk (~PR #625).
 - **Target state** End-to-end live 1+1 run with in-process generation: producer pulls prompts →
   generates → `put` + commit ref; consumer leases → `get` → trains → acks at the optimizer step;
   a bounded sample pool throttles via the channel's in-flight watermark.

--- a/plan.md
+++ b/plan.md
@@ -149,15 +149,16 @@ PRODUCE (inference):
                          SampleRef to the control plane. Stays at the domain↔substrate seam.
 
 CONSUME (training):
-  Trainer             ── owns the lifecycle: loop / eval / checkpoint. WRAPS the runtime
-                         TrainerController/TrainerCore; does NOT replace them. (No weight-sync —
+  Trainer             ── owns the lifecycle: loop / eval / checkpoint. WRAPS the
+                         TrainerCore/TrainerController seam; does NOT replace it. (No weight-sync —
                          the target is frozen, §8.)
-  DraftTrainStrategy  ── per-algorithm forward+loss (eagle3 TTT / dflash block / domino). Kept
-                         in runtime/training (the seam) — already plan-shaped.
+  DraftTrainStrategy  ── per-algorithm forward+loss (eagle3 TTT / dflash block / domino). The
+                         per-step seam; lives in training/strategies (relocated from
+                         runtime/training in E0) — already plan-shaped.
   CheckpointManager / Evaluator / lr_scheduler / fsdp seam  ── the managers (G1).
 
 COMPOSE:
-  models/drafts       ── DRAFT_REGISTRY (@register_draft) for draft *architecture* classes
+  modeling/draft      ── DRAFT_REGISTRY (@register_draft) for draft *architecture* classes
                          (llama / deepseek-MLA / dflash-qwen3). Separate axis from strategy.
   StrategyRegistry    ── per-algorithm spec (today's StrategySpec, converged here).
   config / cli / export ── first-class run surface (predecessor §4.3–4.8, carried forward).
@@ -170,48 +171,59 @@ is fully absorbed by (ref source + `FeatureStore`) behind `FeatureDataLoader →
 
 ```
 specforge/
-├── runtime/                         # CANONICAL DataFlow spine (keep)
+├── runtime/                         # SUBSTRATE ONLY — the canonical DataFlow spine (keep as-is)
 │   ├── contracts.py                 # SampleRef, TrainBatch, PromptTask, *Strategy literal
 │   ├── control_plane/               # metadata-only: controller, metadata_store, backpressure
-│   ├── data_plane/                  # FeatureStore (Local/SharedDir/Mooncake), loader, readers,
-│   │                                #   SampleRefQueue, StreamingRefChannel
-│   ├── inference/                   # rollout: RolloutWorker, capture, adapters  ──┐ converge to
-│   │                                #                                              │  TargetEngine
-│   ├── training/                    # DraftTrainStrategy seam, TrainerCore/Controller, backend,
-│   │                                #   StepContext. (The StrategySpec registry converges into the
-│   │                                #   domain training/strategies/ in Phase E — see §6.)
-│   └── launch.py                    # spec-driven builders (topology = builder, model = strategy=)
+│   └── data_plane/                  # FeatureStore (Local/SharedDir/Mooncake), FeatureDataLoader,
+│                                    #   SampleRefQueue, StreamingRefChannel, offline/disagg readers
 │
-├── models/                          # TARGET layout (today the draft/target code lives under
-│   │                                #   specforge/modeling/ — Phase E moves it here)
-│   ├── drafts/                      # DRAFT_REGISTRY + @register_draft (NEW — predecessor §4.2)
-│   │   ├── base.py  llama3_eagle.py  deepseek_eagle3.py(MLA)  dflash.py  auto.py
-│   │   │                            #   (today: modeling/draft/{base,dflash,llama3_eagle,flex_attention}.py)
-│   └── targets/                     # TargetEngine ABC, EXTRACTED from modeling/target/*TargetModel
-│       │                            #   (runtime/inference adapters then wrap an engine, §G2)
-│       ├── base.py  hf_engine.py  sglang_engine.py  sglang_server_engine.py  custom_engine.py
+├── inference/                       # TOP-LEVEL — the single home for all rollout/capture execution
+│   ├── rollout_worker.py            #   (from runtime/inference/rollout_worker.py)
+│   ├── capture.py                   #   CaptureConfig (from runtime/inference/capture.py)
+│   ├── feature_source.py            #   the FeatureSource Protocol (the worker's only contract)
+│   ├── target_engine/               #   TargetEngine, EXTRACTED from modeling/target/*TargetModel
+│   │   ├── base.py  factory.py       #     (adapters then wrap an engine, §G2)
+│   │   ├── hf.py  sglang.py  sglang_server.py  custom.py   # per-backend generic engines
+│   │   └── sglang_capture_backend.py                       # sglang version-pinned glue
+│   └── adapters/
+│       └── eagle3.py  dflash.py     #   (from runtime/inference/{sglang,dflash}_adapter.py)
+│
+├── training/                        # TOP-LEVEL — the single home for all training execution (NO facade)
+│   ├── trainer.py                   # domain Trainer: owns loop/eval/checkpoint (B3)
+│   ├── controller.py                # TrainerCore + TrainerController seam (from runtime/training/trainer.py)
+│   ├── backend.py                   # FSDPTrainingBackend + no_sync (from runtime/training/backend.py)
+│   ├── checkpoint.py  resume.py  evaluator.py   # NEW managers (§3) — born here
+│   └── strategies/                  # StrategySpec registry + per-algorithm strategies (converges HERE)
+│       ├── base.py                   #   DraftTrainStrategy ABC + StepContext (from runtime/training/strategy.py)
+│       ├── registry.py               #   StrategySpec / resolve_strategy (from runtime/training/registry.py)
+│       └── eagle3.py  dflash.py  domino.py
+│
+├── modeling/                        # MODEL DEFINITIONS ONLY — no orchestration, no capture factory
+│   ├── draft/                       # DRAFT_REGISTRY + @register_draft (NEW registry.py — predecessor §4.2)
+│   │   └── base.py  registry.py  llama3_eagle.py  deepseek_eagle3.py(MLA)  dflash.py  flex_attention.py
+│   └── target/                      # target model nn.Modules + model-specific glue ONLY
+│       └── target_head.py  custom_backend/  sglang_backend/   # (capture orchestration moved to inference/)
 │
 │                                    # (NO separate data/streams package — FeatureDataLoader over
 │                                    #  SampleRef+FeatureStore IS the stream. Ref sources
 │                                    #  (offline/rollout/streaming) live in runtime/data_plane;
 │                                    #  live frozen-target capture is just another ref source)
 │
-├── training/                        # domain lifecycle + managers (WRAPS runtime/training)
-│   ├── trainer.py                   # owns loop/eval/checkpoint; delegates the step to runtime
-│   │                                #   TrainerCore + DraftTrainStrategy (kept seam)
-│   ├── checkpoint.py  lr_scheduler.py  fsdp.py   # NEW managers (§3).
-│   ├── strategies/                  # StrategySpec registry converges HERE in Phase E (§6); the
-│   │                                #   per-step DraftTrainStrategy seam stays in runtime/training.
-│
+├── launch.py                        # TOP-LEVEL — topology assembly only (spec-driven builders; from runtime/launch.py)
 ├── eval/  export/  config/  cli.py  # NEW — carried forward from predecessor §4.4–4.8
-└── core/  optimizer.py  tracker.py  distributed.py  # kept verbatim (predecessor §1)
+└── core/  optimizer.py  tracker.py  distributed.py  lr_scheduler.py  # kept verbatim (predecessor §1)
 ```
 
-> The one real structural move is extracting a `TargetEngine` from the EAGLE3-bound
-> `modeling/target/*TargetModel` into `models/targets` (the `runtime/inference` adapters then wrap
-> it) plus a thin domain `training/` (Trainer + managers) wrapping the kept `runtime/training`
-> seam. The control + data planes stay exactly where they are — they are the substrate, **not**
-> re-housed behind a new stream package.
+> **One implementation home per concern; `runtime/` is substrate-only.** The two structural moves
+> (both gated by the byte-identical suite, executed as the move-only step `E0` — see
+> [docs/roadmap/domain-refactor.md](docs/roadmap/domain-refactor.md)): (1) extract `TargetEngine`
+> out of the EAGLE3-bound `modeling/target/*TargetModel` into top-level `inference/target_engine/`
+> (the `adapters/` then wrap an engine); (2) lift the training seam
+> (`TrainerCore`/`TrainerController`/`TrainingBackend`/strategy+registry) up into top-level
+> `training/`. `runtime/` shrinks to the substrate (control + data plane + contracts) — it is
+> **not** a home for domain/algorithm code, and there is **no facade package**. The control + data
+> planes stay exactly where they are; the online/offline/disaggregated distinction stays absorbed
+> by (ref source + `FeatureStore`) behind `FeatureDataLoader`, invisible to `training/`.
 
 ---
 
@@ -251,7 +263,7 @@ from the in-source `NOTE`s. Each lands behind the canonical spine without re-plu
 - Detailed phases (O1–O3): [`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md).
 
 ### G4 — Composition + models (predecessor Phase 1)
-- `models/drafts` `DRAFT_REGISTRY` (`@register_draft`) for draft **architectures** (separate
+- `modeling/draft` `DRAFT_REGISTRY` (`@register_draft`) for draft **architectures** (separate
   axis from strategy); **MLA Eagle3 draft** (deepseek/Kimi); converge `StrategySpec` →
   `training/strategies` registry. Note: draft-arch registry and strategy registry are two
   registries, not one.
@@ -355,10 +367,10 @@ Chosen: **one path** (spine everywhere) + control-plane-as-no-op for colocated. 
 byte-identical free and avoids two implementations; costs an equivalence gate. (See §4.)
 
 ### Two registries, not one
-`models/drafts` `DRAFT_REGISTRY` (architecture) and `training/strategies` (algorithm) are
+`modeling/draft` `DRAFT_REGISTRY` (architecture) and `training/strategies` (algorithm) are
 **separate** axes — an algorithm (eagle3) runs on multiple draft architectures. Don't merge
 them; the current `StrategySpec` is the *strategy* registry and should converge there, not into
-`models/drafts`.
+`modeling/draft`.
 
 *(The predecessor's other tradeoffs — Pydantic vs OmegaConf, MLA cache compressed vs expanded,
 registry vs HF AutoModel — are unchanged and carry forward.)*
@@ -384,7 +396,10 @@ also folds in the former online-disaggregation roadmap (#618).
   opt-in; add the colocated≡disagg equivalence test.
 - **Phase D — training managers (G1).** `no_sync()`, full optimizer/scheduler/RNG resume,
   `CheckpointManager`, `Evaluator`. Gate: loss/eval parity at fixed steps.
-- **Phase E — `models/drafts` registry + MLA draft + config/CLI/export (G4/G5).** Adding a
+- **Phase E0 — layout consolidation (move-only).** Relocate the training seam + target engine
+  into the top-level `training/` / `inference/` homes; `runtime/` shrinks to substrate. Pure
+  `git mv` + import shims; gate: suite + B byte-identical gate unchanged (no functional diff).
+- **Phase E — `modeling/draft` registry + MLA draft + config/CLI/export (G4/G5).** Adding a
   draft arch = one decorated file; one validated YAML per run; export-loop test.
 - **Online track (parallel; G3) — live *frozen-target* capture.** O1.1 shared control plane +
   O1.2 async loop (in review) → **O1.3** live SGLang-server hidden-state capture (next; gated by a
@@ -433,8 +448,8 @@ statements (now §5/§6) so the code and the plan stop contradicting each other.
 
 Carries the predecessor's gates, plus the reconciliation-specific one.
 
-- **10.1 Numerical-equivalence gate** (per PR touching `core/` / `runtime/training/` /
-  `runtime/data_plane/` / `models/drafts`): fixed seed, 3×4 batches; per-step loss
+- **10.1 Numerical-equivalence gate** (per PR touching `core/` / `training/` /
+  `runtime/data_plane/` / `modeling/draft`): fixed seed, 3×4 batches; per-step loss
   `atol/rtol=1e-4` at steps 0/1/100/500/1000; per-position eval acc + `simulated_acc_len`
   `atol=1e-3`.
 - **10.2 Colocated ≡ disaggregated gate (NEW):** same data through the colocated (no-op control

--- a/plan.md
+++ b/plan.md
@@ -84,17 +84,19 @@ do not conflict.
 | **inference plane** (`runtime/inference`) | **Converge to the predecessor's `TargetEngine`.** | Today it conflates "wrap a target engine" + "capture" inside `SGLangAdapter`, and is bound to `generate_eagle3_data` / EAGLE3 names. The `FeatureSource` Protocol already exists (good); the gap is a real `TargetEngine` abstraction (hf / sglang / **sglang_server** / custom) + de-EAGLE3-ifying. This is the layer that most borrows the draft. |
 | **training plane** (`runtime/training`) | **Keep the seam; fill the managers.** | `DraftTrainStrategy` / `TrainerCore` / `TrainingBackend` (+ the `StepContext` added for Domino) is *already* the predecessor's `training/strategies` shape — keep it. What's missing are the **managers**, not the seam: `no_sync()` accumulation, full optimizer/scheduler/RNG resume, `CheckpointManager` (rotation/best), `Evaluator`. |
 
-**Already landed (the spine + first cleanup):**
+**Landed (merged — the spine):**
 
 - `runtime/` planes (M1–M7/O1): control/data/inference/training, `SampleRef`, `FeatureStore`
   (Local/SharedDir/Mooncake), `StreamingRefChannel`, durable `MetadataStore`, disagg
   producer/consumer + interleaved online loop.
+
+**In the stacked PRs #627/#628/#629 (validated, in review — not yet merged):**
+
 - **Composable launch** (`StrategySpec` registry + parameterized `launch.py`): adding a model
   is a spec entry, not a `build_*_runtime` family. eagle3 / **dflash** / **domino** all train
-  end-to-end through one strategy-parameterized path (PRs #627 / #628 / #629, validated:
-  197 `tests/test_runtime` OK on H200). Domino added `StepContext{global_step, total_steps}`
-  threaded through `forward_loss` — the one deliberate contract extension for schedule-dependent
-  loss.
+  end-to-end through one strategy-parameterized path (validated: 197 `tests/test_runtime` OK on
+  H200). Domino added `StepContext{global_step, total_steps}` threaded through `forward_loss` —
+  the one deliberate contract extension for schedule-dependent loss.
 
 **Explicitly not yet implemented in `runtime/`** (flagged in-source — `contracts.py`,
 `trainer.py`, `controller.py`, both `DESIGN.md`s, `runtime/README.md`): live frozen-target online
@@ -136,7 +138,13 @@ PRODUCE (inference):
   TargetEngine        ── the engine rollout wraps to produce features; the abstraction that
                          replaces the EAGLE3-bound SGLangAdapter.
      HFTargetEngine / SGLangTargetEngine / CustomTargetEngine (in-process)
-     SGLangServerEngine (frozen target as an HTTP/live service; the cross-node capture backend)
+     SGLangServerEngine (frozen target as a live SGLang server, cross-node). ONE engine, two
+       feature transports (the engine is identical; only WHERE features land differs):
+         · capture transport — engine-side hook writes hidden states INTO a FeatureStore
+           (Mooncake/SharedDir). This is W3 / online O1.3.
+         · inline-HTTP transport — features serialized in the HTTP response, no shared store
+           (RemoteStream-style). This is the light W3′ path, the one case features do NOT live
+           in a FeatureStore.
   RolloutWorker       ── drives a TargetEngine → writes tensors to FeatureStore → commits
                          SampleRef to the control plane. Stays at the domain↔substrate seam.
 
@@ -169,14 +177,18 @@ specforge/
 │   │                                #   SampleRefQueue, StreamingRefChannel
 │   ├── inference/                   # rollout: RolloutWorker, capture, adapters  ──┐ converge to
 │   │                                #                                              │  TargetEngine
-│   ├── training/                    # DraftTrainStrategy, TrainerCore/Controller, backend,
-│   │                                #   StepContext, strategy registry
+│   ├── training/                    # DraftTrainStrategy seam, TrainerCore/Controller, backend,
+│   │                                #   StepContext. (The StrategySpec registry converges into the
+│   │                                #   domain training/strategies/ in Phase E — see §6.)
 │   └── launch.py                    # spec-driven builders (topology = builder, model = strategy=)
 │
-├── models/
+├── models/                          # TARGET layout (today the draft/target code lives under
+│   │                                #   specforge/modeling/ — Phase E moves it here)
 │   ├── drafts/                      # DRAFT_REGISTRY + @register_draft (NEW — predecessor §4.2)
-│   │   ├── base.py  llama_eagle3.py  deepseek_eagle3.py(MLA)  dflash_qwen3.py  auto.py
-│   └── targets/                     # TargetEngine ABC (NEW — absorbs runtime/inference adapters)
+│   │   ├── base.py  llama3_eagle.py  deepseek_eagle3.py(MLA)  dflash.py  auto.py
+│   │   │                            #   (today: modeling/draft/{base,dflash,llama3_eagle,flex_attention}.py)
+│   └── targets/                     # TargetEngine ABC, EXTRACTED from modeling/target/*TargetModel
+│       │                            #   (runtime/inference adapters then wrap an engine, §G2)
 │       ├── base.py  hf_engine.py  sglang_engine.py  sglang_server_engine.py  custom_engine.py
 │
 │                                    # (NO separate data/streams package — FeatureDataLoader over
@@ -187,17 +199,19 @@ specforge/
 ├── training/                        # domain lifecycle + managers (WRAPS runtime/training)
 │   ├── trainer.py                   # owns loop/eval/checkpoint; delegates the step to runtime
 │   │                                #   TrainerCore + DraftTrainStrategy (kept seam)
-│   ├── checkpoint.py  lr_scheduler.py  fsdp.py   # NEW managers (§3). Strategies + StrategySpec
-│   │                                #   registry stay in runtime/training (the seam, unchanged).
+│   ├── checkpoint.py  lr_scheduler.py  fsdp.py   # NEW managers (§3).
+│   ├── strategies/                  # StrategySpec registry converges HERE in Phase E (§6); the
+│   │                                #   per-step DraftTrainStrategy seam stays in runtime/training.
 │
 ├── eval/  export/  config/  cli.py  # NEW — carried forward from predecessor §4.4–4.8
 └── core/  optimizer.py  tracker.py  distributed.py  # kept verbatim (predecessor §1)
 ```
 
-> The one real structural move is `runtime/inference` → `models/targets` (extract a
-> `TargetEngine` from the EAGLE3-bound adapter) plus a thin domain `training/` (Trainer +
-> managers) wrapping the kept `runtime/training` seam. The control + data planes stay exactly
-> where they are — they are the substrate, **not** re-housed behind a new stream package.
+> The one real structural move is extracting a `TargetEngine` from the EAGLE3-bound
+> `modeling/target/*TargetModel` into `models/targets` (the `runtime/inference` adapters then wrap
+> it) plus a thin domain `training/` (Trainer + managers) wrapping the kept `runtime/training`
+> seam. The control + data planes stay exactly where they are — they are the substrate, **not**
+> re-housed behind a new stream package.
 
 ---
 
@@ -218,9 +232,13 @@ from the in-source `NOTE`s. Each lands behind the canonical spine without re-plu
 - **lr WSD + per-strategy `fsdp_wrap_policy()`** (predecessor §4.6, §4.2).
 
 ### G2 — `TargetEngine` abstraction (inference convergence)
-- Introduce `TargetEngine` ABC; refactor `SGLangAdapter`/`DFlashAdapter` to wrap a
-  `TargetEngine` and stop binding to `generate_eagle3_data` / EAGLE3 names. Keep the existing
-  `FeatureSource` Protocol. Add `SGLangServerEngine` (HTTP) as the light cross-node engine.
+- Introduce a `TargetEngine` ABC **extracted from the `modeling/target/*TargetModel` classes**
+  (`Eagle3TargetModel`, `DFlashTargetModel`); the `runtime/inference` adapters
+  (`SGLangAdapter`/`DFlashAdapter`) then **wrap** a `TargetEngine` rather than being the engine,
+  and stop binding to `generate_eagle3_data` / EAGLE3 names. Keep the existing `FeatureSource`
+  Protocol. Add `SGLangServerEngine` (live SGLang server) as the cross-node engine — see §2.2 for
+  its two feature transports (capture-into-FeatureStore for W3/O1.3, inline-HTTP for the light
+  W3′).
 
 ### G3 — Live online capture (frozen target; **no** weight sync)
 - Replace the in-process generator with **live SGLang-server hidden-state capture**: a *frozen*
@@ -256,8 +274,8 @@ progress (no staleness, nothing to re-sync).
 |---|---|---|---|---|
 | W1 | Offline (precomputed) | `OfflineManifestReader` (refs) | Local (`file://`/`mem://`) | **no-op** |
 | W2 | In-process online (frozen target) | `RolloutWorker` → `SampleRefQueue` | Local (`mem://`) | **no-op** |
-| W3 | Disaggregated online (frozen target; isolated pools, high BW) | `RolloutWorker` (producer pool) → `StreamingRefChannel` | **Mooncake** | **active** (lease/ack/reconcile/backpressure) |
-| W3′ | Disaggregated online (light/cross-node) | `SGLangServerEngine` over HTTP (RemoteStream-style source) | n/a (HTTP) | minimal |
+| W3 | Disaggregated online (frozen target; isolated pools, high BW) | `RolloutWorker` (producer pool) → `StreamingRefChannel`, `SGLangServerEngine` *capture transport* | **Mooncake** | **active** (lease/ack/reconcile/backpressure) |
+| W3′ | Disaggregated online (light/cross-node) | `SGLangServerEngine` *inline-HTTP transport* (RemoteStream-style source) | n/a — features inline over HTTP, no shared store | minimal |
 
 > **"Train-with-decode" = live *frozen-target* generation** — i.e. W2 (colocated) or W3
 > (disaggregated), **not** a separate workload. The predecessor's dual-purpose
@@ -355,8 +373,9 @@ not a rewrite. Every phase that touches the training path passes the numerical-e
 in [`docs/roadmap/`](docs/roadmap/)** — the phases below are the index; the online track there
 also folds in the former online-disaggregation roadmap (#618).
 
-- **Phase A — composable launch (DONE / in review).** `StrategySpec` registry + parameterized
-  `launch.py`; eagle3/dflash/domino end-to-end (#627/#628/#629). 197 `tests/test_runtime` OK.
+- **Phase A — composable launch (in review).** `StrategySpec` registry + parameterized
+  `launch.py`; eagle3/dflash/domino end-to-end in the stacked PRs #627/#628/#629 (validated,
+  in review). 197 `tests/test_runtime` OK.
 - **Phase B — domain abstractions (no behavior change).** Introduce `TargetEngine` (wrap the
   existing adapters; de-EAGLE3 the names) and the domain `Trainer` wrapping the kept
   `runtime/training` core. No `HiddenStateStream` — `FeatureDataLoader` stays the stream. Gate:
@@ -401,7 +420,7 @@ statements (now §5/§6) so the code and the plan stop contradicting each other.
 ## 9. Success criteria
 | Area | Criterion |
 |---|---|
-| Composable launch (done) | eagle3/dflash/domino train via one strategy-parameterized path; full `test_runtime` green. |
+| Composable launch (in review) | eagle3/dflash/domino train via one strategy-parameterized path; full `test_runtime` green. |
 | Abstractions (B) | `TargetEngine` (wrapping existing adapters) + domain `Trainer` produce byte-identical batches/loss vs the direct spine path. |
 | Colocated (C) | W1/W2 run with control plane as no-op; colocated≡disagg equivalence gate passes. |
 | Managers (D) | resume reproduces the no-resume loss curve; one all-reduce per optimizer step; best-checkpoint tracked. |

--- a/plan.md
+++ b/plan.md
@@ -1,1505 +1,378 @@
-# SpecForge Redesign Plan
+# SpecForge Architecture Plan (Reconciled)
 
-> **Status**: Draft (train-with-decode promoted to Phase 5)
-> **Last updated**: 2026-05-31
-
----
-
-## 1. Context
-
-SpecForge trains speculative decoding draft models (EAGLE3, DFlash) aligned with SGLang
-serving. It works well for single-cluster torchrun workflows, but has accumulated structural
-debt that makes it hard to add new architectures, new training modes, and production tooling.
-
-TorchSpec (a sibling project) solves many of these gaps via Ray + Mooncake disaggregation,
-but at the cost of heavy dependencies and operational complexity. This plan takes a different
-approach: **keep SpecForge's simple torchrun-native design, but restructure internals so
-new capabilities compose cleanly.**
-
-### What we keep verbatim
-
-- `specforge/core/loss.py` — Triton `LogSoftmaxLoss` and `_compute_loss`.
-- `specforge/optimizer.py` — `BF16Optimizer` (FP32 master weights + AdamW + grad clip).
-- `specforge/lr_scheduler.py` — `CosineAnnealingWarmupLR` and the `TwoStageScheduler` family.
-- `specforge/tracker.py` — `Tracker` ABC + `TRACKER_REGISTRY` (wandb/tensorboard/swanlab/mlflow).
-- `specforge/distributed.py` — `init_distributed`, device meshes, yunchang USP integration.
-- `specforge/core/eagle3_adapters.py` — `BackendAdapter` / `StepState` / `UspAdapter`.
-- SGLang target backend code in `specforge/modeling/target/sglang_backend/`.
-- All 30+ existing draft model configs.
-
-### What we throw away
-
-- `scripts/train_eagle3.py` and `scripts/train_dflash.py` as god scripts (become thin shims).
-- Hardcoded `_model_mapping` / `_config_mapping` dicts in `specforge/modeling/auto.py`.
-- `configs/deepseek-v3-671b-eagle3.json` that claims `model_type: llama` for a DeepSeek target.
-- The argparse-flags + per-arch JSON config split.
-- `QwenVLOnlineEagle3Model` (VLM handled by target engine + data pipeline, not a separate model class).
-
-### Workloads in scope
-
-These are the concrete training workflows the redesign must support. All four share the same
-trainer / strategy / draft surface; they differ only in which `HiddenStateStream` and
-`TargetEngine` get composed at the top.
-
-| # | Workload | Description | Engine | Stream |
-|---|---|---|---|---|
-| W1 | **Offline** | Pre-computed hidden states from disk; trainer runs DP-only | none (`TargetHead` for logits) | `OfflineStream` |
-| W2 | **In-process online** | Target on the same GPUs as draft (TP-collective); current default | `SGLangEagle3TargetModel` / `HFEagle3TargetModel` / `CustomEagle3TargetModel` | `OnlineStream` |
-| W3 | **Disaggregated online** | Target on a separate SGLang server cluster; trainer talks HTTP | `SGLangServerEngine` | `RemoteStream` |
-| W4 | **Train-with-decode** *(new in this revision — promoted from Phase 6)* | One long-lived SGLang server simultaneously **(a)** generates training data via prefill+aux and **(b)** serves real spec-decoding traffic. Trainer pushes draft weights into the same server every N steps so production traffic immediately benefits. | `SGLangServerEngine` (decode mode + weight push) | `OnlineStream` over static jsonl, or new `ServingTrafficStream` over a serving-traffic buffer |
-
-W4 is what makes the no-Ray bet non-trivial: TorchSpec gets W4 "for free" because every
-SglEngine actor already supports both modes. SpecForge needs to add three things explicitly
-— `TargetEngine.update_draft_weights`, a decode-mode flag on `SGLangServerEngine`, and a
-periodic weight-sync hook in `Trainer` — but **no actor topology change**: it stays one
-torchrun-native trainer process talking HTTP to one always-on SGLang server. See §4.10.
+> **Status**: Draft — reconciles the original "SpecForge Redesign Plan" (a from-scratch,
+> torchrun-native, HTTP-only target architecture) with the **landed DataFlow `runtime/`
+> spine** (control/data/inference/training planes, SampleRef + FeatureStore + Mooncake).
+>
+> **Supersedes** the previous redesign draft. That draft's detailed component sketches
+> (CheckpointManager, Evaluator, Pydantic config, MLA draft, SGLang export, train-with-decode)
+> remain valid as the **domain-layer target** and are preserved verbatim in
+> [`docs/redesign-draft-legacy.md`](docs/redesign-draft-legacy.md); this document
+> re-frames *where they sit* now that the DataFlow runtime exists, and corrects the one bet
+> the original draft got wrong for our actual workloads (see §6).
 
 ---
 
-## 2. Current State Gap Analysis
+## 0. TL;DR — the decision
 
-This section grounds the design in what is concretely wrong or missing in the current
-codebase. Two flavors of gap: **(A) missing capabilities** — things the design assumes but
-no code exists for; **(B) structural problems** — code that exists but the shape is wrong.
+There were two architecture efforts in flight for the same goal (organize SpecForge so new
+draft models / training modes / disaggregation compose cleanly without a `train_XXX.py` per
+method):
 
-### 2.1 Missing capabilities
+- **The redesign draft** (this doc's predecessor): clean domain decomposition
+  (`models/drafts` registry, `TargetEngine`, `HiddenStateStream`, `DraftTrainStrategy`,
+  `Trainer`, config/eval/export/cli) — but **explicitly torchrun-native with no
+  Ray/Mooncake**; disaggregation was "the target is an HTTP service" (`RemoteStream`).
+- **The DataFlow `runtime/` spine** (landed: the `dataflow-up-1..20` stack, M1–M7/O1): a
+  metadata-only **control plane** + a tensor-carrying **data plane** (`SampleRef` +
+  `FeatureStore` incl. **Mooncake** + `StreamingRefChannel` + durable metadata + backpressure
+  + resume), with disaggregated producer/consumer and an interleaved online loop.
 
-| Gap | Evidence in current tree | Fixed by |
+**The fact that settles it:** there is a real **multi-node / >100 GB/s / isolated-pool**
+requirement (separate rollout and trainer pools, no shared FS / no viable HTTP path for the
+hidden-state volume). That **breaks the original draft's central bet** ("HTTP/gRPC to SGLang
+is sufficient; Mooncake only matters >100 GB/s which we never hit"). So the runtime's
+Mooncake control/data plane is **necessary, not premature**.
+
+**Decision: do not pick one — layer them.**
+
+- **Canonical substrate = the DataFlow `runtime/` control + data plane.** `SampleRef` (metadata
+  on the control plane) + `FeatureStore` (tensors, Local/SharedDir/Mooncake) + `FeatureDataLoader`
+  → `TrainBatch` is the canonical data path. online / offline / disaggregated converge at
+  `SampleRef`.
+- **Front-end = the redesign draft's domain layer.** `TargetEngine` / `DraftTrainStrategy` /
+  `Trainer` / `CheckpointManager` / `Evaluator` / config / eval / export / cli become the
+  user-facing surface. The **canonical "stream" is `FeatureDataLoader` over `SampleRef` +
+  `FeatureStore`** — we do **not** re-introduce a `HiddenStateStream` as a separate source of
+  truth (the loader already plays that role). The online/offline/disaggregated variation lives
+  in the *ref source* (`OfflineManifestReader` / `RolloutWorker` / `StreamingRefChannel`) + the
+  *transport* (`FeatureStore`: Local for colocated, Mooncake/SharedDir for isolated pools), and
+  is shielded from training by `FeatureDataLoader → TrainBatch`. (`RemoteStream`-over-HTTP is
+  just one more ref source / engine — the light cross-node option, not the base abstraction.)
+
+This is, in the predecessor's own terms, pulling **feature #32 ("Mooncake streaming backend")
+forward from Phase 7 to now** because the requirement demands it — and implementing it with the
+already-built `runtime/` work, behind the clean domain interfaces.
+
+---
+
+## 1. Why each side is right (and where each is incomplete)
+
+Two orthogonal slicings. The runtime is sliced by **plane** (how bytes/metadata move); the
+draft is sliced by **domain object** (draft / target / stream / strategy). They compose; they
+do not conflict.
+
+| Layer | Verdict | Rationale |
 |---|---|---|
-| **MLA-aware EAGLE3 draft** | Zero references to `DeepseekV3Config` / `Eagle3Deepseek*` outside test data. `configs/deepseek-v3-671b-eagle3.json` is a *Llama* draft mislabeled as DeepSeek (`model_type: "llama"`, `architectures: ["LlamaForCausalLMEagle3"]`). | Phase 1 #2 — port `deepseek_eagle.py` from TorchSpec, register via `@register_draft`. |
-| **Backbone-agnostic DFlash** | `DFlashDraftModel` extends `Qwen3PreTrainedModel`; uses `Qwen3MLP`, `Qwen3DFlashAttention`, `Qwen3RMSNorm` directly (`specforge/modeling/draft/dflash.py:212`). All DFlash configs are Qwen3-only. | Phase 6 #25 — parameterize MLP/Norm/RoPE; add `llama_dflash.py`. |
-| **Remote / disaggregated target** | `modeling/target/sglang_backend/` only does in-process SGLang (target loaded on same node as trainer). No HTTP client. Online mode for 671B targets is infeasible. | Phase 4 #17 — `SGLangServerEngine` over HTTP. |
-| **Eval during training (proper)** | No `EvalCache`, no `simulated_acc_len`, no per-position-accuracy aggregation, no best-checkpoint tracking — grep is clean. | Phase 2 #9 — `Evaluator` + `EvalCache`. |
-| **Checkpoint rotation / best tracking** | `train_eagle3.py:552:def save_checkpoints(...)` just writes every N steps. No `max_checkpoints`, no `best_checkpointed_iteration.txt`, no `meta.json`. | Phase 2 #8 — `CheckpointManager`. |
-| **Resume that actually advances the stream** | No `stream.seek()`. Current `--resume` reloads weights but the dataloader yields from sample 0, silently re-training on the prefix. | §4.2 trainer pseudo-code + Phase 2 #5 — `HiddenStateStream.seek()`. |
-| **Correct gradient accumulation** | Zero `no_sync()` calls anywhere in the codebase. FSDP all-reduces on every micro-step, defeating the point of `--accumulation-steps`. | Phase 2 #10 — `model.no_sync()` on non-sync micro-steps. |
-| **Plugin registry for drafts** | Hardcoded `_model_mapping = {LlamaConfig: LlamaForCausalLMEagle3}` (`specforge/modeling/auto.py:35`). Code already has TODO: "should support lazy model mapping via registry". | Phase 1 #1 — `@register_draft` decorator. |
-| **Train-with-decode (W4)** | No `update_draft_weights` on any target abstraction. `SGLangEagle3TargetModel.from_pretrained` hardcodes `disable_cuda_graph=True` (training-data-gen only); no notion of a long-lived dual-purpose server. No serving-traffic stream — `core/eagle3.py` only knows about static jsonl batches. No periodic weight push from trainer. | Phase 5 #21–#24 — `update_draft_weights` on `TargetEngine`, decode-mode flag on `SGLangServerEngine`, `ServingTrafficStream`, `Trainer._maybe_sync_draft_weights`. See §4.10. |
-| **SGLang export with MLA weight map** | No `export/to_sglang.py`. MLA draft weights (`q_a_proj`, `kv_a_proj_with_mqa`, `kv_b_proj`) need explicit rename to whatever SGLang's spec-decoder loader expects. | Phase 3 #15 + `docs/export_weight_map_mla.md`. |
-| **FSDP2 readiness** | `apply_fsdp` is FSDP1-only, inlined in scripts. No seam for FSDP2 swap. Locks the trainer to a pattern that composes poorly with `torch.compile`. | §4.9 — versioned `apply_fsdp` seam in Phase 2 (FSDP2 impl deferred to Phase 7 #31). |
-| **Pydantic config + CLI** | `specforge/args.py` is 219 lines of argparse; architecture lives in JSON (`--draft-model-config`); training flags live in CLI. Two sources of truth, no validation. | Phase 3 #13/14 — one validated YAML per run. |
-| **VLM unification** | Separate `QwenVLOnlineEagle3Model` class for VLM targets — parallel hierarchy that doesn't fit the abstraction. | Phase 4 #19 — typed `MediaInputs` in `TargetEngine`. |
+| **control plane** (`runtime/control_plane`) | **Keep — canonical. No predecessor equivalent.** | Metadata-only (every entrypoint runs `assert_no_tensors`), lease/ack/dedup/reconcile/backpressure behind a `MetadataStore` seam. This is exactly the cross-pool machinery the isolated-pool requirement needs, and the HTTP design has nothing like it. |
+| **data plane** (`runtime/data_plane`) | **Keep — canonical; it *is* the stream.** | `SampleRef` (metadata) ÷ `FeatureStore` (tensors) ÷ `FeatureDataLoader` (materialize) is a *finer* decomposition than the predecessor's coarse `HiddenStateStream`, and it's the better substrate for backpressure / lease-ack / resume / Mooncake. `FeatureDataLoader` over `SampleRef`+`FeatureStore` already plays the role plan.md gave `HiddenStateStream`, so **no separate `HiddenStateStream` source-of-truth is introduced** — `seek()`/prefetch land on the loader/ref-source; `FeatureStore` is the transport swap point. |
+| **inference plane** (`runtime/inference`) | **Converge to the predecessor's `TargetEngine`.** | Today it conflates "wrap a target engine" + "capture" inside `SGLangAdapter`, and is bound to `generate_eagle3_data` / EAGLE3 names. The `FeatureSource` Protocol already exists (good); the gap is a real `TargetEngine` abstraction (hf / sglang / **sglang_server** / custom) + de-EAGLE3-ifying. This is the layer that most borrows the draft. |
+| **training plane** (`runtime/training`) | **Keep the seam; fill the managers.** | `DraftTrainStrategy` / `TrainerCore` / `TrainingBackend` (+ the `StepContext` added for Domino) is *already* the predecessor's `training/strategies` shape — keep it. What's missing are the **managers**, not the seam: `no_sync()` accumulation, full optimizer/scheduler/RNG resume, `CheckpointManager` (rotation/best), `Evaluator`. |
 
-### 2.2 Structural / workflow problems
+**Already landed (the spine + first cleanup):**
 
-Code exists for these, but the shape is wrong: duplication, missing abstractions,
-maintenance debt that compounds with each new arch.
+- `runtime/` planes (M1–M7/O1): control/data/inference/training, `SampleRef`, `FeatureStore`
+  (Local/SharedDir/Mooncake), `StreamingRefChannel`, durable `MetadataStore`, disagg
+  producer/consumer + interleaved online loop.
+- **Composable launch** (`StrategySpec` registry + parameterized `launch.py`): adding a model
+  is a spec entry, not a `build_*_runtime` family. eagle3 / **dflash** / **domino** all train
+  end-to-end through one strategy-parameterized path (PRs #627 / #628 / #629, validated:
+  197 `tests/test_runtime` OK on H200). Domino added `StepContext{global_step, total_steps}`
+  threaded through `forward_loss` — the one deliberate contract extension for schedule-dependent
+  loss.
 
-| Problem | Concrete evidence | Fixed by |
-|---|---|---|
-| **God-script duplication** | `train_eagle3.py` = 1012 lines / 60 `add_argument`s; `train_dflash.py` = 562 lines / 44 `add_argument`s. Same argparse, same distributed init, same checkpoint save, same logging — copy-pasted twice. Total ~1574 lines across two top-level scripts. | Phase 2 #6 — single `Trainer`, strategy dispatch. Reduces to one ~70-line loop + strategy classes. |
-| **Target-model duplication in modeling/** | `modeling/target/eagle3_target_model.py` (873 lines) and `modeling/target/dflash_target_model.py` (315 lines) are parallel hierarchies with no shared base. | Phase 2 #4 — single `TargetEngine` ABC; three concrete impls. |
-| **Online ≠ class, offline ≠ class** | `core/eagle3.py` is the "online" wrapper (606 lines); offline is a different path through `OfflineEagle3Dataset` + `TargetHead`. The trainer must branch by mode. | Phase 2 #5 — both become `HiddenStateStream` implementations. Trainer takes one iterator regardless. |
-| **Arch dispatch by 4-file shotgun** | Adding a new arch today touches `modeling/auto.py:35`, `modeling/auto.py:88`, `modeling/auto.py:134`, plus `modeling/draft/__init__.py`. | Phase 1 #1 — one file, one decorator. |
-| **30 hand-maintained shell scripts** | `examples/run_*_online.sh` × 30. Defaults drift between them; new features need 30 edits. | Phase 3 #14 — 30 YAML files derived from one schema; shell scripts collapse to `specforge train --config ...`. |
-| **No data prefetch overlap** | `core/eagle3.py` runs target forward synchronously inside the training step. Draft backward blocks on target forward. | Phase 2 #5 — `OnlineStream.prefetch_factor` overlaps producer and consumer. |
-| **Misleading config in repo** | `configs/deepseek-v3-671b-eagle3.json` declares `model_type: "llama"` for a DeepSeek target — silently wrong if read as "MLA Eagle3 for V3." | §4.7 — rename to `..._llama_draft.json`, add real MLA config, deprecation warning. |
-| **No numerical-equivalence gate for refactors** | Nothing prevents Phase 2's `Trainer` extraction from quietly changing loss curves. | §10.1 — `atol/rtol` gate at fixed steps on every PR touching `core/`, `training/`, `models/drafts/`. |
-| **No FSDP all-reduce verification** | No profiler check that accumulation actually skips sync. `--accumulation-steps` flag exists but the sync isn't suppressed (no `no_sync()`) — same number of all-reduces as without accumulation. | §10.3 — one-time profiler check; one all-reduce per `optimizer.step()`. |
-| **`Eagle3DraftModel.backbone()` ABC return shape** | Returns `Tensor`; KV cache mutates `past_key_values` in place (HF `DynamicCache` pattern). DFlash respects this. A naive MLA port that returns `(out, k, v)` would break the ABC. | §4.7 — explicit "use `DynamicCache.update`, return `Tensor`" rule for MLA. |
-
-### 2.3 The two highest-leverage chunks
-
-If only two things ship this quarter, do these:
-
-**Chunk 1 — Phase 1 (Week 1-2): `@register_draft` + MLA draft + Kimi-K2.5 TP/SP smoke test.**
-Unblocks the actual feature ask (DFlash + MLA Eagle3 on SGLang). Additive — old
-`_model_mapping` dicts stay as a fallback. ~3 new files, ~10 lines of edits to `auto.py`.
-The TP/SP smoke test (§4.7) is the de-risking step that turns Kimi-K2.5 from "should
-work" into a verified deliverable.
-
-**Chunk 2 — Phase 2 (Week 3-6): `TargetEngine` + `HiddenStateStream` + `Trainer` together.**
-These ship as a unit. Extracting one without the others either leaves the trainer talking
-directly to target models (Phase 4 has to undo it) or leaves the stream abstraction
-without a consumer (can't be tested end-to-end). The Phase 2 acceptance gate is that the
-legacy shells, now calling new internals, match the old loss curves to numerical-
-equivalence tolerance (§10.1). Pass that, and Phase 4 becomes drop-in plugins
-(`SGLangServerEngine`, `RemoteStream`) without re-plumbing.
-
-Everything else (export tool, CLI, VLM cleanup, FSDP2, WSD, Mooncake) is debt cleanup
-that compounds — important but not blocking the stated goal.
+**Explicitly not yet implemented in `runtime/`** (flagged in-source — `contracts.py`,
+`trainer.py`, `controller.py`, both `DESIGN.md`s, `runtime/README.md`): the weight-publication
+lifecycle (`WeightVersion`, `WeightPublisher`, `update_draft_weights`, serving accept-length
+gate), full optimizer/scheduler resume, and `no_sync()` accumulation. These are the §3 gaps.
 
 ---
 
-## 3. Design Principles
+## 2. Target architecture
 
-1. **One trainer, many drafts, many targets.** Config-driven dispatch via a plugin registry.
-   New arch = new file, not a new script.
+### 2.1 Canonical data path (unchanged from the runtime, this is the spine)
 
-2. **The target is an interface, not a process.** Same trainer whether the target is in-process
-   HF, a separate SGLang server, or a remote cluster.
+```
+ref source            ─┐
+  OfflineManifestReader │  (offline: re-iterable refs)
+  RolloutWorker         │  (online: produced into a SampleRefQueue)
+  StreamingRefChannel   │  (disaggregated: cross-process/pool stream)
+                        ▼
+DataFlowController  ── metadata only (SampleRef), assert_no_tensors
+                        │
+FeatureStore  ── tensors only: LocalFeatureStore (mem://, colocated)
+                              SharedDirFeatureStore (shared mount)
+                              MooncakeFeatureStore (RDMA, isolated pools)
+                        ▼
+FeatureDataLoader (per_sample_transform + collate) ─► TrainBatch
+                        ▼
+DraftTrainStrategy.forward_loss(batch, ctx)  ─► TrainerCore / TrainerController ─► FSDP
+```
 
-3. **Three data modes behind one abstraction.** Offline-cached, online-local, online-remote —
-   all consumed via the same `HiddenStateStream` iterator. But respect the asymmetry: online
-   streams own GPU resources and backpressure; offline streams are pure readers.
+### 2.2 Domain layer on top (user-facing abstractions over the substrate)
 
-4. **Strategies, not forks.** EAGLE3 (TTT unroll) and DFlash (block-causal) are two
-   `DraftTrainStrategy` implementations sharing the trainer.
+The substrate's source of truth is `SampleRef` + `FeatureStore` + `FeatureDataLoader` (§2.1).
+The domain layer does **not** re-introduce a `HiddenStateStream` as a parallel source of truth —
+`FeatureDataLoader` already *is* the stream. The domain layer is what user/training code sees:
 
-5. **Keep what works.** Don't rewrite battle-tested code for symmetry.
+```
+PRODUCE (inference):
+  TargetEngine        ── the engine rollout wraps to produce features; the abstraction that
+                         replaces the EAGLE3-bound SGLangAdapter.
+     HFTargetEngine / SGLangTargetEngine / CustomTargetEngine (in-process)
+     SGLangServerEngine (HTTP service; owns update_draft_weights + serving_metrics for W4)
+  RolloutWorker       ── drives a TargetEngine → writes tensors to FeatureStore → commits
+                         SampleRef to the control plane. Stays at the domain↔substrate seam.
 
----
+CONSUME (training):
+  Trainer             ── owns the lifecycle: loop / eval / checkpoint / weight-sync. WRAPS the
+                         runtime TrainerController/TrainerCore; does NOT replace them.
+  DraftTrainStrategy  ── per-algorithm forward+loss (eagle3 TTT / dflash block / domino). Kept
+                         in runtime/training (the seam) — already plan-shaped.
+  CheckpointManager / Evaluator / lr_scheduler / fsdp seam  ── the managers (G1).
 
-## 4. Target Architecture
+COMPOSE:
+  models/drafts       ── DRAFT_REGISTRY (@register_draft) for draft *architecture* classes
+                         (llama / deepseek-MLA / dflash-qwen3). Separate axis from strategy.
+  StrategyRegistry    ── per-algorithm spec (today's StrategySpec, converged here).
+  config / cli / export ── first-class run surface (predecessor §4.3–4.8, carried forward).
+```
 
-### 4.1 Module layout
+The online / offline / disaggregated distinction is **not visible to `Trainer`/strategy** — it
+is fully absorbed by (ref source + `FeatureStore`) behind `FeatureDataLoader → TrainBatch`.
+
+### 2.3 Module layout (runtime spine + domain layer)
 
 ```
 specforge/
-├── config/                          # Structured configuration
-│   ├── schema.py                    # Pydantic models (Config, ModelConfig, DatasetConfig, ...)
-│   ├── loader.py                    # YAML load + merge + CLI override + validation
-│   └── draft_configs/               # Draft model JSONs (moved from top-level configs/)
-│       ├── llama3_8b_eagle3.json
-│       ├── qwen3_8b_eagle3.json
-│       ├── qwen3_8b_eagle3_mla.json       # NEW
-│       ├── kimi_k25_eagle3_mla.json       # NEW
-│       ├── deepseek_v3_671b_eagle3.json   # NEW — real MLA config
-│       └── ...
-│
-├── core/                            # Core algorithms (preserved)
-│   ├── eagle3.py                    # Eagle3Model (renamed from OnlineEagle3Model)
-│   ├── dflash.py                    # DFlashModel (renamed from OnlineDFlashModel)
-│   ├── loss.py                      # Triton LogSoftmaxLoss (UNCHANGED)
-│   └── adapters.py                  # BackendAdapter / UspAdapter (UNCHANGED)
+├── runtime/                         # CANONICAL DataFlow spine (keep)
+│   ├── contracts.py                 # SampleRef, TrainBatch, PromptTask, *Strategy literal
+│   ├── control_plane/               # metadata-only: controller, metadata_store, backpressure
+│   ├── data_plane/                  # FeatureStore (Local/SharedDir/Mooncake), loader, readers,
+│   │                                #   SampleRefQueue, StreamingRefChannel
+│   ├── inference/                   # rollout: RolloutWorker, capture, adapters  ──┐ converge to
+│   │                                #                                              │  TargetEngine
+│   ├── training/                    # DraftTrainStrategy, TrainerCore/Controller, backend,
+│   │                                #   StepContext, strategy registry
+│   └── launch.py                    # spec-driven builders (topology = builder, model = strategy=)
 │
 ├── models/
-│   ├── drafts/                      # Draft model plugin registry (see §4.2 for the registry + naming contract)
-│   │   ├── __init__.py              # DRAFT_REGISTRY + @register_draft decorator
-│   │   ├── base.py                  # Eagle3DraftModel ABC (from modeling/draft/base.py)
-│   │   ├── <model>_<strategy>.py    # one file per arch — ${model_name}_${strategy}
-│   │   │                            #   e.g. llama_eagle3, deepseek_eagle3, qwen3_dflash
-│   │   └── auto.py                  # AutoEagle3DraftModel (registry-backed, no hardcoded dicts)
-│   │
-│   └── targets/                     # Target engine abstraction
-│       ├── base.py                  # TargetEngine ABC + TargetOutput dataclass
-│       ├── hf_engine.py             # In-process HF target (lazy import)
-│       ├── sglang_engine.py         # In-process SGLang target (lazy import)
-│       ├── sglang_server_engine.py  # SGLang-as-service over HTTP (NEW)
-│       ├── custom_engine.py         # Custom TP backend (existing custom_backend/)
-│       └── target_head.py           # TargetHead for offline logits (existing)
+│   ├── drafts/                      # DRAFT_REGISTRY + @register_draft (NEW — predecessor §4.2)
+│   │   ├── base.py  llama_eagle3.py  deepseek_eagle3.py(MLA)  dflash_qwen3.py  auto.py
+│   └── targets/                     # TargetEngine ABC (NEW — absorbs runtime/inference adapters)
+│       ├── base.py  hf_engine.py  sglang_engine.py  sglang_server_engine.py  custom_engine.py
 │
-├── data/
-│   ├── streams/                     # HiddenStateStream abstraction
-│   │   ├── base.py                  # HiddenStateStream protocol
-│   │   ├── online.py               # In-process target generates hidden states
-│   │   ├── offline.py              # Pre-computed hidden states from disk
-│   │   └── remote.py               # Target on separate SGLang server (NEW)
-│   ├── template.py                  # TEMPLATE_REGISTRY (UNCHANGED)
-│   ├── parse.py                     # Parsers + KimiK25Parser, MiniMaxParser (NEW)
-│   ├── preprocessing.py             # build_eagle3_dataset etc. (UNCHANGED)
-│   ├── collator.py                  # DataCollatorWithPadding (extracted from utils.py)
-│   └── cache.py                     # Tokenization cache + eval cache (NEW)
+│                                    # (NO separate data/streams package — FeatureDataLoader over
+│                                    #  SampleRef+FeatureStore IS the stream. Ref sources
+│                                    #  (offline/rollout/streaming) live in runtime/data_plane;
+│                                    #  ServingTrafficStream (W4) is just another prompt/ref source)
 │
-├── training/
-│   ├── trainer.py                   # Trainer: unified training loop
-│   ├── strategies/
-│   │   ├── __init__.py              # DraftTrainStrategy protocol
-│   │   ├── eagle3_ttt.py            # Eagle3 TTT unroll + forward-KL
-│   │   └── dflash_block.py          # DFlash block-causal + anchor sampling
-│   ├── optimizer.py                 # BF16Optimizer (UNCHANGED)
-│   ├── lr_scheduler.py              # CosineWarmup + WSD scheduler (NEW)
-│   ├── checkpoint.py                # CheckpointManager (NEW)
-│   ├── fsdp.py                      # apply_fsdp (FSDP1 SHARD_GRAD_OP + future FSDP2)
-│   └── distributed.py               # init_distributed etc. (moved from specforge/distributed.py)
+├── training/                        # domain lifecycle + managers (WRAPS runtime/training)
+│   ├── trainer.py                   # owns loop/eval/checkpoint/weight-sync; delegates the step
+│   │                                #   to runtime TrainerCore + DraftTrainStrategy (kept seam)
+│   ├── checkpoint.py  lr_scheduler.py  fsdp.py   # NEW managers (§3). Strategies + StrategySpec
+│   │                                #   registry stay in runtime/training (the seam, unchanged).
 │
-├── eval/                            # Evaluation system (NEW)
-│   ├── evaluator.py                 # Evaluator: eval loop + metric aggregation
-│   ├── cache.py                     # EvalCache: MD5-keyed disk cache
-│   └── metrics.py                   # simulated_acc_len, avg_loss, avg_acc
-│
-├── export/                          # Model export tools (NEW)
-│   ├── to_hf.py                     # FSDP checkpoint → HF format + vocab pruning
-│   └── to_sglang.py                 # Checkpoint → SGLang spec-decoder layout
-│
-├── tracker.py                       # UNCHANGED
-├── utils.py                         # UNCHANGED
-│
-├── cli.py                           # `specforge train|prepare|export|eval` (NEW)
-└── __init__.py
-
-scripts/
-├── legacy/                          # Old scripts as thin shims
-│   ├── train_eagle3.py
-│   └── train_dflash.py
-├── prepare_data.py                  # UNCHANGED
-├── prepare_hidden_states.py         # UNCHANGED
-└── regenerate_train_data.py         # UNCHANGED
+├── eval/  export/  config/  cli.py  # NEW — carried forward from predecessor §4.4–4.8
+└── core/  optimizer.py  tracker.py  distributed.py  # kept verbatim (predecessor §1)
 ```
 
-### 4.2 Key abstractions
-
-#### Draft model registry
-
-This is the single source of truth for the `models/drafts/` layout sketched in §4.1.
-One file per architecture, named `${model_name}_${strategy}` (strategy ∈ `eagle3`,
-`dflash`, `domino`, `dspark`) — e.g. `llama_eagle3.py`, `deepseek_eagle3.py`,
-`qwen3_dflash.py`; the registry key matches the filename stem.
-
-```python
-# models/drafts/__init__.py
-DRAFT_REGISTRY: dict[str, type] = {}
-
-def register_draft(name: str):
-    """Decorator. New arch = new file + @register_draft("deepseek_v3_eagle3")."""
-    def wrapper(cls):
-        DRAFT_REGISTRY[name] = cls
-        return cls
-    return wrapper
-
-# models/drafts/llama_eagle3.py
-@register_draft("llama_eagle3")
-class LlamaForCausalLMEagle3(Eagle3DraftModel):
-    ...
-
-# models/drafts/deepseek_eagle3.py — MLA (NEW)
-@register_draft("deepseek_v3_eagle3")
-class Eagle3DeepseekV2ForCausalLM(Eagle3DraftModel):
-    config_class = DeepseekV3Config
-    ...
-
-# models/drafts/qwen3_dflash.py — DFlash (existing)
-@register_draft("qwen3_dflash")
-class DFlashDraftModel(Eagle3DraftModel):
-    ...
-```
-
-The `Eagle3DraftModel` ABC is preserved exactly as-is. Its interface is already well-designed:
-
-```python
-class Eagle3DraftModel(PreTrainedModel, ABC):
-    def embed_input_ids(self, input_ids: Tensor) -> Tensor: ...
-    def project_hidden_states(self, hidden_states: Tensor) -> Tensor: ...
-    def backbone(self, input_embeds, hidden_states, cache_hidden,
-                 attention_mask, position_ids, past_key_values=None,
-                 use_cache=True) -> Tensor: ...
-    def compute_logits(self, hidden_states: Tensor) -> Tensor: ...
-    # Concrete: load_embedding, freeze_embedding, load_vocab_mapping, t2d/d2t
-```
-
-`AutoDraftModelConfig.from_file()` is updated to look up `DRAFT_REGISTRY` first, fall back to
-HF config type dispatch for backward compatibility.
-
-#### Target engine
-
-```python
-# models/targets/base.py
-@dataclass
-class TargetOutput:
-    aux_hidden_states: torch.Tensor  # [batch, seq, hidden * num_aux_layers] — raw concat (NOT projected)
-    target_logits: torch.Tensor      # [batch, seq, vocab] — pre-softmax logits in draft vocab space
-    loss_mask: torch.Tensor          # [batch, seq]
-    input_ids: torch.Tensor          # [batch, seq]
-    attention_mask: torch.Tensor     # [batch, seq]
-    last_hidden_states: Optional[torch.Tensor] = None
-
-class TargetEngine(ABC):
-    @abstractmethod
-    def generate_train_data(
-        self,
-        input_ids: Tensor,
-        attention_mask: Tensor,
-        loss_mask: Tensor,
-        media: Optional[MediaInputs] = None,   # typed VLM payload (pixel_values, image_grid_thw, ...)
-    ) -> TargetOutput: ...
-
-    @property
-    @abstractmethod
-    def aux_layer_ids(self) -> list[int]: ...
-
-    def set_aux_hidden_states_layers(self, layers: list[int]) -> None: ...
-```
-
-Naming:
-- `target_logits` (not `target`) — the previous overload of "target" with "target model" was confusing.
-- `aux_hidden_states` — raw concatenated multi-layer hidden states from the target.
-  The projection (3·hidden → hidden) **stays inside the draft model** (`project_hidden_states`),
-  so streams and engines never need to know the draft's hidden_size.
-
-This is a rename + mild generalization of the existing `Eagle3TargetModel` +
-`Eagle3TargetOutput`. The existing SGLang/HF/Custom implementations become concrete engines
-with no API changes. VLM is handled via `**media_kwargs` — no separate model class needed.
-
-Lazy imports ensure SGLang is never imported unless `backend="sglang"`:
-
-```python
-def get_target_engine(backend: str, **kwargs) -> TargetEngine:
-    if backend == "sglang":
-        from specforge.models.targets.sglang_engine import SGLangTargetEngine
-        return SGLangTargetEngine(**kwargs)
-    elif backend == "sglang_server":
-        from specforge.models.targets.sglang_server_engine import SGLangServerEngine
-        return SGLangServerEngine(**kwargs)
-    elif backend == "hf":
-        from specforge.models.targets.hf_engine import HFTargetEngine
-        return HFTargetEngine(**kwargs)
-    elif backend == "custom":
-        from specforge.models.targets.custom_engine import CustomTargetEngine
-        return CustomTargetEngine(**kwargs)
-    raise ValueError(f"Unknown target backend: {backend}")
-```
-
-#### HiddenStateStream
-
-```python
-# data/streams/base.py
-class HiddenStateStream(ABC):
-    """Produces TrainBatch instances for the draft trainer."""
-
-    def setup(self, draft_config) -> None:
-        """Inform stream of draft requirements (aux layers, vocab mapping, etc.)."""
-        pass
-
-    @abstractmethod
-    def __iter__(self) -> Iterator[TrainBatch]: ...
-
-    def seek(self, step: int) -> None:
-        """Resume from step N. Required for checkpoint resume to behave correctly.
-
-        Default behavior (provided by base class): advance the iterator by `step`
-        batches. Implementations with random-access storage (e.g. OfflineStream)
-        should override to seek directly without consuming.
-        """
-
-    def teardown(self) -> None:
-        """Release GPU / network resources."""
-        pass
-
-@dataclass
-class TrainBatch:
-    input_ids: torch.Tensor
-    attention_mask: torch.Tensor
-    target_logits: torch.Tensor     # target logits on draft vocab (pre-softmax)
-    loss_mask: torch.Tensor
-    aux_hidden_states: torch.Tensor # raw concat of target aux layers — draft projects internally
-    position_ids: Optional[torch.Tensor] = None
-```
-
-Three implementations:
-
-| Stream | Source | GPU cost | Notes |
-|--------|--------|----------|-------|
-| `OnlineStream` | In-process `TargetEngine` | High (target on same GPUs) | Current "online" mode; supports `prefetch_factor` to overlap target inference with draft training |
-| `OfflineStream` | Pre-computed .pt files | None | Current "offline" mode; overrides `seek()` for O(1) resume |
-| `RemoteStream` | SGLang server over HTTP | None locally | NEW — target on separate node(s); supports `prefetch_factor` and request batching |
-
-`OnlineStream` owns the target engine lifecycle and handles TP→DP batch sharding
-(currently done manually in `train_eagle3.py:get_dp_data_shard_from_tp`). Exposes
-`prefetch_factor: int = 2` so the next batch's target forward overlaps the current
-batch's draft backward.
-
-`OfflineStream` wraps the existing `OfflineEagle3Dataset` + `TargetHead` path. Overrides
-`seek()` to jump directly to a sample index without iterating intermediate files.
-
-`RemoteStream` sends tokenized batches to an SGLang server, receives hidden states back.
-This covers the "671B target on dedicated GPUs" case without Ray/Mooncake. Should also
-expose `prefetch_factor` (network roundtrip dominates without it) and a `max_in_flight`
-bound so back-pressure is explicit.
-
-#### DraftTrainStrategy
-
-```python
-# training/strategies/__init__.py
-class DraftTrainStrategy(ABC):
-    """Encapsulates one training algorithm's forward + loss computation."""
-
-    @abstractmethod
-    def forward_and_loss(
-        self,
-        draft_model: Eagle3DraftModel,
-        batch: TrainBatch,
-    ) -> tuple[torch.Tensor, dict[str, float]]:
-        """Returns (loss, metrics_dict). Target data is already in batch."""
-        ...
-
-    @abstractmethod
-    def build_model(self, draft_model, **kwargs) -> nn.Module:
-        """Wrap draft_model in the strategy-specific training wrapper."""
-        ...
-
-    def fsdp_wrap_policy(self) -> Optional[Callable]:
-        """Optional: return an FSDP auto-wrap policy tailored to this strategy's wrapper.
-
-        The trainer applies this if non-None; otherwise falls back to a default
-        transformer-block wrap policy. Lets strategies declare wrapping intent
-        instead of the trainer second-guessing.
-        """
-        return None
-```
-
-Two implementations:
-
-- **`Eagle3TTTStrategy`**: wraps draft in `Eagle3Model` (current `core/eagle3.py`), runs
-  TTT unroll, forward-KL loss via `LogSoftmaxLoss`. The existing `Eagle3Model.forward()`
-  signature maps directly.
-
-- **`DFlashBlockStrategy`**: wraps draft in `DFlashModel` (current `core/dflash.py`), does
-  anchor sampling + block-causal CE. The existing `OnlineDFlashModel.forward()` maps directly.
-
-The strategy does NOT touch the target engine — batch already contains materialized tensors.
-This is a hard boundary.
-
-#### Trainer
-
-```python
-# training/trainer.py
-class Trainer:
-    def __init__(self, config: Config):
-        self.config = config
-        self.strategy = self._build_strategy()
-        self.checkpoint_mgr = CheckpointManager(config.training)
-        self.evaluator = Evaluator(config.eval) if config.eval.enabled else None
-        self.tracker = create_tracker(config.logging)
-
-    def train(self):
-        # 1. Distributed setup
-        init_distributed(...)
-
-        # 2. Build draft model from registry
-        draft_config = AutoDraftModelConfig.from_file(self.config.model.draft_model_config)
-        draft_model = DRAFT_REGISTRY[draft_config.architectures[0]].from_config(draft_config)
-
-        # 3. Build strategy-specific wrapper
-        model = self.strategy.build_model(draft_model, ...)
-
-        # 4. Apply FSDP (strategy may override wrap policy)
-        model = apply_fsdp(
-            model,
-            self.config.training,
-            wrap_policy=self.strategy.fsdp_wrap_policy(),
-        )
-
-        # 5. Build optimizer
-        optimizer = BF16Optimizer(model, ...)
-
-        # 6. Build data stream
-        stream = self._build_stream()
-        stream.setup(draft_config)
-
-        # 7. Resume if needed — note: stream.seek() is required for correctness.
-        #    enumerate(stream, start=start_step) only changes the counter; without
-        #    seek(), the stream still yields batch 0 first, silently re-training on it.
-        start_step = 0
-        if self.config.training.resume:
-            start_step = self.checkpoint_mgr.load(model, optimizer)
-            stream.seek(start_step)
-
-        # 8. Training loop
-        accum = self.config.training.accumulation_steps
-        for step, batch in enumerate(stream, start=start_step):
-            if step >= self.config.training.max_steps:
-                break
-
-            # Forward + loss (strategy-specific)
-            loss, metrics = self.strategy.forward_and_loss(model, batch)
-            scaled_loss = loss / accum
-
-            # Skip gradient sync on all but the final micro-step of an accumulation
-            # window. With FSDP this is the difference between one all-reduce per
-            # micro-batch and one per optimizer step — non-trivial on large models.
-            is_sync_step = ((step + 1) % accum == 0)
-            sync_ctx = nullcontext() if is_sync_step else model.no_sync()
-            with sync_ctx:
-                scaled_loss.backward()
-
-            if is_sync_step:
-                optimizer.step()
-
-            # Logging
-            if (step + 1) % self.config.training.log_interval == 0:
-                self.tracker.log(metrics, step=step)
-
-            # Eval
-            if self.evaluator and (step + 1) % self.config.eval.interval == 0:
-                eval_metrics = self.evaluator.run(
-                    lambda b: self.strategy.forward_and_loss(model, b),
-                    self._eval_stream,
-                )
-                self.checkpoint_mgr.update_best(step, eval_metrics)
-                self.tracker.log(eval_metrics, step=step)
-
-            # Save
-            if (step + 1) % self.config.training.save_interval == 0:
-                self.checkpoint_mgr.save(step, model, optimizer)
-
-        stream.teardown()
-        self.tracker.close()
-```
-
-This is ~70 lines of logic. Everything else is behind interfaces.
-
-Two non-obvious correctness points the pseudo-code makes explicit:
-
-1. **Resume requires `stream.seek(start_step)`.** Without it, `enumerate(stream, start=N)`
-   only relabels the counter — the iterator still yields batch 0 first, so resume
-   silently re-trains on the prefix.
-
-2. **Gradient accumulation needs `model.no_sync()` on non-sync steps.** Otherwise FSDP
-   all-reduces on every micro-batch, defeating the point of accumulation.
-
-### 4.3 Checkpoint manager
-
-```python
-# training/checkpoint.py
-class CheckpointManager:
-    def __init__(self, config: TrainingConfig):
-        self.checkpoint_dir = Path(config.checkpoint_dir)
-        self.max_checkpoints = config.max_checkpoints    # 0 = keep all
-        self.best_score = -float("inf")
-
-    def save(self, step: int, model, optimizer, meta: dict = None):
-        """Save model + optimizer + LR state + RNG + meta.json."""
-        step_dir = self.checkpoint_dir / f"iter_{step + 1:07d}"
-        # torch.distributed.checkpoint.save for model, optimizer
-        # rank-0: rng.pt, meta.json (step, timestamp, global_step, world_size)
-        self._update_latest(step + 1)
-        self._rotate()
-
-    def load(self, model, optimizer=None, continual=False) -> int:
-        """Load latest or specified checkpoint. Returns start_step."""
-        step_id = self._read_latest()
-        # torch.distributed.checkpoint.load
-        # If continual: skip optimizer/LR/RNG, only restore weights + rebuild FP32 master
-        return step_id
-
-    def update_best(self, step: int, eval_metrics: dict):
-        """Track best checkpoint by simulated_acc_len."""
-        score = eval_metrics.get("simulated_acc_len", eval_metrics.get("avg_acc", 0))
-        if score > self.best_score:
-            self.best_score = score
-            self._write_best(step + 1, eval_metrics)
-
-    def _rotate(self):
-        """Keep only max_checkpoints newest iter_* directories."""
-        if self.max_checkpoints <= 0:
-            return
-        dirs = sorted(self.checkpoint_dir.glob("iter_*"))
-        for d in dirs[:-self.max_checkpoints]:
-            shutil.rmtree(d)
-
-    def _update_latest(self, step_id: int):
-        (self.checkpoint_dir / "latest_checkpointed_iteration.txt").write_text(str(step_id))
-
-    def _write_best(self, step_id: int, metrics: dict):
-        (self.checkpoint_dir / "best_checkpointed_iteration.txt").write_text(str(step_id))
-        (self.checkpoint_dir / "best_meta.json").write_text(json.dumps(metrics, indent=2))
-```
-
-### 4.4 Evaluation system
-
-```python
-# eval/evaluator.py
-class Evaluator:
-    def __init__(self, config: EvalConfig):
-        self.cache = EvalCache(config.cache_dir)
-        self.micro_batch_size = config.micro_batch_size
-
-    def run(self, forward_fn, eval_stream: HiddenStateStream) -> dict:
-        """Run full eval pass, return aggregated metrics.
-
-        Per-position accuracy must be averaged *across all batches first*, then fed
-        into the geometric sum. Treating each batch's per-position vector as if it
-        were positions makes simulated_acc_len batch-size-dependent.
-        """
-        total_loss_x_tokens = 0.0
-        total_tokens = 0
-        # Sum and count per draft position (TTT step), aggregated across the whole pass.
-        per_pos_acc_sum: Optional[torch.Tensor] = None       # shape [ttt_length]
-        per_pos_acc_count: Optional[torch.Tensor] = None     # shape [ttt_length]
-
-        for batch in self._iter_micro_batches(eval_stream):
-            with torch.no_grad():
-                loss, metrics = forward_fn(batch)
-            total_loss_x_tokens += metrics["loss"] * metrics["num_tokens"]
-            total_tokens += metrics["num_tokens"]
-
-            ppa = metrics.get("per_position_acc")        # [ttt_length], weighted by num_tokens
-            ppc = metrics.get("per_position_count")      # [ttt_length], token counts per position
-            if ppa is not None:
-                if per_pos_acc_sum is None:
-                    per_pos_acc_sum = torch.zeros_like(ppa)
-                    per_pos_acc_count = torch.zeros_like(ppc)
-                per_pos_acc_sum += ppa * ppc             # accumulate weighted sum
-                per_pos_acc_count += ppc
-
-        # Aggregate first, then geometric-sum.
-        per_position_acc = (per_pos_acc_sum / per_pos_acc_count.clamp_min(1)).tolist()
-        return {
-            "eval/avg_loss": total_loss_x_tokens / max(total_tokens, 1),
-            "eval/avg_acc": float(per_position_acc[0]) if per_position_acc else 0.0,
-            "eval/simulated_acc_len": self._simulated_acc_len(per_position_acc),
-        }
-
-    @staticmethod
-    def _simulated_acc_len(per_position_acc: list[float]) -> float:
-        """E[accepted tokens] = acc_0 + acc_0*acc_1 + acc_0*acc_1*acc_2 + ...
-
-        `per_position_acc` is the *aggregated* per-position accuracy across the full
-        eval set, length = ttt_length. Not a list of per-batch vectors.
-        """
-        cumulative = 1.0
-        total = 0.0
-        for acc in per_position_acc:
-            cumulative *= acc
-            total += cumulative
-        return total
-
-# eval/cache.py
-class EvalCache:
-    """Disk cache for pre-computed eval hidden states.
-
-    Cache key must cover everything that would change the cached tensors:
-    eval data, target model identity & revision, tokenizer, chat template,
-    aux layer ids, and sequence length. Missing any of these silently serves
-    stale data after a target swap or template change.
-    """
-
-    def __init__(self, cache_dir: str):
-        self.cache_dir = Path(cache_dir)
-
-    def cache_key(
-        self,
-        eval_path: str,
-        target_path: str,
-        target_revision: str,
-        tokenizer_path: str,
-        chat_template: str,
-        aux_layer_ids: list[int],
-        max_seq_len: int,
-    ) -> str:
-        content = "|".join([
-            eval_path,
-            target_path,
-            target_revision or "",
-            tokenizer_path,
-            chat_template,
-            ",".join(map(str, aux_layer_ids)),
-            str(max_seq_len),
-        ])
-        return hashlib.md5(content.encode()).hexdigest()[:12]
-
-    def try_load(self, key: str) -> Optional[list]:
-        path = self.cache_dir / "eval_cache" / key
-        if path.exists():
-            return [torch.load(f) for f in sorted(path.glob("rank_*.pt"))]
-        return None
-
-    def save(self, key: str, rank: int, data: list):
-        path = self.cache_dir / "eval_cache" / key
-        path.mkdir(parents=True, exist_ok=True)
-        torch.save(data, path / f"rank_{rank:04d}.pt")
-```
-
-Note: `data/cache.py` (tokenization cache) and `eval/cache.py` (eval hidden-state cache)
-are deliberately separate — they key on different things and live at different lifecycle
-points. Don't merge them.
-
-### 4.5 Structured config
-
-```python
-# config/schema.py
-from pydantic import BaseModel, Field
-from typing import Optional, Literal
-
-class ModelConfig(BaseModel):
-    target_model_path: str
-    draft_model_config: str               # path to JSON
-    target_backend: Literal["sglang", "hf", "custom", "sglang_server"] = "sglang"
-    trust_remote_code: bool = False
-    embedding_key: str = "model.embed_tokens.weight"
-    lm_head_key: str = "lm_head.weight"
-    is_vlm: bool = False
-
-class DatasetConfig(BaseModel):
-    train_data_path: str
-    eval_data_path: str = ""
-    train_hidden_states_path: str = ""    # non-empty = offline mode
-    chat_template: str = "llama3"
-    max_length: int = 2048
-    train_only_last_turn: bool = False
-    num_proc: int = 8
-
-class TrainingConfig(BaseModel):
-    strategy: Literal["eagle3", "dflash"] = "eagle3"
-    num_epochs: int = 1
-    max_steps: int = 10000
-    batch_size: int = 1
-    learning_rate: float = 3e-4
-    warmup_ratio: float = 0.015
-    max_grad_norm: float = 0.5
-    accumulation_steps: int = 1
-    ttt_length: int = 7                   # Eagle3-specific
-    block_size: int = 16                  # DFlash-specific
-    num_anchors: int = 512                # DFlash-specific
-    loss_decay_gamma: Optional[float] = None
-    attention_backend: Literal["sdpa", "flex_attention", "fa", "usp"] = "sdpa"
-    fsdp_strategy: Literal["NO_SHARD", "SHARD_GRAD_OP", "FULL_SHARD", "HYBRID_SHARD"] = "SHARD_GRAD_OP"
-    fsdp_version: Literal[1, 2] = 1       # 2 = FSDP2 (PT 2.4+); see §4.9
-    compile_model: bool = False
-    tp_size: int = 1
-    sp_ulysses_size: int = 1
-    sp_ring_size: int = 1
-    save_interval: int = 500
-    log_interval: int = 10
-    max_checkpoints: int = 5              # 0 = keep all
-    checkpoint_dir: str = "checkpoints"
-    resume: bool = False
-    seed: int = 42
-
-class EvalConfig(BaseModel):
-    enabled: bool = False
-    interval: int = 500
-    micro_batch_size: int = 4
-    cache_dir: str = "eval_cache"
-
-class LRConfig(BaseModel):
-    decay_style: Literal["cosine", "WSD"] = "cosine"
-    wsd_decay_steps: int = 0
-    wsd_decay_style: Literal["linear", "cosine", "exponential"] = "cosine"
-
-class LoggingConfig(BaseModel):
-    report_to: Literal["wandb", "tensorboard", "swanlab", "mlflow", "none"] = "wandb"
-    wandb_project: str = "specforge"
-    wandb_run_name: str = ""
-
-class SGLangConfig(BaseModel):
-    attention_backend: str = "flashinfer"
-    # ... other SGLang server args
-
-class Config(BaseModel):
-    model: ModelConfig
-    dataset: DatasetConfig
-    training: TrainingConfig = Field(default_factory=TrainingConfig)
-    eval: EvalConfig = Field(default_factory=EvalConfig)
-    lr: LRConfig = Field(default_factory=LRConfig)
-    logging: LoggingConfig = Field(default_factory=LoggingConfig)
-    sglang: SGLangConfig = Field(default_factory=SGLangConfig)
-    output_dir: str = "output"
-    cache_dir: str = "cache"
-```
-
-YAML example for MLA Eagle3 training:
-
-```yaml
-model:
-  target_model_path: Qwen/Qwen3-8B
-  draft_model_config: specforge/config/draft_configs/qwen3_8b_eagle3_mla.json
-  target_backend: sglang
-
-dataset:
-  train_data_path: data/train.jsonl
-  eval_data_path: data/eval.jsonl
-  chat_template: qwen3
-  max_length: 4096
-
-training:
-  strategy: eagle3
-  max_steps: 20000
-  batch_size: 2
-  learning_rate: 3e-4
-  ttt_length: 7
-  attention_backend: flex_attention
-  accumulation_steps: 2
-  tp_size: 4
-  max_checkpoints: 3
-
-eval:
-  enabled: true
-  interval: 1000
-
-output_dir: runs/qwen3_8b_mla_eagle3
-```
-
-CLI override: `specforge train --config config.yaml --training.learning_rate=1e-4`
-
-### 4.6 WSD learning rate scheduler
-
-> **Deferred to Phase 6** (was Phase 2 in the original draft). Cosine warmup is sufficient
-> for typical draft training runs; WSD is most useful for continued pretraining and long
-> stable-phase runs, which aren't on the immediate roadmap.
-
-Add to `specforge/training/lr_scheduler.py`:
-
-```python
-class WSDScheduler(_LRScheduler):
-    """Warmup → Stable → Decay schedule.
-
-    Stable phase holds max LR until (total_steps - wsd_decay_steps).
-    Decay phase applies linear/cosine/exponential decay to min_lr.
-    """
-    def __init__(self, optimizer, total_steps, warmup_steps, min_lr=0.0,
-                 wsd_decay_steps=0, wsd_decay_style="cosine", last_epoch=-1):
-        ...
-```
-
-Wired via `LRConfig.decay_style == "WSD"` in the trainer.
-
-### 4.7 MLA Eagle3 draft model
-
-Port from TorchSpec's `deepseek_eagle.py`. Key design decisions:
-
-**KV cache in TTT context**: During Eagle3 TTT unroll, cache expanded K/V (not compressed
-latent). This matches TorchSpec's approach and avoids requiring MLA-specific cache logic in
-`core/eagle3.py`. The MLA compression only happens during projection (forward pass), not in
-the cache.
-
-**Cache integration**: use the HF `DynamicCache` pattern (mutate `past_key_values` in place
-via `past_key_values.update(k, v, layer_idx, cache_kwargs)`) — same as the existing
-`DFlashDraftModel` and `Eagle3DraftModel.backbone()` ABC, which returns `Tensor` (hidden
-states) and never a `(Tensor, k, v)` tuple. Returning a tuple would break the base ABC.
-
-```python
-# models/drafts/deepseek_eagle3.py
-@register_draft("deepseek_v3_eagle3")
-class Eagle3DeepseekV2ForCausalLM(Eagle3DraftModel):
-    config_class = DeepseekV3Config
-
-    class DeepSeekMLAAttention(nn.Module):
-        """MLA attention with Q/KV LoRA, decoupled RoPE."""
-        def __init__(self, config: DeepseekV3Config):
-            # Q path: q_a_proj → RMSNorm → q_b_proj (if q_lora_rank)
-            # KV path: kv_a_proj_with_mqa → split(kv_compressed, k_rope_raw)
-            #        → kv_a_layernorm → kv_b_proj → split(k_nope, value)
-            # RoPE: interleaved rotation on qk_rope_head_dim slice only
-            # o_proj: num_heads * v_head_dim → hidden_size
-            ...
-
-        def forward(self, hidden_states, past_key_values=None,
-                    attention_mask=None, position_ids=None, cache_position=None,
-                    use_cache=False):
-            # 1. Project Q (with optional LoRA)
-            # 2. Project KV (compressed → expand via kv_b_proj)
-            # 3. Split k_nope from kv_b_proj, k_rope_raw from kv_a_proj
-            # 4. Apply interleaved RoPE to q_rope and k_rope slices
-            # 5. Expand k_rope (MQA → MHA) across heads
-            # 6. Concat [k_nope, k_rope] → full expanded key
-            # 7. If use_cache and past_key_values is not None:
-            #        k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
-            # 8. Attention (SDPA or FlexAttention)
-            # 9. Return attn_output  — k/v stored in the mutable DynamicCache
-            ...
-```
-
-Config fields consumed from `DeepseekV3Config`:
-- `q_lora_rank` — Q low-rank dim (None = dense Q)
-- `kv_lora_rank` — KV compressed dim
-- `qk_nope_head_dim` — per-head key dim without RoPE
-- `qk_rope_head_dim` — per-head key dim with RoPE
-- `v_head_dim` — per-head value dim (may differ from key dim)
-- `rope_scaling` — YaRN parameters
-
-**Memory budget for expanded TTT cache**. Per token per draft layer:
-
-    key_bytes_per_token   = num_heads * (qk_nope_head_dim + qk_rope_head_dim) * dtype_size
-    value_bytes_per_token = num_heads * v_head_dim                            * dtype_size
-
-For DeepSeek-V3 numbers (128 heads, 128 nope + 64 rope, 128 v_dim, bf16 = 2B):
-- per token: 128*(128+64)*2 = 49 152 B key + 128*128*2 = 32 768 B value ≈ 80 KB
-- at seq=4096, ttt=7, one draft layer, one sample: ~2.3 GB
-- the draft typically has 1 layer, so this scales with `batch_size` not with `num_layers`
-
-So per-GPU peak from the TTT cache ≈ `batch_per_gpu * 2.3 GB`. Bound `batch_size`
-accordingly, or revisit the compressed-cache option if this blocks longer-context training.
-
-**TP/SP for MLA — validate before Phase 1 sign-off**. MLA has asymmetric per-head dims
-(`qk_nope`, `qk_rope`, `v_head_dim`) — Yunchang USP and any TP slicing assume per-head
-homogeneity in places. A small smoke test on Kimi-K2.5 with `tp_size=2`,
-`sp_ulysses_size=2` is on the Phase 1 critical path, not a Phase 4 concern.
-
-**Migration for the old `configs/deepseek-v3-671b-eagle3.json`**. That file declares
-`model_type: "llama"` and trains a Llama-style draft against a DeepSeek target — it's not
-an MLA draft despite the filename. Phase 1 plan:
-- Move it to `specforge/config/draft_configs/deepseek_v3_671b_eagle3_llama_draft.json`
-  (preserves backward compat for anyone training against it).
-- Add the new MLA config at `specforge/config/draft_configs/deepseek_v3_671b_eagle3.json`.
-- Emit a one-time deprecation warning when the old path is loaded.
-
-### 4.8 SGLang export tool
-
-```python
-# export/to_sglang.py
-def export_to_sglang(checkpoint_dir: str, output_dir: str, target_model_path: str,
-                     prune_vocab: bool = False, prune_dataset: str = None):
-    """Convert FSDP training checkpoint to SGLang-loadable spec-decoder format.
-
-    Handles:
-    - FSDP state dict → flat state dict
-    - Weight key renaming (training names → SGLang spec-decoder expected names)
-    - MLA weight naming: q_a_proj, kv_a_proj_with_mqa, kv_b_proj etc.
-    - Optional vocab pruning based on dataset token frequency
-    - Config generation (draft config JSON + tokenizer copy)
-    """
-    ...
-```
-
-**Weight-name compatibility is the riskiest single piece of the rewrite** — it's silent
-when it goes wrong (loader picks up zeros for missing keys, or refuses to load). Before
-Phase 3 starts, produce an explicit two-column map per draft arch:
-
-| Trainer key | SGLang spec-decoder loader key |
+> The one real structural move is `runtime/inference` → `models/targets` (extract a
+> `TargetEngine` from the EAGLE3-bound adapter) plus a thin domain `training/` (Trainer +
+> managers) wrapping the kept `runtime/training` seam. The control + data planes stay exactly
+> where they are — they are the substrate, **not** re-housed behind a new stream package.
+
+---
+
+## 3. Gaps to close (prioritized) — what the domain layer adds on top of the spine
+
+These are the items the landed `runtime/` does **not** have, drawn from the predecessor and
+from the in-source `NOTE`s. Each lands behind the canonical spine without re-plumbing it.
+
+### G1 — Training managers (highest leverage; the spine works but is bare)
+- **`no_sync()` accumulation.** `runtime/training` has **zero** `no_sync()` — FSDP all-reduces
+  every micro-step, defeating `accumulation_steps`. (Predecessor §4.2 #10; verify with one
+  profiler check: one all-reduce per `optimizer.step()`.)
+- **Full resume.** `save_checkpoint` persists training state only; no optimizer/scheduler/RNG
+  restore, no rotation, no best-tracking. Add `CheckpointManager` (predecessor §4.3) + a
+  `seek()`-equivalent on the colocated streams.
+- **`Evaluator` + `EvalCache`.** No `simulated_acc_len` / per-position-acc / best-checkpoint.
+  (Predecessor §4.4 — per-position acc aggregated across batches *before* the geometric sum.)
+- **lr WSD + per-strategy `fsdp_wrap_policy()`** (predecessor §4.6, §4.2).
+
+### G2 — `TargetEngine` abstraction (inference convergence)
+- Introduce `TargetEngine` ABC; refactor `SGLangAdapter`/`DFlashAdapter` to wrap a
+  `TargetEngine` and stop binding to `generate_eagle3_data` / EAGLE3 names. Keep the existing
+  `FeatureSource` Protocol. Add `SGLangServerEngine` (HTTP) as the light cross-node engine.
+
+### G3 — W4 weight lifecycle (explicit gap, flagged in `runtime/` source)
+- `WeightVersion`, `WeightPublisher`, `TargetEngine.update_draft_weights`,
+  `SGLangServerEngine` decode-mode + `serving_metrics()`, `ServingTrafficStream`, and the
+  serving accept-length gate (predecessor §4.10). One trainer ↔ one server scope.
+
+### G4 — Composition + models (predecessor Phase 1)
+- `models/drafts` `DRAFT_REGISTRY` (`@register_draft`) for draft **architectures** (separate
+  axis from strategy); **MLA Eagle3 draft** (deepseek/Kimi); converge `StrategySpec` →
+  `training/strategies` registry. Note: draft-arch registry and strategy registry are two
+  registries, not one.
+
+### G5 — Run surface (predecessor Phase 3)
+- Pydantic `config/` + `specforge` CLI; `export/to_sglang` (+ the documented MLA weight-name
+  map) and `export/to_hf` with vocab pruning.
+
+---
+
+## 4. Topologies & the colocated lightweight path
+
+The four workloads are unchanged; they differ only in which *ref source* + `FeatureStore` +
+`TargetEngine` compose. All consume **one** `FeatureDataLoader → TrainBatch` iterator; the
+trainer/strategy/backend are identical regardless (no per-topology stream class).
+
+| # | Workload | Ref source (→ FeatureDataLoader) | FeatureStore | Control plane |
+|---|---|---|---|---|
+| W1 | Offline (precomputed) | `OfflineManifestReader` (refs) | Local (`file://`/`mem://`) | **no-op** |
+| W2 | In-process online | `RolloutWorker` → `SampleRefQueue` | Local (`mem://`) | **no-op** |
+| W3 | Disaggregated online (isolated pools, high BW) | `RolloutWorker` (producer pool) → `StreamingRefChannel` | **Mooncake** | **active** (lease/ack/reconcile/backpressure) |
+| W3′ | Disaggregated online (light/cross-node) | `SGLangServerEngine` over HTTP (RemoteStream-style source) | n/a (HTTP) | minimal |
+| W4 | Train-with-decode | `RolloutWorker` / `ServingTrafficStream` + `SGLangServerEngine` | per above | per above |
+
+**Colocated lightweight path (W1/W2): keep it, but as a *no-op control plane*, not a fork.**
+The control-plane machinery (lease/ack/reconcile/backpressure/durable metadata/cross-process
+transport) only earns its keep when producer and consumer are decoupled. For W1/W2 (same
+process) it is pure overhead. Resolution:
+
+- **Single canonical path** through `SampleRef` + `FeatureStore`, so colocated and disaggregated
+  produce **byte-identical batches for free** (today's property — "disaggregation changes *where*
+  features live, not their values"). We do **not** fork a second trainer/launch path.
+- "Lightweight" = for colocated, the controller's lease/ack/metadata-store are **opt-in / no-op**,
+  `FeatureStore` is `LocalFeatureStore(mem://)`, and there is **no SQLite, no cross-process, no
+  backpressure**. The colocated ref sources (`OfflineManifestReader` / in-process `RolloutWorker`)
+  flow through the spine but skip the heavy bits.
+- Cost to own honestly: this preserves the free byte-identical guarantee **only if** we keep one
+  path. A numerical-equivalence gate (§7) locks "colocated stream output == disagg stream output"
+  so the no-op path can never silently diverge.
+
+---
+
+## 5. What changed from the predecessor draft (explicit deltas)
+
+1. **"No Mooncake in Phase 1-6" → revised.** The Mooncake control/data plane is now the
+   **canonical** disaggregation backend, because the isolated-pool / >100 GB/s requirement is
+   real and HTTP cannot serve it. The predecessor's `RemoteStream`-over-HTTP remains as the
+   **light** second backend (W3′), and the "Ray actor topology" non-goal still holds (we use
+   Mooncake transport, not Ray scheduling).
+2. **Primary abstraction / `HiddenStateStream` dropped.** Predecessor: a coarse
+   `HiddenStateStream` produces `TrainBatch` and is the source of truth. Reconciled:
+   `SampleRef` + `FeatureStore` + `FeatureDataLoader` is canonical, and `FeatureDataLoader`
+   **already is** the stream — so `HiddenStateStream` is **not introduced** as a parallel
+   abstraction. Topology variation lives in (ref source + `FeatureStore`); `seek()`/prefetch
+   land on the loader/ref-source. This is strictly finer and is what makes
+   lease/ack/backpressure/Mooncake clean.
+3. **`runtime/` is not "thrown away."** The predecessor's "what we throw away" never mentioned
+   `runtime/` (it predated it). The DataFlow spine is the foundation, not debt.
+4. **Module layout** gains a top-level `runtime/` (the spine) under the domain layer; `models/`
+   (drafts + targets), `training/` (Trainer + managers), `eval/`, `export/`, `config/`, `cli.py`
+   are the layer on top. No separate `data/streams/` package — the loader is the stream.
+5. **W4 weight lifecycle** is reframed from "additive HTTP-only" to "an interface that has both
+   an HTTP (`SGLangServerEngine`) and, where needed, a Mooncake-backed implementation."
+
+Everything else in the predecessor (workloads W1–W4, the domain abstractions, the testing
+discipline, the MLA/export/eval/config detail) **carries forward unchanged**.
+
+---
+
+## 6. Tradeoffs (updated)
+
+### Ray + Mooncake vs HTTP/gRPC  — *bet partially reversed*
+The predecessor bet "HTTP is sufficient, Mooncake is gated behind profiling." For the **data
+transport** that bet is now wrong (isolated-pool / >100 GB/s requirement) — Mooncake is in,
+canonically. For **scheduling/orchestration**, the bet still holds: we use Mooncake as a
+*transport*, with our own metadata-only control plane, **not** Ray actors. Multi-job inference-
+pool sharing (Ray's real value, predecessor T2 / #34) stays a non-goal until ≥5 concurrent jobs
+share one target.
+
+### One canonical path vs a light colocated fork
+Chosen: **one path** (spine everywhere) + control-plane-as-no-op for colocated. Keeps
+byte-identical free and avoids two implementations; costs an equivalence gate. (See §4.)
+
+### Two registries, not one
+`models/drafts` `DRAFT_REGISTRY` (architecture) and `training/strategies` (algorithm) are
+**separate** axes — an algorithm (eagle3) runs on multiple draft architectures. Don't merge
+them; the current `StrategySpec` is the *strategy* registry and should converge there, not into
+`models/drafts`.
+
+*(The predecessor's other tradeoffs — Pydantic vs OmegaConf, MLA cache compressed vs expanded,
+registry vs HF AutoModel — are unchanged and carry forward.)*
+
+---
+
+## 7. Migration path (incremental, gated)
+
+The spine is already landed, so migration is "grow the domain layer on top + close the gaps,"
+not a rewrite. Every phase that touches the training path passes the numerical-equivalence gate
+(below) against the prior commit.
+
+- **Phase A — composable launch (DONE / in review).** `StrategySpec` registry + parameterized
+  `launch.py`; eagle3/dflash/domino end-to-end (#627/#628/#629). 197 `tests/test_runtime` OK.
+- **Phase B — domain abstractions (no behavior change).** Introduce `TargetEngine` (wrap the
+  existing adapters; de-EAGLE3 the names) and the domain `Trainer` wrapping the kept
+  `runtime/training` core. No `HiddenStateStream` — `FeatureDataLoader` stays the stream. Gate:
+  byte-identical batches/loss vs the pre-refactor path.
+- **Phase C — colocated no-op control plane + equivalence gate.** Make lease/ack/metadata
+  opt-in; add the colocated≡disagg equivalence test.
+- **Phase D — training managers (G1).** `no_sync()`, full optimizer/scheduler/RNG resume,
+  `CheckpointManager`, `Evaluator`. Gate: loss/eval parity at fixed steps.
+- **Phase E — `models/drafts` registry + MLA draft + config/CLI/export (G4/G5).** Adding a
+  draft arch = one decorated file; one validated YAML per run; export-loop test.
+- **Phase F — W4 weight lifecycle (G3).** `update_draft_weights`, `SGLangServerEngine`
+  decode-mode + serving metrics, `ServingTrafficStream`, accept-length gate.
+
+Doc debt to fix alongside Phase B: revise the predecessor's "No Mooncake / HTTP is sufficient"
+statements (now §5/§6) so the code and the plan stop contradicting each other.
+
+---
+
+## 8. Non-goals (updated)
+- **No Ray dependency / no multi-engine load balancing.** One trainer ↔ one serving engine
+  (incl. W4). Multi-job pool sharing is gated behind ≥5 concurrent jobs.
+- **No two-stack fork for colocated.** One canonical data path; colocated is the spine with the
+  control plane as a no-op, not a parallel implementation.
+- **No vLLM target backend** (possible via `TargetEngine`, not prioritized).
+- **No in-trainer serving-prompt interception** — `ServingTrafficStream` reads an external
+  buffer the serving cluster populates.
+
+*(Reversed from the predecessor: "No Mooncake" — Mooncake transport is now canonical for W3.)*
+
+---
+
+## 9. Success criteria
+| Area | Criterion |
 |---|---|
-| `model.layers.{i}.self_attn.q_a_proj.weight` | _e.g._ `draft_model.layers.{i}.self_attn.q_a_proj.weight` |
-| `model.layers.{i}.self_attn.q_a_layernorm.weight` | ... |
-| `model.layers.{i}.self_attn.q_b_proj.weight` | ... |
-| `model.layers.{i}.self_attn.kv_a_proj_with_mqa.weight` | ... |
-| `model.layers.{i}.self_attn.kv_a_layernorm.weight` | ... |
-| `model.layers.{i}.self_attn.kv_b_proj.weight` | ... |
-| `model.layers.{i}.self_attn.o_proj.weight` | ... |
-| `model.embed_tokens.weight` | ... |
-| `lm_head.weight` | ... |
-| `t2d`, `d2t` (vocab mapping) | ... |
-
-Filling the RHS column requires reading SGLang's current spec-decoding draft loader (the
-`Eagle3*` or `LightseekSpec*` loader, whichever is current in sgl-project/sglang) and
-should be a documented artifact (`docs/export_weight_map_mla.md`), not implicit in code.
-
-### 4.9 FSDP seam (FSDP1 now, FSDP2-ready)
-
-The plan ships on FSDP1 (`SHARD_GRAD_OP`) but `apply_fsdp` is a stable seam from day one,
-gated by `TrainingConfig.fsdp_version`:
-
-```python
-# training/fsdp.py
-def apply_fsdp(model, training_config, wrap_policy=None):
-    if training_config.fsdp_version == 1:
-        return _apply_fsdp1(model, training_config, wrap_policy)
-    elif training_config.fsdp_version == 2:
-        return _apply_fsdp2(model, training_config, wrap_policy)
-    raise ValueError(...)
-```
-
-Rationale: FSDP2 (PT 2.4+) composes much better with `torch.compile` and per-parameter
-sharding (`fully_shard` on individual submodules). The compute-friendly default for the
-next 12 months is FSDP2. Pinning to FSDP1 in the Trainer interface means rewriting again
-once `compile_model: True` becomes the norm. Implementing `_apply_fsdp2` is deferred to
-Phase 7 #31 — the seam is what matters now.
-
-### 4.10 Train-with-decode mode (Phase 5)
-
-W4 from §1 ("Workloads in scope") is a real workload: the same long-lived SGLang server
-simultaneously generates training data and serves real spec-decoding traffic, with the
-trainer pushing freshly-trained draft weights into that server every N steps. The TorchSpec
-implementation does this via Ray actors (`SglEngine.update_weights_from_disk` +
-`controller/loop._maybe_sync_draft_weights`). SpecForge gets the same workload by extending
-the existing `TargetEngine` / `Stream` / `Trainer` interfaces — **no Ray, no Mooncake**.
-
-Three new primitives, all additive to Phase 4 abstractions:
-
-#### (a) `TargetEngine.update_draft_weights` — weight push API
-
-```python
-# models/targets/base.py
-class TargetEngine(ABC):
-    def update_draft_weights(
-        self,
-        weights_path: str | os.PathLike,
-        *,
-        blocking: bool = True,
-        load_format: Literal["pt", "safetensors"] = "safetensors",
-    ) -> dict[str, Any]:
-        """Push new draft weights into a long-lived serving target.
-
-        Default impl raises NotImplementedError. In-process engines (sglang/hf/custom)
-        do not need this — they're torn down with the trainer. Implemented by
-        `SGLangServerEngine`, which forwards to SGLang's
-        `/update_weights_from_disk` endpoint (already present in sglang ≥0.4).
-        """
-        raise NotImplementedError(f"{type(self).__name__} does not support live draft weight updates")
-```
-
-`SGLangServerEngine` adds:
-
-```python
-class SGLangServerEngine(TargetEngine):
-    def update_draft_weights(self, weights_path, *, blocking=True, load_format="safetensors"):
-        return self._post_json(
-            "/update_weights_from_disk",
-            {"model_path": str(weights_path), "load_format": load_format},
-        )
-
-    def serving_metrics(self) -> dict[str, float]:
-        """Pull serving-side acceptance rate / queue depth from SGLang.
-
-        Mapped to wandb keys like serving/spec_accept_rate, serving/spec_accept_length.
-        """
-        return self._get_json("/spec_decoding_stats")
-```
-
-The shared filesystem assumption is the same one TorchSpec already lives with: trainer
-saves to a path readable by the SGLang server (NFS, or rank-0 saves and broadcasts the
-path; the server reads from that path).
-
-#### (b) `ServingTrafficStream` — train on real serving prompts (optional)
-
-For pure W4 you can keep using static jsonl with `OnlineStream`/`RemoteStream` — the
-training data has nothing to do with the serving traffic, just the engine is shared. But
-**true on-policy training** wants to sample prompts from real serving traffic. New stream:
-
-```python
-# data/streams/serving_traffic.py
-class ServingTrafficStream(RemoteStream):
-    """RemoteStream variant that pulls prompts from a serving-traffic buffer
-    instead of a static dataset.
-
-    Buffer backends in scope:
-    - file: jsonl tail (simplest; rotated by serving)
-    - redis: list with LPUSH (serving) / BRPOP (this stream)
-    - kafka: topic with consumer group
-
-    Out of scope: anything that requires Ray.
-    """
-    def __init__(
-        self,
-        buffer_uri: str,           # "file:///var/log/sgl/prompts.jsonl"
-                                   # "redis://host:6379/0/serving_prompts"
-        target_engine: SGLangServerEngine,
-        sample_rate: float = 1.0,  # PII-safe rate limiting
-        cold_start_jsonl: Optional[str] = None,  # bootstrap when buffer is empty
-        **kwargs,
-    ): ...
-```
-
-The privacy / PII / sample-rate decisions live with whoever runs the serving cluster,
-**not in the trainer**. Stream just consumes whatever it's pointed at.
-
-#### (c) `Trainer._maybe_sync_draft_weights` — periodic push hook
-
-```python
-# training/trainer.py — addition to the loop in §4.2
-class Trainer:
-    def _maybe_sync_draft_weights(self, step: int) -> None:
-        """Save draft state and call target_engine.update_draft_weights.
-
-        Mirrors TorchSpec's _maybe_sync_draft_weights (controller/loop.py:42-73)
-        but stays in-trainer. No Ray needed because there's exactly one engine
-        to update (one trainer ↔ one serving SGLang).
-        """
-        cfg = self.config.weight_sync
-        if not cfg.enabled or self._target_engine is None:
-            return
-        if (step + 1) % cfg.interval != 0:
-            return
-
-        with rank_0_priority():
-            tmp = Path(cfg.tmp_dir or self.config.checkpoint_dir) / "draft_weight_sync"
-            tmp.mkdir(parents=True, exist_ok=True)
-            self._save_draft_for_serving(tmp)        # FSDP full-state -> safetensors
-
-        # Only rank 0 actually issues the HTTP call; barrier so other ranks wait.
-        if dist.get_rank() == 0:
-            self._target_engine.update_draft_weights(tmp, load_format="safetensors")
-        dist.barrier()
-```
-
-Wired into the existing `_maybe_log / _maybe_eval / _maybe_save` chain. ~30 LOC.
-
-#### (d) Decode-mode `SGLangServerEngine` — server-side config
-
-The serving SGLang must be launched with both prefill+aux capture (for training data
-generation) **and** spec decoding (for serving traffic) enabled simultaneously. This is
-already supported by sglang ≥0.4 via the `--enable-aux-hidden-states` +
-`--enable-spec-training-mooncake=False` (we don't need mooncake) +
-`--enable-cuda-graph=True` combination. `SGLangServerEngine` gets a `decode_mode: bool`
-config flag that simply governs which set of server-args gets validated; it doesn't
-launch the server itself (operations responsibility).
-
-#### Acceptance-rate as a first-class metric
-
-In W1-W3 the relevant metric is `simulated_acc_len` (computed offline from logged
-per-position accuracy). In W4, the **real serving acceptance rate** is available from
-the same SGLang server. The `Trainer.train()` loop calls `target_engine.serving_metrics()`
-on the same cadence as eval and merges into the tracker dict:
-
-```python
-if self.config.weight_sync.report_serving_metrics and step % self.config.eval.interval == 0:
-    sm = self._target_engine.serving_metrics()
-    self.tracker.log({
-        "serving/spec_accept_rate": sm["accept_rate"],
-        "serving/spec_accept_length": sm["accept_length"],
-    }, step=step)
-```
-
-**Why this is sufficient (no Ray, no Mooncake)**:
-
-- One trainer ↔ one server is a hard scope boundary (§8 non-goal). The dispatcher /
-  multi-engine load balancing that TorchSpec's `AsyncInferenceManager` provides isn't
-  needed at this scope.
-- Weight push is HTTP `/update_weights_from_disk`; SGLang already implements this for
-  serving updates, no new server work.
-- Training data path stays identical to W2/W3 — `RemoteStream` /
-  `ServingTrafficStream` produce `TrainBatch` exactly the same way.
-- The trainer has no idea decode mode is on. It just pushes weights and reads metrics.
-
-If profiling later shows that the HTTP weight-push latency itself is a problem (saving +
-loading 100MB-1GB of weights every 500 steps), the optimization is to upgrade
-`update_draft_weights` to accept an in-memory state_dict + zero-copy transfer, again
-without changing the trainer. Same shape as the L2 transport upgrade discussed in §6.
+| Composable launch (done) | eagle3/dflash/domino train via one strategy-parameterized path; full `test_runtime` green. |
+| Abstractions (B) | `TargetEngine` (wrapping existing adapters) + domain `Trainer` produce byte-identical batches/loss vs the direct spine path. |
+| Colocated (C) | W1/W2 run with control plane as no-op; colocated≡disagg equivalence gate passes. |
+| Managers (D) | resume reproduces the no-resume loss curve; one all-reduce per optimizer step; best-checkpoint tracked. |
+| Drafts/MLA (E) | MLA Eagle3 trains + loads in SGLang; new draft arch = one `@register_draft` file. |
+| W4 (F) | one server serves spec-decode traffic + produces training data; weight push every N steps; serving acceptance rate trends up; weight-sync parity gate passes. |
 
 ---
 
-## 5. Feature List (Prioritized)
-
-**Ordering note (from review):** the original draft put the unified `Trainer` in Phase 2
-and the `TargetEngine` / `HiddenStateStream` abstractions in Phase 4. That meant Phase 2
-would build the trainer against the *old* `Eagle3TargetModel`/`DFlashTargetModel`
-interface and then Phase 4 would re-plumb it. Reordered so the interfaces (and a single
-in-process implementation of each) land in Phase 2 alongside the trainer; Phase 4 then
-adds new implementations (`SGLangServerEngine`, `RemoteStream`) of stable interfaces
-rather than re-plumbing.
-
-### Phase 1: MLA Draft + Registry (Week 1-2)
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 1 | Draft plugin registry (`@register_draft`) | Every new arch today touches 4 files. This is the single biggest extensibility blocker. | S |
-| 2 | MLA Eagle3 draft (`Eagle3DeepseekV2ForCausalLM`) | The gap for DeepSeek-V3 / Kimi-K2. Port from TorchSpec. Includes MLA-aware KV cache handling via HF `DynamicCache` (no ABC break). | M |
-| 3 | MLA draft configs | `qwen3_8b_eagle3_mla.json`, `kimi_k25_eagle3_mla.json`, `deepseek_v3_671b_eagle3.json` (real MLA, not Llama pretending). | S |
-| 3a | **MLA + TP/SP smoke test** | Validate Yunchang USP and TP slicing on Kimi-K2.5 with asymmetric MLA head dims before declaring Phase 1 done. | S |
-
-**Deliverable**: Train an MLA Eagle3 draft for Qwen3-8B / Kimi-K2.5 using existing `train_eagle3.py`.
-Existing scripts unchanged — registry lives alongside the old `_model_mapping` dicts.
-
-### Phase 2: Interfaces + Trainer + Eval + Checkpoints (Week 3-6)
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 4 | `TargetEngine` protocol + in-process impls | Define the interface up front so the trainer is built against it from day 1. Adapt existing `Eagle3TargetModel` / `DFlashTargetModel` as the initial concrete impls. | M |
-| 5 | `HiddenStateStream` protocol + `OnlineStream` + `OfflineStream` | Same reason — stable abstraction before trainer code is written. `RemoteStream` deferred to Phase 4. | M |
-| 6 | `Trainer` class + `DraftTrainStrategy` protocol | Collapse `train_eagle3.py` and `train_dflash.py`. Stop the script-per-arch sprawl. Trainer consumes `TrainBatch` only — no direct target-model calls. | M |
-| 7 | `Eagle3TTTStrategy` + `DFlashBlockStrategy` | Extract from existing scripts into strategy implementations. Each declares its own `fsdp_wrap_policy()`. | M |
-| 8 | `CheckpointManager` | Rotation (`max_checkpoints`), best tracking, `latest_checkpointed_iteration.txt`, `meta.json`. Must integrate with `stream.seek()` on resume. | S |
-| 9 | `Evaluator` + `EvalCache` | Online eval during training: `simulated_acc_len`, `avg_loss`, `avg_acc`. Per-position acc aggregated across batches before geometric sum. Cache key covers eval/target/tokenizer/template/aux/seqlen. | M |
-| 10 | Gradient accumulation correctness | `model.no_sync()` on non-sync micro-steps, explicit `zero_grad`, `accumulation_steps` in config. Verify by step-time profiling. | S |
-| 11 | `target_layer_ids` as first-class contract | EAGLE3 hardcodes 3 aux layers; DFlash uses a list. Generalize so every draft declares what it needs and the stream materializes accordingly. | S |
-| 12 | FSDP seam (FSDP1 default, FSDP2-ready) | `apply_fsdp` dispatches on `fsdp_version`. FSDP2 impl deferred — but the seam is stable now so the trainer doesn't get rewritten when FSDP2 lands. | S |
-
-**Deliverable**: `Trainer` (no CLI yet — legacy scripts call into it) works for both Eagle3
-and DFlash, using the new interfaces with single in-process target/stream impls. Eval
-metrics logged during training. Best checkpoint auto-saved. Numerical equivalence (§10)
-checked against the pre-refactor scripts.
-
-### Phase 3: Config + Export (Week 7-8)
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 13 | Pydantic config schema | Replace argparse + JSON split with one validated YAML per run. | S-M |
-| 14 | CLI (`specforge train\|prepare\|export\|eval`) | Single entry point. Legacy scripts now become shims that build a `Config` and call `Trainer`. | S |
-| 15 | SGLang export tool | Checkpoint → SGLang spec-decoder layout. **Weight-name map (§4.8) is a documented artifact, finalized before this phase starts.** | M |
-| 16 | HF export tool + vocab pruning | FSDP checkpoint → HF format. Optional vocab pruning by dataset frequency. | S-M |
-
-**Deliverable**: Complete train → eval → export → serve pipeline in one tool. Old MLA
-draft trained in Phase 1 successfully loads in a SGLang server.
-
-### Phase 4: Remote Target + VLM + Parsers (Week 9-11)
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 17 | `SGLangServerEngine` | Target as HTTP service. Unlocks online training against 671B targets on separate GPUs. New impl of the Phase-2 `TargetEngine` interface. | M-H |
-| 18 | `RemoteStream` | Stream backend that talks to `SGLangServerEngine`. `prefetch_factor` + `max_in_flight` back-pressure. | M |
-| 19 | VLM unification | Delete `QwenVLOnlineEagle3Model`. VLM handled via typed `MediaInputs` in `TargetEngine` + data pipeline. | M |
-| 20 | Additional parsers | `KimiK25Parser`, `MiniMaxParser` from TorchSpec. | S |
-
-**Deliverable**: Train Eagle3 for DeepSeek-V3 with the target running on a separate SGLang
-server cluster.
-
-### Phase 5: Train-with-decode (Week 12-14)
-
-W4 from §1 — promoted from Phase 6 because it's a real workload, not a future option. All
-features build on the Phase 4 `SGLangServerEngine` + `RemoteStream` foundation; **no
-trainer / strategy / draft changes**.
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 21 | `TargetEngine.update_draft_weights` | Weight push API on the ABC; default raises NotImplementedError. `SGLangServerEngine` impl forwards to SGLang's `/update_weights_from_disk`. | S |
-| 22 | Decode-mode `SGLangServerEngine` | `decode_mode: bool` config + `serving_metrics()` endpoint. Validates that the server was launched with prefill+aux **and** spec decoding both enabled. | S-M |
-| 23 | `Trainer._maybe_sync_draft_weights` | Periodic push hook in the main loop. ~30 LOC. Save draft state on rank 0 → engine.update_draft_weights → barrier. | S |
-| 24 | `ServingTrafficStream` | Optional stream that pulls prompts from a serving-traffic buffer (file / Redis / Kafka). Subclass of `RemoteStream`; cold-start fallback to a static jsonl. | M |
-| 24a | Acceptance-rate metrics | Trainer reads `serving/spec_accept_rate` + `serving/spec_accept_length` from the engine and logs alongside `eval/simulated_acc_len`. Closes the gap between offline proxy and production reality. | S |
-
-**Deliverable**: A long-lived SGLang server simultaneously serves real spec-decoding
-traffic and produces training data; the trainer pushes draft weights every N steps and
-production acceptance rate trends up over the run, monotonically across `weight_sync_interval`.
-End-to-end smoke test: 1k-step run on a small target, acceptance-rate slope > 0.
-
-### Phase 6: Polish (Week 15-16)
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 25 | Backbone-agnostic DFlash | Factor `DFlashDraftModel` so MLP/Norm/RoPE are parameterized. Currently hardcoded to Qwen3. | S-M |
-| 26 | `torch.compile` support | Optional `compile_model` flag for draft model compilation. | S |
-| 27 | `defer_tokenization` + dynamic loss mask | Tokenize at fetch time, not preprocessing time. Enables dynamic loss masking. | M |
-| 28 | Tokenization disk cache | Cache tokenized datasets keyed by data path + template + max_length. | S |
-| 29 | WSD learning rate scheduler | Warmup-Stable-Decay. Useful for long runs / continued pretraining; defer unless a concrete need surfaces. | S |
-| 30 | Remove legacy `scripts/legacy/` shims | After two minor releases with `DeprecationWarning`. Concrete target: SpecForge 0.X. | S |
-
-### Phase 7: Optional / Future
-
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 31 | FSDP2 implementation | Fill in `_apply_fsdp2` behind the Phase-2 seam. Required if `torch.compile` becomes default. | M |
-| 32 | Mooncake streaming backend | GPU↔GPU tensor transport for multi-node disaggregation. Only if profiling shows HTTP/gRPC is the bottleneck (T1 trigger, §6). | H |
-| 33 | In-memory `update_draft_weights` | Bypass save-to-disk in W4 weight sync; transfer state_dict directly over a binary channel. Only if 100MB-1GB / N-step push becomes a measurable slowdown. | M |
-| 34 | Multi-job inference pool sharing | Single SGLang cluster amortized across ≥5 concurrent training jobs (T2 trigger, §6). At this point the actor topology becomes worth the complexity. | H |
-| 35 | FA4 attention backend | FlashAttention 4 support for draft attention. | S-M |
-
----
-
-## 6. Tradeoffs Worth Flagging
-
-### Ray + Mooncake vs HTTP/gRPC
-
-TorchSpec gets a lot from Ray + Mooncake, but they're large dependencies with significant
-operational complexity. For SpecForge, start with HTTP/gRPC to a SGLang server for cross-node
-training — this covers most use cases (target on dedicated GPUs, trainer on others) at a
-fraction of the surface area.
-
-**Train-with-decode (W4) is in scope without Ray.** The TorchSpec value-add from actor
-topology is concentrated in *multi-job inference pool sharing* and *zero-overhead async
-producer-consumer pipelines*. For one-trainer-↔-one-server (which is W4's scope per §8),
-HTTP `/update_weights_from_disk` plus a `ServingTrafficStream` over a Redis/Kafka/file
-buffer is sufficient. See §4.10. Ray actor topology only starts paying off at the T2
-trigger below.
-
-**Triggers that would force a re-evaluation:**
-
-- **T1 — transport bottleneck**: profile shows `last_hidden_states` over JSON/HTTP
-  consumes >30% of step time, with target ≥70B. Response: upgrade `RemoteStream`
-  transport to a binary protocol (gRPC + protobuf, or Mooncake-as-transport).
-  **L1/L3 unchanged.** This is feature #32 in Phase 7.
-
-- **T2 — multi-job inference pool sharing**: ≥5 concurrent training jobs hammering the
-  same 671B target, each tearing the engine up/down is wasteful. Response: introduce
-  Ray actor pool with `AsyncInferenceManager`-style dispatcher. This is the only
-  trigger that genuinely justifies adopting Ray; until then, complexity is pure cost.
-  Feature #34 in Phase 7.
-
-- **T3 — Mooncake transport**: only meaningful after T1; even then, evaluate gRPC
-  binary first. Mooncake's RDMA edge matters for >100GB/s aggregate, which neither W3
-  nor W4 typically hit. Feature #32 in Phase 7.
-
-The bet: 90% of the time we're in W1-W3 territory and the refactor's interface boundaries
-do real work. W4 lands in Phase 5 with ~200 LOC of additive code on those boundaries.
-TorchSpec's full topology is reserved for the day T2 actually fires.
-
-### Plugin registry vs HF AutoModel pattern
-
-HF's "drop in a config JSON" is a nice affordance. Keep both: decorator registry is primary
-for dispatch, HF type dispatch as fallback for configs that specify a known `transformers`
-config class. `AutoDraftModelConfig.from_file()` checks `DRAFT_REGISTRY` by architecture name
-first, falls back to config type mapping.
-
-### Strategy pattern is an indirection
-
-If only EAGLE3 and DFlash ever exist, two scripts are fine. The bet is that Medusa, MTP, or
-hybrid variants will want the same trainer infrastructure — if so, strategies pay off fast.
-If not, the cost is one extra level of dispatch that doesn't hurt readability.
-
-### Pydantic vs OmegaConf
-
-Pydantic gives better validation and serialization. OmegaConf gives effortless YAML merge +
-CLI override (`--training.lr=1e-4`). Options:
-1. **Pydantic + custom CLI overlay** (parse `--key=value` args, `model_validate` from merged dict) — our choice.
-2. OmegaConf + dataclass (TorchSpec's approach).
-3. Pydantic + typer/click for CLI.
-
-We go with (1) because SpecForge already uses Pydantic (`ChatTemplate`) and validation
-matters more than merge ergonomics at this stage. The CLI overlay is ~30 lines of code.
-
-### MLA cache: compressed vs expanded
-
-Two options for KV cache during Eagle3 TTT unroll:
-- **Compressed**: Cache `kv_compressed` (low-rank) + `k_rope_raw`. Saves memory but requires
-  MLA-specific cache logic in `core/eagle3.py`.
-- **Expanded**: Cache full `(K, V)` after projection. More memory but `core/eagle3.py` is
-  architecture-agnostic.
-
-We choose **expanded** (matching TorchSpec). The TTT unroll is typically 5-7 steps with
-short sequences — memory savings from compressed cache are marginal, and keeping
-`core/eagle3.py` architecture-agnostic is worth more.
-
----
-
-## 7. Migration Path
-
-Each phase ships independently and can be validated without breaking existing users.
-
-### Phase 1 plan
-
-1. Add `models/drafts/__init__.py` with `DRAFT_REGISTRY` and `@register_draft`.
-2. Move `LlamaForCausalLMEagle3` to `models/drafts/llama_eagle3.py`, decorate with
-   `@register_draft("LlamaForCausalLMEagle3")`.
-3. Port `deepseek_eagle.py` from TorchSpec → `models/drafts/deepseek_eagle3.py`, decorate
-   with `@register_draft("Eagle3DeepseekV2ForCausalLM")`.
-4. Update `AutoDraftModelConfig.from_file()` to check `DRAFT_REGISTRY` first.
-5. Update `AutoEagle3DraftModel.from_config()` to check `DRAFT_REGISTRY` first.
-6. Add MLA draft configs (`qwen3_8b_eagle3_mla.json`, `kimi_k25_eagle3_mla.json`).
-7. Keep old `_model_mapping` / `_config_mapping` as fallback — remove later.
-8. Test: train MLA Eagle3 draft using existing `train_eagle3.py` — zero changes to script.
-
-### Phase 2 plan
-
-1. Define `TargetEngine` protocol in `models/targets/base.py`.
-2. Adapt existing `SGLangEagle3TargetModel` → `SGLangTargetEngine` (in-process).
-3. Adapt existing `HFEagle3TargetModel` → `HFTargetEngine`.
-4. Adapt existing `CustomEagle3TargetModel` → `CustomTargetEngine`.
-5. Define `HiddenStateStream` protocol + `OnlineStream` + `OfflineStream`. `seek()` method
-   required for resume correctness. `OnlineStream` exposes `prefetch_factor`.
-6. Create `training/trainer.py` with the `Trainer` class. Trainer consumes `TrainBatch`
-   only, never a target model directly.
-7. Extract `Eagle3TTTStrategy` from `train_eagle3.py` logic. Implement `fsdp_wrap_policy()`.
-8. Extract `DFlashBlockStrategy` from `train_dflash.py` logic. Implement `fsdp_wrap_policy()`.
-9. Add the `apply_fsdp` seam dispatching on `fsdp_version` (FSDP1 only for now).
-10. Implement `CheckpointManager` — `save` / `load` / `update_best` / `_rotate`.
-11. Implement `Evaluator` (per-position acc aggregation across batches) + `EvalCache`
-    (full-key MD5).
-12. Move old scripts to `scripts/legacy/`, create shims that instantiate `Trainer`.
-13. **Numerical equivalence test (§10)**: legacy shim must match the pre-refactor script's
-    loss curve to within tolerance on a fixed seed at steps 100/500/1000. Gate.
-
-### Phase 3 plan
-
-1. Define `config/schema.py` with Pydantic models (Literal-typed enums).
-2. Implement `config/loader.py` (YAML load + CLI override).
-3. Implement `cli.py` (`specforge train|prepare|export|eval`).
-4. Finalize the SGLang weight-name map (`docs/export_weight_map_mla.md`) by reading the
-   current SGLang spec-decoding loader. Block #5 on this.
-5. Implement `export/to_sglang.py` and `export/to_hf.py`.
-6. Mechanically migrate existing JSON configs to YAML with the new schema.
-7. Test: `specforge train --config x.yaml` end-to-end. MLA draft from Phase 1 successfully
-   loads in a SGLang server with non-trivial acceptance rate.
-
-### Phase 4 plan
-
-1. Implement `SGLangServerEngine` (HTTP client to SGLang server). Reuses the Phase-2
-   `TargetEngine` interface — no trainer changes.
-2. Implement `RemoteStream` (`prefetch_factor`, `max_in_flight`). Reuses the Phase-2
-   `HiddenStateStream` interface — no trainer changes.
-3. Add typed `MediaInputs` to `TargetEngine.generate_train_data`.
-4. Delete `QwenVLOnlineEagle3Model`; wire VLM through `MediaInputs` + data pipeline.
-5. Port `KimiK25Parser`, `MiniMaxParser` from TorchSpec.
-6. Test: online training with SGLang server on separate node; results within tolerance of
-   in-process training (same target weights).
-
-### Phase 5 plan
-
-1. Add `update_draft_weights(weights_path, *, blocking, load_format)` to `TargetEngine`
-   ABC with `NotImplementedError` default.
-2. Implement `SGLangServerEngine.update_draft_weights` → POST `/update_weights_from_disk`.
-   Implement `serving_metrics()` → GET `/spec_decoding_stats`.
-3. Add `decode_mode: bool` to `SGLangServerEngine`. Validate that the operator's server
-   was launched with prefill+aux **and** spec decoding both enabled (warn loudly otherwise).
-4. Add `Trainer._maybe_sync_draft_weights(step)` hook between `_maybe_eval` and
-   `_maybe_save`. Save FSDP full-state on rank 0 → call engine update on rank 0 → barrier.
-5. Implement `ServingTrafficStream(RemoteStream)` with file/Redis/Kafka buffer backends
-   and a cold-start jsonl fallback. PII / sample-rate are operator concerns, not
-   trainer concerns.
-6. Wire `serving/spec_accept_rate` and `serving/spec_accept_length` through the existing
-   `Tracker` (every `eval_interval` steps).
-7. **End-to-end test**: 1k-step run with a small target (Qwen3-8B) co-located with a
-   spec-decoding load generator. Acceptance-rate slope across `weight_sync_interval`
-   buckets must be > 0; final acceptance rate must exceed cold-start by ≥ X%
-   (X TBD — set baseline from Phase 4 numbers).
-8. **Weight-sync correctness test (§10.5)**: before/after a sync, the served draft's
-   token-level outputs match the trainer's draft on a 32-prompt fixed eval set within
-   acceptance-rate tolerance.
-
----
-
-## 8. Non-Goals (Explicit)
-
-- **No Ray dependency.** SpecForge stays torchrun-native, including for train-with-decode (W4).
-- **No Mooncake in Phase 1-6.** HTTP/gRPC to SGLang is sufficient for both disaggregated
-  training (W3) and train-with-decode (W4). Mooncake is gated behind T1/T3 in §6.
-- **No vLLM target backend.** SGLang is primary; HF is the reference. Adding vLLM is possible
-  via the `TargetEngine` interface but not prioritized.
-- **No multi-engine load balancing / multi-job inference pool sharing.** Exactly **one**
-  target engine instance per training job — including in train-with-decode (one trainer
-  ↔ one server). Scaling within a single engine is via SGLang's own scaling (multiple
-  TP workers, replicas behind a single endpoint). Multi-job sharing is gated behind T2
-  in §6 and lands as Phase 7 #34.
-- **No on-policy serving-prompt mining without a buffer.** `ServingTrafficStream` reads
-  from an external buffer (Redis/Kafka/file) populated by the serving cluster; SpecForge
-  does **not** intercept inflight serving requests directly.
-
----
-
-## 9. Success Criteria
-
-| Phase | Criterion |
-|-------|-----------|
-| 1 | MLA Eagle3 draft trains on Qwen3-8B and converges to comparable loss as Llama draft. Kimi-K2.5 TP/SP smoke test passes. |
-| 2 | Legacy shims (using new `Trainer` internally) match pre-refactor scripts to numerical-equivalence tolerance (§10). Eval metrics agree with manual eval. |
-| 3 | `specforge train --config x.yaml` end-to-end. MLA draft from Phase 1 loads in SGLang and produces non-trivial acceptance rate. |
-| 4 | Online training with 671B target on separate SGLang server; per-step loss within tolerance of in-process baseline using identical target weights. |
-| 5 | **Train-with-decode**: 1k-step run; one long-lived SGLang server simultaneously serves spec-decoding traffic and produces training data; trainer pushes draft weights every `weight_sync_interval`; serving acceptance rate trends up monotonically across sync buckets. Weight-sync correctness gate §10.5 passes. |
-| 6 | DFlash on Llama backbone; tokenization cache cuts data prep time by >50%; legacy shims removed. |
-
----
-
-## 10. Testing Strategy (gating, not optional)
-
-Every phase that changes the training path must pass a numerical-equivalence gate against
-the immediately prior commit. Treat these as CI requirements, not nice-to-haves —
-behavior-preserving refactors are the most common place silent regressions hide.
-
-### 10.1 Numerical-equivalence gate (Phase 2, 4 critical)
-
-For a fixed seed and a fixed micro-batch sequence (3 batches × 4 samples is enough), the
-new code path must match the old:
-
-| Metric | Tolerance | Steps to check |
-|---|---|---|
-| Per-step training loss | `atol=1e-4, rtol=1e-4` (BF16 master copy) | 0, 1, 100, 500, 1000 |
-| Per-position eval acc (vector of length `ttt_length`) | `atol=1e-3` | end of eval at step 1000 |
-| `simulated_acc_len` | `atol=1e-3` | end of eval at step 1000 |
-| Model state dict (selected keys) | `atol=1e-4` | after step 100 |
-
-The gate run uses: Llama Eagle3 draft, Qwen3-8B target, offline mode, sharegpt eval slice.
-Cheap enough to run on every PR that touches `core/`, `training/`, or `models/drafts/`.
-
-### 10.2 Smoke tests (every phase)
-
-- One config per draft arch (`llama_eagle3`, `deepseek_v3_eagle3`, `qwen3_dflash`) trains
-  for 20 steps without crashing under TP=1, TP=2, and TP=2+SP=2.
-- Checkpoint save + resume produces the same loss curve as no-resume (validates
-  `stream.seek()`).
-- Eval cache miss + hit produce identical metrics (validates the cache key set).
-
-### 10.3 Distributed correctness (Phase 1 + 2)
-
-- MLA + Yunchang USP with `qk_nope_head_dim != qk_rope_head_dim != v_head_dim` on
-  Kimi-K2.5. This is the Phase 1 risk item and must be on the critical path, not the
-  Phase 4 wishlist.
-- Gradient accumulation: confirm one `all_reduce` per `optimizer.step()`, not per
-  `backward()`. Use a NCCL communicator log or `torch.profiler` once.
-
-### 10.4 Export-loop test (Phase 3)
-
-- Train MLA draft for 100 steps, export to SGLang, load in SGLang server, run 32 generation
-  requests. Acceptance rate > 0 (i.e. the loader actually consumed the weights, not zeros).
-  This catches weight-name-map regressions at the integration boundary.
-
-### 10.5 Weight-sync correctness gate (Phase 5)
-
-Every PR that touches `Trainer._maybe_sync_draft_weights`, `SGLangServerEngine.update_draft_weights`,
-or the FSDP-state-save path must pass a parity gate:
-
-| Step | Action | Pass condition |
-|---|---|---|
-| 1 | Train 50 steps; capture trainer-side draft state (full FSDP state dict, broadcast to rank 0). | — |
-| 2 | Call `Trainer._maybe_sync_draft_weights(50)`. | Engine returns 200; serving SGLang reports `update_weights/success=True`. |
-| 3 | Run 32 fixed-seed prompts through both: (a) trainer's local draft (offline-style forward), (b) the now-updated serving SGLang. | Logits agree to `atol=1e-2, rtol=1e-2` (allowing for kernel diffs between training and serving stacks). |
-| 4 | Compare serving acceptance rate over 256 prompts before vs after sync. | Acceptance rate **non-decreasing**; if 50 training steps moved the loss meaningfully, acceptance rate strictly increases. |
-
-The gate fails if any of: (i) the HTTP push silently 200-no-ops, (ii) the serving stack
-loaded a corrupt or partial state dict, (iii) FSDP state-dict gather missed a parameter.
-This is the train-with-decode analog of the §10.4 export-loop test.
-
-### 10.6 Long-run weight-sync soak (Phase 5, optional)
-
-- 1k-step run with `weight_sync_interval=100`. Bucket serving acceptance rate by
-  100-step windows; the slope across buckets must be monotonically non-decreasing
-  (allowing one regression bucket per 10 — to absorb rare unlucky prompt batches).
-- Watches for: (a) silent weight push failures (acceptance rate would plateau),
-  (b) draft drift due to incorrect FSDP gather, (c) serving-side OOM that quietly
-  rolls back to old weights.
+## 10. Testing strategy (gating)
+
+Carries the predecessor's gates, plus the reconciliation-specific one.
+
+- **10.1 Numerical-equivalence gate** (per PR touching `core/` / `runtime/training/` /
+  `runtime/data_plane/` / `models/drafts`): fixed seed, 3×4 batches; per-step loss
+  `atol/rtol=1e-4` at steps 0/1/100/500/1000; per-position eval acc + `simulated_acc_len`
+  `atol=1e-3`.
+- **10.2 Colocated ≡ disaggregated gate (NEW):** same data through the colocated (no-op control
+  plane, Local store) and the disaggregated (control plane, SharedDir/Mooncake) paths must yield
+  identical `TrainBatch`es and identical loss. This is what licenses the lightweight path.
+- **10.3 Smoke tests:** each draft arch trains 20 steps under TP=1 / TP=2 / TP=2+SP=2;
+  checkpoint save+resume matches no-resume (validates `seek`); eval cache miss==hit.
+- **10.4 Distributed correctness:** MLA + Yunchang USP with asymmetric head dims; gradient
+  accumulation = one all-reduce per `optimizer.step()`.
+- **10.5 Export-loop test:** train MLA draft 100 steps → export → load in SGLang → 32 gens,
+  acceptance > 0 (catches weight-name-map regressions).
+- **10.6 Weight-sync correctness gate (W4):** after `update_draft_weights`, served draft logits
+  match trainer draft within tolerance; serving acceptance non-decreasing across a sync.

--- a/plan.md
+++ b/plan.md
@@ -54,6 +54,21 @@ This is, in the predecessor's own terms, pulling **feature #32 ("Mooncake stream
 forward from Phase 7 to now** because the requirement demands it — and implementing it with the
 already-built `runtime/` work, behind the clean domain interfaces.
 
+**Two scope decisions that bound this plan** (consolidating with the online-disaggregation
+roadmap, #618):
+
+1. **Frozen target — no weight sync.** "Train-with-decode" means a *frozen* target streams
+   hidden states; the draft is never in the generation loop. Weight sync / hot draft-update /
+   weight-version registry / on-policy are **out of scope**; `draft_weight_version` is provenance
+   only. (This removes the predecessor's W4 weight-lifecycle workload.)
+2. **Ray is an open decision, not a non-goal.** It is a *candidate* for the O2 scale-out
+   orchestrator (multi-node N-producer/M-trainer) — likely necessary, but not committed. Until the
+   decision gate fires we keep the home-grown metadata-only control plane and add nothing.
+
+**Per-phase target/implementation detail lives in [`docs/roadmap/`](docs/roadmap/)** (domain,
+online-disaggregation [folds in #618], eval & breadth); this document is the architecture; the
+roadmap is the build order.
+
 ---
 
 ## 1. Why each side is right (and where each is incomplete)
@@ -82,9 +97,10 @@ do not conflict.
   loss.
 
 **Explicitly not yet implemented in `runtime/`** (flagged in-source — `contracts.py`,
-`trainer.py`, `controller.py`, both `DESIGN.md`s, `runtime/README.md`): the weight-publication
-lifecycle (`WeightVersion`, `WeightPublisher`, `update_draft_weights`, serving accept-length
-gate), full optimizer/scheduler resume, and `no_sync()` accumulation. These are the §3 gaps.
+`trainer.py`, `controller.py`, both `DESIGN.md`s, `runtime/README.md`): live frozen-target online
+capture from a real SGLang server (O1.3), full optimizer/scheduler resume, and `no_sync()`
+accumulation. These are the §3 gaps. (The in-source weight-publication NOTEs — `WeightVersion` /
+`WeightPublisher` / `update_draft_weights` — are **descoped**: the target is frozen, see §8.)
 
 ---
 
@@ -120,13 +136,14 @@ PRODUCE (inference):
   TargetEngine        ── the engine rollout wraps to produce features; the abstraction that
                          replaces the EAGLE3-bound SGLangAdapter.
      HFTargetEngine / SGLangTargetEngine / CustomTargetEngine (in-process)
-     SGLangServerEngine (HTTP service; owns update_draft_weights + serving_metrics for W4)
+     SGLangServerEngine (frozen target as an HTTP/live service; the cross-node capture backend)
   RolloutWorker       ── drives a TargetEngine → writes tensors to FeatureStore → commits
                          SampleRef to the control plane. Stays at the domain↔substrate seam.
 
 CONSUME (training):
-  Trainer             ── owns the lifecycle: loop / eval / checkpoint / weight-sync. WRAPS the
-                         runtime TrainerController/TrainerCore; does NOT replace them.
+  Trainer             ── owns the lifecycle: loop / eval / checkpoint. WRAPS the runtime
+                         TrainerController/TrainerCore; does NOT replace them. (No weight-sync —
+                         the target is frozen, §8.)
   DraftTrainStrategy  ── per-algorithm forward+loss (eagle3 TTT / dflash block / domino). Kept
                          in runtime/training (the seam) — already plan-shaped.
   CheckpointManager / Evaluator / lr_scheduler / fsdp seam  ── the managers (G1).
@@ -165,11 +182,11 @@ specforge/
 │                                    # (NO separate data/streams package — FeatureDataLoader over
 │                                    #  SampleRef+FeatureStore IS the stream. Ref sources
 │                                    #  (offline/rollout/streaming) live in runtime/data_plane;
-│                                    #  ServingTrafficStream (W4) is just another prompt/ref source)
+│                                    #  live frozen-target capture is just another ref source)
 │
 ├── training/                        # domain lifecycle + managers (WRAPS runtime/training)
-│   ├── trainer.py                   # owns loop/eval/checkpoint/weight-sync; delegates the step
-│   │                                #   to runtime TrainerCore + DraftTrainStrategy (kept seam)
+│   ├── trainer.py                   # owns loop/eval/checkpoint; delegates the step to runtime
+│   │                                #   TrainerCore + DraftTrainStrategy (kept seam)
 │   ├── checkpoint.py  lr_scheduler.py  fsdp.py   # NEW managers (§3). Strategies + StrategySpec
 │   │                                #   registry stay in runtime/training (the seam, unchanged).
 │
@@ -205,10 +222,15 @@ from the in-source `NOTE`s. Each lands behind the canonical spine without re-plu
   `TargetEngine` and stop binding to `generate_eagle3_data` / EAGLE3 names. Keep the existing
   `FeatureSource` Protocol. Add `SGLangServerEngine` (HTTP) as the light cross-node engine.
 
-### G3 — W4 weight lifecycle (explicit gap, flagged in `runtime/` source)
-- `WeightVersion`, `WeightPublisher`, `TargetEngine.update_draft_weights`,
-  `SGLangServerEngine` decode-mode + `serving_metrics()`, `ServingTrafficStream`, and the
-  serving accept-length gate (predecessor §4.10). One trainer ↔ one server scope.
+### G3 — Live online capture (frozen target; **no** weight sync)
+- Replace the in-process generator with **live SGLang-server hidden-state capture**: a *frozen*
+  target streams aux+final hidden states into `MooncakeFeatureStore`; the producer commits
+  `SampleRef`s. The cross-process control plane + async loop are in-review; live capture (the
+  gating spike) is next; scale-out (Ray = **open**) and hardening follow.
+- **Weight sync / hot draft-update / on-policy are explicitly out of scope.** The target is
+  frozen, so the streamed data is independent of draft weights — there is nothing to re-sync and
+  no staleness. `draft_weight_version` is kept **only as provenance**.
+- Detailed phases (O1–O3): [`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md).
 
 ### G4 — Composition + models (predecessor Phase 1)
 - `models/drafts` `DRAFT_REGISTRY` (`@register_draft`) for draft **architectures** (separate
@@ -224,17 +246,23 @@ from the in-source `NOTE`s. Each lands behind the canonical spine without re-plu
 
 ## 4. Topologies & the colocated lightweight path
 
-The four workloads are unchanged; they differ only in which *ref source* + `FeatureStore` +
-`TargetEngine` compose. All consume **one** `FeatureDataLoader → TrainBatch` iterator; the
-trainer/strategy/backend are identical regardless (no per-topology stream class).
+The workloads differ only in which *ref source* + `FeatureStore` + `TargetEngine` compose. All
+consume **one** `FeatureDataLoader → TrainBatch` iterator; the trainer/strategy/backend are
+identical regardless (no per-topology stream class). **In every case the target is frozen** — the
+draft is never in the generation loop, so the streamed features do not depend on draft training
+progress (no staleness, nothing to re-sync).
 
 | # | Workload | Ref source (→ FeatureDataLoader) | FeatureStore | Control plane |
 |---|---|---|---|---|
 | W1 | Offline (precomputed) | `OfflineManifestReader` (refs) | Local (`file://`/`mem://`) | **no-op** |
-| W2 | In-process online | `RolloutWorker` → `SampleRefQueue` | Local (`mem://`) | **no-op** |
-| W3 | Disaggregated online (isolated pools, high BW) | `RolloutWorker` (producer pool) → `StreamingRefChannel` | **Mooncake** | **active** (lease/ack/reconcile/backpressure) |
+| W2 | In-process online (frozen target) | `RolloutWorker` → `SampleRefQueue` | Local (`mem://`) | **no-op** |
+| W3 | Disaggregated online (frozen target; isolated pools, high BW) | `RolloutWorker` (producer pool) → `StreamingRefChannel` | **Mooncake** | **active** (lease/ack/reconcile/backpressure) |
 | W3′ | Disaggregated online (light/cross-node) | `SGLangServerEngine` over HTTP (RemoteStream-style source) | n/a (HTTP) | minimal |
-| W4 | Train-with-decode | `RolloutWorker` / `ServingTrafficStream` + `SGLangServerEngine` | per above | per above |
+
+> **"Train-with-decode" = live *frozen-target* generation** — i.e. W2 (colocated) or W3
+> (disaggregated), **not** a separate workload. The predecessor's dual-purpose
+> serve-and-push-weights "W4" is **out of scope**: a frozen target means there is nothing to push.
+> See [`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md).
 
 **Colocated lightweight path (W1/W2): keep it, but as a *no-op control plane*, not a fork.**
 The control-plane machinery (lease/ack/reconcile/backpressure/durable metadata/cross-process
@@ -259,8 +287,10 @@ process) it is pure overhead. Resolution:
 1. **"No Mooncake in Phase 1-6" → revised.** The Mooncake control/data plane is now the
    **canonical** disaggregation backend, because the isolated-pool / >100 GB/s requirement is
    real and HTTP cannot serve it. The predecessor's `RemoteStream`-over-HTTP remains as the
-   **light** second backend (W3′), and the "Ray actor topology" non-goal still holds (we use
-   Mooncake transport, not Ray scheduling).
+   **light** second backend (W3′). Mooncake is used as a *transport*; the scale-out
+   **orchestration** layer (Ray vs. home-grown) is an **open decision** (see §6, §8 and
+   [`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md) §O2), no longer
+   a flat non-goal.
 2. **Primary abstraction / `HiddenStateStream` dropped.** Predecessor: a coarse
    `HiddenStateStream` produces `TrainBatch` and is the source of truth. Reconciled:
    `SampleRef` + `FeatureStore` + `FeatureDataLoader` is canonical, and `FeatureDataLoader`
@@ -273,23 +303,34 @@ process) it is pure overhead. Resolution:
 4. **Module layout** gains a top-level `runtime/` (the spine) under the domain layer; `models/`
    (drafts + targets), `training/` (Trainer + managers), `eval/`, `export/`, `config/`, `cli.py`
    are the layer on top. No separate `data/streams/` package — the loader is the stream.
-5. **W4 weight lifecycle** is reframed from "additive HTTP-only" to "an interface that has both
-   an HTTP (`SGLangServerEngine`) and, where needed, a Mooncake-backed implementation."
+5. **W4 weight lifecycle → dropped.** The predecessor's serve-and-push-weights workload + weight
+   registry are **out of scope**. "Train-with-decode" is *frozen-target* live generation (W2/W3);
+   weight sync / hot draft-update / staleness gate / on-policy are explicitly cut, aligning with
+   #618. `draft_weight_version` survives only as provenance metadata.
+6. **Ray reframed from non-goal → open.** It is a *candidate* for the O2 scale-out orchestrator
+   (multi-node N-producer/M-trainer), not committed and not forbidden; the decision gate lives in
+   the roadmap.
 
-Everything else in the predecessor (workloads W1–W4, the domain abstractions, the testing
+Everything else in the predecessor (workloads W1–W3, the domain abstractions, the testing
 discipline, the MLA/export/eval/config detail) **carries forward unchanged**.
 
 ---
 
 ## 6. Tradeoffs (updated)
 
-### Ray + Mooncake vs HTTP/gRPC  — *bet partially reversed*
+### Mooncake transport vs HTTP/gRPC — *transport bet reversed*
 The predecessor bet "HTTP is sufficient, Mooncake is gated behind profiling." For the **data
 transport** that bet is now wrong (isolated-pool / >100 GB/s requirement) — Mooncake is in,
-canonically. For **scheduling/orchestration**, the bet still holds: we use Mooncake as a
-*transport*, with our own metadata-only control plane, **not** Ray actors. Multi-job inference-
-pool sharing (Ray's real value, predecessor T2 / #34) stays a non-goal until ≥5 concurrent jobs
-share one target.
+canonically. The `RemoteStream`-over-HTTP path stays as the light cross-node backend (W3′).
+
+### Scale-out orchestration: Ray vs. home-grown — *OPEN*
+Today's metadata-only control plane handles a single producer-pool ↔ trainer scope. **O2**
+(multi-node N-producer/M-trainer scale-out) needs an orchestration layer, and **whether that is
+Ray or a home-grown scheduler is undecided** — likely necessary, but not committed. It is **not**
+a non-goal anymore; the decision gate (when ≥1 of: >1 producer pool, cross-node failover,
+multi-job pool sharing) lives in
+[`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md) §O2. Until then
+we keep the home-grown control plane and add nothing.
 
 ### One canonical path vs a light colocated fork
 Chosen: **one path** (spine everywhere) + control-plane-as-no-op for colocated. Keeps
@@ -310,7 +351,9 @@ registry vs HF AutoModel — are unchanged and carry forward.)*
 
 The spine is already landed, so migration is "grow the domain layer on top + close the gaps,"
 not a rewrite. Every phase that touches the training path passes the numerical-equivalence gate
-(below) against the prior commit.
+(below) against the prior commit. **Per-phase target/implementation/tests/done-when detail lives
+in [`docs/roadmap/`](docs/roadmap/)** — the phases below are the index; the online track there
+also folds in the former online-disaggregation roadmap (#618).
 
 - **Phase A — composable launch (DONE / in review).** `StrategySpec` registry + parameterized
   `launch.py`; eagle3/dflash/domino end-to-end (#627/#628/#629). 197 `tests/test_runtime` OK.
@@ -324,8 +367,12 @@ not a rewrite. Every phase that touches the training path passes the numerical-e
   `CheckpointManager`, `Evaluator`. Gate: loss/eval parity at fixed steps.
 - **Phase E — `models/drafts` registry + MLA draft + config/CLI/export (G4/G5).** Adding a
   draft arch = one decorated file; one validated YAML per run; export-loop test.
-- **Phase F — W4 weight lifecycle (G3).** `update_draft_weights`, `SGLangServerEngine`
-  decode-mode + serving metrics, `ServingTrafficStream`, accept-length gate.
+- **Online track (parallel; G3) — live *frozen-target* capture.** O1.1 shared control plane +
+  O1.2 async loop (in review) → **O1.3** live SGLang-server hidden-state capture (next; gated by a
+  throughput spike) → **O2** scale-out (orchestrator: Ray = open) → **O3** hardening. **No weight
+  sync.** Detail: [`docs/roadmap/online-disaggregation.md`](docs/roadmap/online-disaggregation.md).
+- **Eval track (parallel) — E1** acceptance-length eval harness → **E2** algorithm breadth (new
+  algo = a `StrategySpec` + loss). Detail: [`docs/roadmap/eval-and-breadth.md`](docs/roadmap/eval-and-breadth.md).
 
 Doc debt to fix alongside Phase B: revise the predecessor's "No Mooncake / HTTP is sufficient"
 statements (now §5/§6) so the code and the plan stop contradicting each other.
@@ -333,15 +380,21 @@ statements (now §5/§6) so the code and the plan stop contradicting each other.
 ---
 
 ## 8. Non-goals (updated)
-- **No Ray dependency / no multi-engine load balancing.** One trainer ↔ one serving engine
-  (incl. W4). Multi-job pool sharing is gated behind ≥5 concurrent jobs.
+- **No weight sync / hot draft-update / on-policy training.** The target is **frozen**; the
+  draft is never in the generation loop. No `WeightPublisher`, no weight-version registry, no
+  staleness gate. `draft_weight_version` is provenance metadata only.
 - **No two-stack fork for colocated.** One canonical data path; colocated is the spine with the
   control plane as a no-op, not a parallel implementation.
 - **No vLLM target backend** (possible via `TargetEngine`, not prioritized).
-- **No in-trainer serving-prompt interception** — `ServingTrafficStream` reads an external
-  buffer the serving cluster populates.
+- **No multi-engine load balancing / multi-job inference-pool sharing** for now — gated behind
+  ≥5 concurrent jobs sharing one target.
 
-*(Reversed from the predecessor: "No Mooncake" — Mooncake transport is now canonical for W3.)*
+**Open decisions (NOT non-goals):**
+- **Ray (or a home-grown scheduler) for O2 scale-out** — likely necessary for multi-node
+  N-producer/M-trainer; undecided. Decision gate in §6 / the online roadmap.
+
+*(Reversed from the predecessor: "No Mooncake" → Mooncake transport is now canonical for W3;
+"No Ray" → Ray is now an open scale-out decision, not a flat non-goal.)*
 
 ---
 
@@ -353,7 +406,7 @@ statements (now §5/§6) so the code and the plan stop contradicting each other.
 | Colocated (C) | W1/W2 run with control plane as no-op; colocated≡disagg equivalence gate passes. |
 | Managers (D) | resume reproduces the no-resume loss curve; one all-reduce per optimizer step; best-checkpoint tracked. |
 | Drafts/MLA (E) | MLA Eagle3 trains + loads in SGLang; new draft arch = one `@register_draft` file. |
-| W4 (F) | one server serves spec-decode traffic + produces training data; weight push every N steps; serving acceptance rate trends up; weight-sync parity gate passes. |
+| Online (O1.3) | a live **frozen-target** SGLang server feeds training with zero precomputed features; loss/eval matches the offline baseline on the same prompts+seed. (Scale-out O2 / Ray = open.) |
 
 ---
 
@@ -374,5 +427,7 @@ Carries the predecessor's gates, plus the reconciliation-specific one.
   accumulation = one all-reduce per `optimizer.step()`.
 - **10.5 Export-loop test:** train MLA draft 100 steps → export → load in SGLang → 32 gens,
   acceptance > 0 (catches weight-name-map regressions).
-- **10.6 Weight-sync correctness gate (W4):** after `update_draft_weights`, served draft logits
-  match trainer draft within tolerance; serving acceptance non-decreasing across a sync.
+- **10.6 Online-capture parity gate (O1.3):** a live frozen-target capture run produces
+  features + loss matching the offline-precomputed baseline on the same prompts/seed (the target
+  is frozen, so this must hold exactly up to nondeterminism tolerance). No weight-sync gate —
+  weight sync is out of scope.


### PR DESCRIPTION
**Docs only — no code change.** Rewrites `plan.md` to reconcile the original "SpecForge Redesign
Plan" (from-scratch, torchrun-native, HTTP-only) with the **landed DataFlow `runtime/` spine**, and
adds a consolidated `docs/roadmap/` that **folds in the online-disaggregation roadmap (#618)**.

### Why
There were two architecture efforts for the same goal. They aren't either/or — they're
complementary, given a real **multi-node / >100 GB/s / isolated-pool** requirement that overturns
the original draft's "no Mooncake / HTTP is sufficient" bet.

### What the reconciled plan says
- **Canonical substrate = the runtime control + data plane.** `SampleRef` (metadata) +
  `FeatureStore` (tensors, Local/SharedDir/Mooncake) + `FeatureDataLoader` → `TrainBatch`.
- **No separate `HiddenStateStream` source of truth** — `FeatureDataLoader` over
  `SampleRef`+`FeatureStore` already *is* the stream; online/offline/disaggregated variation lives
  in (ref source + `FeatureStore`) and is shielded from training.
- **`training` / `inference` become plan.md-style domain packages on top:** keep the runtime
  `TrainerCore`/`DraftTrainStrategy` seam, add `Trainer` lifecycle + managers
  (`CheckpointManager`/`Evaluator`/`no_sync()`/full resume); converge `SGLangAdapter` →
  `TargetEngine` + backends (de-EAGLE3).
- **Colocated lightweight path** = control plane opt-in/no-op (one canonical path, not a fork),
  guarded by a colocated≡disaggregated numerical-equivalence gate.

### Scope decisions (consolidating with #618)
- **Frozen target — no weight sync.** "Train-with-decode" = a *frozen* target streaming hidden
  states (W2/W3), **not** a serve-and-push workload. The predecessor's W4 weight lifecycle
  (`WeightVersion`/`WeightPublisher`/`update_draft_weights`/`ServingTrafficStream`) is **out of
  scope**; `draft_weight_version` is provenance only.
- **Ray is an open decision, not a non-goal.** Candidate for the O2 scale-out orchestrator
  (multi-node N-producer/M-trainer); decision gate lives in the online roadmap. Until then we keep
  the home-grown metadata-only control plane.

### Consolidated roadmap (`docs/roadmap/`)
Per-phase **Goal / Target state / Implementation (files+symbols) / Tests / Done-when** across three
tracks, with a README index (standing decisions, phase-status-at-a-glance, cross-track deps):
- `domain-refactor.md` — A (done) → B (`TargetEngine` + domain `Trainer`) → C (colocated) → D
  (managers) → E (drafts registry / config / CLI / export).
- `online-disaggregation.md` — **folds in #618**: O1.1/O1.2 (in review) → O1.3 live frozen-target
  capture (next) → O2 scale-out (Ray = open) → O3 hardening.
- `eval-and-breadth.md` — E1 acceptance-length eval harness → E2 algorithm breadth (new algo = a
  `StrategySpec` + loss).

### Relation to the in-flight work
The composable-launch stack (#627 / #628 / #629 — `StrategySpec` registry + parameterized
`launch.py`; eagle3/dflash/domino end-to-end) is **Phase A**. The online track (folding #618)
proceeds in parallel; #618 is superseded by `docs/roadmap/online-disaggregation.md`.

### Files
- `plan.md` — rewritten (reconciled); frozen-target + Ray-open applied.
- `docs/roadmap/` — README + three track docs (new).
- `docs/redesign-draft-legacy.md` — the original redesign draft, preserved **verbatim** (with a
  "superseded by plan.md" banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)