### PR TITLE
[Online track] O1.3 — live SGLang-server capture (reforward transport)

### DIFF
--- a/docs/roadmap/o13-capture-spike.md
+++ b/docs/roadmap/o13-capture-spike.md
@@ -1,0 +1,58 @@
+# O1.3 Capture Spike — findings & transport decision (July 2026)
+
+Run on: `lmsysorg/sglang` dev image (sglang `0.0.0.dev1+g70df09b83`, torch 2.11,
+H200), stock server, tiny + real-model probes over HTTP.
+
+## What the stock SGLang server exposes today
+
+| Surface | Verdict |
+|---|---|
+| `GenerateReqInput.return_hidden_states` (+ `--enable-return-hidden-states`) | **Yes** — per request, `meta_info["hidden_states"]`: one entry per forward pass (the prefill entry carries every prompt position), **LAST layer only** |
+| Raw-token serving (`--skip-tokenizer-init`, `input_ids` in `/generate`) | **Yes** — the capture path needs no tokenizer round-trip |
+| EAGLE3 aux-layer capture per request (3-layer concat) | **No** — `set_eagle3_layers_to_capture` exists on models but is only driven by the *speculative-serving* path (target+draft); nothing routes it into `/generate` responses or a store |
+| Engine-side write-to-FeatureStore transport | **No** |
+
+Calibration: TorchSpec closed exactly this gap with a **17-file / ~530-line
+patch to sglang** (custom `/generate_for_spec_training` endpoint,
+`spec_training_data_id` threading, logits-processor aux capture, scheduler-side
+Mooncake writes). That is the cost of engine-side capture without an upstream
+API.
+
+## Decision — reforward transport now, upstream API next
+
+`SGLangServerEagle3TargetEngine` (landed with this spike) is **patch-free on a
+stock server**:
+
+1. the live server does the decoding (`/generate`, raw input_ids, greedy by
+   default — the frozen-target stream is reproducible);
+2. an in-process capture engine over the same weights (hf/sglang/custom — the
+   extraction-gate-validated backends) runs ONE extend over
+   `[prompt + completion]` for aux+target features.
+
+Same `Eagle3TargetOutput` contract as every backend, so
+RolloutWorker → FeatureStore → SampleRef and the trainer are untouched; the
+"Done when" of O1.3 (live server feeds training with zero precomputed
+features) holds — the capture *compute* runs producer-side until the engine
+can emit aux states itself. Gate: `tests/test_runtime/test_o13_server_capture.py`
+(opt-in, `SPECFORGE_RUN_SERVER_TESTS=1`; launches a real server).
+
+Cost note: the reforward pays one extra prefill over the generated sequence on
+the producer pool. Decode dominates end-to-end time for realistic
+completion:prompt ratios; the extra prefill is batched and runs on the
+producer GPUs, not the server. Measure per model before scale-out (O2).
+
+## The upstream proposal (what sglang should grow, so both the reforward and
+TorchSpec's patch evaporate)
+
+SpecForge is sgl-project's own framework — this is ours to land:
+
+1. per-request `return_aux_hidden_states: list[int]` (layer ids) on
+   `/generate`, reusing the existing `set_eagle3_layers_to_capture` model hook
+   + `CaptureHiddenMode.FULL` plumbing that speculative serving already has;
+2. (transport, later) an optional engine-side sink so captured tensors can
+   land in a store instead of the HTTP response (the W3 Mooncake path — the
+   response then carries keys, TorchSpec-style, but behind a stable API).
+
+With (1) alone, `SGLangServerEagle3TargetEngine` drops its inner engine and the
+W3′ inline-HTTP transport becomes real; with (2), W3 capture-into-store needs
+no producer-side GPUs at all.

--- a/specforge/inference/target_engine/eagle3_target_model.py
+++ b/specforge/inference/target_engine/eagle3_target_model.py
@@ -623,7 +623,9 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         except requests.RequestException:
             return False
 
-    def _server_generate(self, prompt_rows: List[List[int]], **sampling) -> List[List[int]]:
+    def _server_generate(
+        self, prompt_rows: List[List[int]], **sampling
+    ) -> List[List[int]]:
         import requests
 
         params = {

--- a/specforge/inference/target_engine/eagle3_target_model.py
+++ b/specforge/inference/target_engine/eagle3_target_model.py
@@ -518,27 +518,49 @@ class CustomEagle3TargetEngine(Eagle3TargetEngine):
 
 
 class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
-    """Live frozen-target SGLang *server* engine (cross-node) — W3 / W3′.
+    """Live frozen-target SGLang *server* engine (O1.3, W3) — reforward transport.
 
-    The fourth backend: instead of an in-process ``ModelRunner``, a *frozen*
-    target runs as a live SGLang server and streams hidden states (capture into a
-    FeatureStore for W3, or inline over HTTP for the light W3′). It is
-    ``backend="sglang_server"`` — selectable through the factory — but the live
-    capture implementation is gated by the O1.3 throughput spike (see
-    ``docs/roadmap/online-disaggregation.md`` §O1.3), so construction raises with an
-    actionable message until that lands. The de-EAGLE3 extraction and the domain
-    Trainer carry no engine risk and do not depend on this backend.
+    The O1.3 capture spike (July 2026, sglang dev, H200) settled the transport
+    depth: a stock SGLang server exposes per-request ``return_hidden_states``
+    but returns the LAST layer only — the eagle3 aux three-layer capture is not
+    reachable over the stock HTTP surface (TorchSpec closed the same gap with a
+    17-file engine patch; SpecForge's plan is to upstream a capture API into
+    sglang instead — see the spike note in ``docs/roadmap/online-disaggregation.md``).
+
+    Until that API lands, this engine implements the **reforward transport**,
+    patch-free on a stock server:
+
+    1. the live server does what only it can do — the DECODING — via
+       ``POST /generate`` with raw ``input_ids`` (``--skip-tokenizer-init``
+       compatible), greedy by default so the frozen-target stream is
+       reproducible;
+    2. an in-process capture engine over the SAME weights (hf / sglang /
+       custom — the existing, extraction-gate-validated backends) runs ONE
+       extend over ``[prompt + completion]`` to produce aux + target features.
+
+    The training-side contract is byte-identical to every other backend:
+    ``capture()`` returns a normal :class:`Eagle3TargetOutput`, so
+    RolloutWorker → FeatureStore → SampleRef and the trainer see nothing new.
+    A future engine-side transport (upstreamed capture API) replaces step 2
+    without touching callers.
     """
 
     backend = "sglang_server"
 
-    def __init__(self, *args, **kwargs):
-        raise NotImplementedError(
-            "sglang_server target engine (live cross-node frozen-target capture) is "
-            "not implemented yet; its depth is gated by the O1.3 capture spike "
-            "(docs/roadmap/online-disaggregation.md §O1.3). Use backend='sglang' "
-            "(in-process) or 'hf' for now."
-        )
+    def __init__(
+        self,
+        capture_engine: Eagle3TargetEngine,
+        base_url: str,
+        *,
+        temperature: float = 0.0,
+        max_new_tokens: int = 256,
+        timeout_s: float = 300.0,
+    ) -> None:
+        self.capture_engine = capture_engine
+        self.base_url = base_url.rstrip("/")
+        self.temperature = temperature
+        self.max_new_tokens = max_new_tokens
+        self.timeout_s = timeout_s
 
     @classmethod
     def from_pretrained(
@@ -547,9 +569,66 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         torch_dtype: torch.dtype = None,
         device: str = None,
         cache_dir: Optional[str] = None,
+        *,
+        base_url: str = None,
+        capture_backend: str = "hf",
+        temperature: float = 0.0,
+        max_new_tokens: int = 256,
         **kwargs,
     ) -> "SGLangServerEagle3TargetEngine":
-        return cls()
+        if not base_url:
+            raise ValueError(
+                "sglang_server engine needs base_url=<http://host:port> of a "
+                "running SGLang server over the same weights as "
+                f"{pretrained_model_name_or_path!r} (launch with "
+                "--skip-tokenizer-init to feed raw input_ids)."
+            )
+        inner = get_eagle3_target_model(
+            pretrained_model_name_or_path,
+            backend=capture_backend,
+            torch_dtype=torch_dtype,
+            device=device,
+            cache_dir=cache_dir,
+            **kwargs,
+        )
+        return cls(
+            inner,
+            base_url,
+            temperature=temperature,
+            max_new_tokens=max_new_tokens,
+        )
+
+    # aux-layer selection etc. delegate to the capture engine (same weights)
+    def set_aux_hidden_states_layers(self, aux_hidden_states_layers=None) -> None:
+        self.capture_engine.set_aux_hidden_states_layers(aux_hidden_states_layers)
+
+    def health(self) -> bool:
+        import requests
+
+        try:
+            return (
+                requests.get(f"{self.base_url}/health", timeout=10).status_code == 200
+            )
+        except requests.RequestException:
+            return False
+
+    def _server_generate(self, prompt_rows: List[List[int]], **sampling) -> List[List[int]]:
+        import requests
+
+        params = {
+            "temperature": sampling.get("temperature", self.temperature),
+            "max_new_tokens": sampling.get("max_new_tokens", self.max_new_tokens),
+        }
+        resp = requests.post(
+            f"{self.base_url}/generate",
+            json={"input_ids": prompt_rows, "sampling_params": params},
+            timeout=self.timeout_s,
+        )
+        resp.raise_for_status()
+        out = resp.json()
+        if isinstance(out, dict):
+            out = [out]
+        return [row["output_ids"] for row in out]
 
     def generate_eagle3_data(
         self,
@@ -557,8 +636,38 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         attention_mask: torch.Tensor,
         loss_mask: torch.Tensor,
         **kwargs,
-    ) -> Eagle3TargetOutput:  # pragma: no cover - unreachable (ctor raises)
-        raise NotImplementedError
+    ) -> Eagle3TargetOutput:
+        """Live decode on the server, then one capture extend over the result.
+
+        ``input_ids``/``attention_mask`` describe the PROMPTS (right-padded);
+        the returned features cover ``[prompt + completion]`` with the loss
+        masked to the generated region — the online eagle3 convention (the
+        model learns to draft the frozen target's own continuations).
+        """
+        device = input_ids.device
+        prompt_rows = [
+            row[mask.bool()].tolist()
+            for row, mask in zip(input_ids.cpu(), attention_mask.cpu())
+        ]
+        completions = self._server_generate(prompt_rows, **kwargs)
+
+        extended, ext_attn, ext_loss = [], [], []
+        for prompt, completion in zip(prompt_rows, completions):
+            seq = prompt + list(completion)
+            extended.append(torch.tensor(seq, dtype=torch.long))
+            ext_attn.append(torch.ones(len(seq), dtype=torch.long))
+            row_loss = torch.zeros(len(seq), dtype=torch.long)
+            row_loss[len(prompt) :] = 1  # train on the generated region
+            ext_loss.append(row_loss)
+
+        pad = torch.nn.utils.rnn.pad_sequence
+        ext_ids = pad(extended, batch_first=True, padding_value=0).to(device)
+        ext_attn = pad(ext_attn, batch_first=True, padding_value=0).to(device)
+        ext_loss = pad(ext_loss, batch_first=True, padding_value=0).to(device)
+
+        return self.capture_engine.capture(
+            input_ids=ext_ids, attention_mask=ext_attn, loss_mask=ext_loss
+        )
 
 
 def get_eagle3_target_model(

--- a/specforge/inference/target_engine/eagle3_target_model.py
+++ b/specforge/inference/target_engine/eagle3_target_model.py
@@ -561,6 +561,11 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         self.temperature = temperature
         self.max_new_tokens = max_new_tokens
         self.timeout_s = timeout_s
+        # Mirror the capture contract surface (adapters/launch read it off the
+        # engine to build + verify CaptureConfig).
+        self.aux_hidden_states_layers = getattr(
+            capture_engine, "aux_hidden_states_layers", None
+        )
 
     @classmethod
     def from_pretrained(
@@ -574,6 +579,7 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         capture_backend: str = "hf",
         temperature: float = 0.0,
         max_new_tokens: int = 256,
+        timeout_s: float = 300.0,
         **kwargs,
     ) -> "SGLangServerEagle3TargetEngine":
         if not base_url:
@@ -596,11 +602,16 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
             base_url,
             temperature=temperature,
             max_new_tokens=max_new_tokens,
+            timeout_s=timeout_s,
         )
 
-    # aux-layer selection etc. delegate to the capture engine (same weights)
+    # aux-layer selection delegates to the capture engine (same weights) and is
+    # mirrored here so the adapter's recorded-vs-requested verification sees it.
     def set_aux_hidden_states_layers(self, aux_hidden_states_layers=None) -> None:
         self.capture_engine.set_aux_hidden_states_layers(aux_hidden_states_layers)
+        self.aux_hidden_states_layers = getattr(
+            self.capture_engine, "aux_hidden_states_layers", aux_hidden_states_layers
+        )
 
     def health(self) -> bool:
         import requests
@@ -649,7 +660,13 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
             row[mask.bool()].tolist()
             for row, mask in zip(input_ids.cpu(), attention_mask.cpu())
         ]
-        completions = self._server_generate(prompt_rows, **kwargs)
+        # Split kwargs: sampling knobs go to the server; everything else
+        # (e.g. shard_returns) belongs to the inner capture call — dropping
+        # them would silently break the per-backend capture contract.
+        sampling = {
+            k: kwargs.pop(k) for k in ("temperature", "max_new_tokens") if k in kwargs
+        }
+        completions = self._server_generate(prompt_rows, **sampling)
 
         extended, ext_attn, ext_loss = [], [], []
         for prompt, completion in zip(prompt_rows, completions):
@@ -658,6 +675,11 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
             ext_attn.append(torch.ones(len(seq), dtype=torch.long))
             row_loss = torch.zeros(len(seq), dtype=torch.long)
             row_loss[len(prompt) :] = 1  # train on the generated region
+            # The capture backends left-shift target/input_ids (padding
+            # left=False): the row's FINAL position has no next-token teacher,
+            # so it must not carry loss — the offline pipeline's convention
+            # (preprocessing zeroes loss_mask[-1]) holds here too.
+            row_loss[-1] = 0
             ext_loss.append(row_loss)
 
         pad = torch.nn.utils.rnn.pad_sequence
@@ -666,7 +688,7 @@ class SGLangServerEagle3TargetEngine(Eagle3TargetEngine):
         ext_loss = pad(ext_loss, batch_first=True, padding_value=0).to(device)
 
         return self.capture_engine.capture(
-            input_ids=ext_ids, attention_mask=ext_attn, loss_mask=ext_loss
+            input_ids=ext_ids, attention_mask=ext_attn, loss_mask=ext_loss, **kwargs
         )
 
 

--- a/tests/test_runtime/test_o13_server_capture.py
+++ b/tests/test_runtime/test_o13_server_capture.py
@@ -1,0 +1,207 @@
+# coding=utf-8
+"""O1.3 gate: a LIVE SGLang server feeds eagle3 training with zero precomputed
+features, through the reforward transport (server decodes; the in-process
+capture engine extracts aux+target over [prompt + completion]).
+
+What is pinned here:
+- the live pipeline end-to-end: raw-input_ids HTTP decode on a real server
+  (``--skip-tokenizer-init``) -> reforward capture -> a training-shaped
+  ``Eagle3TargetOutput`` -> one real train step, no precomputed features;
+- frozen-target determinism: the same request twice yields the same tokens,
+  and the captured features over the same tokens are bit-identical;
+- the loss region covers exactly the generated tokens (online convention).
+
+Token-level decode parity against another engine is deliberately NOT asserted
+on the random tiny model (near-uniform logits make argmax ties flaky); the
+extraction-correctness gate (`test_extraction_vs_hf_reference`) covers feature
+parity, and real-model decode parity belongs to the throughput spike runs.
+
+OPT-IN: launches a real SGLang server (slow, GPU + sglang required). Enable
+with SPECFORGE_RUN_SERVER_TESTS=1; the default suite skips it.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+ENABLED = os.environ.get("SPECFORGE_RUN_SERVER_TESTS") == "1"
+PORT = 30987
+
+
+@unittest.skipUnless(
+    CUDA and ENABLED, "O1.3 server gate: set SPECFORGE_RUN_SERVER_TESTS=1 (GPU)"
+)
+class TestO13ServerCapture(unittest.TestCase):
+    server = None
+    workdir = None
+    target_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+        from transformers import LlamaConfig, LlamaForCausalLM
+
+        cls.workdir = tempfile.mkdtemp(prefix="o13_")
+        cfg = LlamaConfig(
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=8,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=256,
+            max_position_embeddings=512,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=False,
+        )
+        torch.manual_seed(1234)
+        model = LlamaForCausalLM(cfg).to(torch.bfloat16)
+        cls.target_dir = os.path.join(cls.workdir, "target")
+        model.save_pretrained(cls.target_dir)
+
+        env = dict(os.environ, FLASHINFER_DISABLE_VERSION_CHECK="1")
+        cls.server = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                cls.target_dir,
+                "--skip-tokenizer-init",
+                "--attention-backend",
+                "triton",
+                "--mem-fraction-static",
+                "0.3",
+                "--port",
+                str(PORT),
+            ],
+            stdout=open(os.path.join(cls.workdir, "server.log"), "w"),
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+        import requests
+
+        deadline = time.time() + 300
+        while time.time() < deadline:
+            try:
+                if requests.get(f"http://localhost:{PORT}/health", timeout=5).ok:
+                    return
+            except requests.RequestException:
+                pass
+            if cls.server.poll() is not None:
+                break
+            time.sleep(5)
+        raise RuntimeError(
+            f"sglang server did not become healthy; see {cls.workdir}/server.log"
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.server is not None and cls.server.poll() is None:
+            cls.server.terminate()
+            try:
+                cls.server.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                cls.server.kill()
+
+    def test_live_server_feeds_training(self):
+        from specforge.inference.target_engine import get_eagle3_target_model
+
+        engine = get_eagle3_target_model(
+            self.target_dir,
+            backend="sglang_server",
+            base_url=f"http://localhost:{PORT}",
+            capture_backend="hf",
+            torch_dtype=torch.bfloat16,
+            device="cuda",
+            max_new_tokens=6,
+        )
+        engine.set_aux_hidden_states_layers([1, 3, 4])
+        self.assertTrue(engine.health())
+
+        # two prompts, ragged lengths, right-padded
+        rows = [[5, 6, 7, 8, 9, 10], [11, 12, 13, 14]]
+        maxlen = max(len(r) for r in rows)
+        input_ids = torch.zeros(2, maxlen, dtype=torch.long)
+        attn = torch.zeros(2, maxlen, dtype=torch.long)
+        for i, r in enumerate(rows):
+            input_ids[i, : len(r)] = torch.tensor(r)
+            attn[i, : len(r)] = 1
+        loss_mask = torch.zeros_like(attn)
+
+        out1 = engine.capture(
+            input_ids=input_ids.cuda(), attention_mask=attn.cuda(), loss_mask=loss_mask
+        )
+        out2 = engine.capture(
+            input_ids=input_ids.cuda(), attention_mask=attn.cuda(), loss_mask=loss_mask
+        )
+
+        # frozen target: the live stream is reproducible, features bit-identical
+        self.assertTrue(torch.equal(out1.input_ids, out2.input_ids))
+        self.assertTrue(torch.equal(out1.hidden_states, out2.hidden_states))
+
+        # shapes: aux = 3 layers concat; sequences grew by the completion
+        H = 64
+        self.assertEqual(out1.hidden_states.shape[-1], 3 * H)
+        self.assertGreater(out1.input_ids.shape[1], maxlen)
+        # loss covers exactly the generated region of each row
+        for i, r in enumerate(rows):
+            row_loss = out1.loss_mask[i].squeeze(-1)
+            self.assertEqual(int(row_loss[: len(r)].sum()), 0)
+            self.assertGreater(int(row_loss.sum()), 0)
+
+        # zero precomputed features -> one real train step
+        from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
+        from specforge.optimizer import BF16Optimizer
+        from specforge.training.backend import FSDPTrainingBackend, ParallelConfig
+        from specforge.training.strategies.base import Eagle3TrainStrategy
+        from specforge.training.controller import TrainerCore
+        from specforge.runtime.contracts import TrainBatch
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29574")
+        torch.manual_seed(0)
+        draft_cfg = AutoDraftModelConfig.from_file(
+            fx.write_draft_config(os.path.join(self.workdir, "draft.json"))
+        )
+        dm = AutoEagle3DraftModel.from_config(
+            draft_cfg, attention_backend="sdpa", torch_dtype=torch.bfloat16
+        ).cuda()
+        dm.load_vocab_mapping(
+            fx.write_vocab_mapping(os.path.join(self.workdir, "vm.pt"))
+        )
+        dm.freeze_embedding()
+        model = OnlineEagle3Model(dm, length=3, attention_backend="sdpa").cuda()
+
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.prepare_model(model, wrap=False)
+        backend.set_optimizer(
+            BF16Optimizer(
+                dm, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
+            )
+        )
+        core = TrainerCore(
+            Eagle3TrainStrategy(model, target_head=None), backend
+        )
+        batch = TrainBatch(
+            sample_ids=["a", "b"],
+            strategy="eagle3",
+            tensors={
+                "input_ids": out1.input_ids.cuda(),
+                "attention_mask": out1.attention_mask.cuda(),
+                "loss_mask": out1.loss_mask.cuda(),
+                "target": out1.target.cuda(),
+                "hidden_state": out1.hidden_states.cuda(),
+            },
+            metadata={"target_repr": "logits", "ttt_length": 3},
+        )
+        result = core.train_step(batch)
+        self.assertTrue(torch.isfinite(torch.tensor(result.loss)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_o13_server_capture.py
+++ b/tests/test_runtime/test_o13_server_capture.py
@@ -153,11 +153,14 @@ class TestO13ServerCapture(unittest.TestCase):
         H = 64
         self.assertEqual(out1.hidden_states.shape[-1], 3 * H)
         self.assertGreater(out1.input_ids.shape[1], maxlen)
-        # loss covers exactly the generated region of each row
+        # loss covers the generated region of each row, except the final
+        # position (left-shifted target: no next-token teacher there)
         for i, r in enumerate(rows):
             row_loss = out1.loss_mask[i].squeeze(-1)
             self.assertEqual(int(row_loss[: len(r)].sum()), 0)
             self.assertGreater(int(row_loss.sum()), 0)
+            last_real = int(out1.attention_mask[i].sum()) - 1
+            self.assertEqual(int(row_loss[last_real]), 0)
 
         # zero precomputed features -> one real train step
         from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model

--- a/tests/test_runtime/test_o13_server_capture.py
+++ b/tests/test_runtime/test_o13_server_capture.py
@@ -163,12 +163,16 @@ class TestO13ServerCapture(unittest.TestCase):
             self.assertEqual(int(row_loss[last_real]), 0)
 
         # zero precomputed features -> one real train step
-        from specforge import AutoDraftModelConfig, AutoEagle3DraftModel, OnlineEagle3Model
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
         from specforge.optimizer import BF16Optimizer
-        from specforge.training.backend import FSDPTrainingBackend, ParallelConfig
-        from specforge.training.strategies.base import Eagle3TrainStrategy
-        from specforge.training.controller import TrainerCore
         from specforge.runtime.contracts import TrainBatch
+        from specforge.training.backend import FSDPTrainingBackend, ParallelConfig
+        from specforge.training.controller import TrainerCore
+        from specforge.training.strategies.base import Eagle3TrainStrategy
         from tests.test_runtime import _fixtures as fx
 
         torch.manual_seed(0)
@@ -191,9 +195,7 @@ class TestO13ServerCapture(unittest.TestCase):
                 dm, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
             )
         )
-        core = TrainerCore(
-            Eagle3TrainStrategy(model, target_head=None), backend
-        )
+        core = TrainerCore(Eagle3TrainStrategy(model, target_head=None), backend)
         batch = TrainBatch(
             sample_ids=["a", "b"],
             strategy="eagle3",

--- a/tests/test_runtime/test_o13_server_capture.py
+++ b/tests/test_runtime/test_o13_server_capture.py
@@ -109,6 +109,11 @@ class TestO13ServerCapture(unittest.TestCase):
                 cls.server.kill()
 
     def test_live_server_feeds_training(self):
+        from tests.test_runtime import _fixtures as fx
+
+        # the in-process capture engine reads the TP group at construction
+        fx.build_single_rank_distributed(port="29574")
+
         from specforge.inference.target_engine import get_eagle3_target_model
 
         engine = get_eagle3_target_model(
@@ -163,7 +168,6 @@ class TestO13ServerCapture(unittest.TestCase):
         from specforge.runtime.contracts import TrainBatch
         from tests.test_runtime import _fixtures as fx
 
-        fx.build_single_rank_distributed(port="29574")
         torch.manual_seed(0)
         draft_cfg = AutoDraftModelConfig.from_file(
             fx.write_draft_config(os.path.join(self.workdir, "draft.json"))

--- a/tests/test_runtime/test_sglang_capture_backend.py
+++ b/tests/test_runtime/test_sglang_capture_backend.py
@@ -73,9 +73,9 @@ class EngineSglangDecouplingTest(unittest.TestCase):
 
 
 class SglangServerBackendTest(unittest.TestCase):
-    """sglang_server is selectable via the factory (capture gated by O1.3)."""
+    """sglang_server is selectable via the factory (O1.3 reforward transport)."""
 
-    def test_server_backend_tag_and_gated_construction(self):
+    def test_server_backend_tag_and_url_fail_fast(self):
         try:
             import torch  # noqa: F401
         except Exception:
@@ -86,9 +86,11 @@ class SglangServerBackendTest(unittest.TestCase):
         )
 
         self.assertEqual(SGLangServerEagle3TargetEngine.backend, "sglang_server")
-        # Selectable, but gated: construction raises an actionable NotImplementedError.
-        with self.assertRaises(NotImplementedError):
+        # Selectable; without a live server URL it fails fast and actionably
+        # (the O1.3 engine needs base_url= of a running SGLang server).
+        with self.assertRaises(ValueError) as ctx:
             get_eagle3_target_model("some/model", backend="sglang_server")
+        self.assertIn("base_url", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## O1.3 — live SGLang-server capture (reforward transport) + spike findings

The gating spike ran on stock sglang dev (H200): per-request `return_hidden_states` exists but returns the **last layer only** — eagle3 aux capture is not reachable over the stock HTTP surface (TorchSpec closed the same gap with a 17-file sglang patch). Findings + the **upstream API proposal** (per-request aux-layer capture; optional engine-side store sink) are recorded in `docs/roadmap/o13-capture-spike.md` — as sgl-project's own framework, upstreaming is ours to land. Stacked on #638.

`SGLangServerEagle3TargetEngine` goes from stub to a working engine with the patch-free **reforward transport**: the live server does the decoding (`/generate` with raw input_ids, `--skip-tokenizer-init`, greedy default → reproducible frozen-target stream); an in-process capture engine over the same weights (hf/sglang/custom — the extraction-gate-validated backends) runs one extend over `[prompt+completion]` for aux+target features. Same `Eagle3TargetOutput` contract as every backend — RolloutWorker/FeatureStore/trainer see nothing new; an upstreamed engine-side transport later replaces the reforward without touching callers. Loss is masked to the generated region, with the final position zeroed (left-shifted-target convention).

**Gate** (`test_o13_server_capture.py`, opt-in `SPECFORGE_RUN_SERVER_TESTS=1`): boots a real SGLang server, live decode → reforward capture → **one real train step with zero precomputed features**; frozen-target reproducibility (same request twice → same tokens, bit-identical features); loss region = generated tokens minus the teacherless final position. **Validated on H200: suite 241 OK + server gate OK.** An adversarial review confirmed 4 defects (teacher-alignment on the final loss position — high; capture-contract surface; timeout routing; kwargs routing) — all fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
