### PR TITLE
[DataFlow runtime] Phase B4 — adopt the de-EAGLE3 surface (cutover + docs + gate)

### DIFF
--- a/specforge/runtime/ARCHITECTURE.md
+++ b/specforge/runtime/ARCHITECTURE.md
@@ -14,7 +14,7 @@ its own design note (see "Per-plane internals" below).
 
 ## End-to-end flow
 
-**Online:** `RolloutWorker.run_once` leases prompts (`lease_prompt_tasks`), calls `generate_features` (which drives `generate_eagle3_data`), runs `verify_capture`, then `FeatureStore.put` writes tensors **directly to the data plane**. Only the resulting `SampleRef` metadata goes to the controller via `commit_samples`, which dedups through `MetadataStore.commit_sample` and enqueues fresh refs onto `SampleRefQueue`.
+**Online:** `RolloutWorker.run_once` leases prompts (`lease_prompt_tasks`), calls `generate_features` (which drives the engine's generic `TargetEngine.capture`), runs `verify_capture`, then `FeatureStore.put` writes tensors **directly to the data plane**. Only the resulting `SampleRef` metadata goes to the controller via `commit_samples`, which dedups through `MetadataStore.commit_sample` and enqueues fresh refs onto `SampleRefQueue`.
 
 **Offline:** `OfflineManifestReader.read()` emits in-place `file://` `SampleRef`s (no tensor copy) and the launcher calls `enqueue_offline_refs`, which dedups and enqueues onto the **same** `SampleRefQueue`.
 
@@ -36,7 +36,7 @@ flowchart TD
   subgraph COMPUTE[compute autonomous loops]
     RW[RolloutWorker run_once loop]
     SG[SGLangAdapter generate_features]
-    TGT[Eagle3TargetModel generate_eagle3_data]
+    TGT[TargetEngine capture via SGLangCaptureBackend]
     TR[TrainerController fit loop]
     CORE[TrainerCore train_step]
     STRAT[Eagle3TrainStrategy forward_loss]
@@ -59,7 +59,7 @@ flowchart TD
   RW -->|register_rollout_worker| CTRL
   RW -->|lease_prompt_tasks| CTRL
   RW -->|generate_features| SG
-  SG -->|generate_eagle3_data| TGT
+  SG -->|capture| TGT
   RW -.->|put| STORE
   RW -->|commit_samples| CTRL
   RW -->|fail_prompt_tasks| CTRL
@@ -97,7 +97,7 @@ flowchart TD
 | RolloutWorker | register_rollout_worker | control | Register worker, obtain authoritative worker_id (no-tensor guard on info) |
 | RolloutWorker | lease_prompt_tasks | control | Pop up to max_tasks pending PromptTasks, mark leased to worker_id |
 | RolloutWorker | generate_features | compute | Ask the FeatureSource (SGLangAdapter) for one feature dict per task |
-| SGLangAdapter | generate_eagle3_data | compute | Run the target engine's batched forward to extract hidden_states/target |
+| SGLangAdapter | TargetEngine.capture | compute | Run the target engine's batched forward (sglang glue in SGLangCaptureBackend) to extract hidden_states/target |
 | RolloutWorker | put | data | Persist verified feature tensors directly to FeatureStore, get back a SampleRef |
 | RolloutWorker | abort | data | Clean up a partial/failed write so no corrupt sample is left |
 | RolloutWorker | commit_samples | control | Commit metadata-only SampleRefs; dedup + enqueue fresh refs |

--- a/specforge/runtime/inference/DESIGN.md
+++ b/specforge/runtime/inference/DESIGN.md
@@ -7,7 +7,7 @@ plane exchanges are in [`../contracts.py`](../contracts.py).
 
 ## Responsibility
 
-The rollout/inference plane turns leased PromptTasks into per-sample feature tensors and commits only their typed SampleRef metadata to the controller — it never hands a tensor to the controller. It owns the clean boundary to the target engine (Eagle3TargetModel via generate_eagle3_data), the only place target→draft projection/pruning happens, and the loud pre-write validation (verify_capture against a typed CaptureConfig) that converts layer/name/width/target-dim mismatches into immediate, localized errors at the extraction boundary instead of downstream trainer bugs.
+The rollout/inference plane turns leased PromptTasks into per-sample feature tensors and commits only their typed SampleRef metadata to the controller — it never hands a tensor to the controller. It owns the clean boundary to the target engine (a `TargetEngine` via its generic `capture()`; the sglang-version glue lives behind `SGLangCaptureBackend`), the only place target→draft projection/pruning happens, and the loud pre-write validation (verify_capture against a typed CaptureConfig) that converts layer/name/width/target-dim mismatches into immediate, localized errors at the extraction boundary instead of downstream trainer bugs.
 
 ## Internal mechanics
 
@@ -19,7 +19,7 @@ flowchart TD
 
   A[lease_prompt_tasks] --> B[generate_features per batch]
   B --> C[SGLangAdapter group by len single forward]
-  C --> D[generate_eagle3_data]
+  C --> D[TargetEngine.capture]
   D --> E[_project_target logits or pruned_logits]
   E --> F[verify_capture vs CaptureConfig]
   F -->|mismatch| G[fail_prompt_tasks non retryable]
@@ -34,7 +34,7 @@ flowchart TD
   class G control;
 ```
 
-The rollout plane turns leased `PromptTask`s into per-sample feature tensors and commits only their typed `SampleRef` metadata — it never hands a tensor to the controller. `RolloutWorker.run_once` is the core loop: lease up to `max_tasks`, call `feature_source.generate_features(tasks, capture=...)` once for the whole batch, enforce a strict `len(feats)==len(tasks)` contract, then per sample pop the out-of-band `__aux_layer_ids__`, run `verify_capture`, and on success `FeatureStore.put` (tensors go straight to the data plane). Every leased task ends in exactly one terminal controller action — `commit_samples` on success or `fail_prompt_tasks` on generate failure / wrong count / capture mismatch / put failure — with `sample_id = f"{run_id}:{task.task_id}"` deterministic and a put exception triggering `abort`. `CaptureConfig` is a frozen, strategy-derived contract carrying `feature_names`, `aux_hidden_state_layer_ids`, `target_repr`, and the derived `expected_aux_width` / `expected_target_dim()`. `verify_capture` is the loud pre-`put` validator: it checks name presence, aux-layer-id equality, aux last-dim width, and target last-dim, gating `pruned_logits` on a non-None `vocab_map_version`, raising `CaptureMismatchError` at the boundary. `SGLangAdapter` is the only place target to draft projection happens (`_project_target`: passthrough for `logits`, `t2d`-indexing for `pruned_logits`), batching equal-length tasks into one padding-free `generate_eagle3_data` forward and slicing rows back into original task order.
+The rollout plane turns leased `PromptTask`s into per-sample feature tensors and commits only their typed `SampleRef` metadata — it never hands a tensor to the controller. `RolloutWorker.run_once` is the core loop: lease up to `max_tasks`, call `feature_source.generate_features(tasks, capture=...)` once for the whole batch, enforce a strict `len(feats)==len(tasks)` contract, then per sample pop the out-of-band `__aux_layer_ids__`, run `verify_capture`, and on success `FeatureStore.put` (tensors go straight to the data plane). Every leased task ends in exactly one terminal controller action — `commit_samples` on success or `fail_prompt_tasks` on generate failure / wrong count / capture mismatch / put failure — with `sample_id = f"{run_id}:{task.task_id}"` deterministic and a put exception triggering `abort`. `CaptureConfig` is a frozen, strategy-derived contract carrying `feature_names`, `aux_hidden_state_layer_ids`, `target_repr`, and the derived `expected_aux_width` / `expected_target_dim()`. `verify_capture` is the loud pre-`put` validator: it checks name presence, aux-layer-id equality, aux last-dim width, and target last-dim, gating `pruned_logits` on a non-None `vocab_map_version`, raising `CaptureMismatchError` at the boundary. `SGLangAdapter` is the only place target to draft projection happens (`_project_target`: passthrough for `logits`, `t2d`-indexing for `pruned_logits`), batching equal-length tasks into one padding-free `TargetEngine.capture` forward and slicing rows back into original task order.
 
 ## Endpoints
 
@@ -45,7 +45,7 @@ The rollout plane turns leased `PromptTask`s into per-sample feature tensors and
 | `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
 | `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
 | `RolloutWorker` | `SGLangAdapter.generate_features` | compute |
-| `SGLangAdapter` | `Eagle3TargetModel.generate_eagle3_data` | compute |
+| `SGLangAdapter` | `TargetEngine.capture` (→ `SGLangCaptureBackend`) | compute |
 | `RolloutWorker` | `FeatureStore.put` | data |
 | `RolloutWorker` | `FeatureStore.abort` | data |
 | `RolloutWorker` | `DataFlowController.commit_samples` | control |

--- a/specforge/runtime/inference/dflash_adapter.py
+++ b/specforge/runtime/inference/dflash_adapter.py
@@ -8,8 +8,9 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 """DFlashAdapter: the DFlash counterpart of SGLangAdapter.
 
-Wraps a ``DFlashTargetModel`` (sglang / hf, both expose ``generate_dflash_data``)
-and returns per-sample feature dicts for the DataFlow rollout. DFlash's schema is
+Wraps a DFlash ``TargetEngine`` (sglang / hf), calling its generic ``capture(...)``
+(the legacy ``generate_dflash_data`` is kept as a back-compat alias), and returns
+per-sample feature dicts for the DataFlow rollout. DFlash's schema is
 ``{input_ids, hidden_states, loss_mask}`` — note ``hidden_states`` is the
 concatenated target capture layers, and there is NO ``target`` distribution / no
 vocab projection (DFlash trains on hard real-token labels), so unlike
@@ -43,7 +44,7 @@ def _as_2d_long(values, device) -> torch.Tensor:
 
 
 class DFlashAdapter:
-    """Adapter over a SpecForge ``DFlashTargetModel`` (any ``generate_dflash_data``)."""
+    """Adapter over a SpecForge DFlash ``TargetEngine`` (via its generic ``capture()``)."""
 
     SUPPORTED_FEATURE_NAMES = {"input_ids", "hidden_states", "loss_mask"}
 
@@ -63,8 +64,8 @@ class DFlashAdapter:
     ) -> List[Dict[str, Any]]:
         """Extract per-sample DFlash features, batching equal-length prompts.
 
-        Mirrors SGLangAdapter's length-grouped batching, but calls
-        ``generate_dflash_data`` and emits the DFlash schema. The target must have
+        Mirrors SGLangAdapter's length-grouped batching, but calls the engine's
+        generic ``capture(...)`` and emits the DFlash schema. The target must have
         had ``set_capture_layers`` called so ``hidden_states`` width matches the
         draft's ``len(target_layer_ids) * hidden_size``.
         """
@@ -95,7 +96,7 @@ class DFlashAdapter:
                 dim=0,
             )
             attention_mask = torch.ones_like(input_ids)
-            data = self.target_model.generate_dflash_data(
+            data = self.target_model.capture(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 loss_mask=loss_mask,

--- a/specforge/runtime/inference/sglang_adapter.py
+++ b/specforge/runtime/inference/sglang_adapter.py
@@ -10,9 +10,10 @@
 
 ``generate_features(tasks, *, capture)`` is the single extraction entry point.
 ``capture`` is the typed :class:`CaptureConfig` derived from the active strategy,
-not an untyped dict. The adapter wraps the existing ``Eagle3TargetModel`` (sglang
-/ hf / custom backends all expose ``generate_eagle3_data``), records the exact
-aux-layer IDs it captured, applies the target→draft projection demanded by
+not an untyped dict. The adapter wraps an EAGLE3 ``TargetEngine`` (sglang / hf /
+custom backends), calling its generic ``capture(...)`` (the de-EAGLE3'd boundary;
+the legacy ``generate_eagle3_data`` is kept as a back-compat alias), records the
+exact aux-layer IDs it captured, applies the target→draft projection demanded by
 ``capture.target_repr`` (the only place pruning happens), and returns per-sample
 feature dicts. The RolloutWorker then runs :func:`verify_capture` before any
 store write, so a layer/name/width mismatch fails loudly at this boundary rather
@@ -39,7 +40,7 @@ def _as_2d_long(values, device) -> torch.Tensor:
 
 
 class SGLangAdapter:
-    """Adapter over a SpecForge ``Eagle3TargetModel`` (or any ``generate_eagle3_data``)."""
+    """Adapter over a SpecForge EAGLE3 ``TargetEngine`` (via its generic ``capture()``)."""
 
     SUPPORTED_FEATURE_NAMES = {
         "input_ids",
@@ -94,8 +95,8 @@ class SGLangAdapter:
         """Extract per-sample features, batching the engine call.
 
         Tasks are grouped by sequence length and each group is run through
-        ``generate_eagle3_data`` in ONE batched forward (the engine's native
-        batching), instead of a per-sample loop that would serialize N forwards.
+        the engine's generic ``capture(...)`` in ONE batched forward (the engine's
+        native batching), instead of a per-sample loop that would serialize N forwards.
         Equal-length grouping avoids intra-batch padding, so per-sample features
         are sliced out cleanly. The result preserves task order.
         """
@@ -125,7 +126,7 @@ class SGLangAdapter:
                 dim=0,
             )
             attention_mask = torch.ones_like(input_ids)
-            data = self.target_model.generate_eagle3_data(
+            data = self.target_model.capture(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
                 loss_mask=loss_mask,

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -153,7 +153,7 @@ def build_hf_target(workdir, hidden=H, layers=8, vocab=V, aux_layer_ids=(1, 3, 4
     """Build a tiny HF Llama target wrapped by the SpecForge HF eagle3 backend."""
     from transformers import LlamaConfig, LlamaForCausalLM
 
-    from specforge.modeling.target import get_eagle3_target_model
+    from specforge.modeling.target import get_target_engine
 
     cfg = LlamaConfig(
         hidden_size=hidden,
@@ -170,8 +170,9 @@ def build_hf_target(workdir, hidden=H, layers=8, vocab=V, aux_layer_ids=(1, 3, 4
     model = LlamaForCausalLM(cfg)
     target_dir = os.path.join(workdir, "hf_target")
     model.save_pretrained(target_dir)
-    target = get_eagle3_target_model(
-        pretrained_model_name_or_path=target_dir,
+    target = get_target_engine(
+        target_dir,
+        strategy="eagle3",
         backend="hf",
         torch_dtype=torch.bfloat16,
         device="cuda",

--- a/tests/test_runtime/test_dflash_online_launch.py
+++ b/tests/test_runtime/test_dflash_online_launch.py
@@ -27,9 +27,7 @@ class TestDFlashOnlineLaunch(unittest.TestCase):
 
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-        from specforge.modeling.target.dflash_target_model import (
-            get_dflash_target_model,
-        )
+        from specforge.modeling.target import get_target_engine
         from specforge.optimizer import BF16Optimizer
         from specforge.runtime.contracts import assert_no_tensors
         from specforge.runtime.launch import build_online_runtime
@@ -49,8 +47,9 @@ class TestDFlashOnlineLaunch(unittest.TestCase):
         self.assertEqual(width, HIDDEN)
 
         # HF DFlash target (no sglang) capturing the same layers the draft expects
-        target = get_dflash_target_model(
-            pretrained_model_name_or_path=target_dir,
+        target = get_target_engine(
+            target_dir,
+            strategy="dflash",
             backend="hf",
             torch_dtype=torch.bfloat16,
             device="cuda",

--- a/tests/test_runtime/test_domino_launch.py
+++ b/tests/test_runtime/test_domino_launch.py
@@ -115,9 +115,7 @@ class TestDominoOnlineLaunch(unittest.TestCase):
 
         from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-        from specforge.modeling.target.dflash_target_model import (
-            get_dflash_target_model,
-        )
+        from specforge.modeling.target import get_target_engine
         from specforge.optimizer import BF16Optimizer
         from specforge.runtime.launch import build_online_runtime
 
@@ -135,8 +133,9 @@ class TestDominoOnlineLaunch(unittest.TestCase):
         self.assertEqual(width, HIDDEN)
 
         # domino captures the same hidden_states as DFlash -> reuse the DFlash target
-        target = get_dflash_target_model(
-            pretrained_model_name_or_path=target_dir,
+        target = get_target_engine(
+            target_dir,
+            strategy="domino",
             backend="hf",
             torch_dtype=torch.bfloat16,
             device="cuda",

--- a/tests/test_runtime/test_phase_b_gate.py
+++ b/tests/test_runtime/test_phase_b_gate.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Phase B explicit gate — target capture is byte-identical pre/post refactor.
+
+The roadmap's Phase B gate is "byte-identical batches and loss vs the pre-refactor
+run." This file pins it directly rather than leaning only on the full-suite's
+indirect coverage:
+
+1. ``capture() ≡ legacy generate_*_data()`` **bytewise** (eagle3 + dflash, HF
+   backend). ``generate_*_data`` is the pre-Phase-B extraction method (kept as a
+   back-compat alias); the whole B refactor (B1 rename + B2 SGLangCaptureBackend +
+   B4 adapter cutover to ``capture()``) routes through ``capture()`` now, so this
+   is the pre/post-refactor capture equality gate.
+2. A **TrainBatch-style feature digest** over the captured tensors is stable
+   run-to-run (fixed seed) — a concrete regression pin for the capture pipeline.
+3. **Per-step loss** through the full online capture→train path (which now calls
+   ``capture()``) is reproducible run-to-run at atol=1e-4.
+
+(The dataflow-vs-legacy per-step loss equality is additionally covered by
+``test_equiv_online_eagle3`` / ``test_equiv_offline_eagle3``, which after the B4
+cutover exercise the ``capture()`` path.)
+
+GPU-only. Run on the H200 box via rcli.
+"""
+
+import hashlib
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+
+
+def _digest(*tensors) -> str:
+    h = hashlib.sha256()
+    for t in tensors:
+        t = t.detach().to("cpu").contiguous()
+        h.update(str(tuple(t.shape)).encode())
+        h.update(str(t.dtype).encode())
+        h.update(t.float().numpy().tobytes())
+    return h.hexdigest()
+
+
+@unittest.skipUnless(CUDA, "Phase B gate requires CUDA")
+class PhaseBCaptureEqualityTest(unittest.TestCase):
+    """capture() is a faithful, byte-identical alias of the legacy generate_*."""
+
+    def test_capture_equals_legacy_eagle3_hf(self):
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29572")
+        workdir = tempfile.mkdtemp(prefix="pb_gate_eagle3_")
+        target, _dir, _aux = fx.build_hf_target(
+            workdir, hidden=fx.H, layers=8, vocab=fx.V
+        )
+
+        torch.manual_seed(0)
+        ids = torch.randint(0, fx.V, (2, 32)).cuda()
+        attn = torch.ones_like(ids)
+        lm = torch.ones_like(ids)
+
+        legacy = target.generate_eagle3_data(
+            input_ids=ids, attention_mask=attn, loss_mask=lm
+        )
+        via_capture = target.capture(input_ids=ids, attention_mask=attn, loss_mask=lm)
+
+        self.assertTrue(torch.equal(legacy.hidden_states, via_capture.hidden_states))
+        self.assertTrue(torch.equal(legacy.target, via_capture.target))
+        self.assertTrue(torch.equal(legacy.loss_mask, via_capture.loss_mask))
+        self.assertTrue(torch.equal(legacy.input_ids, via_capture.input_ids))
+
+    def test_capture_equals_legacy_dflash_hf(self):
+        from specforge.modeling.target import get_target_engine
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29573")
+        workdir = tempfile.mkdtemp(prefix="pb_gate_dflash_")
+        _model, _w, target_dir, layers = fx.build_dflash(
+            workdir,
+            hidden=64,
+            vocab=fx.V,
+            block_size=4,
+            num_anchors=8,
+            attention_backend="sdpa",
+        )
+        target = get_target_engine(
+            target_dir,
+            strategy="dflash",
+            backend="hf",
+            torch_dtype=torch.bfloat16,
+            device="cuda",
+        )
+        target.set_capture_layers(layers)
+
+        torch.manual_seed(0)
+        ids = torch.randint(0, fx.V, (2, 32)).cuda()
+        attn = torch.ones_like(ids)
+        lm = torch.ones_like(ids)
+
+        legacy = target.generate_dflash_data(
+            input_ids=ids, attention_mask=attn, loss_mask=lm
+        )
+        via_capture = target.capture(input_ids=ids, attention_mask=attn, loss_mask=lm)
+
+        self.assertTrue(torch.equal(legacy.hidden_states, via_capture.hidden_states))
+        self.assertTrue(torch.equal(legacy.input_ids, via_capture.input_ids))
+        self.assertTrue(torch.equal(legacy.loss_mask, via_capture.loss_mask))
+
+    def test_eagle3_captured_feature_digest_is_stable(self):
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29574")
+        workdir = tempfile.mkdtemp(prefix="pb_gate_digest_")
+        target, _dir, _aux = fx.build_hf_target(
+            workdir, hidden=fx.H, layers=8, vocab=fx.V
+        )
+
+        def capture_digest():
+            g = torch.Generator().manual_seed(1234)
+            ids = torch.randint(0, fx.V, (2, 24), generator=g).cuda()
+            out = target.capture(
+                input_ids=ids,
+                attention_mask=torch.ones_like(ids),
+                loss_mask=torch.ones_like(ids),
+            )
+            return _digest(out.hidden_states, out.target, out.input_ids, out.loss_mask)
+
+        self.assertEqual(capture_digest(), capture_digest())
+
+
+@unittest.skipUnless(CUDA, "Phase B gate requires CUDA")
+class PhaseBLossReproducibilityTest(unittest.TestCase):
+    """Per-step loss through the full online capture→train path is reproducible."""
+
+    def _run_losses(self, port):
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.launch import build_online_runtime
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port=port)
+        H, V, SEQ, TTT, ACC, MAX_OPT_STEPS, N = fx.H, fx.V, 12, 3, 2, 2, 8
+        workdir = tempfile.mkdtemp(prefix="pb_gate_loss_")
+
+        target, _dir, aux_ids = fx.build_hf_target(workdir, hidden=H, layers=8, vocab=V)
+        cfg = fx.write_draft_config(os.path.join(workdir, "draft.json"))
+        vocab_path = fx.write_vocab_mapping(os.path.join(workdir, "vm.pt"))
+        torch.manual_seed(0)
+        draft = AutoEagle3DraftModel.from_config(
+            AutoDraftModelConfig.from_file(cfg),
+            attention_backend="flex_attention",
+            torch_dtype=torch.bfloat16,
+        ).cuda()
+        draft.load_vocab_mapping(vocab_path)
+        draft.freeze_embedding()
+        eagle3_model = OnlineEagle3Model(
+            draft, length=TTT, attention_backend="flex_attention"
+        ).cuda()
+
+        g = torch.Generator().manual_seed(7)
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": torch.randint(0, V, (SEQ,), generator=g).tolist(),
+                    "loss_mask": [1] * SEQ,
+                }
+            }
+            for _ in range(N)
+        ]
+
+        losses = []
+
+        trainer, loader, workers, controller, drive_rollout = build_online_runtime(
+            strategy="eagle3",
+            target_model=target,
+            prompts=prompts,
+            eagle3_model=eagle3_model,
+            optimizer_factory=lambda m: BF16Optimizer(
+                m, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
+            ),
+            run_id="pb-gate",
+            output_dir=os.path.join(workdir, "out"),
+            target_hidden_size=H,
+            target_vocab_size=V,
+            target_repr="logits",
+            aux_hidden_state_layer_ids=tuple(aux_ids),
+            batch_size=1,
+            accumulation_steps=ACC,
+            num_epochs=1,
+            max_steps=MAX_OPT_STEPS,
+        )
+        # capture per-optimizer-step loss via the controller's logger hook
+        trainer.logger = lambda metrics, step: losses.append(metrics["loss"])
+        trainer.log_interval = 1
+        drive_rollout()
+        trainer.fit(loader)
+        return losses
+
+    def test_online_eagle3_losses_reproducible(self):
+        a = self._run_losses("29575")
+        b = self._run_losses("29576")
+        self.assertTrue(len(a) >= 1 and len(a) == len(b), f"losses: {a} vs {b}")
+        for x, y in zip(a, b):
+            self.assertTrue(
+                abs(x - y) <= 1e-4, f"per-step loss not reproducible: {a} vs {b}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_sglang_adapter_batching.py
+++ b/tests/test_runtime/test_sglang_adapter_batching.py
@@ -14,13 +14,23 @@ H, V = 4, 16
 
 
 class FakeTarget:
-    """Records each generate_eagle3_data call's batch size; encodes the first
-    token id into hidden_states so per-sample slicing can be verified."""
+    """Records each capture() call's batch size; encodes the first token id into
+    hidden_states so per-sample slicing can be verified. Mirrors the TargetEngine
+    contract the adapter now speaks: capture() dispatches to generate_eagle3_data
+    (the back-compat method), exactly like the real engine."""
 
     aux_hidden_states_layers = [1, 2, 3]
 
     def __init__(self):
         self.call_batch_sizes = []
+
+    def capture(self, input_ids, attention_mask, loss_mask, **kwargs):
+        return self.generate_eagle3_data(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            **kwargs,
+        )
 
     def generate_eagle3_data(
         self, input_ids, attention_mask, loss_mask, shard_returns=False


### PR DESCRIPTION
**Phase B — 4/4 (clean-up).** Stacked on #633 (B3). Makes the Phase B abstractions **load-bearing** instead of forward-only scaffolding: after B1–B3 the new generic surface (`get_target_engine`, `TargetEngine.capture`) existed but no production caller used it yet — callers still hit `generate_eagle3_data` / `get_eagle3_target_model`. This adopts it.

1. **adapter cutover** — `SGLangAdapter` / `DFlashAdapter` now call the engine's generic `capture(...)` instead of `generate_eagle3_data` / `generate_dflash_data` (kept as byte-identical back-compat aliases). This is the dataflow runtime's real capture path, so `TargetEngine.capture()` is now exercised end-to-end.
2. **factory cutover** — the dataflow test fixtures + online launch tests build targets via `get_target_engine(strategy=, backend=)`; `get_eagle3_target_model` / `get_dflash_target_model` stay as shims (legacy scripts untouched).
3. **docs** — `runtime/inference/DESIGN.md`, `runtime/ARCHITECTURE.md`, and the adapter docstrings now describe the boundary as `TargetEngine.capture` (sglang glue behind `SGLangCaptureBackend`) instead of `Eagle3TargetModel.generate_eagle3_data`.
4. **explicit B gate** — `tests/test_runtime/test_phase_b_gate.py`: `capture() ≡ legacy generate_*_data()` **bytewise** (eagle3 + dflash), a stable captured-feature digest, and per-step-loss reproducibility through the full online capture→train path — instead of relying only on the full-suite's indirect coverage.

**No behavior change**: `capture()` dispatches to the legacy method.

### Validation (8×H200)
Full `tests/test_runtime` **218 OK** (2 skip, 1 xfail) = the prior 214 + the 4 new gate tests. The new gate confirms `capture()` is byte-identical to the legacy extraction for both eagle3 and dflash.

With this, Phase B is complete. (Deferred to Phase E by decision: collapsing the per-`(algorithm × backend)` engine classes into per-backend generic engines + a `CaptureSpec`, alongside the `models/targets/` move — see plan.md §2.3.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)