### PR TITLE
[Online track] O2 — server-side spec capture: sglang 0.5.14 patch + zero-copy Mooncake transport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,9 @@ repos:
       - id: check-symlinks
       - id: destroyed-symlinks
       - id: trailing-whitespace
+        exclude: \.patch$  # stripping context-line whitespace breaks git apply
       - id: end-of-file-fixer
+        exclude: \.patch$
       - id: check-yaml
         args: [--allow-multiple-documents]
       - id: check-toml

--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -1,3 +1,14 @@
+# Disaggregated examples
+
+Two flavors live here:
+
+- **Online DFlash via server-capture** (`run_disagg_dflash.py` +
+  `run_qwen3.6_27b_dflash_disagg.sh`) — the real zero-copy split: a live patched
+  SGLang server captures features and writes them straight into Mooncake; the
+  trainer consumes them by key. See [Online DFlash](#online-dflash-via-server-capture-real-zero-copy).
+- **Offline EAGLE3** (`run_disagg_eagle3.py`) — precomputed features ingested
+  into a shared store, documented below.
+
 # Disaggregated offline EAGLE3 example
 
 Runs the offline EAGLE3 training of `scripts/train_eagle3_dataflow.py`, but splits
@@ -99,3 +110,46 @@ acc / acceptance_rate climb over training in both (baseline direction). Per-step
 values are noisy at `batch_size=1` over 64 diverse samples. Note this is the
 training-time acceptance proxy; the serving accept-length (τ via spec-decoding) is
 a separate eval gate.
+
+# Online DFlash via server-capture (real zero-copy)
+
+The engine-side transport: a live SGLang server does the capture and writes
+straight into Mooncake, so inference and training are fully separate processes
+that share only the object store — no in-process target, no shared *data* mount.
+
+```
+ inference pool (GPU)                 mooncake                training pool (GPU)
+ ────────────────────                ─────────               ───────────────────
+ patched SGLang server  ──put()────▶  object    ──get()────▶ FeatureDataLoader
+ (--enable-spec-capture)   RDMA/TCP    store       zero-copy  -> OnlineDFlashModel
+        ▲                                                     TrainerController.fit()
+        │ /generate + spec_capture   (keys only)
+ SGLangServerCaptureAdapter ───────▶ StreamingRefChannel ───▶ (consumer reads refs)
+```
+
+The server is stock `sglang==0.5.14` patched with
+`patches/sglang/v0.5.14/spec-capture.patch` — apply it to the installed package
+with `scripts/apply_sglang_spec_capture_patch.sh`. Only tiny `SampleRef`s cross
+the ref channel; the DFlash context hidden states go server → Mooncake →
+trainer with no re-copy. Strategy-agnostic: the same server serves eagle3 or
+dflash requests, named per request by the client
+(`specforge/inference/adapters/server_capture.py`).
+
+## Run it (single 8-GPU node)
+
+```bash
+export WANDB_API_KEY=<key>            # or add --report-to none in the wrapper
+bash examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+```
+
+The wrapper starts a `mooncake_master`, the patched server (GPU 0), a thin CPU
+producer, and the trainer (GPU 1). `--spec-capture-aux-layer-ids` must match
+`dflash_config.target_layer_ids` in `configs/qwen3.6-27b-dflash.json` (the
+producer reads the same list for contract verification). Mooncake connection is
+the standard `MOONCAKE_*` env (see the wrapper for defaults).
+
+The transport is gate-validated end-to-end (patched server → Mooncake → one real
+train step, with aux parity vs an HF reference) in
+`tests/test_runtime/test_server_capture_gate.py`
+(`SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1`, GPU); the contract/ref/adapter logic is
+covered on CPU in `tests/test_runtime/test_server_capture.py`.

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -1,44 +1,40 @@
-"""Disaggregated ONLINE DFlash example: rollout/inference pool and trainer pool
-as separate processes that share only a filesystem mount.
+"""Disaggregated ONLINE DFlash example — real server-capture zero-copy transport.
 
-Online analogue of ``run_disagg_eagle3.py`` (which wires the *offline* seam). Here
-the target model is never precomputed to disk — the **producer** runs it live and
-streams captured features to the **consumer**, which trains the DFlash draft:
+Inference and training are fully decoupled processes that share only a Mooncake
+object store (RDMA-capable, no shared *data* mount):
 
-* **producer** (rollout / inference pool): builds the DFlash target engine and
-  drives ``build_disagg_online_producer`` — RolloutWorkers ``put()`` consume-once
-  features into a ``SharedDirFeatureStore`` and stream tensor-free ``SampleRef``s
-  through a ``StreamingRefChannel``. No draft, no optimizer.
-* **consumer** (training pool): builds the DFlash draft (``OnlineDFlashModel``) and
-  trains via ``build_disagg_online_consumer``, reading refs off the channel and
-  features from the shared store. The target model is never loaded here.
+* **producer** (inference pool): a live SGLang server — patched with
+  ``patches/sglang/v0.5.14/spec-capture.patch`` and launched with
+  ``--enable-spec-capture`` — runs the frozen Qwen3.6-27B target and writes the
+  captured DFlash context hidden states straight into Mooncake. This process is
+  a thin driver: it sends prompts through ``SGLangServerCaptureAdapter`` and
+  streams the resulting tensor-free ``SampleRef``s to the consumer. No target
+  weights, no draft, no GPU model here.
+* **consumer** (training pool): trains the DFlash draft (``OnlineDFlashModel``),
+  reading refs off the channel and features from Mooncake — zero re-copy.
 
-The two pools share a run-scoped SQLite metadata store (``DISAGG_DB``) so commits
-and consume-once acks land together, exactly as in a real two-node split.
+This replaces the old in-process producer (which loaded the 27B target locally
+and ran staged, since DFlash's HF capture is not thread-safe): the server does
+the capture, so a single prefill per prompt feeds training directly. It is the
+disaggregated sibling of ``examples/run_qwen3.6_27b_dflash_online.sh``.
 
-This mirrors ``scripts/train_dflash.py``'s model assembly (``build_models``, mask
-token, ``TargetEmbeddingsAndHead``, ``OnlineDFlashModel``) so the disaggregated
-curve is comparable to the colocated ``examples/run_qwen3.6_27b_dflash_online.sh``
-run. It runs **staged** (producer drains, then consumer trains): the interleaved
-single-process runner forwards the target in a thread, and DFlash's HF capture
-(``output_hidden_states=True``) trips transformers' non-thread-safe hook wrapper.
-
-Config comes from the environment so one wrapper can drive both pools; role is
-``DISAGG_ROLE`` (``producer``/``consumer``), or derived from ``RCLI_NODE_RANK``:
+Config is environment-driven so one wrapper drives both roles; role is
+``DISAGG_ROLE`` (``producer``/``consumer``) or derived from ``RCLI_NODE_RANK``:
 
     DISAGG_ROLE=producer|consumer      # else rank 0 -> producer, else consumer
-    DISAGG_STORE_ROOT=/root/disagg36   # shared *data* mount (both pools)
-    DISAGG_STORE_ID=qwen36-dflash-disagg   # producer/consumer must match
-    DISAGG_DB=/root/disagg36/run.db    # shared durable metadata store
-    DISAGG_MAX_PROMPTS=300             # cap the prompt pool (0 = all)
-    DISAGG_MAX_STEPS=150               # trainer max optimizer steps (0 = all)
-    DISAGG_LOG_INTERVAL=1              # per-step metric logging cadence
+    DISAGG_SERVER_URL=http://host:30000   # the patched SGLang server (producer)
+    DISAGG_STORE_ID=qwen36-dflash-disagg  # Mooncake key namespace (both roles)
+    DISAGG_REF_CHANNEL=/root/disagg/refs.jsonl   # tiny ref manifest (both roles)
+    DISAGG_DB=/root/disagg/run.db      # shared durable metadata store
+    DISAGG_MAX_PROMPTS=400             # cap the prompt pool (0 = all)
+    DISAGG_MAX_STEPS=0                 # trainer max optimizer steps (0 = all)
 
-W&B logging on the consumer is driven by ``train_dflash``'s tracker args
-(``--report-to wandb --wandb-project ... --wandb-name ...``); export
-``WANDB_API_KEY`` in the environment (never hard-code it).
+Mooncake connection uses the standard ``MOONCAKE_*`` env vars (see
+``examples/disagg/README.md``); the server sink reads the same ones, so both
+sides land on one master. Export ``WANDB_API_KEY`` for consumer W&B logging.
 """
 
+import json
 import os
 
 from accelerate.utils import set_seed
@@ -47,10 +43,11 @@ from transformers import AutoTokenizer
 
 from specforge.core.dflash import OnlineDFlashModel
 from specforge.distributed import destroy_distributed, init_distributed
+from specforge.inference.adapters.server_capture import SGLangServerCaptureAdapter
 from specforge.launch import build_disagg_online_consumer, build_disagg_online_producer
 from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
 from specforge.optimizer import BF16Optimizer
-from specforge.runtime.data_plane.disaggregated import SharedDirFeatureStore
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
 from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
 from specforge.tracker import create_tracker
 
@@ -64,25 +61,29 @@ def _role() -> str:
     return "producer" if os.environ.get("RCLI_NODE_RANK", "0") == "0" else "consumer"
 
 
-def _store_root() -> str:
-    return os.path.join(os.environ["DISAGG_STORE_ROOT"], RUN_ID)
-
-
 def _max(name: str, default: int) -> int:
     return int(os.environ.get(name, str(default)))
 
 
-def _resolve_mask_token(args, tokenizer) -> int:
-    if args.mask_token_id is not None:
-        return args.mask_token_id
-    if tokenizer.mask_token_id is not None:
-        return tokenizer.mask_token_id
-    tokenizer.add_special_tokens({"mask_token": "<|MASK|>"})
-    return tokenizer.mask_token_id
+def _ref_channel() -> StreamingRefChannel:
+    return StreamingRefChannel(os.environ["DISAGG_REF_CHANNEL"])
+
+
+def _mooncake_store() -> MooncakeFeatureStore:
+    """Connect to the same Mooncake master the server sink writes to."""
+    return MooncakeFeatureStore(
+        store_id=RUN_ID,
+        setup_kwargs={
+            "local_hostname": os.environ.get("MOONCAKE_LOCAL_HOSTNAME", "127.0.0.1"),
+            "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
+            "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
+            "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
+            "rdma_devices": os.environ.get("MOONCAKE_RDMA_DEVICES", ""),
+        },
+    )
 
 
 def _extract_prompts(train_dataloader):
-    """Flatten the training dataloader into rollout prompts (input_ids + mask)."""
     prompts = []
     for batch in train_dataloader:
         input_ids = batch["input_ids"]
@@ -101,51 +102,67 @@ def _extract_prompts(train_dataloader):
     return prompts
 
 
-def _configure_draft(args, draft_model, tokenizer) -> int:
-    """Pin the mask token on the draft config (matches train_dflash.main)."""
-    mask_token_id = _resolve_mask_token(args, tokenizer)
-    draft_model.mask_token_id = mask_token_id
-    draft_model.config.dflash_config["mask_token_id"] = mask_token_id
-    draft_model.config.dflash_config["target_layer_ids"] = draft_model.target_layer_ids
-    return mask_token_id
+def _resolve_mask_token(args, tokenizer) -> int:
+    if args.mask_token_id is not None:
+        return args.mask_token_id
+    if tokenizer.mask_token_id is not None:
+        return tokenizer.mask_token_id
+    tokenizer.add_special_tokens({"mask_token": "<|MASK|>"})
+    return tokenizer.mask_token_id
 
 
 def run_producer(args) -> None:
-    """Inference pool: run the target live, stream captured features out."""
-    tokenizer = AutoTokenizer.from_pretrained(args.target_model_path)
-    target_model, draft_model = build_models(args)  # sets capture layers from draft
-    _configure_draft(args, draft_model, tokenizer)
-
+    """Thin driver: prompts -> patched server (captures to Mooncake) -> refs."""
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.target_model_path, trust_remote_code=args.trust_remote_code
+    )
     train_dataloader, _eval = build_dataloader(args, tokenizer)
     prompts = _extract_prompts(train_dataloader)
     max_prompts = _max("DISAGG_MAX_PROMPTS", 0)
     if max_prompts:
         prompts = prompts[:max_prompts]
 
-    store = SharedDirFeatureStore(_store_root(), store_id=RUN_ID)
-    channel = StreamingRefChannel(os.path.join(_store_root(), "refs.jsonl"))
-    print(f"[producer] {len(prompts)} prompts -> {_store_root()}", flush=True)
+    # DFlash captures the concatenation of these target layers; the shell passes
+    # the same list to the server's --spec-capture-aux-layer-ids.
+    draft_cfg = json.load(open(args.draft_config_path))
+    aux_layer_ids = tuple(draft_cfg["dflash_config"]["target_layer_ids"])
+    target_hidden = int(draft_cfg["hidden_size"])
+
+    store = _mooncake_store()
+    channel = _ref_channel()
+    adapter = SGLangServerCaptureAdapter(
+        os.environ["DISAGG_SERVER_URL"],
+        store,
+        run_id=RUN_ID,
+        strategy="dflash",
+        target_model_version=args.target_model_path,
+    )
+    print(f"[producer] {len(prompts)} prompts -> {os.environ['DISAGG_SERVER_URL']}")
 
     _workers, drive_producer = build_disagg_online_producer(
         strategy="dflash",
-        target_model=target_model,
+        feature_source=adapter,
         prompts=prompts,
         feature_store=store,
         channel=channel,
         run_id=RUN_ID,
-        target_hidden_size=int(draft_model.config.hidden_size),
+        target_hidden_size=target_hidden,
         target_repr=None,  # DFlash trains on captured hidden states, no target dist.
+        aux_hidden_state_layer_ids=aux_layer_ids,
         metadata_db_path=os.environ.get("DISAGG_DB") or None,
     )
-    produced = drive_producer()  # generates, streams, closes the channel (EOF)
+    produced = drive_producer()
     print(f"[producer] streamed {produced} samples; channel closed", flush=True)
 
 
 def run_consumer(args) -> None:
-    """Training pool: train the DFlash draft off the shared store + ref channel."""
+    """Training pool: train the DFlash draft off Mooncake + the ref channel."""
     tokenizer = AutoTokenizer.from_pretrained(args.target_model_path)
     _target_unused, draft_model = build_models(args)
-    mask_token_id = _configure_draft(args, draft_model, tokenizer)
+    mask_token_id = _resolve_mask_token(args, tokenizer)
+    draft_model.mask_token_id = mask_token_id
+    draft_model.config.dflash_config["mask_token_id"] = mask_token_id
+    draft_model.config.dflash_config["target_layer_ids"] = draft_model.target_layer_ids
 
     target_components = TargetEmbeddingsAndHead.from_pretrained(
         args.target_model_path,
@@ -178,7 +195,6 @@ def run_consumer(args) -> None:
             total_steps=max_steps or 10_000,
         )
 
-    # Route the trainer's per-step metrics to the configured tracker (W&B).
     tracker = create_tracker(args, args.output_dir)
 
     def logger(metrics, step):
@@ -191,14 +207,11 @@ def run_consumer(args) -> None:
         if logdict:
             tracker.log(logdict, step=step)
 
-    store = SharedDirFeatureStore(_store_root(), store_id=RUN_ID)
-    channel = StreamingRefChannel(os.path.join(_store_root(), "refs.jsonl"))
-    print(f"[consumer] training from {_store_root()}", flush=True)
-
+    print(f"[consumer] training from mooncake://{RUN_ID}", flush=True)
     trainer, loader = build_disagg_online_consumer(
         strategy="dflash",
-        feature_store=store,
-        channel=channel,
+        feature_store=_mooncake_store(),
+        channel=_ref_channel(),
         eagle3_model=dflash_model,  # legacy param name = the trainable draft model
         optimizer_factory=optimizer_factory,
         run_id=RUN_ID,
@@ -220,19 +233,16 @@ def run_consumer(args) -> None:
 def main() -> None:
     args = parse_args()
     set_seed(args.seed)
-    init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
-
     role = _role()
-    print(
-        f"[disagg-dflash] role={role} run_id={RUN_ID} "
-        f"node_rank={os.environ.get('RCLI_NODE_RANK', '0')}",
-        flush=True,
-    )
+    print(f"[disagg-dflash] role={role} run_id={RUN_ID}", flush=True)
+    # The producer is a thin HTTP driver (no torch model); only the trainer
+    # needs the process group.
+    if role == "producer":
+        run_producer(args)
+        return
+    init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     try:
-        if role == "producer":
-            run_producer(args)
-        else:
-            run_consumer(args)
+        run_consumer(args)
     finally:
         destroy_distributed()
 

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -1,46 +1,82 @@
 #!/bin/bash
-# Qwen3.6-27B DFlash, ONLINE disaggregated on a single 8-GPU node:
-#   producer (27B target inference) -> GPU 0
-#   consumer (DFlash draft trainer) -> GPU 1
-# sharing a SharedDirFeatureStore + StreamingRefChannel + SQLite metadata store.
-# Producer and consumer are separate processes launched concurrently; the
-# consumer's loader blocks on the ref channel and terminates on EOF (producer
-# close). This is the disaggregated sibling of run_qwen3.6_27b_dflash_online.sh.
+# Qwen3.6-27B DFlash, ONLINE disaggregated via server-capture on one 8-GPU node:
+#   mooncake master        -> CPU (RDMA/TCP object store)
+#   patched SGLang server   -> GPU 0   (frozen 27B target, captures to mooncake)
+#   producer (HTTP driver)  -> CPU     (prompts -> server, streams refs)
+#   consumer (DFlash trainer)-> GPU 1  (trains from mooncake, zero-copy)
 #
-# Validated on 8xH200 (sci-h200): producer (GPU0) + consumer (GPU1), 400 prompts
-# consume-once -> train loss 12.7 -> 7.1 over 400 steps. Curve:
-#   examples/disagg/assets/qwen36-27b-dflash-nemotron-disagg.png
+# The server is sglang 0.5.14 patched with patches/sglang/v0.5.14/spec-capture.patch
+# (apply with scripts/apply_sglang_spec_capture_patch.sh). Feature tensors travel
+# server -> mooncake -> trainer with no re-copy; only tiny SampleRefs cross the
+# ref channel. Disaggregated sibling of run_qwen3.6_27b_dflash_online.sh.
 #
-# Prerequisites (same as the colocated example):
-#   - Qwen/Qwen3.6-27B weights + a chat dataset at $ROOT_DIR/cache/dataset/.
-#   - For W&B logging on the consumer: export WANDB_API_KEY=<your key>
-#     (never hard-code it), or pass --report-to none.
+# Prereqs: Qwen/Qwen3.6-27B weights + a chat dataset at $ROOT_DIR/cache/dataset/;
+# the `mooncake` package + `mooncake_master` on PATH; export WANDB_API_KEY for
+# consumer W&B logging (or pass --report-to none).
 set -uxo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
 export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
 export FLASHINFER_DISABLE_VERSION_CHECK=1
-# the launcher does `from train_dflash import ...`, so scripts/ must be importable
 export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
 cd "$ROOT_DIR"
 
-PRODUCER_GPU=${PRODUCER_GPU:-0}
+SERVER_GPU=${SERVER_GPU:-0}
 CONSUMER_GPU=${CONSUMER_GPU:-1}
+SERVER_PORT=${SERVER_PORT:-30000}
+# DFlash target capture layers — must match dflash_config.target_layer_ids in
+# the draft config below.
+AUX_LAYER_IDS=${AUX_LAYER_IDS:-"1 16 31 46 61"}
 
-export DISAGG_STORE_ROOT=${DISAGG_STORE_ROOT:-$ROOT_DIR/outputs/qwen36-disagg-store}
+# --- mooncake connection (server sink + producer + consumer share these) ---
+export MOONCAKE_LOCAL_HOSTNAME=${MOONCAKE_LOCAL_HOSTNAME:-127.0.0.1}
+export MOONCAKE_MASTER_SERVER_ADDR=${MOONCAKE_MASTER_SERVER_ADDR:-127.0.0.1:50051}
+export MOONCAKE_METADATA_SERVER=${MOONCAKE_METADATA_SERVER:-http://127.0.0.1:8080/metadata}
+export MOONCAKE_PROTOCOL=${MOONCAKE_PROTOCOL:-tcp}
+export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((4 << 30))}
+
 export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg}
-export DISAGG_DB=${DISAGG_DB:-$DISAGG_STORE_ROOT/$DISAGG_STORE_ID.db}
+export DISAGG_SERVER_URL=http://127.0.0.1:$SERVER_PORT
+export DISAGG_REF_CHANNEL=${DISAGG_REF_CHANNEL:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/refs.jsonl}
+export DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
 export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-400}
-export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}      # 0 = train on all produced
+export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}
 export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
 
-rm -rf "$DISAGG_STORE_ROOT/$DISAGG_STORE_ID" "$DISAGG_DB"
-mkdir -p "$DISAGG_STORE_ROOT/$DISAGG_STORE_ID"
-: > "$DISAGG_STORE_ROOT/$DISAGG_STORE_ID/refs.jsonl"
+rm -rf "$(dirname "$DISAGG_REF_CHANNEL")" "$DISAGG_DB"
+mkdir -p "$(dirname "$DISAGG_REF_CHANNEL")"
+: > "$DISAGG_REF_CHANNEL"
 
-# recipe matches run_qwen3.6_27b_dflash_online.sh; max-length trimmed to 2048 for a
-# bounded single-node demo (online disagg is consume-once / single-DP-rank).
+cleanup() { kill "${MASTER_PID:-}" "${SERVER_PID:-}" "${PRODUCER_PID:-}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- mooncake master ---
+mooncake_master --enable-http-metadata-server=true &
+MASTER_PID=$!
+sleep 3
+
+# --- patched SGLang server: frozen 27B target, spec-capture on ---
+CUDA_VISIBLE_DEVICES=$SERVER_GPU MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAME \
+    python -m sglang.launch_server \
+        --model-path Qwen/Qwen3.6-27B \
+        --trust-remote-code \
+        --skip-tokenizer-init \
+        --mem-fraction-static 0.85 \
+        --chunked-prefill-size -1 \
+        --enable-spec-capture \
+        --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
+        --port $SERVER_PORT &
+SERVER_PID=$!
+
+# wait for the server to come up before driving prompts
+until curl -sf "http://127.0.0.1:$SERVER_PORT/health" > /dev/null; do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then echo "server died"; exit 1; fi
+    sleep 5
+done
+
+# recipe matches run_qwen3.6_27b_dflash_online.sh; max-length 2048 for a bounded
+# single-node demo (online disagg is consume-once / single-DP-rank).
 ARGS=(
     --target-model-path Qwen/Qwen3.6-27B
     --target-model-backend hf
@@ -67,10 +103,9 @@ ARGS=(
 
 LAUNCHER=$SCRIPT_DIR/run_disagg_dflash.py
 
-# --- producer: inference pool (GPU $PRODUCER_GPU) ---
-CUDA_VISIBLE_DEVICES=$PRODUCER_GPU DISAGG_ROLE=producer \
-    torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29701 \
-        --nnodes 1 --nproc_per_node 1 "$LAUNCHER" "${ARGS[@]}" \
+# --- producer: HTTP driver (no torch model; shares the box, no GPU model) ---
+DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
+    python "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-producer" &
 PRODUCER_PID=$!
 
@@ -80,9 +115,8 @@ CUDA_VISIBLE_DEVICES=$CONSUMER_GPU DISAGG_ROLE=consumer \
         --nnodes 1 --nproc_per_node 1 "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-consumer" \
         --report-to wandb \
-        --wandb-project qwen36-dflash-pr645 \
-        --wandb-name qwen36-27b-dflash-nemotron-disagg &
-CONSUMER_PID=$!
+        --wandb-project qwen36-dflash-disagg \
+        --wandb-name qwen36-27b-dflash-nemotron-server-capture
 
-wait $PRODUCER_PID $CONSUMER_PID
+wait $PRODUCER_PID
 echo "DISAGG36-DONE"

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -1,25 +1,23 @@
 diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
-index a99d25267..73d88e04b 100644
+index a99d25267..f5d0b35e7 100644
 --- a/python/sglang/srt/layers/logits_processor.py
 +++ b/python/sglang/srt/layers/logits_processor.py
-@@ -94,6 +94,10 @@ class LogitsProcessorOutput:
+@@ -94,6 +94,9 @@ class LogitsProcessorOutput:
      # Used by speculative decoding (EAGLE)
      # The last hidden layers
      hidden_states: Optional[torch.Tensor] = None
-+    # Spec-training capture only: when CaptureHiddenMode.FULL runs with aux
-+    # capture, `hidden_states` above carries the aux concatenation, so the
-+    # post-norm last-layer hidden states are exposed here separately.
++    # Spec-training capture: under FULL+aux, `hidden_states` is the aux
++    # concatenation, so the post-norm last hidden is exposed here separately.
 +    last_hidden_states: Optional[torch.Tensor] = None
  
      ## Part 2: This part will be assigned in python/sglang/srt/layers/sampler.py::Sampler
      # he log probs of output tokens, if SGLANG_RETURN_ORIGINAL_LOGPROB = True, will get the log probs before applying temperature. If False, will get the log probs before applying temperature.
-@@ -361,6 +365,17 @@ class LogitsProcessor(nn.Module):
+@@ -361,6 +364,16 @@ class LogitsProcessor(nn.Module):
              sample_indices,
              logits_metadata,
          )
-+        # Spec-training capture: under FULL with aux capture active,
-+        # hidden_states_to_store is the aux concatenation — keep the post-norm
-+        # last-layer hidden states too (the training target representation).
++        # Spec-training capture: keep the post-norm last hidden (the training
++        # target) alongside the aux concatenation in hidden_states_to_store.
 +        last_hidden_states_to_store = (
 +            hidden_states
 +            if (
@@ -31,7 +29,7 @@ index a99d25267..73d88e04b 100644
          del hidden_states
  
          if not logits_metadata.extend_return_logprob:
-@@ -374,6 +389,7 @@ class LogitsProcessor(nn.Module):
+@@ -374,6 +387,7 @@ class LogitsProcessor(nn.Module):
              return LogitsProcessorOutput(
                  next_token_logits=sampled_logits,
                  hidden_states=hidden_states_to_store,
@@ -40,22 +38,21 @@ index a99d25267..73d88e04b 100644
                  # workaround since ForwardBatch is local to forward_batch_generation().
                  # They should be moved to GenerationBatchResult to keep this class clean.
 diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
-index 951f35495..03851edba 100644
+index 951f35495..082f3a114 100644
 --- a/python/sglang/srt/managers/io_struct.py
 +++ b/python/sglang/srt/managers/io_struct.py
-@@ -284,6 +284,11 @@ class GenerateReqInput(BaseReq):
+@@ -284,6 +284,10 @@ class GenerateReqInput(BaseReq):
      # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
      multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
  
-+    # Spec-training capture (requires --enable-spec-capture): per-request dict
-+    # telling the scheduler-side sink where/what to write in the Mooncake
-+    # store. Batch-level: List[Optional[dict]]. See sglang/srt/spec_capture_sink.py.
++    # Spec-training capture sink instructions (see spec_capture_sink.py).
++    # Batch-level: List[Optional[dict]]; per-request after __getitem__.
 +    spec_capture: Optional[Union[List[Optional[Dict]], Dict]] = None
 +
      def contains_mm_input(self) -> bool:
          return (
              has_valid_data(self.image_data)
-@@ -743,6 +748,11 @@ class GenerateReqInput(BaseReq):
+@@ -743,6 +747,11 @@ class GenerateReqInput(BaseReq):
                  if self.multi_item_delimiter_indices is not None
                  else None
              ),
@@ -67,7 +64,7 @@ index 951f35495..03851edba 100644
          )
          cache[i] = sub
          return sub
-@@ -842,6 +852,9 @@ class TokenizedGenerateReqInput(BaseReq):
+@@ -842,6 +851,9 @@ class TokenizedGenerateReqInput(BaseReq):
      # Pre-computed delimiter indices for multi-item scoring
      multi_item_delimiter_indices: Optional[List[int]] = None
  
@@ -78,7 +75,7 @@ index 951f35495..03851edba 100644
      time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
  
 diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
-index f1dc81d17..5baf7740e 100755
+index f1dc81d17..4ab4fc985 100755
 --- a/python/sglang/srt/managers/schedule_batch.py
 +++ b/python/sglang/srt/managers/schedule_batch.py
 @@ -708,6 +708,7 @@ class Req(ReqDllmMixin):
@@ -89,14 +86,13 @@ index f1dc81d17..5baf7740e 100755
      ):
          # Input and output info
          self.rid = rid
-@@ -771,7 +772,13 @@ class Req(ReqDllmMixin):
+@@ -771,7 +772,12 @@ class Req(ReqDllmMixin):
              }
          self.sampling_params = sampling_params
          self.custom_logit_processor = custom_logit_processor
 -        self.return_hidden_states = return_hidden_states
-+        # Spec-training capture: piggyback on the return_hidden_states path so
-+        # CaptureHiddenMode.FULL fires and per-request hidden slices accumulate;
-+        # the sink then consumes them instead of the response payload.
++        # Spec-training capture: piggyback the return_hidden_states path (fires
++        # CaptureHiddenMode.FULL); the sink consumes the slices, not the response.
 +        self.spec_capture = spec_capture
 +        self.return_hidden_states = return_hidden_states or spec_capture is not None
 +        self.spec_capture_aux: List[torch.Tensor] = []
@@ -105,17 +101,16 @@ index f1dc81d17..5baf7740e 100755
          # extra key for classifying the request (e.g. cache_salt)
          if lora_id is not None:
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index abba37441..b25928ac0 100644
+index abba37441..3018b8247 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -576,6 +576,20 @@ class Scheduler(
+@@ -576,6 +576,19 @@ class Scheduler(
  
          self.init_batch_result_processor()
  
 +        if server_args.enable_spec_capture:
-+            # Spec-training capture requires single-pass prefill: per-request
-+            # hidden slices are taken from one packed extend forward, and the
-+            # chunked path would drop all but the final chunk's rows.
++            # Capture needs single-pass prefill; chunking would drop all but the
++            # final chunk's hidden rows.
 +            if server_args.chunked_prefill_size != -1:
 +                raise ValueError(
 +                    "--enable-spec-capture requires --chunked-prefill-size -1 "
@@ -129,7 +124,7 @@ index abba37441..b25928ac0 100644
          self.is_initializing = False
  
      def init_zbal_on_npu(self):
-@@ -2054,6 +2068,7 @@ class Scheduler(
+@@ -2054,6 +2067,7 @@ class Scheduler(
                  dllm_config=self.dllm_config,
                  time_stats=recv_req.time_stats,
                  multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
@@ -138,19 +133,17 @@ index abba37441..b25928ac0 100644
              req.tokenizer = self.tokenizer
  
 diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-index a9d5f0c28..a8e2d197f 100644
+index a9d5f0c28..2b2547509 100644
 --- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 +++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-@@ -257,6 +257,20 @@ class SchedulerBatchResultProcessor:
+@@ -257,6 +257,18 @@ class SchedulerBatchResultProcessor:
                          )
  
                      if (
 +                        req.spec_capture is not None
 +                        and logits_output.hidden_states is not None
 +                    ):
-+                        # Spec-training capture: keep tensor slices (not the
-+                        # .tolist() response path) and sink to the store when
-+                        # the request finishes.
++                        # Spec-training capture: keep tensor slices, sink on finish.
 +                        hidden_state_offset = self._append_spec_capture_states(
 +                            req=req,
 +                            logits_output=logits_output,
@@ -162,7 +155,7 @@ index a9d5f0c28..a8e2d197f 100644
                          req.return_hidden_states
                          and logits_output.hidden_states is not None
                      ):
-@@ -462,6 +476,66 @@ class SchedulerBatchResultProcessor:
+@@ -462,6 +474,62 @@ class SchedulerBatchResultProcessor:
                      f"Placeholder zeros would be appended to output_ids."
                  )
  
@@ -173,13 +166,11 @@ index a9d5f0c28..a8e2d197f 100644
 +        logits_output: LogitsProcessorOutput,
 +        hidden_state_offset: int,
 +    ) -> int:
-+        """Accumulate this request's captured rows as CPU tensors.
++        """Accumulate captured rows as CPU tensors for the Mooncake sink.
 +
-+        Mirrors ``_append_prefill_hidden_states``'s offset arithmetic but keeps
-+        tensors (bf16 slices) for the Mooncake sink instead of building the
-+        JSON-able ``req.hidden_states`` response payload. Under aux capture,
-+        ``logits_output.hidden_states`` is the aux concatenation and
-+        ``logits_output.last_hidden_states`` the post-norm last hidden.
++        Same offset arithmetic as ``_append_prefill_hidden_states`` but keeps
++        tensor slices (aux concat in ``hidden_states``, post-norm last in
++        ``last_hidden_states``) rather than the JSON-able response payload.
 +        """
 +        start = hidden_state_offset
 +        end = start + len(req.origin_input_ids)
@@ -212,14 +203,12 @@ index a9d5f0c28..a8e2d197f 100644
 +        )
 +        try:
 +            result = sink.put_sample(req.spec_capture, aux=aux, last_hidden=last_hidden)
-+            # One-element per-token list: the streamer slices [0:1] and the
-+            # tokenizer manager extends it into meta_info["spec_capture"].
 +            payload = {"spec_capture": [result]}
 +        except Exception as e:
 +            logger.error("spec-capture sink failed for %s: %s", req.rid, e)
 +            payload = {"spec_capture_error": [str(e)]}
-+        # Ride the existing customized_info channel (streamer slices [0:1],
-+        # tokenizer manager extends into meta_info) — no new IPC fields.
++        # Ride the customized_info channel into meta_info (one-elem list: the
++        # streamer slices [0:1]) — no new IPC fields.
 +        if req.customized_info is None:
 +            req.customized_info = {}
 +        req.customized_info.update(payload)
@@ -242,17 +231,15 @@ index bf932611a..dc7615f44 100644
          elif isinstance(obj, EmbeddingReqInput):
              # Resolve unresolved embed overrides now that input_ids are available
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 1cff5c983..da49196b1 100644
+index 1cff5c983..d978ce788 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -471,6 +471,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -471,6 +471,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                      # if there is no aux layer, set to None
                      self.eagle_aux_hidden_state_layer_ids = None
  
 +        if server_args.enable_spec_capture and not self.is_draft_worker:
-+            # Spec-training capture (no draft worker needed): enable EAGLE3-style
-+            # aux capture on the target model, layer ids from server args (None
-+            # falls through to the model's default low/mid/high selection).
++            # Aux capture without a draft worker; None layer ids -> model default.
 +            self.eagle_use_aux_hidden_state = True
 +            self.eagle_aux_hidden_state_layer_ids = (
 +                server_args.spec_capture_aux_layer_ids
@@ -287,10 +274,10 @@ index c7162c16d..257d8b4f7 100644
          "Enable returning routed experts of each layer with responses.",
 diff --git a/python/sglang/srt/spec_capture_sink.py b/python/sglang/srt/spec_capture_sink.py
 new file mode 100644
-index 000000000..9dd68075f
+index 000000000..d317b2801
 --- /dev/null
 +++ b/python/sglang/srt/spec_capture_sink.py
-@@ -0,0 +1,261 @@
+@@ -0,0 +1,231 @@
 +# Copyright 2024 SGLang Team
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -299,54 +286,26 @@ index 000000000..9dd68075f
 +#     http://www.apache.org/licenses/LICENSE-2.0
 +"""Server-side spec-training capture sink (SpecForge DataFlow transport).
 +
-+When the server is launched with ``--enable-spec-capture``, a request may carry
-+a ``spec_capture`` dict. During that request's prefill the model runs with
-+``CaptureHiddenMode.FULL`` and aux-hidden-state capture enabled, and this sink
-+writes the captured tensors straight into a Mooncake distributed store —
-+feature tensors never travel over the HTTP/ZMQ response path. The response's
-+``meta_info["spec_capture"]`` carries only keys + shapes/dtypes, from which the
-+training side constructs a ``SampleRef`` and reads the tensors zero-copy.
++Under ``--enable-spec-capture``, a request's ``spec_capture`` dict tells this
++sink to write the prefill's captured tensors straight into a Mooncake store
++(one hard-pinned object per tensor at ``{store_id}/{sample_id}/g{gen}/{name}``,
++raw bytes — shape/dtype travel on the returned spec). Feature tensors never
++touch the response path; ``meta_info["spec_capture"]`` returns only keys +
++shapes/dtypes. Strategy naming is the client's (the ``features`` mapping); the
++server knows only generic artifacts. Self-contained: the scheduler hooks are
++one-liners, every capture decision lives here.
 +
-+The wire/key format is pinned to SpecForge's ``MooncakeFeatureStore`` zero-copy
-+layout: one hard-pinned object per tensor at key
++Request schema::
 +
-+    {store_id}/{sample_id}/g{gen}/{name}
++    {"store_id", "sample_id", "gen",           # key namespace / id / staleness
++     "features": {"aux": <name>, "last_hidden": <name>},   # artifact -> feature
++     "passthrough": [{"name", "data", "shape", "dtype"}]}  # client tensors verbatim
 +
-+holding the raw contiguous tensor bytes (no serialization header; shape/dtype
-+travel on the returned spec). This module is deliberately self-contained: the
-+hooks in scheduler components are one-liners, and every capture-specific
-+decision lives here.
++Response (``meta_info["spec_capture"]``): ``{"sample_id", "store_id", "gen",
++"aux_layer_ids", "features": {name: {"shape", "dtype"}}}``.
 +
-+Request ``spec_capture`` schema (all strategy-specific naming is decided by the
-+CLIENT via the ``features`` mapping — the server only knows generic artifacts)::
-+
-+    {
-+      "store_id":  "run-abc",          # key namespace (client's store_id)
-+      "sample_id": "run-abc:task-7",   # unique per sample
-+      "gen":       1,                  # generation for the key (staleness guard)
-+      "features":  {                   # artifact -> stored feature name
-+          "aux":         "hidden_state",   # cat of captured aux layers (1, L, k*H)
-+          "last_hidden": "target"          # post-norm last hidden      (1, L, H)
-+      },
-+      "passthrough": [                 # small client tensors stored verbatim
-+          {"name": "input_ids", "data": [...], "shape": [1, L], "dtype": "int64"},
-+          {"name": "loss_mask", "data": [...], "shape": [1, L, 1], "dtype": "int64"}
-+      ]
-+    }
-+
-+Response (``meta_info["spec_capture"]``, one dict)::
-+
-+    {
-+      "sample_id": "...", "store_id": "...", "gen": 1,
-+      "aux_layer_ids": [2, 20, 37],
-+      "features": {"hidden_state": {"shape": [1, L, 3*H], "dtype": "bfloat16"}, ...}
-+    }
-+
-+Mooncake connection is configured via the same environment variables SpecForge's
-+``MooncakeFeatureStore`` uses: ``MOONCAKE_LOCAL_HOSTNAME``,
-+``MOONCAKE_METADATA_SERVER``, ``MOONCAKE_MASTER_SERVER_ADDR``,
-+``MOONCAKE_PROTOCOL`` (default tcp), ``MOONCAKE_GLOBAL_SEGMENT_SIZE``,
-+``MOONCAKE_RDMA_DEVICES``.
++Mooncake connection uses the standard ``MOONCAKE_*`` env vars (see
++``MooncakeFeatureStore``).
 +"""
 +
 +from __future__ import annotations
@@ -468,11 +427,9 @@ index 000000000..9dd68075f
 +    ) -> Dict[str, Any]:
 +        """Write one sample's artifacts; return the meta_info result dict.
 +
-+        ``aux``/``last_hidden`` are the (L, W) captured tensors for this request
-+        (already sliced per request); stored with a leading batch dim of 1 to
-+        match SpecForge's online feature convention. On any failure, keys
-+        already written for this sample are best-effort removed so a partial
-+        sample is never consumable (mirrors FeatureStore.abort semantics).
++        ``aux``/``last_hidden`` are the per-request (L, W) captured tensors,
++        stored with a leading batch dim of 1. On any failure the keys already
++        written are best-effort removed (no partial sample is consumable).
 +        """
 +        store_id = str(spec["store_id"])
 +        sample_id = str(spec["sample_id"])

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -1,0 +1,554 @@
+diff --git a/python/sglang/srt/layers/logits_processor.py b/python/sglang/srt/layers/logits_processor.py
+index a99d25267..73d88e04b 100644
+--- a/python/sglang/srt/layers/logits_processor.py
++++ b/python/sglang/srt/layers/logits_processor.py
+@@ -94,6 +94,10 @@ class LogitsProcessorOutput:
+     # Used by speculative decoding (EAGLE)
+     # The last hidden layers
+     hidden_states: Optional[torch.Tensor] = None
++    # Spec-training capture only: when CaptureHiddenMode.FULL runs with aux
++    # capture, `hidden_states` above carries the aux concatenation, so the
++    # post-norm last-layer hidden states are exposed here separately.
++    last_hidden_states: Optional[torch.Tensor] = None
+ 
+     ## Part 2: This part will be assigned in python/sglang/srt/layers/sampler.py::Sampler
+     # he log probs of output tokens, if SGLANG_RETURN_ORIGINAL_LOGPROB = True, will get the log probs before applying temperature. If False, will get the log probs before applying temperature.
+@@ -361,6 +365,17 @@ class LogitsProcessor(nn.Module):
+             sample_indices,
+             logits_metadata,
+         )
++        # Spec-training capture: under FULL with aux capture active,
++        # hidden_states_to_store is the aux concatenation — keep the post-norm
++        # last-layer hidden states too (the training target representation).
++        last_hidden_states_to_store = (
++            hidden_states
++            if (
++                logits_metadata.capture_hidden_mode.is_full()
++                and aux_hidden_states is not None
++            )
++            else None
++        )
+         del hidden_states
+ 
+         if not logits_metadata.extend_return_logprob:
+@@ -374,6 +389,7 @@ class LogitsProcessor(nn.Module):
+             return LogitsProcessorOutput(
+                 next_token_logits=sampled_logits,
+                 hidden_states=hidden_states_to_store,
++                last_hidden_states=last_hidden_states_to_store,
+                 # FIXME: These fields are not logits-related but are passed through here as a
+                 # workaround since ForwardBatch is local to forward_batch_generation().
+                 # They should be moved to GenerationBatchResult to keep this class clean.
+diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
+index 951f35495..03851edba 100644
+--- a/python/sglang/srt/managers/io_struct.py
++++ b/python/sglang/srt/managers/io_struct.py
+@@ -284,6 +284,11 @@ class GenerateReqInput(BaseReq):
+     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
+     multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
+ 
++    # Spec-training capture (requires --enable-spec-capture): per-request dict
++    # telling the scheduler-side sink where/what to write in the Mooncake
++    # store. Batch-level: List[Optional[dict]]. See sglang/srt/spec_capture_sink.py.
++    spec_capture: Optional[Union[List[Optional[Dict]], Dict]] = None
++
+     def contains_mm_input(self) -> bool:
+         return (
+             has_valid_data(self.image_data)
+@@ -743,6 +748,11 @@ class GenerateReqInput(BaseReq):
+                 if self.multi_item_delimiter_indices is not None
+                 else None
+             ),
++            spec_capture=(
++                self.spec_capture[i]
++                if isinstance(self.spec_capture, list)
++                else self.spec_capture
++            ),
+         )
+         cache[i] = sub
+         return sub
+@@ -842,6 +852,9 @@ class TokenizedGenerateReqInput(BaseReq):
+     # Pre-computed delimiter indices for multi-item scoring
+     multi_item_delimiter_indices: Optional[List[int]] = None
+ 
++    # Spec-training capture sink instructions (see GenerateReqInput.spec_capture)
++    spec_capture: Optional[Dict] = None
++
+     # For observability
+     time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
+ 
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index f1dc81d17..5baf7740e 100755
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -708,6 +708,7 @@ class Req(ReqDllmMixin):
+         ] = None,
+         return_pooled_hidden_states: bool = False,
+         multi_item_delimiter_indices: Optional[List[int]] = None,
++        spec_capture: Optional[Dict[str, Any]] = None,
+     ):
+         # Input and output info
+         self.rid = rid
+@@ -771,7 +772,13 @@ class Req(ReqDllmMixin):
+             }
+         self.sampling_params = sampling_params
+         self.custom_logit_processor = custom_logit_processor
+-        self.return_hidden_states = return_hidden_states
++        # Spec-training capture: piggyback on the return_hidden_states path so
++        # CaptureHiddenMode.FULL fires and per-request hidden slices accumulate;
++        # the sink then consumes them instead of the response payload.
++        self.spec_capture = spec_capture
++        self.return_hidden_states = return_hidden_states or spec_capture is not None
++        self.spec_capture_aux: List[torch.Tensor] = []
++        self.spec_capture_last_hidden: List[torch.Tensor] = []
+ 
+         # extra key for classifying the request (e.g. cache_salt)
+         if lora_id is not None:
+diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
+index abba37441..b25928ac0 100644
+--- a/python/sglang/srt/managers/scheduler.py
++++ b/python/sglang/srt/managers/scheduler.py
+@@ -576,6 +576,20 @@ class Scheduler(
+ 
+         self.init_batch_result_processor()
+ 
++        if server_args.enable_spec_capture:
++            # Spec-training capture requires single-pass prefill: per-request
++            # hidden slices are taken from one packed extend forward, and the
++            # chunked path would drop all but the final chunk's rows.
++            if server_args.chunked_prefill_size != -1:
++                raise ValueError(
++                    "--enable-spec-capture requires --chunked-prefill-size -1 "
++                    "(single-pass prefill) so captured hidden states cover the "
++                    "whole sequence"
++                )
++            from sglang.srt import spec_capture_sink
++
++            spec_capture_sink.maybe_init_sink(server_args)
++
+         self.is_initializing = False
+ 
+     def init_zbal_on_npu(self):
+@@ -2054,6 +2068,7 @@ class Scheduler(
+                 dllm_config=self.dllm_config,
+                 time_stats=recv_req.time_stats,
+                 multi_item_delimiter_indices=recv_req.multi_item_delimiter_indices,
++                spec_capture=recv_req.spec_capture,
+             )
+             req.tokenizer = self.tokenizer
+ 
+diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+index a9d5f0c28..a8e2d197f 100644
+--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
++++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+@@ -257,6 +257,20 @@ class SchedulerBatchResultProcessor:
+                         )
+ 
+                     if (
++                        req.spec_capture is not None
++                        and logits_output.hidden_states is not None
++                    ):
++                        # Spec-training capture: keep tensor slices (not the
++                        # .tolist() response path) and sink to the store when
++                        # the request finishes.
++                        hidden_state_offset = self._append_spec_capture_states(
++                            req=req,
++                            logits_output=logits_output,
++                            hidden_state_offset=hidden_state_offset,
++                        )
++                        if req.finished():
++                            self._sink_spec_capture(req)
++                    elif (
+                         req.return_hidden_states
+                         and logits_output.hidden_states is not None
+                     ):
+@@ -462,6 +476,66 @@ class SchedulerBatchResultProcessor:
+                     f"Placeholder zeros would be appended to output_ids."
+                 )
+ 
++    def _append_spec_capture_states(
++        self,
++        *,
++        req: Req,
++        logits_output: LogitsProcessorOutput,
++        hidden_state_offset: int,
++    ) -> int:
++        """Accumulate this request's captured rows as CPU tensors.
++
++        Mirrors ``_append_prefill_hidden_states``'s offset arithmetic but keeps
++        tensors (bf16 slices) for the Mooncake sink instead of building the
++        JSON-able ``req.hidden_states`` response payload. Under aux capture,
++        ``logits_output.hidden_states`` is the aux concatenation and
++        ``logits_output.last_hidden_states`` the post-norm last hidden.
++        """
++        start = hidden_state_offset
++        end = start + len(req.origin_input_ids)
++        req.spec_capture_aux.append(
++            logits_output.hidden_states[start:end].cpu().clone()
++        )
++        if logits_output.last_hidden_states is not None:
++            req.spec_capture_last_hidden.append(
++                logits_output.last_hidden_states[start:end].cpu().clone()
++            )
++        return end
++
++    def _sink_spec_capture(self, req: Req) -> None:
++        """Write a finished capture request's tensors to the Mooncake sink.
++
++        Runs on the attention-TP rank that streams output; failures land in
++        ``req.customized_info["spec_capture_error"]`` so the client sees a loud
++        per-request error instead of a silent missing feature.
++        """
++        from sglang.srt import spec_capture_sink
++
++        sink = spec_capture_sink.get_sink()
++        if sink is None or self.output_streamer.ps.attn_tp_rank != 0:
++            return
++        aux = torch.cat(req.spec_capture_aux, dim=0) if req.spec_capture_aux else None
++        last_hidden = (
++            torch.cat(req.spec_capture_last_hidden, dim=0)
++            if req.spec_capture_last_hidden
++            else None
++        )
++        try:
++            result = sink.put_sample(req.spec_capture, aux=aux, last_hidden=last_hidden)
++            # One-element per-token list: the streamer slices [0:1] and the
++            # tokenizer manager extends it into meta_info["spec_capture"].
++            payload = {"spec_capture": [result]}
++        except Exception as e:
++            logger.error("spec-capture sink failed for %s: %s", req.rid, e)
++            payload = {"spec_capture_error": [str(e)]}
++        # Ride the existing customized_info channel (streamer slices [0:1],
++        # tokenizer manager extends into meta_info) — no new IPC fields.
++        if req.customized_info is None:
++            req.customized_info = {}
++        req.customized_info.update(payload)
++        req.spec_capture_aux = []
++        req.spec_capture_last_hidden = []
++
+     def _append_prefill_hidden_states(
+         self,
+         *,
+diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
+index bf932611a..dc7615f44 100644
+--- a/python/sglang/srt/managers/tokenizer_manager.py
++++ b/python/sglang/srt/managers/tokenizer_manager.py
+@@ -1172,6 +1172,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+                 multi_item_delimiter_indices=obj.multi_item_delimiter_indices,
+                 mm_data_mooncake=obj.mm_data_mooncake,
+                 encoder_urls=obj.encoder_urls,
++                spec_capture=obj.spec_capture,
+             )
+         elif isinstance(obj, EmbeddingReqInput):
+             # Resolve unresolved embed overrides now that input_ids are available
+diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
+index 1cff5c983..da49196b1 100644
+--- a/python/sglang/srt/model_executor/model_runner.py
++++ b/python/sglang/srt/model_executor/model_runner.py
+@@ -471,6 +471,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                     # if there is no aux layer, set to None
+                     self.eagle_aux_hidden_state_layer_ids = None
+ 
++        if server_args.enable_spec_capture and not self.is_draft_worker:
++            # Spec-training capture (no draft worker needed): enable EAGLE3-style
++            # aux capture on the target model, layer ids from server args (None
++            # falls through to the model's default low/mid/high selection).
++            self.eagle_use_aux_hidden_state = True
++            self.eagle_aux_hidden_state_layer_ids = (
++                server_args.spec_capture_aux_layer_ids
++            )
++
+         if self.spec_algorithm.is_dflash() and not self.is_draft_worker:
+             from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+ 
+diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
+index c7162c16d..257d8b4f7 100644
+--- a/python/sglang/srt/server_args.py
++++ b/python/sglang/srt/server_args.py
+@@ -2127,6 +2127,19 @@ class ServerArgs:
+         bool,
+         "Enable returning hidden states with responses.",
+     ] = False
++    enable_spec_capture: A[
++        bool,
++        "Enable server-side speculative-training capture: per-request aux/last "
++        "hidden states are written to a Mooncake store (SpecForge DataFlow "
++        "layout) instead of the response payload. Enables aux-hidden-state "
++        "capture on the target model without a speculative draft worker.",
++    ] = False
++    spec_capture_aux_layer_ids: A[
++        Optional[List[int]],
++        "Target layer ids whose hidden states are captured (concatenated) for "
++        "spec-capture requests. Defaults to the model's EAGLE3 default layers "
++        "(low/mid/high) when unset.",
++    ] = None
+     enable_return_routed_experts: A[
+         bool,
+         "Enable returning routed experts of each layer with responses.",
+diff --git a/python/sglang/srt/spec_capture_sink.py b/python/sglang/srt/spec_capture_sink.py
+new file mode 100644
+index 000000000..9dd68075f
+--- /dev/null
++++ b/python/sglang/srt/spec_capture_sink.py
+@@ -0,0 +1,261 @@
++# Copyright 2024 SGLang Team
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++"""Server-side spec-training capture sink (SpecForge DataFlow transport).
++
++When the server is launched with ``--enable-spec-capture``, a request may carry
++a ``spec_capture`` dict. During that request's prefill the model runs with
++``CaptureHiddenMode.FULL`` and aux-hidden-state capture enabled, and this sink
++writes the captured tensors straight into a Mooncake distributed store —
++feature tensors never travel over the HTTP/ZMQ response path. The response's
++``meta_info["spec_capture"]`` carries only keys + shapes/dtypes, from which the
++training side constructs a ``SampleRef`` and reads the tensors zero-copy.
++
++The wire/key format is pinned to SpecForge's ``MooncakeFeatureStore`` zero-copy
++layout: one hard-pinned object per tensor at key
++
++    {store_id}/{sample_id}/g{gen}/{name}
++
++holding the raw contiguous tensor bytes (no serialization header; shape/dtype
++travel on the returned spec). This module is deliberately self-contained: the
++hooks in scheduler components are one-liners, and every capture-specific
++decision lives here.
++
++Request ``spec_capture`` schema (all strategy-specific naming is decided by the
++CLIENT via the ``features`` mapping — the server only knows generic artifacts)::
++
++    {
++      "store_id":  "run-abc",          # key namespace (client's store_id)
++      "sample_id": "run-abc:task-7",   # unique per sample
++      "gen":       1,                  # generation for the key (staleness guard)
++      "features":  {                   # artifact -> stored feature name
++          "aux":         "hidden_state",   # cat of captured aux layers (1, L, k*H)
++          "last_hidden": "target"          # post-norm last hidden      (1, L, H)
++      },
++      "passthrough": [                 # small client tensors stored verbatim
++          {"name": "input_ids", "data": [...], "shape": [1, L], "dtype": "int64"},
++          {"name": "loss_mask", "data": [...], "shape": [1, L, 1], "dtype": "int64"}
++      ]
++    }
++
++Response (``meta_info["spec_capture"]``, one dict)::
++
++    {
++      "sample_id": "...", "store_id": "...", "gen": 1,
++      "aux_layer_ids": [2, 20, 37],
++      "features": {"hidden_state": {"shape": [1, L, 3*H], "dtype": "bfloat16"}, ...}
++    }
++
++Mooncake connection is configured via the same environment variables SpecForge's
++``MooncakeFeatureStore`` uses: ``MOONCAKE_LOCAL_HOSTNAME``,
++``MOONCAKE_METADATA_SERVER``, ``MOONCAKE_MASTER_SERVER_ADDR``,
++``MOONCAKE_PROTOCOL`` (default tcp), ``MOONCAKE_GLOBAL_SEGMENT_SIZE``,
++``MOONCAKE_RDMA_DEVICES``.
++"""
++
++from __future__ import annotations
++
++import logging
++import os
++import threading
++from typing import Any, Dict, List, Optional
++
++import torch
++
++logger = logging.getLogger(__name__)
++
++# torch dtype -> the FeatureSpec dtype string SpecForge's zero-copy get() maps
++# back to a torch dtype. Keep in sync with MooncakeFeatureStore._TORCH_DTYPES.
++_DTYPE_STR = {
++    torch.float32: "float32",
++    torch.float64: "float64",
++    torch.float16: "float16",
++    torch.bfloat16: "bfloat16",
++    torch.int64: "int64",
++    torch.int32: "int32",
++    torch.int16: "int16",
++    torch.int8: "int8",
++    torch.uint8: "uint8",
++    torch.bool: "bool",
++}
++_STR_DTYPE = {v: k for k, v in _DTYPE_STR.items()}
++
++_ARTIFACT_AUX = "aux"
++_ARTIFACT_LAST_HIDDEN = "last_hidden"
++
++
++class SpecCaptureSink:
++    """Writes captured per-request tensors into Mooncake in SpecForge layout."""
++
++    def __init__(self, aux_layer_ids: Optional[List[int]] = None) -> None:
++        self.aux_layer_ids = list(aux_layer_ids) if aux_layer_ids else None
++        self._store = None
++        self._put_config = None
++        self._lock = threading.Lock()
++
++    # -- connection ---------------------------------------------------------
++    def _connect(self):
++        if self._store is not None:
++            return self._store
++        with self._lock:
++            if self._store is not None:
++                return self._store
++            from mooncake.store import MooncakeDistributedStore, ReplicateConfig
++
++            store = MooncakeDistributedStore()
++            rc = store.setup(
++                local_hostname=os.environ.get("MOONCAKE_LOCAL_HOSTNAME", "localhost"),
++                metadata_server=os.environ.get(
++                    "MOONCAKE_METADATA_SERVER", "http://localhost:8080/metadata"
++                ),
++                global_segment_size=int(
++                    os.environ.get("MOONCAKE_GLOBAL_SEGMENT_SIZE", 1 << 30)
++                ),
++                local_buffer_size=int(
++                    os.environ.get("MOONCAKE_LOCAL_BUFFER_SIZE", 1 << 30)
++                ),
++                protocol=os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
++                rdma_devices=os.environ.get("MOONCAKE_RDMA_DEVICES", ""),
++                master_server_addr=os.environ.get(
++                    "MOONCAKE_MASTER_SERVER_ADDR", "localhost:50051"
++                ),
++            )
++            if rc is not None and int(rc) != 0:
++                raise RuntimeError(f"spec-capture mooncake setup failed (status {rc})")
++            # Hard-pin every object: SpecForge (not Mooncake's LRU) is the
++            # lifetime authority — a committed feature must never be evicted
++            # before the trainer consumes it.
++            cfg = ReplicateConfig()
++            cfg.replica_num = 1
++            cfg.with_hard_pin = True
++            self._put_config = cfg
++            self._store = store
++            logger.info("spec-capture mooncake sink connected")
++            return store
++
++    # -- key/put primitives (pinned to MooncakeFeatureStore's layout) --------
++    @staticmethod
++    def _tkey(store_id: str, sample_id: str, gen: int, name: str) -> str:
++        return f"{store_id}/{sample_id}/g{gen}/{name}"
++
++    def _put_tensor(self, key: str, t: torch.Tensor) -> None:
++        store = self._connect()
++        t = t.detach().to("cpu").contiguous()
++        nbytes = t.element_size() * t.numel()
++        try:
++            store.register_buffer(t.data_ptr(), nbytes)
++        except Exception:
++            pass  # some builds auto-register
++        try:
++            rc = store.put_from(key, t.data_ptr(), nbytes, self._put_config)
++        finally:
++            try:
++                store.unregister_buffer(t.data_ptr())
++            except Exception:
++                pass
++        if rc is not None and int(rc) < 0:
++            raise RuntimeError(f"spec-capture put_from failed (status {rc}) for {key}")
++
++    def _remove_quiet(self, key: str) -> None:
++        try:
++            self._connect().remove(key)
++        except Exception:
++            pass
++
++    # -- the one entry point --------------------------------------------------
++    def put_sample(
++        self,
++        spec: Dict[str, Any],
++        *,
++        aux: Optional[torch.Tensor],
++        last_hidden: Optional[torch.Tensor],
++    ) -> Dict[str, Any]:
++        """Write one sample's artifacts; return the meta_info result dict.
++
++        ``aux``/``last_hidden`` are the (L, W) captured tensors for this request
++        (already sliced per request); stored with a leading batch dim of 1 to
++        match SpecForge's online feature convention. On any failure, keys
++        already written for this sample are best-effort removed so a partial
++        sample is never consumable (mirrors FeatureStore.abort semantics).
++        """
++        store_id = str(spec["store_id"])
++        sample_id = str(spec["sample_id"])
++        gen = int(spec.get("gen", 1))
++        features: Dict[str, str] = dict(spec.get("features") or {})
++
++        written: List[str] = []
++        result_feats: Dict[str, Dict[str, Any]] = {}
++
++        def _write(name: str, t: torch.Tensor) -> None:
++            key = self._tkey(store_id, sample_id, gen, name)
++            self._put_tensor(key, t)
++            written.append(key)
++            result_feats[name] = {
++                "shape": list(t.shape),
++                "dtype": _DTYPE_STR.get(t.dtype, str(t.dtype).replace("torch.", "")),
++            }
++
++        try:
++            aux_name = features.get(_ARTIFACT_AUX)
++            if aux_name is not None:
++                if aux is None:
++                    raise RuntimeError(
++                        "spec_capture requested 'aux' but no aux hidden states were "
++                        "captured — launch the server with --enable-spec-capture "
++                        "(and optionally --spec-capture-aux-layer-ids)"
++                    )
++                _write(aux_name, aux.unsqueeze(0))
++            lh_name = features.get(_ARTIFACT_LAST_HIDDEN)
++            if lh_name is not None:
++                if last_hidden is None:
++                    raise RuntimeError(
++                        "spec_capture requested 'last_hidden' but the logits "
++                        "processor did not return it (is aux capture enabled?)"
++                    )
++                _write(lh_name, last_hidden.unsqueeze(0))
++            for item in spec.get("passthrough") or []:
++                dtype = _STR_DTYPE.get(str(item.get("dtype", "int64")))
++                if dtype is None:
++                    raise RuntimeError(
++                        f"spec_capture passthrough {item.get('name')!r}: "
++                        f"unsupported dtype {item.get('dtype')!r}"
++                    )
++                t = torch.tensor(item["data"], dtype=dtype).reshape(
++                    [int(d) for d in item["shape"]]
++                )
++                _write(str(item["name"]), t)
++        except Exception:
++            for key in written:
++                self._remove_quiet(key)
++            raise
++
++        return {
++            "sample_id": sample_id,
++            "store_id": store_id,
++            "gen": gen,
++            "aux_layer_ids": self.aux_layer_ids,
++            "features": result_feats,
++        }
++
++
++_SINK: Optional[SpecCaptureSink] = None
++
++
++def maybe_init_sink(server_args) -> None:
++    """Called from Scheduler init on the writer rank when spec capture is on.
++
++    Connection to Mooncake is lazy (first put), so a capture-enabled server
++    without a reachable Mooncake master still boots and serves normal traffic.
++    """
++    global _SINK
++    if getattr(server_args, "enable_spec_capture", False) and _SINK is None:
++        _SINK = SpecCaptureSink(
++            aux_layer_ids=getattr(server_args, "spec_capture_aux_layer_ids", None)
++        )
++
++
++def get_sink() -> Optional[SpecCaptureSink]:
++    return _SINK

--- a/scripts/apply_sglang_spec_capture_patch.sh
+++ b/scripts/apply_sglang_spec_capture_patch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Apply the spec-capture patch to the INSTALLED sglang (site-packages).
+#
+# The patch file is authored against the sglang source tree (paths like
+# python/sglang/srt/...); an installed package drops the python/ prefix, so we
+# strip one component and apply from the site-packages parent.
+#
+# Usage: scripts/apply_sglang_spec_capture_patch.sh [--reverse]
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+PATCH="$HERE/patches/sglang/v0.5.14/spec-capture.patch"
+
+SGL_PARENT="$(python -c 'import sglang, os; print(os.path.dirname(os.path.dirname(sglang.__file__)))')"
+SGL_VERSION="$(python -c 'import sglang; print(sglang.__version__)')"
+
+if [[ "$SGL_VERSION" != 0.5.14* ]]; then
+    echo "WARNING: installed sglang is $SGL_VERSION; the patch targets v0.5.14" >&2
+fi
+
+REVERSE=()
+if [[ "${1:-}" == "--reverse" ]]; then
+    REVERSE=(--reverse)
+fi
+
+# Idempotence: skip when already applied (forward mode only).
+if [[ ${#REVERSE[@]} -eq 0 ]] && [[ -f "$SGL_PARENT/sglang/srt/spec_capture_sink.py" ]]; then
+    echo "spec-capture patch already applied at $SGL_PARENT/sglang"
+    exit 0
+fi
+
+patch "${REVERSE[@]}" -p1 -d "$SGL_PARENT" < "$PATCH"
+echo "spec-capture patch ${REVERSE[0]:-applied} at $SGL_PARENT/sglang (sglang $SGL_VERSION)"

--- a/scripts/apply_sglang_spec_capture_patch.sh
+++ b/scripts/apply_sglang_spec_capture_patch.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Apply the spec-capture patch to the INSTALLED sglang (site-packages).
 #
-# The patch file is authored against the sglang source tree (paths like
-# python/sglang/srt/...); an installed package drops the python/ prefix, so we
-# strip one component and apply from the site-packages parent.
+# The patch file is authored against the sglang source tree (git-style paths
+# a/python/sglang/srt/...); an installed package drops the python/ prefix, so
+# strip TWO components (a/ + python/) and apply from the site-packages parent.
 #
 # Usage: scripts/apply_sglang_spec_capture_patch.sh [--reverse]
 set -euo pipefail
@@ -29,5 +29,5 @@ if [[ ${#REVERSE[@]} -eq 0 ]] && [[ -f "$SGL_PARENT/sglang/srt/spec_capture_sink
     exit 0
 fi
 
-patch "${REVERSE[@]}" -p1 -d "$SGL_PARENT" < "$PATCH"
+patch "${REVERSE[@]}" -p2 --batch -N -d "$SGL_PARENT" < "$PATCH"
 echo "spec-capture patch ${REVERSE[0]:-applied} at $SGL_PARENT/sglang (sglang $SGL_VERSION)"

--- a/specforge/inference/adapters/__init__.py
+++ b/specforge/inference/adapters/__init__.py
@@ -6,4 +6,10 @@ batched capture, per-sample slicing, vocab projection); each strategy registers
 a ``FeatureSchema`` for the store-ready dict shape. ``eagle3.SGLangAdapter``
 and ``dflash.DFlashAdapter`` are thin schema-pinning subclasses kept for
 back-compat; all implement the ``rollout_worker.FeatureSource`` protocol.
+
+``server_capture.SGLangServerCaptureAdapter`` is the zero-copy SERVER
+transport (``rollout_worker.RefSource``): a patched live SGLang server writes
+the features straight into the Mooncake store and the adapter returns
+committed-ready ``SampleRef``s — import it from its module (it stays out of
+this package ``__init__`` so the registry import path remains light).
 """

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -99,7 +99,9 @@ register_server_capture_schema(
         last_hidden_feature="target",  # target_repr="hidden_state"
         passthrough=(
             ("input_ids", "input_ids", ()),
-            ("loss_mask", "loss_mask", (1,)),  # eagle3 stores (1, L, 1)
+            # (1, L): the hidden_state train path mirrors the OFFLINE
+            # convention — TargetHead.preprocess adds the trailing mask dim.
+            ("loss_mask", "loss_mask", ()),
         ),
         attention_mask_feature="attention_mask",
     )

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -8,30 +8,21 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 """Server-side spec-capture rollout source (zero-copy Mooncake transport).
 
-The in-process adapters (``PolicyFeatureAdapter``) run the frozen target
-locally and hand tensors to the RolloutWorker, which ``put()``s them into the
-FeatureStore. This module is the *server* transport: a live SGLang server —
-patched with ``patches/sglang/v0.5.14/spec-capture.patch`` and launched with
-``--enable-spec-capture`` — runs the prefill forward, captures aux/last hidden
-states, and writes them straight into the Mooncake store in
-:class:`MooncakeFeatureStore`'s zero-copy key layout. Feature tensors never
-travel through this process: the ``/generate`` response's
-``meta_info["spec_capture"]`` carries only key/shape/dtype metadata, from which
-:meth:`SGLangServerCaptureAdapter.produce_refs` builds committed-ready
-``SampleRef``s. One forward per sample, engine-side capture, RDMA-capable
-transport — the transport PR #641's reforward engine anticipated.
+The *server* transport (vs the in-process ``PolicyFeatureAdapter``): a live
+SGLang server patched with ``patches/sglang/v0.5.14/spec-capture.patch`` runs
+the prefill and writes captured features straight into Mooncake in
+:class:`MooncakeFeatureStore`'s key layout. Tensors never pass through this
+process — the ``/generate`` response's ``meta_info["spec_capture"]`` carries
+only key/shape/dtype, from which :meth:`SGLangServerCaptureAdapter.produce_refs`
+builds committed-ready ``SampleRef``s.
 
-Strategy-agnostic by construction: the server knows only two generic artifacts
-(``aux`` = concatenated capture layers, ``last_hidden`` = post-norm final
-hidden) plus verbatim passthrough tensors; *this* module maps them onto each
-strategy's feature names and shapes via :class:`ServerCaptureSchema`
-(eagle3 / dflash / domino registered below; register new strategies with
-:func:`register_server_capture_schema`).
-
-EAGLE3 note: the server transport stores the target as the LAST HIDDEN STATE
-(``target_repr="hidden_state"``, the offline convention — the train strategy
-re-runs the frozen ``TargetHead``), never full logits: a (L, vocab) logits
-tensor would be ~50x the traffic of (L, hidden) for no training benefit.
+Strategy-agnostic: the server knows only generic artifacts (``aux`` = capture
+layers concatenated, ``last_hidden`` = post-norm final hidden) plus passthrough
+tensors; :class:`ServerCaptureSchema` maps them onto each strategy's feature
+names/shapes (eagle3 / dflash / domino below; add more via
+:func:`register_server_capture_schema`). eagle3 stores the target as the last
+hidden state (``target_repr="hidden_state"``, offline convention — the trainer
+re-runs the frozen ``TargetHead``), not logits (~50x the traffic).
 """
 
 from __future__ import annotations
@@ -52,15 +43,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class ServerCaptureSchema:
-    """How one strategy's features map onto the server's capture artifacts.
+    """Maps a strategy's feature names onto the server's capture artifacts.
 
-    ``aux_feature`` / ``last_hidden_feature`` name the stored features that
-    receive the two engine-side artifacts (None = strategy doesn't want it).
-    ``passthrough`` lists ``(feature_name, payload_key, trailing_shape)`` for
-    small client-known tensors stored verbatim by the server; ``trailing_shape``
-    is appended after ``(1, L)`` — e.g. ``(1,)`` turns loss_mask into the
-    eagle3 ``(1, L, 1)`` convention. ``attention_mask_feature`` (optional) is
-    synthesized as all-ones by the client (PromptTasks are unpadded).
+    ``aux_feature`` / ``last_hidden_feature`` name the features fed by the two
+    engine artifacts (None = not wanted). ``passthrough`` is
+    ``(feature_name, payload_key, trailing_shape)`` for client tensors stored
+    verbatim (``trailing_shape`` is appended after ``(1, L)``).
+    ``attention_mask_feature`` is synthesized all-ones (PromptTasks are unpadded).
     """
 
     strategy: str

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -1,0 +1,409 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Server-side spec-capture rollout source (zero-copy Mooncake transport).
+
+The in-process adapters (``PolicyFeatureAdapter``) run the frozen target
+locally and hand tensors to the RolloutWorker, which ``put()``s them into the
+FeatureStore. This module is the *server* transport: a live SGLang server —
+patched with ``patches/sglang/v0.5.14/spec-capture.patch`` and launched with
+``--enable-spec-capture`` — runs the prefill forward, captures aux/last hidden
+states, and writes them straight into the Mooncake store in
+:class:`MooncakeFeatureStore`'s zero-copy key layout. Feature tensors never
+travel through this process: the ``/generate`` response's
+``meta_info["spec_capture"]`` carries only key/shape/dtype metadata, from which
+:meth:`SGLangServerCaptureAdapter.produce_refs` builds committed-ready
+``SampleRef``s. One forward per sample, engine-side capture, RDMA-capable
+transport — the transport PR #641's reforward engine anticipated.
+
+Strategy-agnostic by construction: the server knows only two generic artifacts
+(``aux`` = concatenated capture layers, ``last_hidden`` = post-norm final
+hidden) plus verbatim passthrough tensors; *this* module maps them onto each
+strategy's feature names and shapes via :class:`ServerCaptureSchema`
+(eagle3 / dflash / domino registered below; register new strategies with
+:func:`register_server_capture_schema`).
+
+EAGLE3 note: the server transport stores the target as the LAST HIDDEN STATE
+(``target_repr="hidden_state"``, the offline convention — the train strategy
+re-runs the frozen ``TargetHead``), never full logits: a (L, vocab) logits
+tensor would be ~50x the traffic of (L, hidden) for no training benefit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+from specforge.inference.capture import (
+    FeatureContract,
+    FeatureContractError,
+    verify_feature_contract_specs,
+)
+from specforge.runtime.contracts import SCHEMA_VERSION, FeatureSpec, PromptTask
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ServerCaptureSchema:
+    """How one strategy's features map onto the server's capture artifacts.
+
+    ``aux_feature`` / ``last_hidden_feature`` name the stored features that
+    receive the two engine-side artifacts (None = strategy doesn't want it).
+    ``passthrough`` lists ``(feature_name, payload_key, trailing_shape)`` for
+    small client-known tensors stored verbatim by the server; ``trailing_shape``
+    is appended after ``(1, L)`` — e.g. ``(1,)`` turns loss_mask into the
+    eagle3 ``(1, L, 1)`` convention. ``attention_mask_feature`` (optional) is
+    synthesized as all-ones by the client (PromptTasks are unpadded).
+    """
+
+    strategy: str
+    aux_feature: Optional[str]
+    last_hidden_feature: Optional[str]
+    passthrough: Tuple[Tuple[str, str, Tuple[int, ...]], ...]
+    attention_mask_feature: Optional[str] = None
+
+
+_SERVER_CAPTURE_SCHEMAS: Dict[str, ServerCaptureSchema] = {}
+
+
+def register_server_capture_schema(schema: ServerCaptureSchema) -> None:
+    existing = _SERVER_CAPTURE_SCHEMAS.get(schema.strategy)
+    if existing is not None and existing != schema:
+        raise ValueError(
+            f"server-capture schema for {schema.strategy!r} already registered"
+        )
+    _SERVER_CAPTURE_SCHEMAS[schema.strategy] = schema
+
+
+def resolve_server_capture_schema(strategy: str) -> ServerCaptureSchema:
+    schema = _SERVER_CAPTURE_SCHEMAS.get(strategy)
+    if schema is None:
+        raise KeyError(
+            f"no server-capture schema registered for strategy {strategy!r}; "
+            f"registered: {sorted(_SERVER_CAPTURE_SCHEMAS)}"
+        )
+    return schema
+
+
+register_server_capture_schema(
+    ServerCaptureSchema(
+        strategy="eagle3",
+        aux_feature="hidden_state",
+        last_hidden_feature="target",  # target_repr="hidden_state"
+        passthrough=(
+            ("input_ids", "input_ids", ()),
+            ("loss_mask", "loss_mask", (1,)),  # eagle3 stores (1, L, 1)
+        ),
+        attention_mask_feature="attention_mask",
+    )
+)
+register_server_capture_schema(
+    ServerCaptureSchema(
+        strategy="dflash",
+        aux_feature="hidden_states",
+        last_hidden_feature=None,  # hard-label training: no target distribution
+        passthrough=(
+            ("input_ids", "input_ids", ()),
+            ("loss_mask", "loss_mask", ()),
+        ),
+    )
+)
+register_server_capture_schema(
+    ServerCaptureSchema(
+        strategy="domino",
+        aux_feature="hidden_states",
+        last_hidden_feature=None,
+        passthrough=(
+            ("input_ids", "input_ids", ()),
+            ("loss_mask", "loss_mask", ()),
+        ),
+    )
+)
+
+
+@dataclass(frozen=True)
+class ServerCaptureFailure:
+    """Per-task failure from the server transport (worker fails just this task)."""
+
+    task_id: str
+    reason: str
+    retryable: bool = True
+
+
+def _default_post(url: str, json_body: Dict[str, Any], timeout: float):
+    import requests
+
+    resp = requests.post(url, json=json_body, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+class SGLangServerCaptureAdapter:
+    """RefSource over a live spec-capture SGLang server.
+
+    Implements ``produce_refs`` (not ``generate_features``): the returned
+    ``SampleRef``s point at tensors the SERVER already wrote to the Mooncake
+    store, so the RolloutWorker commits them without any local put. The refs
+    are verified against the :class:`FeatureContract` from their FeatureSpecs
+    alone — same loud extraction-boundary guarantee, no tensor fetch.
+
+    ``store`` must be the run's :class:`MooncakeFeatureStore` (its ``store_id``
+    namespaces the keys and ``adopt()`` registers each ref so a later
+    ``abort()``/``gc()`` on the producer side can free server-written objects).
+    ``post_fn`` is injectable for tests.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        store,
+        *,
+        run_id: str,
+        strategy: str = "eagle3",
+        schema: Optional[ServerCaptureSchema] = None,
+        timeout_s: float = 300.0,
+        post_fn: Optional[Callable[..., Any]] = None,
+        target_model_version: str = "unknown",
+    ) -> None:
+        if not hasattr(store, "adopt") or not hasattr(store, "store_id"):
+            raise TypeError(
+                "SGLangServerCaptureAdapter needs a MooncakeFeatureStore-like "
+                "store exposing .store_id and .adopt(ref)"
+            )
+        self.base_url = base_url.rstrip("/")
+        self.store = store
+        self.run_id = run_id
+        self.schema = schema or resolve_server_capture_schema(strategy)
+        self.strategy = self.schema.strategy
+        self.timeout_s = timeout_s
+        self.post_fn = post_fn or _default_post
+        self.target_model_version = target_model_version
+        self._healthy = True
+
+    # -- request construction -------------------------------------------------
+    def _sample_id(self, task: PromptTask) -> str:
+        return f"{self.run_id}:{task.task_id}"
+
+    def _spec_capture_payload(self, task: PromptTask) -> Dict[str, Any]:
+        input_ids = list(task.payload["input_ids"])
+        length = len(input_ids)
+        features: Dict[str, str] = {}
+        if self.schema.aux_feature is not None:
+            features["aux"] = self.schema.aux_feature
+        if self.schema.last_hidden_feature is not None:
+            features["last_hidden"] = self.schema.last_hidden_feature
+        passthrough: List[Dict[str, Any]] = []
+        for feature_name, payload_key, trailing in self.schema.passthrough:
+            if payload_key == "input_ids":
+                data = input_ids
+            else:
+                data = list(task.payload.get(payload_key, [1] * length))
+            if len(data) != length:
+                raise ValueError(
+                    f"task {task.task_id}: payload {payload_key!r} length "
+                    f"{len(data)} != input_ids length {length}"
+                )
+            passthrough.append(
+                {
+                    "name": feature_name,
+                    "data": data,
+                    "shape": [1, length, *trailing],
+                    "dtype": "int64",
+                }
+            )
+        if self.schema.attention_mask_feature is not None:
+            passthrough.append(
+                {
+                    "name": self.schema.attention_mask_feature,
+                    "data": [1] * length,
+                    "shape": [1, length],
+                    "dtype": "int64",
+                }
+            )
+        return {
+            "store_id": self.store.store_id,
+            "sample_id": self._sample_id(task),
+            # retried tasks re-capture under a bumped generation so a stale
+            # ref from the failed attempt can never resolve (B5)
+            "gen": int(task.attempt) + 1,
+            "features": features,
+            "passthrough": passthrough,
+        }
+
+    # -- ref construction ------------------------------------------------------
+    def _ref_from_result(
+        self, task: PromptTask, result: Dict[str, Any], contract: FeatureContract
+    ):
+        from specforge.runtime.contracts import SampleRef
+
+        sample_id = str(result["sample_id"])
+        gen = int(result["gen"])
+        feats: Dict[str, Dict[str, Any]] = result["features"]
+        specs: Dict[str, FeatureSpec] = {}
+        nbytes = 0
+        for name, meta in feats.items():
+            shape = tuple(int(d) for d in meta["shape"])
+            dtype = str(meta["dtype"])
+            extra: Dict[str, Any] = {}
+            if name == self.schema.last_hidden_feature:
+                extra["target_repr"] = contract.target_repr
+                if contract.vocab_map_version:
+                    extra["target_meta"] = {
+                        "vocab_map_version": contract.vocab_map_version
+                    }
+            specs[name] = FeatureSpec(name=name, shape=shape, dtype=dtype, **extra)
+            nbytes += _spec_nbytes(shape, dtype)
+        num_tokens = int(task.metadata.get("num_tokens", 0)) or len(
+            task.payload["input_ids"]
+        )
+        return SampleRef(
+            sample_id=sample_id,
+            run_id=self.run_id,
+            source_task_id=task.task_id,
+            feature_store_uri=f"mooncake://{result['store_id']}/{sample_id}",
+            feature_keys={n: f"{sample_id}/{n}" for n in specs},
+            feature_specs=specs,
+            strategy=self.strategy,
+            schema_version=SCHEMA_VERSION,
+            target_model_version=self.target_model_version,
+            tokenizer_version=str(task.metadata.get("tokenizer_version", "unknown")),
+            num_tokens=num_tokens,
+            estimated_bytes=nbytes,
+            metadata={
+                "run_id": self.run_id,
+                "source_task_id": task.task_id,
+                "strategy": self.strategy,
+                "target_repr": contract.target_repr,
+                "vocab_map_version": contract.vocab_map_version,
+                "transport": "sglang_server_capture",
+                "generation": gen,  # the zero-copy get() locator
+            },
+        )
+
+    # -- the RefSource entry point ----------------------------------------------
+    def produce_refs(
+        self, tasks: List[PromptTask], *, capture: FeatureContract
+    ) -> List[Union["SampleRef", ServerCaptureFailure]]:  # noqa: F821
+        """One batched server call -> one committed-ready ref per task.
+
+        Order-aligned with ``tasks``; a per-task server error becomes a
+        :class:`ServerCaptureFailure` (the worker fails just that lease). Any
+        transport-level error raises — the worker fails the whole lease batch
+        retryable, mirroring ``generate_features`` semantics.
+        """
+        body = {
+            "input_ids": [list(t.payload["input_ids"]) for t in tasks],
+            "sampling_params": {"temperature": 0.0, "max_new_tokens": 1},
+            "spec_capture": [self._spec_capture_payload(t) for t in tasks],
+        }
+        rows = self.post_fn(
+            f"{self.base_url}/generate", json_body=body, timeout=self.timeout_s
+        )
+        if isinstance(rows, dict):
+            rows = [rows]
+        if len(rows) != len(tasks):
+            raise RuntimeError(
+                f"spec-capture server returned {len(rows)} rows for "
+                f"{len(tasks)} tasks"
+            )
+        out: List[Union[Any, ServerCaptureFailure]] = []
+        for task, row in zip(tasks, rows):
+            meta = row.get("meta_info") or {}
+            err = meta.get("spec_capture_error")
+            if err:
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id,
+                        reason=f"server_capture:{err[0]}",
+                        retryable=True,
+                    )
+                )
+                continue
+            results = meta.get("spec_capture")
+            if not results:
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id,
+                        reason=(
+                            "server_capture: response carries no spec_capture "
+                            "result — is the server patched and launched with "
+                            "--enable-spec-capture?"
+                        ),
+                        retryable=False,
+                    )
+                )
+                continue
+            result = results[0]
+            ref = self._ref_from_result(task, result, capture)
+            try:
+                verify_feature_contract_specs(
+                    ref.feature_specs,
+                    capture,
+                    sample_id=ref.sample_id,
+                    recorded_aux_layer_ids=(
+                        tuple(result["aux_layer_ids"])
+                        if result.get("aux_layer_ids") is not None
+                        else None
+                    ),
+                    aux_feature_name=self.schema.aux_feature or "hidden_state",
+                    target_feature_name=self.schema.last_hidden_feature or "target",
+                )
+            except FeatureContractError as exc:
+                # Loud boundary failure; free the server-written keys so a
+                # mismatched sample is never consumable.
+                self.store.adopt(ref)
+                self.store.abort(ref.sample_id, reason=f"contract:{exc}")
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id, reason=str(exc), retryable=False
+                    )
+                )
+                continue
+            self.store.adopt(ref)
+            out.append(ref)
+        return out
+
+    def health(self) -> Dict[str, Any]:
+        return {
+            "healthy": self._healthy,
+            "backend": "sglang_server_capture",
+            "base_url": self.base_url,
+            "strategy": self.strategy,
+        }
+
+
+_DTYPE_BYTES = {
+    "float64": 8,
+    "int64": 8,
+    "float32": 4,
+    "int32": 4,
+    "float16": 2,
+    "bfloat16": 2,
+    "int16": 2,
+    "int8": 1,
+    "uint8": 1,
+    "bool": 1,
+}
+
+
+def _spec_nbytes(shape: Tuple[int, ...], dtype: str) -> int:
+    n = 1
+    for d in shape:
+        n *= int(d)
+    return n * _DTYPE_BYTES.get(dtype, 2)
+
+
+__all__ = [
+    "ServerCaptureSchema",
+    "ServerCaptureFailure",
+    "SGLangServerCaptureAdapter",
+    "register_server_capture_schema",
+    "resolve_server_capture_schema",
+]

--- a/specforge/inference/capture.py
+++ b/specforge/inference/capture.py
@@ -142,6 +142,34 @@ def verify_feature_contract(
             )
 
 
+def verify_feature_contract_specs(
+    specs: Dict[str, Any],
+    contract: FeatureContract,
+    *,
+    sample_id: str,
+    recorded_aux_layer_ids: Optional[Tuple[int, ...]] = None,
+    aux_feature_name: str = "hidden_state",
+    target_feature_name: str = "target",
+) -> None:
+    """Contract verification from ``FeatureSpec``s alone — no tensors.
+
+    Used by ref-producing sources (server-side capture): the tensors already
+    live in the store, so the extraction-boundary checks run against the
+    returned shape/dtype metadata. Every check in
+    :func:`verify_feature_contract` reads only ``.shape`` from the mapping's
+    values, which ``FeatureSpec`` provides — so this is the same validation,
+    same error messages, same loudness.
+    """
+    verify_feature_contract(
+        specs,
+        contract,
+        sample_id=sample_id,
+        recorded_aux_layer_ids=recorded_aux_layer_ids,
+        aux_feature_name=aux_feature_name,
+        target_feature_name=target_feature_name,
+    )
+
+
 def verify_capture(
     tensors: Dict[str, Any],
     capture: FeatureContract,
@@ -172,6 +200,7 @@ __all__ = [
     "FeatureContract",
     "FeatureContractError",
     "verify_feature_contract",
+    "verify_feature_contract_specs",
     "CaptureConfig",
     "CaptureMismatchError",
     "verify_capture",

--- a/specforge/inference/rollout_worker.py
+++ b/specforge/inference/rollout_worker.py
@@ -38,6 +38,21 @@ class FeatureSource(Protocol):
     ) -> List[Dict[str, Any]]: ...
 
 
+class RefSource(Protocol):
+    """A source whose features are ALREADY in the feature store.
+
+    Server-side capture transports (e.g. ``SGLangServerCaptureAdapter``) write
+    tensors into the store from the inference server and return
+    committed-ready ``SampleRef``s (or per-task failure markers with
+    ``task_id``/``reason``/``retryable`` attributes). The worker then commits
+    refs without any local put — tensors never pass through this process.
+    """
+
+    def produce_refs(
+        self, tasks: List[PromptTask], *, capture: FeatureContract
+    ) -> List[Any]: ...
+
+
 class RolloutWorker:
     def __init__(
         self,
@@ -90,6 +105,8 @@ class RolloutWorker:
             return []
         self._inflight = len(tasks)
         self._state = "ready"
+        if hasattr(self.feature_source, "produce_refs"):
+            return self._run_once_refs(tasks)
         try:
             feats_list = self.feature_source.generate_features(
                 tasks, capture=self.feature_contract
@@ -166,6 +183,66 @@ class RolloutWorker:
             raise capture_error
         return refs
 
+    def _run_once_refs(self, tasks: List[PromptTask]) -> List[SampleRef]:
+        """Lease -> produce_refs -> commit for ref-producing sources.
+
+        The source verified each ref against the FeatureContract and wrote the
+        tensors store-side, so the worker's job reduces to terminal-state
+        bookkeeping: every leased task still ends in exactly one controller
+        action — ``commit_samples`` for a returned ref, ``fail_prompt_tasks``
+        for a per-task failure marker or a transport error.
+        """
+        try:
+            results = self.feature_source.produce_refs(
+                tasks, capture=self.feature_contract
+            )
+        except Exception as exc:  # transport failure before any commit
+            self._state = "unhealthy"
+            self._recent_failures.append(f"produce_refs: {exc}")
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=f"produce_refs:{exc}",
+                retryable=True,
+            )
+            self._inflight = 0
+            raise
+        if len(results) != len(tasks):
+            reason = (
+                f"produce_refs returned {len(results)} results for "
+                f"{len(tasks)} tasks"
+            )
+            self._state = "unhealthy"
+            self._recent_failures.append(reason)
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [t.task_id for t in tasks],
+                reason=reason,
+                retryable=False,
+            )
+            self._inflight = 0
+            raise ValueError(reason)
+
+        refs: List[SampleRef] = []
+        for task, result in zip(tasks, results):
+            if isinstance(result, SampleRef):
+                refs.append(result)
+                continue
+            # per-task failure marker (duck-typed: reason/retryable)
+            reason = getattr(result, "reason", f"produce_refs:{result!r}")
+            self._recent_failures.append(reason)
+            self.controller.fail_prompt_tasks(
+                self.worker_id,
+                [task.task_id],
+                reason=reason,
+                retryable=bool(getattr(result, "retryable", True)),
+            )
+        if refs:
+            self.controller.commit_samples(self.worker_id, refs)
+            self._last_commit_count += len(refs)
+        self._inflight = 0
+        return refs
+
     def _put_metadata(self, task: PromptTask) -> Dict[str, Any]:
         return {
             "run_id": self.run_id,
@@ -199,4 +276,4 @@ class RolloutWorker:
         }
 
 
-__all__ = ["RolloutWorker", "FeatureSource", "HEALTH_STATES"]
+__all__ = ["RolloutWorker", "FeatureSource", "RefSource", "HEALTH_STATES"]

--- a/specforge/inference/sglang_patch_inventory.md
+++ b/specforge/inference/sglang_patch_inventory.md
@@ -35,7 +35,8 @@ The extraction-correctness gate must be green on every pinned version. `status`:
 |---|---|---|---|---|
 | `0.5.5` (`lmsysorg/sglang:v0.5.5`) | 2.x / 4.x | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (repo CI image) |
 | `dev` (`lmsysorg/sglang:dev`) | 2.11 / 5.8 | sglang, hf, custom | `set_eagle3_layers_to_capture` | validated (H200 box) |
-| `0.5.9` (pyproject pin) | 2.9.1 / 4.57.1 | sglang, hf, custom | `set_eagle3_layers_to_capture` | target |
+| `0.5.9` (pyproject pin) | 2.9.1 / 4.57.1 | sglang, hf, custom | `set_eagle3_layers_to_capture` | superseded by 0.5.14 |
+| `0.5.14` (pyproject pin) | 2.9.1 / 4.57.1 | sglang, hf, custom, **server (spec-capture patch)** | `set_eagle3_layers_to_capture` / `--enable-spec-capture` | pin (PR #652); server transport gated by `test_server_capture_gate` |
 
 `0.5.9` is the dependency pin, but it is not an M4 sign-off until the
 extraction-correctness gate is green on that exact image/version.
@@ -55,6 +56,23 @@ a failure on a new image blocks the version bump.
 ## Patch files
 
 When an SGLang upgrade requires source changes to the extraction surface, add a
-versioned patch under `specforge/runtime/inference/patches/<sglang-version>.patch`
-and record it in the matrix above. None are required for the validated versions
-(extraction goes through the public capture API).
+versioned patch under `patches/sglang/<version>/` and record it in the matrix
+above. The in-process backends need none (extraction goes through the public
+capture API).
+
+### `patches/sglang/v0.5.14/spec-capture.patch` — server-side capture sink
+
+The **server transport**: 8 small hooks + one self-contained module
+(`sglang/srt/spec_capture_sink.py`) that let a live SGLang server, launched
+with `--enable-spec-capture [--spec-capture-aux-layer-ids ...]
+--chunked-prefill-size -1`, capture per-request aux/last hidden states during
+prefill and write them straight into a Mooncake store in
+`MooncakeFeatureStore`'s zero-copy key layout
+(`{store_id}/{sample_id}/g{gen}/{name}`, raw bytes, hard-pinned). The response
+`meta_info["spec_capture"]` carries only keys/shapes/dtypes; the client side is
+`specforge/inference/adapters/server_capture.py`. Apply to an installed sglang
+with `scripts/apply_sglang_spec_capture_patch.sh`. Strategy naming is decided
+per request by the client (eagle3 / dflash / domino registered;
+`register_server_capture_schema` for new ones). It also answers the stock
+`model_runner.py` TODO ("expose this to server args?") — the aux-capture
+upstream proposal from the O1.3 spike (PR #641) is exactly this surface.

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -165,7 +165,6 @@ def _checkpoint_global_step(resume_from: str) -> int:
 def _assemble_rollout_workers(
     *,
     spec: StrategySpec,
-    target_model,
     controller: DataFlowController,
     store: FeatureStore,
     run_id: str,
@@ -178,11 +177,16 @@ def _assemble_rollout_workers(
     t2d,
     num_rollout_workers: int,
     device: str,
+    target_model=None,
+    feature_source=None,
 ):
     """Build the rollout producer workers (colocated-online + disagg producer).
 
-    The capture contract derives from ``spec.required_features``; strategies with
-    ``supports_online=False`` raise here rather than emit the wrong feature schema.
+    ``feature_source`` overrides the in-process adapter with a pre-built
+    FeatureSource/RefSource (e.g. the server-capture transport, whose live
+    SGLang server writes features straight to the store — no ``target_model``
+    is loaded here). Otherwise an in-process adapter is built over
+    ``target_model``.
     """
     if not spec.supports_online:
         raise NotImplementedError(
@@ -197,7 +201,9 @@ def _assemble_rollout_workers(
         aux_hidden_state_layer_ids = tuple(
             getattr(target_model, "aux_hidden_states_layers", ()) or ()
         )
-    if spec.make_adapter is not None:
+    if feature_source is not None:
+        adapter = feature_source
+    elif spec.make_adapter is not None:
         adapter = spec.make_adapter(target_model, device=device, t2d=t2d)
     else:
         from specforge.inference.adapters.policy import (
@@ -503,7 +509,7 @@ def build_online_runtime(
 def build_disagg_online_producer(
     *,
     strategy: str = "eagle3",
-    target_model,
+    target_model=None,
     prompts,
     feature_store: FeatureStore,
     channel,
@@ -517,6 +523,7 @@ def build_disagg_online_producer(
     t2d=None,
     num_rollout_workers: int = 1,
     device: str = "cuda",
+    feature_source=None,
     lease: int = 8,
     in_flight_high_watermark: int = 256,
     backpressure_poll_s: float = 0.2,
@@ -527,11 +534,13 @@ def build_disagg_online_producer(
     """Producer side of an ONLINE disaggregated run (rollout pool).
 
     Workers put() into a cross-node ``feature_store``; committed refs stream to
-    the consumer via ``channel``. ``metadata_store``/``metadata_db_path`` must be
-    the same durable store the consumer opens. Returns ``(workers,
-    drive_producer)``: ``drive_producer(should_stop=...)`` runs until the prompt
-    pool drains, pauses above ``in_flight_high_watermark``, and always closes the
-    channel on exit (EOF terminates the consumer's loader).
+    the consumer via ``channel``. Pass ``feature_source`` for the server-capture
+    transport (live SGLang server writes to the store; ``target_model`` stays
+    None). ``metadata_store``/``metadata_db_path`` must be the same durable store
+    the consumer opens. Returns ``(workers, drive_producer)``:
+    ``drive_producer(should_stop=...)`` runs until the prompt pool drains, pauses
+    above ``in_flight_high_watermark``, and always closes the channel on exit
+    (EOF terminates the consumer's loader).
     """
     import time
 
@@ -546,6 +555,7 @@ def build_disagg_online_producer(
     workers = _assemble_rollout_workers(
         spec=spec,
         target_model=target_model,
+        feature_source=feature_source,
         controller=controller,
         store=feature_store,
         run_id=run_id,

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -414,6 +414,30 @@ class MooncakeFeatureStore(FeatureStore):
             },
         )
 
+    def adopt(self, sample_ref: SampleRef) -> None:
+        """Register an externally-produced sample for lifecycle management.
+
+        The server-capture transport writes tensors into this store's key
+        namespace from ANOTHER process (the SGLang server's sink), so this
+        instance has no put-side bookkeeping for them. ``adopt()`` records the
+        ref's generation / feature names / size so ``release``/``abort``/``gc``
+        can free the server-written objects exactly like locally-put ones.
+        """
+        gen = sample_ref.metadata.get("generation")
+        if gen is None:
+            raise ValueError(
+                f"cannot adopt {sample_ref.sample_id}: ref carries no generation"
+            )
+        with self._lock:
+            self._generation[sample_ref.sample_id] = int(gen)
+            self._sample_names[sample_ref.sample_id] = list(
+                sample_ref.feature_keys.keys()
+            )
+            self._sample_bytes[sample_ref.sample_id] = int(
+                sample_ref.estimated_bytes or 0
+            )
+            self._put_time[sample_ref.sample_id] = self._clock()
+
     # -- read --------------------------------------------------------------
     def get(
         self,

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -251,7 +251,9 @@ class TestServerCaptureAdapter(unittest.TestCase):
             )
             self.assertEqual(ref.feature_specs["target"].shape, (1, length, HIDDEN))
             self.assertEqual(ref.feature_specs["target"].target_repr, "hidden_state")
-            self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, length, 1))
+            # offline convention for the hidden_state train path: (B, L);
+            # TargetHead.preprocess adds the trailing mask dim
+            self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, length))
             # zero-copy consume: bytes come back bit-exact from the fake store
             out, handle = store.get(ref)
             for name, expected in server.expected[ref.sample_id].items():

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -14,6 +14,8 @@ zero-copy ``MooncakeFeatureStore.get``. The real-server end-to-end lives in
 """
 
 import ctypes
+import os
+import tempfile
 import unittest
 from typing import Any, Dict, List
 
@@ -386,8 +388,6 @@ class TestServerCaptureProducerWiring(unittest.TestCase):
     """The example's exact path: build_disagg_online_producer(feature_source=...)."""
 
     def test_producer_streams_refs_via_feature_source(self):
-        import tempfile
-
         from specforge.launch import build_disagg_online_producer
         from specforge.runtime.data_plane.streaming_ref_channel import (
             StreamingRefChannel,
@@ -428,7 +428,7 @@ class TestServerCaptureProducerWiring(unittest.TestCase):
         )
         produced = drive()
         self.assertEqual(produced, len(prompts))
-        self.assertEqual(channel.published(), len(prompts))
+        self.assertEqual(channel.published, len(prompts))
         self.assertTrue(channel.is_closed())
 
 

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -1,0 +1,388 @@
+# coding=utf-8
+"""Unit tests for the server-side spec-capture transport (no GPU, no server).
+
+A stub ``post_fn`` stands in for the patched SGLang server: it writes raw
+tensor bytes into the shared fake Mooncake backend at the sink's key layout
+(``{store_id}/{sample_id}/g{gen}/{name}``) and returns the
+``meta_info["spec_capture"]`` result rows — i.e. it emulates
+``patches/sglang/v0.5.14/spec-capture.patch``'s ``SpecCaptureSink`` byte-for-
+byte. The tests then drive the REAL client stack over it:
+``SGLangServerCaptureAdapter.produce_refs`` -> contract verification from
+FeatureSpecs -> ``MooncakeFeatureStore.adopt`` -> ``RolloutWorker`` commit ->
+zero-copy ``MooncakeFeatureStore.get``. The real-server end-to-end lives in
+``test_server_capture_gate.py`` (opt-in, needs GPU + mooncake master).
+"""
+
+import ctypes
+import unittest
+from typing import Any, Dict, List
+
+import torch
+
+from specforge.inference.adapters.server_capture import (
+    SGLangServerCaptureAdapter,
+    ServerCaptureFailure,
+    resolve_server_capture_schema,
+)
+from specforge.inference.capture import (
+    FeatureContract,
+    FeatureContractError,
+    verify_feature_contract_specs,
+)
+from specforge.runtime.contracts import FeatureSpec, PromptTask, SampleRef
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+
+HIDDEN = 8
+AUX_LAYERS = (2, 5, 8)
+
+
+class _FakeMooncakeStore:
+    """API-subset fake (mirrors test_mooncake_store's), shared server<->client."""
+
+    def __init__(self) -> None:
+        self._d = {}
+        self.last_config = None
+
+    def is_exist(self, key):
+        return 1 if key in self._d else 0
+
+    def register_buffer(self, ptr, size):
+        return 0
+
+    def unregister_buffer(self, ptr):
+        return 0
+
+    def put_from(self, key, ptr, size, config=None):
+        self.last_config = config
+        self._d[key] = ctypes.string_at(ptr, size)
+        return 0
+
+    def get_into(self, key, ptr, size):
+        data = self._d.get(key)
+        if not data:
+            return -1
+        n = min(size, len(data))
+        ctypes.memmove(ptr, data, n)
+        return n
+
+    def remove(self, key):
+        self._d.pop(key, None)
+        return 0
+
+    def get_size(self, key):
+        return len(self._d.get(key, b""))
+
+
+def _dtype_str(t: torch.Tensor) -> str:
+    return str(t.dtype).replace("torch.", "")
+
+
+class _StubCaptureServer:
+    """Emulates the patched server: sink writes + meta_info result rows."""
+
+    def __init__(
+        self,
+        backend: _FakeMooncakeStore,
+        *,
+        hidden: int = HIDDEN,
+        aux_width: int = len(AUX_LAYERS) * HIDDEN,
+        aux_layer_ids=AUX_LAYERS,
+        error_sample_ids=(),
+    ) -> None:
+        self.backend = backend
+        self.hidden = hidden
+        self.aux_width = aux_width
+        self.aux_layer_ids = list(aux_layer_ids)
+        self.error_sample_ids = set(error_sample_ids)
+        self.expected: Dict[str, Dict[str, torch.Tensor]] = {}
+
+    def _put(self, key: str, t: torch.Tensor) -> None:
+        t = t.detach().cpu().contiguous()
+        self.backend.put_from(key, t.data_ptr(), t.element_size() * t.numel())
+
+    def __call__(self, url: str, json_body: Dict[str, Any], timeout: float):
+        assert url.endswith("/generate")
+        rows: List[Dict[str, Any]] = []
+        for input_ids, spec in zip(
+            json_body["input_ids"], json_body["spec_capture"]
+        ):
+            sid, gen = spec["sample_id"], int(spec["gen"])
+            if sid in self.error_sample_ids:
+                rows.append(
+                    {"meta_info": {"spec_capture_error": ["injected sink error"]}}
+                )
+                continue
+            length = len(input_ids)
+            torch.manual_seed(length + gen)
+            written: Dict[str, torch.Tensor] = {}
+            feats: Dict[str, Dict[str, Any]] = {}
+
+            def _write(name: str, t: torch.Tensor) -> None:
+                self._put(f"{spec['store_id']}/{sid}/g{gen}/{name}", t)
+                written[name] = t
+                feats[name] = {"shape": list(t.shape), "dtype": _dtype_str(t)}
+
+            mapping = spec["features"]
+            if "aux" in mapping:
+                _write(
+                    mapping["aux"],
+                    torch.randn(1, length, self.aux_width, dtype=torch.bfloat16),
+                )
+            if "last_hidden" in mapping:
+                _write(
+                    mapping["last_hidden"],
+                    torch.randn(1, length, self.hidden, dtype=torch.bfloat16),
+                )
+            for item in spec.get("passthrough", []):
+                _write(
+                    item["name"],
+                    torch.tensor(item["data"], dtype=torch.int64).reshape(
+                        item["shape"]
+                    ),
+                )
+            self.expected[sid] = written
+            rows.append(
+                {
+                    "meta_info": {
+                        "spec_capture": [
+                            {
+                                "sample_id": sid,
+                                "store_id": spec["store_id"],
+                                "gen": gen,
+                                "aux_layer_ids": self.aux_layer_ids,
+                                "features": feats,
+                            }
+                        ]
+                    }
+                }
+            )
+        return rows
+
+
+class _FakeController:
+    def __init__(self):
+        self.committed: List[SampleRef] = []
+        self.failed: List[Dict[str, Any]] = []
+        self.leased: List[PromptTask] = []
+
+    def register_rollout_worker(self, info):
+        return info.get("worker_id") or "w0"
+
+    def lease_prompt_tasks(self, worker_id, max_tasks):
+        out, self.leased = self.leased[:max_tasks], self.leased[max_tasks:]
+        return out
+
+    def commit_samples(self, worker_id, refs):
+        self.committed.extend(refs)
+
+    def fail_prompt_tasks(self, worker_id, task_ids, *, reason, retryable):
+        self.failed.append(
+            {"task_ids": list(task_ids), "reason": reason, "retryable": retryable}
+        )
+
+
+def _task(i: int, length: int) -> PromptTask:
+    return PromptTask(
+        task_id=f"t{i}",
+        run_id="run0",
+        source_id="unit",
+        payload={
+            "input_ids": list(range(1, length + 1)),
+            "loss_mask": [0] * (length // 2) + [1] * (length - length // 2),
+        },
+        max_length=length,
+    )
+
+
+def _eagle3_contract() -> FeatureContract:
+    return FeatureContract.from_strategy(
+        required_features={
+            "input_ids",
+            "attention_mask",
+            "loss_mask",
+            "hidden_state",
+            "target",
+        },
+        aux_hidden_state_layer_ids=AUX_LAYERS,
+        target_repr="hidden_state",
+        target_hidden_size=HIDDEN,
+    )
+
+
+def _dflash_contract() -> FeatureContract:
+    return FeatureContract.from_strategy(
+        required_features={"input_ids", "hidden_states", "loss_mask"},
+        aux_hidden_state_layer_ids=AUX_LAYERS,
+        target_repr="hidden_state",
+        target_hidden_size=HIDDEN,
+    )
+
+
+def _mk(strategy="eagle3", server=None, backend=None):
+    backend = backend or _FakeMooncakeStore()
+    server = server or _StubCaptureServer(backend)
+    store = MooncakeFeatureStore(store=backend, store_id="run0")
+    adapter = SGLangServerCaptureAdapter(
+        "http://server:30000",
+        store,
+        run_id="run0",
+        strategy=strategy,
+        post_fn=server,
+    )
+    return backend, server, store, adapter
+
+
+class TestServerCaptureAdapter(unittest.TestCase):
+    def test_eagle3_refs_and_zero_copy_roundtrip(self):
+        backend, server, store, adapter = _mk()
+        tasks = [_task(0, 6), _task(1, 9)]
+        refs = adapter.produce_refs(tasks, capture=_eagle3_contract())
+        self.assertEqual(len(refs), 2)
+        for task, ref in zip(tasks, refs):
+            self.assertIsInstance(ref, SampleRef)
+            self.assertEqual(ref.sample_id, f"run0:{task.task_id}")
+            self.assertEqual(ref.strategy, "eagle3")
+            self.assertEqual(ref.metadata["generation"], 1)
+            self.assertEqual(ref.metadata["transport"], "sglang_server_capture")
+            length = len(task.payload["input_ids"])
+            self.assertEqual(
+                ref.feature_specs["hidden_state"].shape,
+                (1, length, len(AUX_LAYERS) * HIDDEN),
+            )
+            self.assertEqual(ref.feature_specs["target"].shape, (1, length, HIDDEN))
+            self.assertEqual(ref.feature_specs["target"].target_repr, "hidden_state")
+            self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, length, 1))
+            # zero-copy consume: bytes come back bit-exact from the fake store
+            out, handle = store.get(ref)
+            for name, expected in server.expected[ref.sample_id].items():
+                self.assertTrue(
+                    torch.equal(out[name], expected),
+                    f"{name} mismatch after zero-copy roundtrip",
+                )
+            store.release(handle)
+        # consume-once: released samples are physically freed
+        self.assertFalse(any(backend._d))
+
+    def test_dflash_schema_names_and_no_target(self):
+        backend, server, store, adapter = _mk(strategy="dflash")
+        refs = adapter.produce_refs([_task(0, 5)], capture=_dflash_contract())
+        (ref,) = refs
+        self.assertIsInstance(ref, SampleRef)
+        self.assertEqual(
+            sorted(ref.feature_specs), ["hidden_states", "input_ids", "loss_mask"]
+        )
+        self.assertEqual(
+            ref.feature_specs["hidden_states"].shape,
+            (1, 5, len(AUX_LAYERS) * HIDDEN),
+        )
+        self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, 5))
+        out, _ = store.get(ref)
+        self.assertEqual(
+            out["input_ids"].tolist(), [list(range(1, 6))]
+        )
+
+    def test_aux_width_mismatch_fails_loud_and_frees_keys(self):
+        backend = _FakeMooncakeStore()
+        server = _StubCaptureServer(backend, aux_width=HIDDEN)  # wrong width
+        _, _, store, adapter = _mk(server=server, backend=backend)
+        (result,) = adapter.produce_refs([_task(0, 4)], capture=_eagle3_contract())
+        self.assertIsInstance(result, ServerCaptureFailure)
+        self.assertFalse(result.retryable)
+        self.assertIn("aux width", result.reason)
+        # the mismatched sample's server-written keys were freed via abort
+        self.assertFalse(any(backend._d), f"leaked keys: {list(backend._d)}")
+
+    def test_per_task_server_error_becomes_failure_marker(self):
+        backend = _FakeMooncakeStore()
+        server = _StubCaptureServer(backend, error_sample_ids={"run0:t0"})
+        _, _, store, adapter = _mk(server=server, backend=backend)
+        results = adapter.produce_refs(
+            [_task(0, 4), _task(1, 4)], capture=_eagle3_contract()
+        )
+        self.assertIsInstance(results[0], ServerCaptureFailure)
+        self.assertIn("injected sink error", results[0].reason)
+        self.assertIsInstance(results[1], SampleRef)
+
+    def test_rollout_worker_ref_path(self):
+        from specforge.inference.rollout_worker import RolloutWorker
+
+        backend = _FakeMooncakeStore()
+        server = _StubCaptureServer(backend, error_sample_ids={"run0:t1"})
+        _, _, store, adapter = _mk(server=server, backend=backend)
+        controller = _FakeController()
+        controller.leased = [_task(0, 4), _task(1, 4), _task(2, 7)]
+        worker = RolloutWorker(
+            controller,
+            store,
+            adapter,
+            _eagle3_contract(),
+            run_id="run0",
+            worker_id="w0",
+        )
+        worker.start()
+        refs = worker.run_once(max_tasks=8)
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(len(controller.committed), 2)
+        self.assertEqual(len(controller.failed), 1)
+        self.assertEqual(controller.failed[0]["task_ids"], ["t1"])
+        self.assertIn("injected sink error", controller.failed[0]["reason"])
+
+    def test_adopt_enables_abort_of_server_written_keys(self):
+        backend, server, store, adapter = _mk()
+        (ref,) = adapter.produce_refs([_task(0, 4)], capture=_eagle3_contract())
+        self.assertTrue(any(backend._d))
+        store.abort(ref.sample_id, reason="unit")  # adopt() made this effective
+        self.assertFalse(any(backend._d))
+        with self.assertRaises(KeyError):
+            store.get(ref)
+
+    def test_retry_bumps_generation(self):
+        backend, server, store, adapter = _mk()
+        task = PromptTask(
+            task_id="t0",
+            run_id="run0",
+            source_id="unit",
+            payload={"input_ids": [1, 2, 3]},
+            max_length=3,
+            attempt=2,
+        )
+        (ref,) = adapter.produce_refs([task], capture=_eagle3_contract())
+        self.assertEqual(ref.metadata["generation"], 3)
+        self.assertTrue(any("/g3/" in k for k in backend._d))
+
+    def test_verify_specs_matches_tensor_verification_semantics(self):
+        contract = _eagle3_contract()
+        specs = {
+            n: FeatureSpec(name=n, shape=s, dtype="bfloat16")
+            for n, s in {
+                "input_ids": (1, 4),
+                "attention_mask": (1, 4),
+                "loss_mask": (1, 4, 1),
+                "hidden_state": (1, 4, len(AUX_LAYERS) * HIDDEN),
+                "target": (1, 4, HIDDEN),
+            }.items()
+        }
+        verify_feature_contract_specs(
+            specs, contract, sample_id="s0", recorded_aux_layer_ids=AUX_LAYERS
+        )
+        bad = dict(specs)
+        bad["hidden_state"] = FeatureSpec(
+            name="hidden_state", shape=(1, 4, HIDDEN), dtype="bfloat16"
+        )
+        with self.assertRaises(FeatureContractError):
+            verify_feature_contract_specs(bad, contract, sample_id="s0")
+        with self.assertRaises(FeatureContractError):
+            verify_feature_contract_specs(
+                specs,
+                contract,
+                sample_id="s0",
+                recorded_aux_layer_ids=(1, 2, 3),
+            )
+
+    def test_unknown_strategy_raises(self):
+        with self.assertRaises(KeyError):
+            resolve_server_capture_schema("nonexistent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -20,8 +20,8 @@ from typing import Any, Dict, List
 import torch
 
 from specforge.inference.adapters.server_capture import (
-    SGLangServerCaptureAdapter,
     ServerCaptureFailure,
+    SGLangServerCaptureAdapter,
     resolve_server_capture_schema,
 )
 from specforge.inference.capture import (
@@ -103,9 +103,7 @@ class _StubCaptureServer:
     def __call__(self, url: str, json_body: Dict[str, Any], timeout: float):
         assert url.endswith("/generate")
         rows: List[Dict[str, Any]] = []
-        for input_ids, spec in zip(
-            json_body["input_ids"], json_body["spec_capture"]
-        ):
+        for input_ids, spec in zip(json_body["input_ids"], json_body["spec_capture"]):
             sid, gen = spec["sample_id"], int(spec["gen"])
             if sid in self.error_sample_ids:
                 rows.append(
@@ -279,9 +277,7 @@ class TestServerCaptureAdapter(unittest.TestCase):
         )
         self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, 5))
         out, _ = store.get(ref)
-        self.assertEqual(
-            out["input_ids"].tolist(), [list(range(1, 6))]
-        )
+        self.assertEqual(out["input_ids"].tolist(), [list(range(1, 6))])
 
     def test_aux_width_mismatch_fails_loud_and_frees_keys(self):
         backend = _FakeMooncakeStore()
@@ -384,6 +380,56 @@ class TestServerCaptureAdapter(unittest.TestCase):
     def test_unknown_strategy_raises(self):
         with self.assertRaises(KeyError):
             resolve_server_capture_schema("nonexistent")
+
+
+class TestServerCaptureProducerWiring(unittest.TestCase):
+    """The example's exact path: build_disagg_online_producer(feature_source=...)."""
+
+    def test_producer_streams_refs_via_feature_source(self):
+        import tempfile
+
+        from specforge.launch import build_disagg_online_producer
+        from specforge.runtime.data_plane.streaming_ref_channel import (
+            StreamingRefChannel,
+        )
+
+        backend = _FakeMooncakeStore()
+        server = _StubCaptureServer(backend)
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        adapter = SGLangServerCaptureAdapter(
+            "http://server:30000",
+            store,
+            run_id="run0",
+            strategy="dflash",
+            post_fn=server,
+        )
+        prompts = [
+            {
+                "payload": {
+                    "input_ids": list(range(1, 5 + i)),
+                    "loss_mask": [1] * (4 + i),
+                }
+            }
+            for i in range(3)
+        ]
+        channel = StreamingRefChannel(
+            os.path.join(tempfile.mkdtemp(prefix="sc_prod_"), "refs.jsonl")
+        )
+        _workers, drive = build_disagg_online_producer(
+            strategy="dflash",
+            feature_source=adapter,
+            prompts=prompts,
+            feature_store=store,
+            channel=channel,
+            run_id="run0",
+            target_hidden_size=HIDDEN,
+            target_repr=None,
+            aux_hidden_state_layer_ids=AUX_LAYERS,
+        )
+        produced = drive()
+        self.assertEqual(produced, len(prompts))
+        self.assertEqual(channel.published(), len(prompts))
+        self.assertTrue(channel.is_closed())
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime/test_server_capture_gate.py
+++ b/tests/test_runtime/test_server_capture_gate.py
@@ -281,9 +281,7 @@ class TestServerCaptureGate(unittest.TestCase):
         )
         refs = adapter.produce_refs(self._tasks(rows), capture=contract)
         for ref in refs:
-            self.assertIsInstance(
-                ref, SampleRef, f"expected a ref, got failure: {ref}"
-            )
+            self.assertIsInstance(ref, SampleRef, f"expected a ref, got failure: {ref}")
 
         aux_ref, logits_ref = self._hf_reference(rows)
         from specforge.modeling.target.target_head import TargetHead
@@ -351,9 +349,7 @@ class TestServerCaptureGate(unittest.TestCase):
                 dm, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
             )
         )
-        core = TrainerCore(
-            Eagle3TrainStrategy(model, target_head=head), backend
-        )
+        core = TrainerCore(Eagle3TrainStrategy(model, target_head=head), backend)
         # batch_size=1 batches (ragged lengths), one step each
         for i, out in enumerate(fetched):
             batch = TrainBatch(
@@ -392,12 +388,8 @@ class TestServerCaptureGate(unittest.TestCase):
         (ref,) = adapter.produce_refs(self._tasks(rows), capture=contract)
         self.assertIsInstance(ref, SampleRef, f"expected a ref, got: {ref}")
         out, handle = store.get(ref)
-        self.assertEqual(
-            sorted(out), ["hidden_states", "input_ids", "loss_mask"]
-        )
-        self.assertEqual(
-            out["hidden_states"].shape, (1, 5, len(AUX_LAYER_IDS) * H)
-        )
+        self.assertEqual(sorted(out), ["hidden_states", "input_ids", "loss_mask"])
+        self.assertEqual(out["hidden_states"].shape, (1, 5, len(AUX_LAYER_IDS) * H))
         aux_ref, _ = self._hf_reference(rows)
         torch.testing.assert_close(
             out["hidden_states"].float(), aux_ref[0].float(), rtol=TOL, atol=TOL

--- a/tests/test_runtime/test_server_capture_gate.py
+++ b/tests/test_runtime/test_server_capture_gate.py
@@ -87,6 +87,22 @@ class TestServerCaptureGate(unittest.TestCase):
         model = LlamaForCausalLM(cfg).to(torch.bfloat16)
         cls.target_dir = os.path.join(cls.workdir, "target")
         model.save_pretrained(cls.target_dir)
+        # save_pretrained writes a single un-indexed shard for tiny models;
+        # TargetHead.load_weights locates lm_head.weight via the index file.
+        index = os.path.join(cls.target_dir, "model.safetensors.index.json")
+        if not os.path.exists(index):
+            import json
+
+            with open(index, "w") as f:
+                json.dump(
+                    {
+                        "metadata": {},
+                        "weight_map": {
+                            "lm_head.weight": "model.safetensors",
+                        },
+                    },
+                    f,
+                )
 
         cls._ensure_mooncake_master()
 
@@ -284,7 +300,7 @@ class TestServerCaptureGate(unittest.TestCase):
             )
             self.assertEqual(out["target"].shape, (1, length, H))
             self.assertEqual(out["input_ids"].tolist(), [rows[i]])
-            self.assertEqual(out["loss_mask"].shape, (1, length, 1))
+            self.assertEqual(out["loss_mask"].shape, (1, length))
             # extraction correctness vs the independent HF forward
             torch.testing.assert_close(
                 out["hidden_state"].float(),

--- a/tests/test_runtime/test_server_capture_gate.py
+++ b/tests/test_runtime/test_server_capture_gate.py
@@ -1,0 +1,393 @@
+# coding=utf-8
+"""Server-capture gate: a LIVE patched SGLang server writes features into a
+LIVE Mooncake store; the data plane consumes them zero-copy and trains.
+
+What is pinned here:
+- the whole zero-copy transport end-to-end: ``/generate`` with ``spec_capture``
+  -> engine-side sink put (SpecForge key layout) -> ``SampleRef`` from
+  ``meta_info`` only -> ``MooncakeFeatureStore.get`` reads the server-written
+  bytes -> one real eagle3 train step (``target_repr="hidden_state"``, the
+  frozen TargetHead recomputes logits);
+- extraction correctness: the server-captured aux hidden states match an
+  independent HF ``output_hidden_states=True`` forward at the configured
+  layers, and ``lm_head(last_hidden)`` matches the HF logits (norm-placement
+  agnostic), within the documented bf16 tolerance;
+- strategy-agnosticism: the same server serves eagle3 (aux + last_hidden) and
+  dflash (aux only) requests, named per strategy by the client schema.
+
+OPT-IN: needs a GPU, sglang patched with
+``patches/sglang/v0.5.14/spec-capture.patch`` (see
+``scripts/apply_sglang_spec_capture_patch.sh``), the ``mooncake`` package, and
+a reachable/spawnable ``mooncake_master``. Enable with
+``SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1``.
+"""
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+ENABLED = os.environ.get("SPECFORGE_RUN_SERVER_CAPTURE_TESTS") == "1"
+PORT = 30989
+AUX_LAYER_IDS = [1, 3, 4]
+H, TOL = 64, 2e-2  # fixture hidden size; documented bf16 tolerance
+
+
+def _patched_sglang() -> bool:
+    return importlib.util.find_spec("sglang.srt.spec_capture_sink") is not None
+
+
+def _mooncake_available() -> bool:
+    return importlib.util.find_spec("mooncake.store") is not None
+
+
+@unittest.skipUnless(
+    CUDA and ENABLED,
+    "server-capture gate: set SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1 (GPU)",
+)
+class TestServerCaptureGate(unittest.TestCase):
+    server = None
+    master = None
+    workdir = None
+    target_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+        if not _patched_sglang():
+            raise unittest.SkipTest(
+                "installed sglang lacks spec_capture_sink — apply "
+                "patches/sglang/v0.5.14/spec-capture.patch "
+                "(scripts/apply_sglang_spec_capture_patch.sh)"
+            )
+        if not _mooncake_available():
+            raise unittest.SkipTest("mooncake package not installed")
+
+        from transformers import LlamaConfig, LlamaForCausalLM
+
+        cls.workdir = tempfile.mkdtemp(prefix="spec_capture_gate_")
+        cfg = LlamaConfig(
+            hidden_size=H,
+            intermediate_size=128,
+            num_hidden_layers=8,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            vocab_size=256,
+            max_position_embeddings=512,
+            rms_norm_eps=1e-5,
+            tie_word_embeddings=False,
+        )
+        torch.manual_seed(1234)
+        model = LlamaForCausalLM(cfg).to(torch.bfloat16)
+        cls.target_dir = os.path.join(cls.workdir, "target")
+        model.save_pretrained(cls.target_dir)
+
+        cls._ensure_mooncake_master()
+
+        env = dict(
+            os.environ,
+            FLASHINFER_DISABLE_VERSION_CHECK="1",
+            MOONCAKE_LOCAL_HOSTNAME=os.environ.get(
+                "MOONCAKE_LOCAL_HOSTNAME", "127.0.0.1"
+            ),
+        )
+        cls.server = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "sglang.launch_server",
+                "--model-path",
+                cls.target_dir,
+                "--skip-tokenizer-init",
+                "--attention-backend",
+                "triton",
+                "--mem-fraction-static",
+                "0.3",
+                "--chunked-prefill-size",
+                "-1",
+                "--enable-spec-capture",
+                "--spec-capture-aux-layer-ids",
+                *[str(i) for i in AUX_LAYER_IDS],
+                "--port",
+                str(PORT),
+            ],
+            stdout=open(os.path.join(cls.workdir, "server.log"), "w"),
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+        import requests
+
+        deadline = time.time() + 300
+        while time.time() < deadline:
+            try:
+                if requests.get(f"http://localhost:{PORT}/health", timeout=5).ok:
+                    return
+            except requests.RequestException:
+                pass
+            if cls.server.poll() is not None:
+                break
+            time.sleep(5)
+        raise RuntimeError(
+            f"sglang server did not become healthy; see {cls.workdir}/server.log"
+        )
+
+    @classmethod
+    def _ensure_mooncake_master(cls):
+        """Use an externally provided master, else spawn one locally."""
+        if os.environ.get("MOONCAKE_MASTER_SERVER_ADDR"):
+            return
+        binary = shutil.which("mooncake_master")
+        if binary is None:
+            raise unittest.SkipTest(
+                "no MOONCAKE_MASTER_SERVER_ADDR in env and no mooncake_master "
+                "binary on PATH"
+            )
+        cls.master = subprocess.Popen(
+            [binary, "--enable-http-metadata-server=true"],
+            stdout=open(os.path.join(cls.workdir, "mooncake_master.log"), "w"),
+            stderr=subprocess.STDOUT,
+        )
+        time.sleep(3)
+        if cls.master.poll() is not None:
+            raise unittest.SkipTest(
+                f"mooncake_master exited at startup; see "
+                f"{cls.workdir}/mooncake_master.log"
+            )
+        os.environ.setdefault("MOONCAKE_MASTER_SERVER_ADDR", "127.0.0.1:50051")
+        os.environ.setdefault(
+            "MOONCAKE_METADATA_SERVER", "http://127.0.0.1:8080/metadata"
+        )
+        os.environ.setdefault("MOONCAKE_LOCAL_HOSTNAME", "127.0.0.1")
+        os.environ.setdefault("MOONCAKE_PROTOCOL", "tcp")
+
+    @classmethod
+    def tearDownClass(cls):
+        for proc in (cls.server, cls.master):
+            if proc is not None and proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=30)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+    # -- helpers ---------------------------------------------------------------
+    def _store(self, store_id):
+        from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+
+        return MooncakeFeatureStore(
+            store_id=store_id,
+            setup_kwargs={
+                "local_hostname": os.environ["MOONCAKE_LOCAL_HOSTNAME"],
+                "metadata_server": os.environ["MOONCAKE_METADATA_SERVER"],
+                "global_segment_size": 1 << 28,
+                "local_buffer_size": 1 << 28,
+                "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
+                "rdma_devices": "",
+                "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
+            },
+        )
+
+    def _tasks(self, rows):
+        from specforge.runtime.contracts import PromptTask
+
+        return [
+            PromptTask(
+                task_id=f"t{i}",
+                run_id="gate0",
+                source_id="gate",
+                payload={
+                    "input_ids": list(r),
+                    "loss_mask": [0] + [1] * (len(r) - 2) + [0],
+                },
+                max_length=len(r),
+            )
+            for i, r in enumerate(rows)
+        ]
+
+    def _hf_reference(self, rows):
+        """Independent HF forward: per-row aux cat + full logits."""
+        from transformers import AutoModelForCausalLM
+
+        model = (
+            AutoModelForCausalLM.from_pretrained(
+                self.target_dir, torch_dtype=torch.bfloat16
+            )
+            .cuda()
+            .eval()
+        )
+        aux, logits = [], []
+        with torch.no_grad():
+            for r in rows:
+                ids = torch.tensor([r], dtype=torch.long, device="cuda")
+                out = model(input_ids=ids, output_hidden_states=True, use_cache=False)
+                # hidden_states[0]=embeddings; [k]=output of layer k-1, so
+                # "capture layer id L" (sglang convention) == hidden_states[L+1]
+                aux.append(
+                    torch.cat(
+                        [out.hidden_states[i + 1] for i in AUX_LAYER_IDS], dim=-1
+                    ).cpu()
+                )
+                logits.append(out.logits.cpu())
+        del model
+        torch.cuda.empty_cache()
+        return aux, logits
+
+    # -- tests -------------------------------------------------------------------
+    def test_eagle3_zero_copy_end_to_end(self):
+        from specforge.inference.adapters.server_capture import (
+            SGLangServerCaptureAdapter,
+        )
+        from specforge.inference.capture import FeatureContract
+        from specforge.runtime.contracts import SampleRef
+
+        rows = [[5, 6, 7, 8, 9, 10], [11, 12, 13, 14]]
+        store = self._store("gate-eagle3")
+        adapter = SGLangServerCaptureAdapter(
+            f"http://localhost:{PORT}", store, run_id="gate0", strategy="eagle3"
+        )
+        contract = FeatureContract.from_strategy(
+            required_features={
+                "input_ids",
+                "attention_mask",
+                "loss_mask",
+                "hidden_state",
+                "target",
+            },
+            aux_hidden_state_layer_ids=tuple(AUX_LAYER_IDS),
+            target_repr="hidden_state",
+            target_hidden_size=H,
+        )
+        refs = adapter.produce_refs(self._tasks(rows), capture=contract)
+        for ref in refs:
+            self.assertIsInstance(
+                ref, SampleRef, f"expected a ref, got failure: {ref}"
+            )
+
+        aux_ref, logits_ref = self._hf_reference(rows)
+        from specforge.modeling.target.target_head import TargetHead
+
+        head = TargetHead.from_pretrained(self.target_dir)
+
+        fetched = []
+        for i, ref in enumerate(refs):
+            out, handle = store.get(ref)
+            fetched.append(out)
+            length = len(rows[i])
+            self.assertEqual(
+                out["hidden_state"].shape, (1, length, len(AUX_LAYER_IDS) * H)
+            )
+            self.assertEqual(out["target"].shape, (1, length, H))
+            self.assertEqual(out["input_ids"].tolist(), [rows[i]])
+            self.assertEqual(out["loss_mask"].shape, (1, length, 1))
+            # extraction correctness vs the independent HF forward
+            torch.testing.assert_close(
+                out["hidden_state"].float(),
+                aux_ref[i].float(),
+                rtol=TOL,
+                atol=TOL,
+            )
+            with torch.no_grad():
+                recomputed = head(out["target"].cuda()).cpu().float()
+            torch.testing.assert_close(
+                recomputed, logits_ref[i].float(), rtol=TOL, atol=TOL
+            )
+            store.release(handle)
+
+        # one real train step from the server-captured features
+        self._train_step(fetched, head)
+
+    def _train_step(self, fetched, head):
+        from specforge import (
+            AutoDraftModelConfig,
+            AutoEagle3DraftModel,
+            OnlineEagle3Model,
+        )
+        from specforge.optimizer import BF16Optimizer
+        from specforge.runtime.contracts import TrainBatch
+        from specforge.training.backend import FSDPTrainingBackend, ParallelConfig
+        from specforge.training.controller import TrainerCore
+        from specforge.training.strategies.base import Eagle3TrainStrategy
+        from tests.test_runtime import _fixtures as fx
+
+        fx.build_single_rank_distributed(port="29576")
+        torch.manual_seed(0)
+        draft_cfg = AutoDraftModelConfig.from_file(
+            fx.write_draft_config(os.path.join(self.workdir, "draft.json"))
+        )
+        dm = AutoEagle3DraftModel.from_config(
+            draft_cfg, attention_backend="sdpa", torch_dtype=torch.bfloat16
+        ).cuda()
+        dm.load_vocab_mapping(
+            fx.write_vocab_mapping(os.path.join(self.workdir, "vm.pt"))
+        )
+        dm.freeze_embedding()
+        model = OnlineEagle3Model(dm, length=3, attention_backend="sdpa").cuda()
+        backend = FSDPTrainingBackend(ParallelConfig.from_distributed())
+        backend.prepare_model(model, wrap=False)
+        backend.set_optimizer(
+            BF16Optimizer(
+                dm, lr=1e-3, max_grad_norm=0.5, warmup_ratio=0.0, total_steps=10
+            )
+        )
+        core = TrainerCore(
+            Eagle3TrainStrategy(model, target_head=head), backend
+        )
+        # batch_size=1 batches (ragged lengths), one step each
+        for i, out in enumerate(fetched):
+            batch = TrainBatch(
+                sample_ids=[f"s{i}"],
+                strategy="eagle3",
+                tensors={
+                    "input_ids": out["input_ids"].cuda(),
+                    "attention_mask": out["attention_mask"].cuda(),
+                    "loss_mask": out["loss_mask"].cuda(),
+                    "target": out["target"].cuda(),
+                    "hidden_state": out["hidden_state"].cuda(),
+                },
+                metadata={"target_repr": "hidden_state", "ttt_length": 3},
+            )
+            result = core.train_step(batch)
+            self.assertTrue(torch.isfinite(torch.tensor(result.loss)))
+
+    def test_dflash_capture_same_server(self):
+        from specforge.inference.adapters.server_capture import (
+            SGLangServerCaptureAdapter,
+        )
+        from specforge.inference.capture import FeatureContract
+        from specforge.runtime.contracts import SampleRef
+
+        rows = [[3, 1, 4, 1, 5]]
+        store = self._store("gate-dflash")
+        adapter = SGLangServerCaptureAdapter(
+            f"http://localhost:{PORT}", store, run_id="gate1", strategy="dflash"
+        )
+        contract = FeatureContract.from_strategy(
+            required_features={"input_ids", "hidden_states", "loss_mask"},
+            aux_hidden_state_layer_ids=tuple(AUX_LAYER_IDS),
+            target_repr="hidden_state",
+            target_hidden_size=H,
+        )
+        (ref,) = adapter.produce_refs(self._tasks(rows), capture=contract)
+        self.assertIsInstance(ref, SampleRef, f"expected a ref, got: {ref}")
+        out, handle = store.get(ref)
+        self.assertEqual(
+            sorted(out), ["hidden_states", "input_ids", "loss_mask"]
+        )
+        self.assertEqual(
+            out["hidden_states"].shape, (1, 5, len(AUX_LAYER_IDS) * H)
+        )
+        aux_ref, _ = self._hf_reference(rows)
+        torch.testing.assert_close(
+            out["hidden_states"].float(), aux_ref[0].float(), rtol=TOL, atol=TOL
+        )
+        store.release(handle)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# [Online track] O2 — server-side spec capture: sglang 0.5.14 patch + zero-copy Mooncake transport into the data plane

## What this is

The **engine-side transport** that PR #641's reforward engine anticipated ("a future engine-side transport replaces step 2 without touching callers"). A live SGLang server — patched with a versioned, self-contained patch — captures aux/last hidden states **during its own prefill forward** and writes them **straight into the Mooncake store** in `MooncakeFeatureStore`'s zero-copy key layout. The rollout side builds committed-ready `SampleRef`s from response *metadata alone*; the trainer's existing `MooncakeFeatureStore.get()` reads the server-written bytes with **zero changes**. Feature tensors never cross the HTTP response, the rollout worker, or any re-serialization — one forward per sample, engine-side capture, RDMA-capable transport.

```
      producer pool                                     consumer pool
 ┌──────────────────────┐        ┌────────────┐        ┌─────────────────────┐
 │ patched SGLang server │ put() │  Mooncake  │ get()  │ FeatureDataLoader   │
 │ (--enable-spec-capture)──────▶│   store    │◀───────│  -> TrainStrategy   │
 └──────────▲───────────┘  RDMA/ └────────────┘  zero- └─────────────────────┘
            │ /generate + spec_capture         copy
 ┌──────────┴───────────┐  keys/shapes only   ┌─────────────────────┐
 │ SGLangServerCapture-  │────────────────────▶│ RolloutWorker       │
 │ Adapter (RefSource)   │      SampleRef      │ commit_samples      │
 └──────────────────────┘                      └─────────────────────┘
```

## vs the alternatives

| | in-process (`sglang` backend) | #641 reforward | **this PR** |
|---|---|---|---|
| forwards per sample | 1 | 2 (decode + re-capture) | **1** |
| sglang fork surface | 4 files (white-box ModelRunner) | 0 | versioned patch, 8 small hooks + 1 self-contained module |
| tensors travel | in-process | in-process (capture half) | **server → Mooncake → trainer, zero-copy** |
| inference/training scaling | colocated | server decouples decode only | **fully disaggregated** |

TorchSpec closed the same gap with a 16-file engine fork; this patch is deliberately smaller because sglang 0.5.14 already ships most of the machinery (`CaptureHiddenMode.FULL` returns the aux concatenation; `ModelRunner.init_aux_hidden_state_capture()` exists with a literal `TODO: expose this to server args?` — the patch answers that TODO, which is also the upstream API proposal from the O1.3 spike).

## The sglang patch (`patches/sglang/v0.5.14/spec-capture.patch`)

410 insertions: 8 existing files get thin hooks (~150 lines), all capture/store logic lives in ONE new self-contained module (`sglang/srt/spec_capture_sink.py`):

- `--enable-spec-capture` + `--spec-capture-aux-layer-ids`: aux capture on the target **without a speculative draft worker** (requires `--chunked-prefill-size -1`, asserted at boot)
- per-request `spec_capture` dict threaded `GenerateReqInput → Req` (one optional field; rides the existing `return_hidden_states`/`CaptureHiddenMode.FULL` path)
- `LogitsProcessorOutput.last_hidden_states`: under FULL+aux, the post-norm last hidden is exposed alongside the aux concatenation (the `target_repr="hidden_state"` representation)
- scheduler sink: per-request tensor slices → `put_from` raw bytes at `{store_id}/{sample_id}/g{gen}/{name}`, hard-pinned (SpecForge, not Mooncake LRU, is the lifetime authority); results ride the existing `customized_info` channel into `meta_info["spec_capture"]` — **no new IPC fields**
- failure → per-request `meta_info["spec_capture_error"]` + best-effort key cleanup (a partial sample is never consumable)

Apply to an installed sglang: `scripts/apply_sglang_spec_capture_patch.sh`.

## Strategy-agnostic (eagle3 + dflash + domino, and future drafts)

The server knows only two generic artifacts (`aux`, `last_hidden`) plus verbatim passthrough tensors. Feature **naming and shapes are decided per request by the client** via `ServerCaptureSchema` (`specforge/inference/adapters/server_capture.py`):

- **eagle3**: `aux → hidden_state`, `last_hidden → target` (`target_repr="hidden_state"`: the trainer's frozen `TargetHead` recomputes logits — storing (L, vocab) logits would be ~50× the traffic for no benefit), `loss_mask` stored `(1, L, 1)`
- **dflash / domino**: `aux → hidden_states`, no target, `loss_mask` `(1, L)`
- new strategies: `register_server_capture_schema(...)`

## Data-plane integration

- `RolloutWorker` gains the `RefSource` path: `produce_refs → verify-from-specs → commit`; per-task failure markers keep the lease bookkeeping exact (every leased task still ends in exactly one terminal controller action)
- `verify_feature_contract_specs()`: the same loud extraction-boundary checks (names / aux-layer ids / aux width / target dim), run from the returned `FeatureSpec` shapes — no tensor fetch
- `MooncakeFeatureStore.adopt(ref)`: registers server-written samples so producer-side `abort()`/`gc()` frees them; the consumer side needed **zero changes** (its consumer-cache path already handles refs it never put)

## Tests

- `tests/test_runtime/test_server_capture.py` (CPU, in the default suite): a stub server emulates the sink byte-for-byte against the fake Mooncake backend; drives the real adapter → worker → store stack. Covers: eagle3 zero-copy roundtrip (bit-exact), dflash naming, aux-width mismatch fails loud **and frees keys**, per-task server errors, worker commit/fail bookkeeping, adopt→abort, retry generation bump, spec-based verification parity.
- `tests/test_runtime/test_server_capture_gate.py` (opt-in `SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1`, GPU): boots a **real patched server + real mooncake master**; eagle3 refs → zero-copy `get()` → aux parity vs an independent HF `output_hidden_states` forward + `lm_head(last_hidden)` vs HF logits (bf16 `2e-2`, the extraction-gate tolerance) → **one real train step** with `target_repr="hidden_state"`; dflash capture on the same server.

## Validation (sci-h200, 8×H200, sglang==0.5.14 pip + patch applied, torch 2.11+cu130, live `mooncake_master`, TCP)

- patch applies cleanly to pristine `v0.5.14` (`git apply --check`) and to an installed sglang via the helper script (`patch -p2`)
- **GPU gate** (`SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1`): **2/2 OK** — eagle3: refs → zero-copy `get()` → aux parity vs HF `output_hidden_states` + `lm_head(last_hidden)` vs HF logits (bf16 2e-2) → one finite train step; dflash capture on the same server
- **full `tests/test_runtime` regression: 310 OK (skipped=4, xfail=1), zero failures** (includes the 9 new CPU contract tests)
- the gate caught a real integration bug during bring-up (eagle3 `loss_mask` must follow the offline `(B, L)` convention — `TargetHead.preprocess` adds the mask dim); fixed in this PR

## Relationship to PR #641

#641 (reforward, patch-free, base `dataflow-mla-draft`) stays valuable as the zero-patch fallback and for live-decode online capture; this PR is the transport its engine docstring anticipated. The two compose: #641's server decode + this patch's capture-on-prefill = one-forward online capture with generation (follow-up). Long-term both converge on upstreaming the capture API into sglang (`docs/roadmap/o13-capture-spike.md`) — this patch's server-args surface is that proposal, validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
