### PR TITLE
[SpecForge] Phase E — draft-architecture registry (@register_draft)

### DIFF
--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -19,6 +19,7 @@ from transformers import (
 )
 
 from .draft.llama3_eagle import LlamaForCausalLMEagle3
+from .draft.registry import DRAFT_REGISTRY, available_drafts
 from .target.custom_backend import (
     GptOssForCausalLM,
     Llama4ForCausalLM,
@@ -31,7 +32,8 @@ from .target.custom_backend import (
 
 
 class AutoEagle3DraftModel(AutoModelForCausalLMBase):
-    # the model mapping is currently hardcoded, we should support lazy model mapping via registry
+    # legacy config-type dispatch, kept as the fallback for configs that carry
+    # no ``architectures``; new drafts register via @register_draft instead.
     _model_mapping = {
         LlamaConfig: LlamaForCausalLMEagle3,
     }
@@ -39,8 +41,9 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
     @classmethod
     def from_config(cls, config: PretrainedConfig, torch_dtype=None, **config_kwargs):
         """
-        This class method takes a configuration object and create its model based on the
-        _model_mapping class variable.
+        This class method takes a configuration object and creates its model,
+        resolving the class from DRAFT_REGISTRY via ``config.architectures``
+        first, then falling back to the legacy config-type mapping.
 
         Args:
             config (PretrainedConfig): A configuration object.
@@ -48,8 +51,11 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         Returns:
             A model instance.
         """
-        # get the model class from the
-        _model_cls = cls._model_mapping[type(config)]
+        archs = getattr(config, "architectures", None) or []
+        if len(archs) == 1 and archs[0] in DRAFT_REGISTRY:
+            _model_cls = DRAFT_REGISTRY[archs[0]]
+        else:
+            _model_cls = cls._model_mapping[type(config)]
         model = _model_cls(config, **config_kwargs)
 
         # Convert model to specified dtype if provided
@@ -165,11 +171,18 @@ class AutoDraftModelConfig:
 
         architecture = architectures[0]
 
-        if architecture not in cls._config_mapping:
-            raise ValueError(f"Architecture {architecture} not supported")
+        if architecture in DRAFT_REGISTRY:
+            config_cls = DRAFT_REGISTRY[architecture].config_class
+        elif architecture in cls._config_mapping:
+            config_cls = cls._config_mapping[architecture]
+        else:
+            raise ValueError(
+                f"Architecture {architecture} not registered; "
+                f"available: {available_drafts()}"
+            )
 
         # If draft_vocab_size is not in config or is None, set draft_vocab_size to vocab_size
         if "draft_vocab_size" not in config or config["draft_vocab_size"] is None:
             config["draft_vocab_size"] = config.get("vocab_size", None)
 
-        return cls._config_mapping[architecture].from_dict(config)
+        return config_cls.from_dict(config)

--- a/specforge/modeling/draft/__init__.py
+++ b/specforge/modeling/draft/__init__.py
@@ -6,12 +6,7 @@ from .dflash import (
     sample,
 )
 from .llama3_eagle import LlamaForCausalLMEagle3
-from .registry import (
-    DRAFT_REGISTRY,
-    available_drafts,
-    register_draft,
-    resolve_draft,
-)
+from .registry import DRAFT_REGISTRY, available_drafts, register_draft, resolve_draft
 
 __all__ = [
     "Eagle3DraftModel",

--- a/specforge/modeling/draft/__init__.py
+++ b/specforge/modeling/draft/__init__.py
@@ -6,6 +6,12 @@ from .dflash import (
     sample,
 )
 from .llama3_eagle import LlamaForCausalLMEagle3
+from .registry import (
+    DRAFT_REGISTRY,
+    available_drafts,
+    register_draft,
+    resolve_draft,
+)
 
 __all__ = [
     "Eagle3DraftModel",
@@ -14,4 +20,8 @@ __all__ = [
     "build_target_layer_ids",
     "extract_context_feature",
     "sample",
+    "DRAFT_REGISTRY",
+    "register_draft",
+    "resolve_draft",
+    "available_drafts",
 ]

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -19,6 +19,8 @@ from transformers.models.qwen3.modeling_qwen3 import (
 )
 from typing_extensions import Tuple, Unpack
 
+from .registry import register_draft
+
 
 def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
     if temperature < 1e-5:
@@ -209,6 +211,7 @@ def extract_context_feature(
     return target_hidden
 
 
+@register_draft
 class DFlashDraftModel(Qwen3PreTrainedModel):
     config_class = Qwen3Config
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -21,6 +21,7 @@ from specforge.utils import print_with_rank
 
 from ...distributed import get_sp_ring_group, get_sp_ulysses_group
 from .base import Eagle3DraftModel
+from .registry import register_draft
 
 try:
     from flash_attn import flash_attn_varlen_func as _std_flash_attn_varlen_func
@@ -1624,6 +1625,7 @@ class LlamaDecoderLayer(nn.Module):
         return hidden_states
 
 
+@register_draft
 class LlamaForCausalLMEagle3(Eagle3DraftModel):
 
     config_class = LlamaConfig

--- a/specforge/modeling/draft/registry.py
+++ b/specforge/modeling/draft/registry.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Draft-architecture registry: the extension point for new draft model classes.
+
+A draft *architecture* (the model class) is a separate axis from the
+per-algorithm training strategy (``specforge.training.strategies.registry``):
+one architecture can train under several algorithms and vice versa. Registering
+a class here makes it constructible from a draft-config JSON whose
+``architectures[0]`` names it — adding an architecture is a new file plus
+``@register_draft``, not an edit to ``modeling/auto.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+DRAFT_REGISTRY: Dict[str, type] = {}
+
+
+def register_draft(cls: Optional[type] = None, *, name: Optional[str] = None):
+    """Class decorator registering a draft architecture.
+
+    The key defaults to the class name — exactly what draft-config JSONs carry
+    in ``architectures``. The class must declare ``config_class`` (the HF
+    ``PretrainedConfig`` subclass it is built from) so the auto loaders can
+    resolve both the model and its config from the one registry entry.
+    """
+
+    def _register(cls: type) -> type:
+        key = name or cls.__name__
+        if getattr(cls, "config_class", None) is None:
+            raise TypeError(
+                f"@register_draft: {cls.__name__} must declare config_class"
+            )
+        existing = DRAFT_REGISTRY.get(key)
+        if existing is not None and existing is not cls:
+            raise ValueError(
+                f"draft architecture {key!r} already registered to "
+                f"{existing.__name__}"
+            )
+        DRAFT_REGISTRY[key] = cls
+        return cls
+
+    return _register(cls) if cls is not None else _register
+
+
+def resolve_draft(name: str) -> type:
+    try:
+        return DRAFT_REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown draft architecture {name!r}; available: {available_drafts()}"
+        ) from None
+
+
+def available_drafts() -> List[str]:
+    return sorted(DRAFT_REGISTRY)
+
+
+__all__ = ["DRAFT_REGISTRY", "register_draft", "resolve_draft", "available_drafts"]

--- a/specforge/modeling/draft/registry.py
+++ b/specforge/modeling/draft/registry.py
@@ -6,15 +6,7 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-"""Draft-architecture registry: the extension point for new draft model classes.
-
-A draft *architecture* (the model class) is a separate axis from the
-per-algorithm training strategy (``specforge.training.strategies.registry``):
-one architecture can train under several algorithms and vice versa. Registering
-a class here makes it constructible from a draft-config JSON whose
-``architectures[0]`` names it — adding an architecture is a new file plus
-``@register_draft``, not an edit to ``modeling/auto.py``.
-"""
+"""Registry for draft model architectures."""
 
 from __future__ import annotations
 
@@ -24,13 +16,7 @@ DRAFT_REGISTRY: Dict[str, type] = {}
 
 
 def register_draft(cls: Optional[type] = None, *, name: Optional[str] = None):
-    """Class decorator registering a draft architecture.
-
-    The key defaults to the class name — exactly what draft-config JSONs carry
-    in ``architectures``. The class must declare ``config_class`` (the HF
-    ``PretrainedConfig`` subclass it is built from) so the auto loaders can
-    resolve both the model and its config from the one registry entry.
-    """
+    """Register a draft model class by architecture name."""
 
     def _register(cls: type) -> type:
         key = name or cls.__name__

--- a/tests/test_modeling/test_draft_registry.py
+++ b/tests/test_modeling/test_draft_registry.py
@@ -1,0 +1,129 @@
+# coding=utf-8
+"""E gate: draft-architecture registry drives the auto loaders.
+
+Adding a draft architecture = a class + @register_draft; both auto loaders
+(config-from-file and model-from-config) resolve it from the registry with the
+legacy hardcoded mappings kept only as fallback.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from transformers import LlamaConfig, Qwen3Config
+
+from specforge.modeling.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from specforge.modeling.draft import (
+    DRAFT_REGISTRY,
+    DFlashDraftModel,
+    LlamaForCausalLMEagle3,
+    available_drafts,
+    register_draft,
+    resolve_draft,
+)
+
+TINY_EAGLE3 = {
+    "architectures": ["LlamaForCausalLMEagle3"],
+    "model_type": "llama",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "max_position_embeddings": 512,
+    "vocab_size": 256,
+    "draft_vocab_size": 64,
+    "tie_word_embeddings": False,
+}
+
+TINY_DFLASH = {
+    "architectures": ["DFlashDraftModel"],
+    "model_type": "qwen3",
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 1,
+    "head_dim": 16,
+    "max_position_embeddings": 512,
+    "vocab_size": 256,
+}
+
+
+def _write(cfg: dict) -> str:
+    fd, path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f)
+    return path
+
+
+class DraftRegistryTest(unittest.TestCase):
+    def test_builtin_architectures_registered(self):
+        self.assertIn("LlamaForCausalLMEagle3", available_drafts())
+        self.assertIn("DFlashDraftModel", available_drafts())
+        self.assertIs(resolve_draft("LlamaForCausalLMEagle3"), LlamaForCausalLMEagle3)
+        self.assertIs(resolve_draft("DFlashDraftModel"), DFlashDraftModel)
+
+    def test_unknown_architecture_raises_with_available_list(self):
+        with self.assertRaises(KeyError) as ctx:
+            resolve_draft("NoSuchDraft")
+        self.assertIn("LlamaForCausalLMEagle3", str(ctx.exception))
+
+    def test_register_is_idempotent_but_rejects_conflicts(self):
+        cls = resolve_draft("LlamaForCausalLMEagle3")
+        self.assertIs(register_draft(cls), cls)  # same class again: fine
+
+        class Impostor:
+            config_class = LlamaConfig
+
+        with self.assertRaises(ValueError):
+            register_draft(Impostor, name="LlamaForCausalLMEagle3")
+
+    def test_register_requires_config_class_and_honors_name(self):
+        class NoConfig:
+            pass
+
+        with self.assertRaises(TypeError):
+            register_draft(NoConfig)
+
+        @register_draft(name="tiny_fake_draft")
+        class FakeDraft:
+            config_class = LlamaConfig
+
+        self.addCleanup(DRAFT_REGISTRY.pop, "tiny_fake_draft", None)
+        self.assertIs(resolve_draft("tiny_fake_draft"), FakeDraft)
+
+
+class AutoLoaderRegistryTest(unittest.TestCase):
+    def test_from_file_resolves_eagle3_via_registry(self):
+        path = _write(TINY_EAGLE3)
+        self.addCleanup(os.unlink, path)
+        config = AutoDraftModelConfig.from_file(path)
+        self.assertIsInstance(config, LlamaConfig)
+        self.assertEqual(config.draft_vocab_size, 64)
+
+    def test_from_file_resolves_dflash_via_registry(self):
+        # Not in the legacy _config_mapping: only the registry makes this load.
+        path = _write(TINY_DFLASH)
+        self.addCleanup(os.unlink, path)
+        config = AutoDraftModelConfig.from_file(path)
+        self.assertIsInstance(config, Qwen3Config)
+
+    def test_from_file_unknown_architecture_raises(self):
+        path = _write({**TINY_EAGLE3, "architectures": ["NoSuchDraft"]})
+        self.addCleanup(os.unlink, path)
+        with self.assertRaises(ValueError) as ctx:
+            AutoDraftModelConfig.from_file(path)
+        self.assertIn("available", str(ctx.exception))
+
+    def test_from_config_resolves_class_via_architectures(self):
+        path = _write(TINY_EAGLE3)
+        self.addCleanup(os.unlink, path)
+        config = AutoDraftModelConfig.from_file(path)
+        model = AutoEagle3DraftModel.from_config(config)
+        self.assertIsInstance(model, LlamaForCausalLMEagle3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Phase E (1/4) — draft-architecture registry

`modeling/draft/registry.py`: `DRAFT_REGISTRY` + `@register_draft` for draft *architecture* classes — a separate axis from the strategy registry (plan G4: two registries, not one). Existing drafts registered. Stacked on #638; authored by the E-stack session, reconciled with the fixed up-30 (clean merge), adversarially reviewed, validated in the stack suite (256 OK on H200 at head).

**Known follow-ups from review** (documented, not blockers): `AutoEagle3DraftModel.from_pretrained` still resolves via the hardcoded `_model_mapping` and does not consult the registry (two sources of truth — unifying them is the natural next commit, but naively dropping the mapping breaks the from_pretrained finetune path); `DFlashDraftModel` registers but does not implement the `Eagle3DraftModel` embedding/vocab helpers. Reconciliation with #640 (MLA): merge is clean; MLA should additionally be `@register_draft`-ed post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)