### PR TITLE
[DataFlow runtime] Phase B3 — domain Trainer wrapping the runtime seam

### DIFF
--- a/specforge/runtime/launch.py
+++ b/specforge/runtime/launch.py
@@ -44,14 +44,12 @@ from specforge.runtime.control_plane.metadata_store import (
     MetadataStore,
     SQLiteMetadataStore,
 )
-from specforge.runtime.data_plane import (
-    FeatureDataLoader,
-    FeatureStore,
-    LocalFeatureStore,
-)
-from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
+from specforge.runtime.data_plane import FeatureStore, LocalFeatureStore
 from specforge.runtime.training.registry import StrategySpec, resolve_strategy
-from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+# The trainer/loader assembly (FeatureDataLoader + FSDPTrainingBackend +
+# TrainerCore + TrainerController) now lives in the domain ``Trainer``
+# (``specforge.training``); ``_assemble_trainer`` below delegates to it.
 
 # ---------------------------------------------------------------------------
 # Shared assemblers — strategy- and topology-agnostic. Every builder is a thin
@@ -93,48 +91,39 @@ def _assemble_trainer(
     the optimizer-step ack — are identical. ``optimizer_factory`` runs AFTER
     FSDP-wrap, over the wrapped module's inner draft.
     """
-    # Offline = a fixed, re-iterable ref set: record committed state so the ack
-    # lookup works (num_epochs > 1 then re-iterates). Online streams refs through
-    # a queue and commits them elsewhere (rollout / channel).
-    if "refs" in ref_source:
-        controller.enqueue_offline_refs(ref_source["refs"])
-    trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
-    loader = FeatureDataLoader(
-        store,
-        **ref_source,
-        batch_size=batch_size,
-        collate_fn=collate_fn,
-        per_sample_transform=per_sample_transform,
-        drop_last=True,
-        strategy=spec.name,
-    )
+    # Delegates to the domain Trainer (``specforge.training``) — the canonical
+    # assembler for this seam since Phase B3. It performs the exact composition
+    # this function used to inline; we return the same
+    # (TrainerController, FeatureDataLoader) tuple so every build_* path is
+    # unchanged. New code can build a ``Trainer`` directly and call ``.fit()``.
+    from specforge.training import Trainer
 
-    parallel = ParallelConfig.from_distributed(
-        tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
-    )
-    backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
-    # FSDP-wrap the composite model and build the optimizer over the inner draft
-    # AFTER wrapping; the strategy MUST run forward through the wrapped module so
-    # FSDP is actually in the forward/backward path (not bypassed at >1 rank).
-    wrapped = backend.prepare_model(model, optimizer_target=model.draft_model)
-    strategy = spec.make_strategy(wrapped, target_head=target_head)
-    core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
-    trainer = TrainerController(
-        core,
+    trainer = Trainer(
+        spec=spec,
+        controller=controller,
+        store=store,
+        ref_source=ref_source,
+        model=model,
+        target_head=target_head,
+        optimizer_factory=optimizer_factory,
         run_id=run_id,
         output_dir=output_dir,
+        batch_size=batch_size,
+        accumulation_steps=accumulation_steps,
         num_epochs=num_epochs,
         max_steps=max_steps,
         total_steps=total_steps,
         save_interval=save_interval,
         eval_interval=eval_interval,
-        log_interval=log_interval,
+        tp_size=tp_size,
+        sp_ulysses_size=sp_ulysses_size,
+        sp_ring_size=sp_ring_size,
         logger=logger,
-        ack_fn=lambda ids, step: controller.ack_train_refs(
-            trainer_id, ids, global_step=step, optimizer_durable=True
-        ),
+        log_interval=log_interval,
+        collate_fn=collate_fn,
+        per_sample_transform=per_sample_transform,
     )
-    return trainer, loader
+    return trainer.controller, trainer.loader
 
 
 def _offline_io(spec: StrategySpec, max_len: int):

--- a/specforge/training/__init__.py
+++ b/specforge/training/__init__.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Domain training layer (Phase B): the caller-facing lifecycle over the runtime.
+
+``Trainer`` WRAPS — does not replace — the runtime training seam
+(``TrainerController`` / ``TrainerCore`` / ``DraftTrainStrategy`` /
+``FSDPTrainingBackend``). Future managers (CheckpointManager / Evaluator /
+lr_scheduler — Phase D) land here on top of the same seam.
+
+Import-light: the ``Trainer`` (which imports the GPU/model-heavy runtime backend)
+is imported lazily so ``import specforge.training`` stays cheap.
+"""
+
+from __future__ import annotations
+
+__all__ = ["Trainer"]
+
+
+def __getattr__(name):  # PEP 562 lazy re-export
+    if name == "Trainer":
+        from .trainer import Trainer
+
+        return Trainer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/specforge/training/trainer.py
+++ b/specforge/training/trainer.py
@@ -1,0 +1,140 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Domain ``Trainer``: the caller-facing training object (Phase B).
+
+``Trainer`` composes — behind one object with a ``.fit()`` — exactly what
+``launch._assemble_trainer`` wired inline before:
+
+    ref source + FeatureStore
+        -> FeatureDataLoader(transform, collate)              (the data path)
+    model + spec.make_strategy
+        -> FSDPTrainingBackend.prepare_model (FSDP wrap)
+        -> TrainerCore -> TrainerController                    (the trainer seam)
+
+The runtime seam (``TrainerController`` / ``TrainerCore`` /
+``DraftTrainStrategy`` / ``FSDPTrainingBackend``) is byte-for-byte unchanged —
+this is the domain facade over it, so ``launch._assemble_trainer`` now delegates
+here (one wiring path, no fork). The online / offline / disaggregated distinction
+is invisible to ``Trainer``: it is fully absorbed by the (ref source +
+``FeatureStore``) it is handed, behind ``FeatureDataLoader -> TrainBatch``. There
+is NO ``HiddenStateStream`` — the loader is the stream.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from specforge.runtime.data_plane import FeatureDataLoader, FeatureStore
+from specforge.runtime.training.backend import FSDPTrainingBackend, ParallelConfig
+from specforge.runtime.training.registry import StrategySpec, resolve_strategy
+from specforge.runtime.training.trainer import TrainerController, TrainerCore
+
+
+class Trainer:
+    """Domain training lifecycle wrapping the runtime controller/core seam."""
+
+    def __init__(
+        self,
+        *,
+        spec: StrategySpec,
+        controller,  # runtime.control_plane.DataFlowController (metadata only)
+        store: FeatureStore,
+        ref_source: dict,  # {"refs": [...]} (offline) | {"queue": q} (online)
+        model,
+        target_head,
+        optimizer_factory,
+        run_id: str,
+        output_dir: str,
+        batch_size: int,
+        accumulation_steps: int,
+        num_epochs: int,
+        max_steps: Optional[int],
+        save_interval: int,
+        eval_interval: int,
+        tp_size: int,
+        sp_ulysses_size: int,
+        sp_ring_size: int,
+        logger,
+        log_interval: int,
+        collate_fn,
+        total_steps: Optional[int] = None,
+        per_sample_transform=None,
+    ):
+        # Offline = a fixed, re-iterable ref set: record committed state so the ack
+        # lookup works (num_epochs > 1 then re-iterates). Online streams refs through
+        # a queue and commits them elsewhere (rollout / channel).
+        if "refs" in ref_source:
+            controller.enqueue_offline_refs(ref_source["refs"])
+        trainer_id = controller.register_trainer({"role": "trainer", "run_id": run_id})
+        loader = FeatureDataLoader(
+            store,
+            **ref_source,
+            batch_size=batch_size,
+            collate_fn=collate_fn,
+            per_sample_transform=per_sample_transform,
+            drop_last=True,
+            strategy=spec.name,
+        )
+
+        parallel = ParallelConfig.from_distributed(
+            tp_size=tp_size, sp_ulysses_size=sp_ulysses_size, sp_ring_size=sp_ring_size
+        )
+        backend = FSDPTrainingBackend(parallel, optimizer_factory=optimizer_factory)
+        # FSDP-wrap the composite model and build the optimizer over the inner draft
+        # AFTER wrapping; the strategy MUST run forward through the wrapped module so
+        # FSDP is actually in the forward/backward path (not bypassed at >1 rank).
+        wrapped = backend.prepare_model(model, optimizer_target=model.draft_model)
+        strategy = spec.make_strategy(wrapped, target_head=target_head)
+        core = TrainerCore(strategy, backend, accumulation_steps=accumulation_steps)
+        controller_obj = TrainerController(
+            core,
+            run_id=run_id,
+            output_dir=output_dir,
+            num_epochs=num_epochs,
+            max_steps=max_steps,
+            total_steps=total_steps,
+            save_interval=save_interval,
+            eval_interval=eval_interval,
+            log_interval=log_interval,
+            logger=logger,
+            ack_fn=lambda ids, step: controller.ack_train_refs(
+                trainer_id, ids, global_step=step, optimizer_durable=True
+            ),
+        )
+
+        # The runtime pieces, exposed for callers that still want them directly
+        # (and for launch._assemble_trainer's (controller, loader) tuple).
+        self.spec = spec
+        self.dataflow_controller = controller
+        self.trainer_id = trainer_id
+        self.backend = backend
+        self.core = core
+        #: the runtime TrainerController (has fit / evaluate / save_checkpoint)
+        self.controller = controller_obj
+        #: the FeatureDataLoader -> TrainBatch iterator (the canonical "stream")
+        self.loader = loader
+
+    @classmethod
+    def from_strategy_name(cls, strategy: str, **kwargs) -> "Trainer":
+        """Resolve the :class:`StrategySpec` by name, then assemble."""
+        return cls(spec=resolve_strategy(strategy), **kwargs)
+
+    def fit(self, eval_data=None) -> int:
+        """Run the training loop over the loader; returns the final global step."""
+        return self.controller.fit(self.loader, eval_data=eval_data)
+
+    def evaluate(self, data=None):
+        return self.controller.evaluate(self.loader if data is None else data)
+
+    def save_checkpoint(self, step: Optional[int] = None):
+        step = self.controller.global_step if step is None else step
+        return self.controller.save_checkpoint(step)
+
+
+__all__ = ["Trainer"]

--- a/tests/test_runtime/test_domain_trainer.py
+++ b/tests/test_runtime/test_domain_trainer.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Phase B3 — the domain ``Trainer`` wires the seam exactly like _assemble_trainer.
+
+This verifies the *composition* (which runtime objects get built, with which
+args, and that ``.fit()`` delegates to the controller over the loader) with fakes
+in place of the FSDP/model-heavy runtime pieces — no GPU, no real model. The
+byte-identical loss gate is the full ``tests/test_runtime`` suite, which now runs
+through this Trainer because ``launch._assemble_trainer`` delegates to it.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+
+class DomainTrainerWiringTest(unittest.TestCase):
+    def _build(self, ref_source):
+        import specforge.training.trainer as tr
+
+        cap = {}
+
+        class FakeLoader:
+            def __init__(self, store, **kw):
+                cap["loader_store"] = store
+                cap["loader_kw"] = kw
+
+        class FakeParallel:
+            @classmethod
+            def from_distributed(cls, **kw):
+                cap["parallel_kw"] = kw
+                return "PARALLEL"
+
+        class FakeBackend:
+            def __init__(self, parallel, *, optimizer_factory):
+                cap["backend_parallel"] = parallel
+                cap["optimizer_factory"] = optimizer_factory
+
+            def prepare_model(self, model, *, optimizer_target):
+                cap["prepare_model"] = (model, optimizer_target)
+                return "WRAPPED"
+
+        class FakeCore:
+            def __init__(self, strategy, backend, *, accumulation_steps):
+                cap["core"] = (strategy, backend, accumulation_steps)
+
+        class FakeController:
+            def __init__(self, core, **kw):
+                cap["ctrl_core"] = core
+                cap["ctrl_kw"] = kw
+                self.global_step = 0
+
+            def fit(self, loader, eval_data=None):
+                cap["fit"] = (loader, eval_data)
+                return 42
+
+        dfc_calls = []
+
+        class FakeDataflowController:
+            def enqueue_offline_refs(self, refs):
+                dfc_calls.append(("enqueue", refs))
+
+            def register_trainer(self, meta):
+                dfc_calls.append(("register", meta))
+                return "trainer-0"
+
+            def ack_train_refs(self, tid, ids, *, global_step, optimizer_durable):
+                dfc_calls.append(("ack", tid, ids, global_step, optimizer_durable))
+
+        spec = SimpleNamespace(
+            name="eagle3",
+            make_strategy=lambda wrapped, *, target_head: (
+                "STRAT",
+                wrapped,
+                target_head,
+            ),
+        )
+        model = SimpleNamespace(draft_model="DRAFT")
+        dfc = FakeDataflowController()
+
+        with mock.patch.multiple(
+            tr,
+            FeatureDataLoader=FakeLoader,
+            ParallelConfig=FakeParallel,
+            FSDPTrainingBackend=FakeBackend,
+            TrainerCore=FakeCore,
+            TrainerController=FakeController,
+        ):
+            trainer = tr.Trainer(
+                spec=spec,
+                controller=dfc,
+                store="STORE",
+                ref_source=ref_source,
+                model=model,
+                target_head="HEAD",
+                optimizer_factory="OPT",
+                run_id="run",
+                output_dir="/out",
+                batch_size=2,
+                accumulation_steps=3,
+                num_epochs=1,
+                max_steps=None,
+                total_steps=None,
+                save_interval=0,
+                eval_interval=0,
+                tp_size=1,
+                sp_ulysses_size=1,
+                sp_ring_size=1,
+                logger=None,
+                log_interval=50,
+                collate_fn="COLLATE",
+            )
+        return trainer, cap, dfc_calls, model
+
+    def test_offline_wiring_matches_assemble_trainer(self):
+        try:
+            import torch  # noqa: F401
+        except Exception:
+            self.skipTest("torch unavailable")
+        trainer, cap, dfc_calls, model = self._build({"refs": [1, 2]})
+
+        # offline refs enqueued; trainer registered
+        self.assertIn(("enqueue", [1, 2]), dfc_calls)
+        self.assertIn(("register", {"role": "trainer", "run_id": "run"}), dfc_calls)
+
+        # loader built over the store with the spec's name + drop_last + ref_source
+        self.assertEqual(cap["loader_store"], "STORE")
+        self.assertEqual(cap["loader_kw"]["batch_size"], 2)
+        self.assertEqual(cap["loader_kw"]["strategy"], "eagle3")
+        self.assertIs(cap["loader_kw"]["drop_last"], True)
+        self.assertEqual(cap["loader_kw"]["refs"], [1, 2])
+
+        # optimizer built over the inner draft AFTER FSDP wrap
+        self.assertEqual(cap["prepare_model"], (model, "DRAFT"))
+        self.assertEqual(cap["core"][0], ("STRAT", "WRAPPED", "HEAD"))
+        self.assertEqual(cap["core"][2], 3)  # accumulation_steps threaded
+
+        # ack_fn wired to the DataFlowController with optimizer_durable=True
+        ack = cap["ctrl_kw"]["ack_fn"]
+        ack(["s1"], 7)
+        self.assertIn(("ack", "trainer-0", ["s1"], 7, True), dfc_calls)
+
+    def test_fit_delegates_to_controller_over_loader(self):
+        try:
+            import torch  # noqa: F401
+        except Exception:
+            self.skipTest("torch unavailable")
+        trainer, cap, _, _ = self._build({"refs": []})
+        out = trainer.fit(eval_data="EVAL")
+        self.assertEqual(out, 42)
+        self.assertEqual(cap["fit"], (trainer.loader, "EVAL"))
+
+    def test_online_ref_source_not_enqueued(self):
+        try:
+            import torch  # noqa: F401
+        except Exception:
+            self.skipTest("torch unavailable")
+        _, _, dfc_calls, _ = self._build({"queue": object()})
+        # a streamed (online) ref source is committed elsewhere — not enqueued here
+        self.assertNotIn("enqueue", [c[0] for c in dfc_calls])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Phase B (domain abstractions) — 3/3.** Stacked on #632 (B2).

Introduces the domain training layer `specforge/training/` with a caller-facing `Trainer` that composes the whole spine behind one object + `.fit()`:

```
FeatureDataLoader  +  FSDPTrainingBackend.prepare_model (FSDP wrap)
                   +  spec.make_strategy -> TrainerCore -> TrainerController
```

`Trainer` is the canonical assembler now; `launch._assemble_trainer` **delegates** to it and returns the same `(TrainerController, FeatureDataLoader)` tuple, so every `build_*_runtime` path is byte-for-byte unchanged (one wiring path, no fork). The runtime seam (`TrainerController` / `TrainerCore` / `DraftTrainStrategy` / `FSDPTrainingBackend`) is untouched — this is the domain facade over it. Topology (offline/online/disagg) stays invisible to `Trainer`; it's absorbed by the (ref source + `FeatureStore`) it's handed. No `HiddenStateStream` — the loader is the stream.

- `specforge/training/{__init__.py, trainer.py}` (new)
- `launch.py`: `_assemble_trainer` delegates to `Trainer`; drops the now-unused `FeatureDataLoader`/`FSDPTrainingBackend`/`ParallelConfig`/`TrainerCore`/`TrainerController` imports.
- New test: `tests/test_runtime/test_domain_trainer.py` — fakes the runtime pieces and asserts the composition (refs enqueued, loader/backend/core/controller args, `ack_fn` wired to the DataFlowController, `.fit()` delegates over the loader).

### Validation
Full `tests/test_runtime` **214 OK** (2 skip, 1 xfail) on 8×H200 — the existing launch/equivalence tests now run through this `Trainer`, so byte-identical loss is covered. Adversarial review: 0 confirmed defects.

### Known gap (not blocking)
No single test drives the online loop with a **real SGLang target** (`backend="sglang"` → capture backend → adapter → RolloutWorker → `fit`); the sglang capture is validated end-to-end at the capture level (parity test) and the online rollout→train loop is validated with an HF target, but not combined. Can add on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)