### PR TITLE
[DataFlow runtime] fix: NameError on device/device_type in scripts/train_dflash.py main()

### DIFF
--- a/scripts/train_dflash.py
+++ b/scripts/train_dflash.py
@@ -449,6 +449,8 @@ def main():
     print_on_rank0(f"Total training steps: {total_steps}")
 
     print_on_rank0("Loading target embeddings and head...")
+    device = get_local_device()
+    device_type = device.type
     target_components = TargetEmbeddingsAndHead.from_pretrained(
         args.target_model_path,
         embed_key=args.embedding_key,


### PR DESCRIPTION
## Problem

`scripts/train_dflash.py` crashes with `NameError` when run standalone on the dataflow stack:

- line ~456: `device_type` is undefined (passed to `TargetEmbeddingsAndHead.from_pretrained`)
- lines ~554–560: `device` is undefined (training-loop `.to(device, non_blocking=True)` calls)

Both names are locals of `build_models()`, never defined in `main()`. Confirmed by pyflakes (5 undefined-name errors). The bug is inherited from the older `main` base of this stack — upstream `main` already fixed it identically in 0b948e7 (VP drafter training mode).

## Fix

Define `device = get_local_device()` / `device_type = device.type` in `main()`, at the exact location upstream used, so the eventual merge with `main` resolves as an identical change (verified: `git diff origin/main -- scripts/train_dflash.py` shows no delta for these lines).

## Validation

- `python3 -m py_compile scripts/train_dflash.py` — OK
- `pyflakes scripts/train_dflash.py` — clean (was 5 errors)

Independent of the open stack PRs (#637, #638); targeting the stack trunk `dataflow-up-16-zerocopy` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)