### PR TITLE
[DataFlow runtime] Phase B1 — TargetEngine ABC + de-EAGLE3 the target boundary

### DIFF
--- a/specforge/modeling/__init__.py
+++ b/specforge/modeling/__init__.py
@@ -1,19 +1,33 @@
 # from .auto import AutoDistributedTargetModel, AutoDraftModelConfig, AutoEagle3DraftModel
 from .auto import AutoDraftModelConfig, AutoEagle3DraftModel
 from .draft.llama3_eagle import LlamaForCausalLMEagle3
-from .target.eagle3_target_model import (
+from .target import (
+    CustomEagle3TargetEngine,
     CustomEagle3TargetModel,
+    Eagle3TargetEngine,
+    HFEagle3TargetEngine,
     HFEagle3TargetModel,
+    SGLangEagle3TargetEngine,
     SGLangEagle3TargetModel,
+    TargetEngine,
     get_eagle3_target_model,
+    get_target_engine,
 )
 
 __all__ = [
     "LlamaForCausalLMEagle3",
+    # Generic (Phase B) surface
+    "TargetEngine",
+    "Eagle3TargetEngine",
+    "SGLangEagle3TargetEngine",
+    "HFEagle3TargetEngine",
+    "CustomEagle3TargetEngine",
+    "get_target_engine",
+    "get_eagle3_target_model",
+    # Back-compat aliases (pre-Phase-B names)
     "SGLangEagle3TargetModel",
     "HFEagle3TargetModel",
     "CustomEagle3TargetModel",
-    "get_eagle3_target_model",
     "AutoDraftModelConfig",
     "AutoEagle3DraftModel",
 ]

--- a/specforge/modeling/target/__init__.py
+++ b/specforge/modeling/target/__init__.py
@@ -1,17 +1,40 @@
+from .base import KNOWN_BACKENDS, TargetEngine
 from .eagle3_target_model import (
+    CustomEagle3TargetEngine,
     CustomEagle3TargetModel,
+    Eagle3TargetEngine,
     Eagle3TargetModel,
+    HFEagle3TargetEngine,
     HFEagle3TargetModel,
+    SGLangEagle3TargetEngine,
     SGLangEagle3TargetModel,
     get_eagle3_target_model,
 )
+from .factory import available_target_engines, get_target_engine
 from .target_head import TargetHead
 
 __all__ = [
+    # Generic (Phase B) surface
+    "TargetEngine",
+    "KNOWN_BACKENDS",
+    "get_target_engine",
+    "available_target_engines",
+    # EAGLE3 engines
+    "Eagle3TargetEngine",
+    "SGLangEagle3TargetEngine",
+    "HFEagle3TargetEngine",
+    "CustomEagle3TargetEngine",
+    "get_eagle3_target_model",
+    # Back-compat aliases (pre-Phase-B names)
     "Eagle3TargetModel",
     "SGLangEagle3TargetModel",
     "HFEagle3TargetModel",
     "CustomEagle3TargetModel",
-    "get_eagle3_target_model",
     "TargetHead",
 ]
+
+# NOTE: the DFlash engines (dflash_target_model) are intentionally NOT eagerly
+# imported here — that module imports sglang internals unconditionally, and this
+# package must stay importable without the pinned sglang (see factory._resolve_loader
+# and eagle3_target_model's module docstring). Import them from the submodule, or
+# via get_target_engine(strategy="dflash", ...).

--- a/specforge/modeling/target/base.py
+++ b/specforge/modeling/target/base.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""TargetEngine: the backend-agnostic target-model abstraction (Phase B).
+
+This is the de-EAGLE3'd boundary extracted from the former ``Eagle3TargetModel``
+ABC. A ``TargetEngine`` wraps a *frozen* target model and exposes ONE generic
+extraction entry point, :meth:`capture`, plus a real ``backend`` tag. The
+inference/transport split (sglang in-process / hf / custom / sglang_server) is a
+*backend* axis **under** each algorithm engine, and — crucially — the
+sglang-version-specific glue lives behind a replaceable capture backend
+(``sglang_backend``), NOT in the algorithm engine, so a sglang bump touches one
+place instead of every ``*TargetModel`` subclass.
+
+Two sibling algorithm engines subclass this ABC:
+
+* :class:`Eagle3TargetEngine` (``eagle3_target_model``) — EAGLE3 TTT capture
+  (aux hidden states + logits), keeps the EAGLE3-specific
+  ``set_aux_hidden_states_layers`` / ``generate_eagle3_data``.
+* :class:`DFlashTargetEngine` (``dflash_target_model``) — DFlash block capture
+  (concatenated layer hidden states, no target distribution).
+
+The runtime inference adapters (``SGLangAdapter`` / ``DFlashAdapter``) wrap a
+``TargetEngine`` and remain the ``FeatureSource`` seam to the ``RolloutWorker`` —
+they are unchanged by this extraction; they call the generic engine and read the
+now-real ``.backend`` tag in ``health()``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List, Optional
+
+import torch
+
+# Known transport/backend tags. ``sglang_server`` (a live frozen-target SGLang
+# server, cross-node) is introduced by the sglang-capture-backend PR; its capture
+# depth is gated by the O1.3 spike. The tag set is advisory (informational, used
+# by adapter health + provenance), not an enum the ABC enforces.
+KNOWN_BACKENDS = ("sglang", "hf", "custom", "sglang_server")
+
+
+class TargetEngine(ABC):
+    """Backend-agnostic frozen-target engine.
+
+    Subclasses are organised on two axes: the *algorithm* (EAGLE3 / DFlash —
+    the intermediate ABCs :class:`Eagle3TargetEngine` / :class:`DFlashTargetEngine`)
+    and the *backend/transport* (sglang / hf / custom / sglang_server — the
+    concrete leaf classes). Only the leaf classes are instantiable; each sets a
+    real :attr:`backend` tag.
+    """
+
+    #: Transport tag; concrete leaf engines override this class attribute
+    #: ("sglang" / "hf" / "custom" / "sglang_server"). Read by the inference
+    #: adapters' ``health()`` and recorded as rollout provenance.
+    backend: str = "unknown"
+
+    @classmethod
+    @abstractmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        torch_dtype: Optional[torch.dtype] = None,
+        device: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        **kwargs,
+    ) -> "TargetEngine":
+        """Load a frozen target model for this backend."""
+
+    @abstractmethod
+    def capture(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        **kwargs,
+    ) -> Any:
+        """Run the frozen target forward and extract training features.
+
+        The generic extraction entry point that replaces the EAGLE3-named
+        ``generate_eagle3_data``. Returns a per-algorithm output dataclass
+        (``Eagle3TargetOutput`` / ``DFlashTargetOutput``). Algorithm engines keep
+        their original ``generate_*_data`` method as the concrete implementation
+        and as a back-compat alias; ``capture`` simply dispatches to it, so the
+        extraction is byte-identical to the pre-refactor path.
+        """
+
+    def set_capture_layers(self, layer_ids: Optional[List[int]] = None) -> None:
+        """Select which target layers' hidden states to capture.
+
+        The generic hook. EAGLE3 maps this onto its 3 aux layers
+        (``set_aux_hidden_states_layers``); DFlash captures an arbitrary list.
+        Engines that do not capture intermediate layers may leave this
+        unimplemented.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement set_capture_layers"
+        )
+
+
+__all__ = ["TargetEngine", "KNOWN_BACKENDS"]

--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -19,6 +19,7 @@ from transformers import AutoModelForCausalLM
 
 from specforge.distributed import get_tp_group
 
+from .base import TargetEngine
 from .sglang_backend import SGLangRunner
 
 
@@ -30,9 +31,14 @@ class DFlashTargetOutput:
     loss_mask: torch.Tensor  # [batch, seq_len]
 
 
-class DFlashTargetModel(ABC):
-    """
-    Abstract base class for DFlash target model backend.
+class DFlashTargetEngine(TargetEngine):
+    """DFlash target engine — the algorithm ABC over a frozen target backend.
+
+    DFlash captures the concatenated hidden states of an arbitrary list of
+    target layers (``set_capture_layers``) and trains on hard real-token labels,
+    so — unlike EAGLE3 — there is no target distribution / vocab map. The generic
+    :meth:`TargetEngine.capture` hook dispatches to ``generate_dflash_data``, so
+    the extraction is byte-identical to the pre-Phase-B path.
     """
 
     def __init__(self):
@@ -47,7 +53,7 @@ class DFlashTargetModel(ABC):
         device: str = None,
         cache_dir: Optional[str] = None,
         **kwargs,
-    ) -> "DFlashTargetModel":
+    ) -> "DFlashTargetEngine":
         """Initialize the target model backend."""
 
     @abstractmethod
@@ -59,12 +65,33 @@ class DFlashTargetModel(ABC):
     ) -> DFlashTargetOutput:
         """Generate context hidden states for DFlash training."""
 
-    def set_capture_layers(self, layer_ids: List[int]) -> None:
-        """Set which layers' hidden states to capture."""
+    def capture(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        **kwargs,
+    ) -> DFlashTargetOutput:
+        """Generic extraction entry point (see :meth:`TargetEngine.capture`).
+
+        Dispatches to the DFlash-specific ``generate_dflash_data``. DFlash takes
+        no extra extraction kwargs, so any are ignored.
+        """
+        return self.generate_dflash_data(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+        )
+
+    def set_capture_layers(self, layer_ids: Optional[List[int]] = None) -> None:
+        """Set which layers' hidden states to capture (TargetEngine hook)."""
         self.capture_layer_ids = layer_ids
 
 
-class SGLangDFlashTargetModel(DFlashTargetModel):
+class SGLangDFlashTargetEngine(DFlashTargetEngine):
+
+    backend = "sglang"
+
     def __init__(self, model_runner: SGLangRunner):
         super().__init__()
         self.model_runner = model_runner
@@ -78,7 +105,7 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
         cache_dir: Optional[str] = None,
         trust_remote_code: bool = False,
         **kwargs,
-    ) -> "SGLangDFlashTargetModel":
+    ) -> "SGLangDFlashTargetEngine":
         tp_size = dist.get_world_size(get_tp_group())
         server_args = ServerArgs(
             model_path=pretrained_model_name_or_path,
@@ -225,7 +252,10 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
         )
 
 
-class HFDFlashTargetModel(DFlashTargetModel):
+class HFDFlashTargetEngine(DFlashTargetEngine):
+
+    backend = "hf"
+
     def __init__(self, model: nn.Module):
         super().__init__()
         self.model = model
@@ -239,7 +269,7 @@ class HFDFlashTargetModel(DFlashTargetModel):
         cache_dir: Optional[str] = None,
         trust_remote_code: bool = True,
         **kwargs,
-    ) -> "HFDFlashTargetModel":
+    ) -> "HFDFlashTargetEngine":
 
         target_model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name_or_path,
@@ -294,9 +324,9 @@ def get_dflash_target_model(
     device: str = None,
     cache_dir: Optional[str] = None,
     **kwargs,
-) -> DFlashTargetModel:
+) -> DFlashTargetEngine:
     if backend == "sglang":
-        return SGLangDFlashTargetModel.from_pretrained(
+        return SGLangDFlashTargetEngine.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             torch_dtype=torch_dtype,
             device=device,
@@ -304,7 +334,7 @@ def get_dflash_target_model(
             **kwargs,
         )
     elif backend == "hf":
-        return HFDFlashTargetModel.from_pretrained(
+        return HFDFlashTargetEngine.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             torch_dtype=torch_dtype,
             device=device,
@@ -313,3 +343,11 @@ def get_dflash_target_model(
         )
     else:
         raise ValueError(f"Invalid backend: {backend}")
+
+
+# --- Back-compat aliases (pre-Phase-B names) -------------------------------
+# See the note in eagle3_target_model.py: the ``*TargetModel`` -> ``*TargetEngine``
+# rename is import-compatible; these aliases keep existing callers working.
+DFlashTargetModel = DFlashTargetEngine
+SGLangDFlashTargetModel = SGLangDFlashTargetEngine
+HFDFlashTargetModel = HFDFlashTargetEngine

--- a/specforge/modeling/target/eagle3_target_model.py
+++ b/specforge/modeling/target/eagle3_target_model.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -10,6 +10,8 @@ from transformers import AutoModelForCausalLM
 
 from specforge.distributed import get_tp_device_mesh, get_tp_group
 from specforge.utils import padding
+
+from .base import TargetEngine
 
 # SGLang internals back the *sglang* target backend only. Keep these imports
 # optional so `import specforge` (and the HF / offline / draft paths) still works
@@ -76,12 +78,20 @@ class Eagle3TargetOutput:
     last_hidden_states: Optional[torch.Tensor] = None
 
 
-class Eagle3TargetModel(ABC):
-    """
-    This  offers a layer of abstraction for the target model backend. The user can choose different backends to suit their needs:
+class Eagle3TargetEngine(TargetEngine):
+    """EAGLE3 target engine — the algorithm ABC over a frozen target backend.
+
+    Offers a layer of abstraction for the target model backend. The user can
+    choose different backends to suit their needs:
     1. SGLang backend: for the mainstream model support with the fastest inference speed
     2. HuggingFace backend: for models that are not supported by SGLang but can be loaded by HuggingFace.
     3. Custom backend: for models with customized architecture and inference plan.
+
+    EAGLE3 captures three *aux* hidden-state layers plus (optionally) target
+    logits. The generic :meth:`capture` / :meth:`set_capture_layers` hooks from
+    :class:`TargetEngine` are thin dispatchers onto the EAGLE3-specific
+    ``generate_eagle3_data`` / ``set_aux_hidden_states_layers`` below, so the
+    extraction is byte-identical to the pre-Phase-B path.
     """
 
     def __init__(self):
@@ -96,7 +106,7 @@ class Eagle3TargetModel(ABC):
         device: str = None,
         cache_dir: Optional[str] = None,
         **kwargs,
-    ) -> "Eagle3TargetModel":
+    ) -> "Eagle3TargetEngine":
         """
         Initialize the target model backend from a pretrained model path.
         """
@@ -112,6 +122,28 @@ class Eagle3TargetModel(ABC):
         """
         Generate the eagle3 data from the target model.
         """
+
+    def capture(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        **kwargs,
+    ) -> Eagle3TargetOutput:
+        """Generic extraction entry point (see :meth:`TargetEngine.capture`).
+
+        Dispatches to the EAGLE3-specific ``generate_eagle3_data``.
+        """
+        return self.generate_eagle3_data(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            **kwargs,
+        )
+
+    def set_capture_layers(self, layer_ids: Optional[List[int]] = None) -> None:
+        """Generic alias for EAGLE3 aux-layer selection (TargetEngine hook)."""
+        self.set_aux_hidden_states_layers(layer_ids)
 
     def set_aux_hidden_states_layers(
         self, aux_hidden_states_layers: Optional[List[int]] = None
@@ -137,7 +169,9 @@ class Eagle3TargetModel(ABC):
         ), "aux_hidden_states_layers is expected to be 3 layers for EAGLE3"
 
 
-class HFEagle3TargetModel(Eagle3TargetModel):
+class HFEagle3TargetEngine(Eagle3TargetEngine):
+
+    backend = "hf"
 
     def __init__(self, model: nn.Module):
         super().__init__()
@@ -151,7 +185,7 @@ class HFEagle3TargetModel(Eagle3TargetModel):
         device: str = None,
         cache_dir: Optional[str] = None,
         **kwargs,
-    ) -> "HFEagle3TargetModel":
+    ) -> "HFEagle3TargetEngine":
         """
         Initialize the HuggingFace target model backend from a pretrained model path.
         """
@@ -286,7 +320,9 @@ class HFEagle3TargetModel(Eagle3TargetModel):
         )
 
 
-class SGLangEagle3TargetModel(Eagle3TargetModel):
+class SGLangEagle3TargetEngine(Eagle3TargetEngine):
+
+    backend = "sglang"
 
     def __init__(self, model_runner: SGLangRunner, hf_config=None):
         super().__init__()
@@ -334,7 +370,7 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         cache_dir: Optional[str] = None,
         trust_remote_code: bool = False,
         **kwargs,
-    ) -> "SGLangEagle3TargetModel":
+    ) -> "SGLangEagle3TargetEngine":
         tp_size = dist.get_world_size(get_tp_group())
         # NOTE: sglang 0.5.9 requires dtype to be non-None
         # If torch_dtype is None, use "auto" to let sglang decide the dtype
@@ -846,7 +882,9 @@ class SGLangEagle3TargetModel(Eagle3TargetModel):
         )
 
 
-class CustomEagle3TargetModel(Eagle3TargetModel):
+class CustomEagle3TargetEngine(Eagle3TargetEngine):
+
+    backend = "custom"
 
     def __init__(self, model: nn.Module):
         super().__init__()
@@ -860,7 +898,7 @@ class CustomEagle3TargetModel(Eagle3TargetModel):
         device: str = None,
         cache_dir: Optional[str] = None,
         **kwargs,
-    ) -> "CustomEagle3TargetModel":
+    ) -> "CustomEagle3TargetEngine":
         from specforge.modeling.auto import AutoDistributedTargetModel
 
         target_model = AutoDistributedTargetModel.from_pretrained(
@@ -916,9 +954,9 @@ def get_eagle3_target_model(
     device: str = None,
     cache_dir: Optional[str] = None,
     **kwargs,
-) -> Eagle3TargetModel:
+) -> Eagle3TargetEngine:
     if backend == "sglang":
-        return SGLangEagle3TargetModel.from_pretrained(
+        return SGLangEagle3TargetEngine.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             torch_dtype=torch_dtype,
             device=device,
@@ -926,7 +964,7 @@ def get_eagle3_target_model(
             **kwargs,
         )
     elif backend == "hf":
-        return HFEagle3TargetModel.from_pretrained(
+        return HFEagle3TargetEngine.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             torch_dtype=torch_dtype,
             device=device,
@@ -934,7 +972,7 @@ def get_eagle3_target_model(
             **kwargs,
         )
     elif backend == "custom":
-        return CustomEagle3TargetModel.from_pretrained(
+        return CustomEagle3TargetEngine.from_pretrained(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             torch_dtype=torch_dtype,
             device=device,
@@ -956,3 +994,14 @@ def _get_sharded_return(
     for j, idx in enumerate(valid_indices):
         out[idx] = input_scatter[j]
     return out
+
+
+# --- Back-compat aliases (pre-Phase-B names) -------------------------------
+# The de-EAGLE3 rename (``*TargetModel`` -> ``*TargetEngine``, ``Eagle3TargetModel``
+# -> ``Eagle3TargetEngine``) is import-compatible: existing scripts, tests and
+# ``specforge.modeling`` re-exports keep importing the old names. These aliases
+# are removed once callers migrate (tracked in the Phase E model-layout move).
+Eagle3TargetModel = Eagle3TargetEngine
+HFEagle3TargetModel = HFEagle3TargetEngine
+SGLangEagle3TargetModel = SGLangEagle3TargetEngine
+CustomEagle3TargetModel = CustomEagle3TargetEngine

--- a/specforge/modeling/target/factory.py
+++ b/specforge/modeling/target/factory.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Generic target-engine factory (Phase B).
+
+``get_target_engine(strategy=..., backend=...)`` is the de-EAGLE3'd factory: it
+dispatches on the *algorithm* (``eagle3`` / ``dflash``) and delegates to the
+per-algorithm loaders, which in turn dispatch on the *backend* (sglang / hf /
+custom / sglang_server). The legacy ``get_eagle3_target_model`` /
+``get_dflash_target_model`` remain as thin shims (they ARE the per-algorithm
+loaders this factory calls), so nothing that imports them breaks.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from .base import TargetEngine
+
+# strategy name -> per-algorithm engine. Domino reuses the DFlash engine (same
+# capture: concatenated layer hidden states, no target distribution). The loaders
+# are imported LAZILY inside the factory: dflash_target_model imports sglang
+# internals unconditionally, so eager import here would break the design property
+# that ``import specforge`` works even when the installed sglang lacks the pinned
+# symbols (eagle3_target_model guards its imports; see its module docstring).
+_ENGINE_STRATEGIES = ("eagle3", "dflash", "domino")
+
+
+def available_target_engines():
+    """Strategy names with a registered target-engine loader."""
+    return sorted(_ENGINE_STRATEGIES)
+
+
+def _resolve_loader(strategy: str):
+    if strategy == "eagle3":
+        from .eagle3_target_model import get_eagle3_target_model
+
+        return get_eagle3_target_model
+    if strategy in ("dflash", "domino"):
+        from .dflash_target_model import get_dflash_target_model
+
+        return get_dflash_target_model
+    raise ValueError(
+        f"no target engine for strategy {strategy!r}; "
+        f"registered: {available_target_engines()}"
+    )
+
+
+def get_target_engine(
+    pretrained_model_name_or_path: str,
+    *,
+    strategy: str = "eagle3",
+    backend: str = "sglang",
+    torch_dtype: Optional[torch.dtype] = None,
+    device: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    **kwargs,
+) -> TargetEngine:
+    """Load a frozen :class:`TargetEngine` for ``strategy`` on ``backend``.
+
+    The single, algorithm-agnostic entry point launch code should prefer. The
+    older ``get_eagle3_target_model`` / ``get_dflash_target_model`` stay valid.
+    """
+    loader = _resolve_loader(strategy)
+    return loader(
+        pretrained_model_name_or_path=pretrained_model_name_or_path,
+        backend=backend,
+        torch_dtype=torch_dtype,
+        device=device,
+        cache_dir=cache_dir,
+        **kwargs,
+    )
+
+
+__all__ = ["get_target_engine", "available_target_engines"]

--- a/tests/test_runtime/test_target_engine_abc.py
+++ b/tests/test_runtime/test_target_engine_abc.py
@@ -1,0 +1,124 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Phase B — TargetEngine ABC / de-EAGLE3 extraction (structure, no behavior change).
+
+These assertions are about the *abstraction*, not the GPU forward: the generic
+``TargetEngine`` ABC, the real ``.backend`` tags, the ``capture`` /
+``set_capture_layers`` dispatch onto the algorithm-specific methods, the
+back-compat aliases, and the generic ``get_target_engine`` factory. They do not
+load a model. (They still import torch, so run on the GPU box like the rest of
+tests/test_runtime.)
+"""
+
+import unittest
+
+import torch
+
+from specforge.modeling.target import (
+    CustomEagle3TargetEngine,
+    CustomEagle3TargetModel,
+    Eagle3TargetEngine,
+    Eagle3TargetModel,
+    HFEagle3TargetEngine,
+    HFEagle3TargetModel,
+    SGLangEagle3TargetEngine,
+    SGLangEagle3TargetModel,
+    TargetEngine,
+    available_target_engines,
+    get_target_engine,
+)
+from specforge.modeling.target.base import KNOWN_BACKENDS
+
+
+class TargetEngineABCTest(unittest.TestCase):
+    def test_base_is_abstract(self):
+        with self.assertRaises(TypeError):
+            TargetEngine()  # abstract: from_pretrained + capture unimplemented
+
+    def test_eagle3_hierarchy_under_target_engine(self):
+        # The EAGLE3 algorithm ABC is now a TargetEngine subclass ...
+        self.assertTrue(issubclass(Eagle3TargetEngine, TargetEngine))
+        # ... and the concrete backends sit under it.
+        for cls in (
+            HFEagle3TargetEngine,
+            SGLangEagle3TargetEngine,
+            CustomEagle3TargetEngine,
+        ):
+            self.assertTrue(issubclass(cls, Eagle3TargetEngine))
+
+    def test_backend_tags_are_real(self):
+        # Previously the adapters read getattr(target, "backend", "unknown") and
+        # always got "unknown" — the tag is now a real class attribute.
+        self.assertEqual(SGLangEagle3TargetEngine.backend, "sglang")
+        self.assertEqual(HFEagle3TargetEngine.backend, "hf")
+        self.assertEqual(CustomEagle3TargetEngine.backend, "custom")
+        self.assertEqual(TargetEngine.backend, "unknown")
+        for cls in (
+            SGLangEagle3TargetEngine,
+            HFEagle3TargetEngine,
+            CustomEagle3TargetEngine,
+        ):
+            self.assertIn(cls.backend, KNOWN_BACKENDS)
+
+    def test_backcompat_aliases_are_identical(self):
+        # Pre-Phase-B names resolve to the exact same classes (import-compatible).
+        self.assertIs(Eagle3TargetModel, Eagle3TargetEngine)
+        self.assertIs(HFEagle3TargetModel, HFEagle3TargetEngine)
+        self.assertIs(SGLangEagle3TargetModel, SGLangEagle3TargetEngine)
+        self.assertIs(CustomEagle3TargetModel, CustomEagle3TargetEngine)
+
+    def test_capture_dispatches_to_generate_eagle3_data(self):
+        calls = {}
+
+        class FakeEagle3(Eagle3TargetEngine):
+            backend = "custom"
+
+            @classmethod
+            def from_pretrained(cls, *a, **k):  # pragma: no cover - not used
+                return cls()
+
+            def generate_eagle3_data(
+                self, input_ids, attention_mask, loss_mask, **kwargs
+            ):
+                calls["args"] = (input_ids, attention_mask, loss_mask)
+                calls["kwargs"] = kwargs
+                return "sentinel"
+
+        eng = FakeEagle3()
+        out = eng.capture(
+            input_ids=torch.zeros(1, 3, dtype=torch.long),
+            attention_mask=torch.ones(1, 3, dtype=torch.long),
+            loss_mask=torch.ones(1, 3, dtype=torch.long),
+            shard_returns=True,
+        )
+        self.assertEqual(out, "sentinel")
+        # capture forwards extraction kwargs verbatim (byte-identical path).
+        self.assertEqual(calls["kwargs"], {"shard_returns": True})
+
+    def test_set_capture_layers_maps_to_aux_layers(self):
+        class FakeEagle3(Eagle3TargetEngine):
+            @classmethod
+            def from_pretrained(cls, *a, **k):  # pragma: no cover
+                return cls()
+
+            def generate_eagle3_data(self, *a, **k):  # pragma: no cover
+                raise NotImplementedError
+
+        eng = FakeEagle3()
+        eng.set_capture_layers([1, 5, 9])  # generic hook -> aux layers
+        self.assertEqual(eng.aux_hidden_states_layers, [1, 5, 9])
+
+    def test_factory_lists_and_rejects_unknown_strategy(self):
+        self.assertEqual(available_target_engines(), ["dflash", "domino", "eagle3"])
+        with self.assertRaises(ValueError):
+            get_target_engine("some/path", strategy="does-not-exist")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase B (domain abstractions) — 1/3.** Stacked on #629 (`dataflow-up-23-domino`). Pure structure/naming, **no behavior change**.

Extracts a backend-agnostic `TargetEngine` ABC (`modeling/target/base.py`) with a generic `capture()` entry point + a real `backend` tag, as the shared base of two sibling algorithm engines:

```
TargetEngine
├── Eagle3TargetEngine  (was Eagle3TargetModel)  {HF, SGLang, Custom}
└── DFlashTargetEngine  (was DFlashTargetModel)   {SGLang, HF}
```

- `capture()` / `set_capture_layers()` are thin dispatchers onto the unchanged `generate_eagle3_data` / `generate_dflash_data` / `set_aux_hidden_states_layers`, so extraction is byte-identical.
- Real `backend` class attr on every leaf (`"sglang"`/`"hf"`/`"custom"`); the inference adapters' `health()` stops falling back to `"unknown"`.
- Generic `get_target_engine(strategy=, backend=)` factory; loaders imported **lazily** so `import specforge` still works without the pinned sglang.
- **All pre-Phase-B names kept as aliases** (`Eagle3TargetModel`, `get_eagle3_target_model`, …) — scripts/tests untouched.

New test: `tests/test_runtime/test_target_engine_abc.py`.

### Validation
Part of the Phase B stack validated together on 8×H200: full `tests/test_runtime` **214 OK** (2 skip, 1 xfail), target-model hf-vs-sglang-vs-custom parity **2 OK** (TP=2). Adversarial review over the stack: 0 confirmed defects.

Plan: `docs/roadmap/domain-refactor.md` §B (see #630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)