### PR TITLE
[Online track] O2 follow-up — server-capture fixes from the first real 5k-step disaggregated run

### DIFF
--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -70,7 +70,14 @@ def _ref_channel() -> StreamingRefChannel:
 
 
 def _mooncake_store() -> MooncakeFeatureStore:
-    """Connect to the same Mooncake master the server sink writes to."""
+    """Connect to the same Mooncake master the server sink writes to.
+
+    global_segment_size=0: producer/consumer are pure clients contributing NO
+    storage — every object lives in the long-lived server process's segment, so
+    a producer exit cannot take committed features with it. Size the SERVER's
+    segment (MOONCAKE_GLOBAL_SEGMENT_SIZE) for the in-flight watermark: objects
+    are hard-pinned, so an undersized segment fails puts rather than evicting.
+    """
     return MooncakeFeatureStore(
         store_id=RUN_ID,
         setup_kwargs={
@@ -79,6 +86,10 @@ def _mooncake_store() -> MooncakeFeatureStore:
             "master_server_addr": os.environ["MOONCAKE_MASTER_SERVER_ADDR"],
             "protocol": os.environ.get("MOONCAKE_PROTOCOL", "tcp"),
             "rdma_devices": os.environ.get("MOONCAKE_RDMA_DEVICES", ""),
+            "global_segment_size": int(os.environ.get("DISAGG_CLIENT_SEGMENT_SIZE", 0)),
+            "local_buffer_size": int(
+                os.environ.get("DISAGG_CLIENT_BUFFER_SIZE", 1 << 30)
+            ),
         },
     )
 

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -203,9 +203,16 @@ def run_consumer(args) -> None:
             try:
                 logdict[f"train/{key}"] = float(value)
             except (TypeError, ValueError):
-                continue
+                try:  # per-TTT-position list metrics -> log the mean
+                    seq = [float(x) for x in value]
+                except (TypeError, ValueError):
+                    continue
+                if seq:
+                    logdict[f"train/{key}_mean"] = sum(seq) / len(seq)
         if logdict:
             tracker.log(logdict, step=step)
+            summary = {k.split("/")[-1]: round(v, 4) for k, v in logdict.items()}
+            print(f"[consumer] step {step} {summary}", flush=True)
 
     print(f"[consumer] training from mooncake://{RUN_ID}", flush=True)
     trainer, loader = build_disagg_online_consumer(

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -242,14 +242,15 @@ def main() -> None:
     set_seed(args.seed)
     role = _role()
     print(f"[disagg-dflash] role={role} run_id={RUN_ID}", flush=True)
-    # The producer is a thin HTTP driver (no torch model); only the trainer
-    # needs the process group.
-    if role == "producer":
-        run_producer(args)
-        return
+    # Both roles need the process group: the producer loads no model, but the
+    # control plane / feature store query dist rank. Launch each under torchrun
+    # (the producer on a spare GPU, its own rendezvous endpoint).
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     try:
-        run_consumer(args)
+        if role == "producer":
+            run_producer(args)
+        else:
+            run_consumer(args)
     finally:
         destroy_distributed()
 

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -34,7 +34,13 @@ export MOONCAKE_LOCAL_HOSTNAME=${MOONCAKE_LOCAL_HOSTNAME:-127.0.0.1}
 export MOONCAKE_MASTER_SERVER_ADDR=${MOONCAKE_MASTER_SERVER_ADDR:-127.0.0.1:50051}
 export MOONCAKE_METADATA_SERVER=${MOONCAKE_METADATA_SERVER:-http://127.0.0.1:8080/metadata}
 export MOONCAKE_PROTOCOL=${MOONCAKE_PROTOCOL:-tcp}
-export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((4 << 30))}
+# The server sink's segment is the ONLY object storage (features are
+# hard-pinned: undersizing fails puts rather than evicting). Size it above the
+# producer watermark: 256 in-flight x ~100MB/sample at seq 2048 ~= 26GB.
+export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((64 << 30))}
+# Producer/consumer are pure clients (no segment): objects must not live in a
+# process that exits before training finishes.
+export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
 
 export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg}
 export DISAGG_SERVER_URL=http://127.0.0.1:$SERVER_PORT

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -37,8 +37,20 @@ index a99d25267..f5d0b35e7 100644
                  # FIXME: These fields are not logits-related but are passed through here as a
                  # workaround since ForwardBatch is local to forward_batch_generation().
                  # They should be moved to GenerationBatchResult to keep this class clean.
+diff --git a/python/sglang/srt/managers/detokenizer_manager.py b/python/sglang/srt/managers/detokenizer_manager.py
+index b05334dea..2853c8231 100644
+--- a/python/sglang/srt/managers/detokenizer_manager.py
++++ b/python/sglang/srt/managers/detokenizer_manager.py
+@@ -441,6 +441,7 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
+             output_token_ids_logprobs_idx=recv_obj.output_token_ids_logprobs_idx,
+             output_token_entropy_val=recv_obj.output_token_entropy_val,
+             output_hidden_states=recv_obj.output_hidden_states,
++            spec_capture=recv_obj.spec_capture,
+             routed_experts=routed_experts,
+             indexer_topk=indexer_topk,
+             customized_info=recv_obj.customized_info,
 diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/managers/io_struct.py
-index 951f35495..082f3a114 100644
+index 951f35495..2359c31b7 100644
 --- a/python/sglang/srt/managers/io_struct.py
 +++ b/python/sglang/srt/managers/io_struct.py
 @@ -284,6 +284,10 @@ class GenerateReqInput(BaseReq):
@@ -74,8 +86,28 @@ index 951f35495..082f3a114 100644
      # For observability
      time_stats: Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]] = None
  
+@@ -1179,6 +1191,9 @@ class BatchTokenIDOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
+     # The trainer step id. Used to know which step's weights are used for sampling.
+     token_steps: List[List[int]] = None
+ 
++    # Spec-training capture: one result dict per request (see spec_capture_sink).
++    spec_capture: Optional[List[Any]] = None
++
+     # Customized info
+     customized_info: Optional[Dict[str, List[Any]]] = None
+     # Detailed breakdown of cached tokens by source (device/host/storage)
+@@ -1247,6 +1262,9 @@ class BatchStrOutput(BaseBatchReq, SpeculativeDecodingMetricsMixin):
+     # The trainer step id. Used to know which step's weights are used for sampling.
+     token_steps: List[List[int]] = None
+ 
++    # Spec-training capture: one result dict per request (see spec_capture_sink).
++    spec_capture: Optional[List[Any]] = None
++
+     # Customized info
+     customized_info: Optional[Dict[str, List[Any]]] = None
+     # Detailed breakdown of cached tokens by source (device/host/storage)
 diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
-index f1dc81d17..4ab4fc985 100755
+index f1dc81d17..a93a466b7 100755
 --- a/python/sglang/srt/managers/schedule_batch.py
 +++ b/python/sglang/srt/managers/schedule_batch.py
 @@ -708,6 +708,7 @@ class Req(ReqDllmMixin):
@@ -86,7 +118,7 @@ index f1dc81d17..4ab4fc985 100755
      ):
          # Input and output info
          self.rid = rid
-@@ -771,7 +772,12 @@ class Req(ReqDllmMixin):
+@@ -771,7 +772,13 @@ class Req(ReqDllmMixin):
              }
          self.sampling_params = sampling_params
          self.custom_logit_processor = custom_logit_processor
@@ -97,6 +129,7 @@ index f1dc81d17..4ab4fc985 100755
 +        self.return_hidden_states = return_hidden_states or spec_capture is not None
 +        self.spec_capture_aux: List[torch.Tensor] = []
 +        self.spec_capture_last_hidden: List[torch.Tensor] = []
++        self.spec_capture_result = None  # per-request sink result -> output field
  
          # extra key for classifying the request (e.g. cache_salt)
          if lora_id is not None:
@@ -133,7 +166,7 @@ index abba37441..3018b8247 100644
              req.tokenizer = self.tokenizer
  
 diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-index a9d5f0c28..2b2547509 100644
+index a9d5f0c28..001eff804 100644
 --- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 +++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 @@ -257,6 +257,18 @@ class SchedulerBatchResultProcessor:
@@ -186,9 +219,10 @@ index a9d5f0c28..2b2547509 100644
 +    def _sink_spec_capture(self, req: Req) -> None:
 +        """Write a finished capture request's tensors to the Mooncake sink.
 +
-+        Runs on the attention-TP rank that streams output; failures land in
-+        ``req.customized_info["spec_capture_error"]`` so the client sees a loud
-+        per-request error instead of a silent missing feature.
++        Runs on the attention-TP rank that streams output; the per-request result
++        (or an ``{"error": ...}`` marker) is set on ``req.spec_capture_result``,
++        returned to the client via the dedicated ``spec_capture`` output field
++        (a per-request channel, unlike per-token ``customized_info``).
 +        """
 +        from sglang.srt import spec_capture_sink
 +
@@ -202,24 +236,52 @@ index a9d5f0c28..2b2547509 100644
 +            else None
 +        )
 +        try:
-+            result = sink.put_sample(req.spec_capture, aux=aux, last_hidden=last_hidden)
-+            payload = {"spec_capture": [result]}
++            req.spec_capture_result = sink.put_sample(
++                req.spec_capture, aux=aux, last_hidden=last_hidden
++            )
 +        except Exception as e:
 +            logger.error("spec-capture sink failed for %s: %s", req.rid, e)
-+            payload = {"spec_capture_error": [str(e)]}
-+        # Ride the customized_info channel into meta_info (one-elem list: the
-+        # streamer slices [0:1]) — no new IPC fields.
-+        if req.customized_info is None:
-+            req.customized_info = {}
-+        req.customized_info.update(payload)
++            req.spec_capture_result = {
++                "sample_id": req.spec_capture.get("sample_id"),
++                "error": str(e),
++            }
 +        req.spec_capture_aux = []
 +        req.spec_capture_last_hidden = []
 +
      def _append_prefill_hidden_states(
          self,
          *,
+diff --git a/python/sglang/srt/managers/scheduler_components/output_streamer.py b/python/sglang/srt/managers/scheduler_components/output_streamer.py
+index f95c59f6f..9e64326a1 100644
+--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
++++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
+@@ -273,6 +273,7 @@ class _GenerationStreamAccumulator:
+     spec_correct_drafts_histogram: list = field(default_factory=list)
+     retraction_counts: list = field(default_factory=list)
+     output_hidden_states: Optional[list] = None
++    spec_capture: list = field(default_factory=list)
+     routed_experts: Optional[list] = None
+     indexer_topk: Optional[list] = None
+     customized_info: dict = field(default_factory=dict)
+@@ -482,6 +483,8 @@ class _GenerationStreamAccumulator:
+                 self.output_hidden_states.append(hs)
+             else:
+                 self.output_hidden_states.append(None)
++        # Per-request spec-capture result (aligned with rids), like the field above.
++        self.spec_capture.append(getattr(req, "spec_capture_result", None))
+         if self.return_routed_experts:
+             self.routed_experts.append(
+                 req.routed_experts if req.return_routed_experts else None
+@@ -540,6 +543,7 @@ class _GenerationStreamAccumulator:
+             output_token_ids_logprobs_idx=self.output_token_ids_logprobs_idx,
+             output_token_entropy_val=None,
+             output_hidden_states=self.output_hidden_states,
++            spec_capture=self.spec_capture or None,
+             routed_experts=self.routed_experts,
+             indexer_topk=self.indexer_topk,
+             customized_info=self.customized_info,
 diff --git a/python/sglang/srt/managers/tokenizer_manager.py b/python/sglang/srt/managers/tokenizer_manager.py
-index bf932611a..dc7615f44 100644
+index bf932611a..f0e821ec4 100644
 --- a/python/sglang/srt/managers/tokenizer_manager.py
 +++ b/python/sglang/srt/managers/tokenizer_manager.py
 @@ -1172,6 +1172,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
@@ -230,6 +292,17 @@ index bf932611a..dc7615f44 100644
              )
          elif isinstance(obj, EmbeddingReqInput):
              # Resolve unresolved embed overrides now that input_ids are available
+@@ -1922,6 +1923,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
+                 hidden_states = recv_obj.output_hidden_states[i]
+                 if hidden_states is not None:
+                     meta_info["hidden_states"] = hidden_states
++            if getattr(recv_obj, "spec_capture", None):
++                sc = recv_obj.spec_capture[i]
++                if sc is not None:
++                    meta_info["spec_capture"] = sc
+             if getattr(recv_obj, "routed_experts", None):
+                 val = recv_obj.routed_experts[i]
+                 if val is not None:
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
 index 1cff5c983..a5935fa3c 100644
 --- a/python/sglang/srt/model_executor/model_runner.py

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -231,28 +231,34 @@ index bf932611a..dc7615f44 100644
          elif isinstance(obj, EmbeddingReqInput):
              # Resolve unresolved embed overrides now that input_ids are available
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 1cff5c983..d978ce788 100644
+index 1cff5c983..a5935fa3c 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -471,6 +471,13 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -471,6 +471,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                      # if there is no aux layer, set to None
                      self.eagle_aux_hidden_state_layer_ids = None
  
 +        if server_args.enable_spec_capture and not self.is_draft_worker:
-+            # Aux capture without a draft worker; None layer ids -> model default.
-+            self.eagle_use_aux_hidden_state = True
-+            self.eagle_aux_hidden_state_layer_ids = (
-+                server_args.spec_capture_aux_layer_ids
-+            )
++            # Aux capture without a draft worker, routed to the strategy's own
++            # capture method (they wire different submodules — e.g. VL models
++            # only populate layers_to_capture via the dflash path).
++            if getattr(server_args, "spec_capture_method", "eagle3") == "dflash":
++                self.dflash_use_aux_hidden_state = True
++                self.dflash_target_layer_ids = server_args.spec_capture_aux_layer_ids
++            else:
++                self.eagle_use_aux_hidden_state = True
++                self.eagle_aux_hidden_state_layer_ids = (
++                    server_args.spec_capture_aux_layer_ids
++                )
 +
          if self.spec_algorithm.is_dflash() and not self.is_draft_worker:
              from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
  
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index c7162c16d..257d8b4f7 100644
+index c7162c16d..d515b3c69 100644
 --- a/python/sglang/srt/server_args.py
 +++ b/python/sglang/srt/server_args.py
-@@ -2127,6 +2127,19 @@ class ServerArgs:
+@@ -2127,6 +2127,25 @@ class ServerArgs:
          bool,
          "Enable returning hidden states with responses.",
      ] = False
@@ -269,6 +275,12 @@ index c7162c16d..257d8b4f7 100644
 +        "spec-capture requests. Defaults to the model's EAGLE3 default layers "
 +        "(low/mid/high) when unset.",
 +    ] = None
++    spec_capture_method: A[
++        str,
++        "Capture method for --enable-spec-capture: 'eagle3' or 'dflash'. Must "
++        "match the draft strategy being trained; they wire capture onto "
++        "different submodules (VL targets only populate the dflash path).",
++    ] = "eagle3"
      enable_return_routed_experts: A[
          bool,
          "Enable returning routed experts of each layer with responses.",

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -307,18 +307,10 @@ class SGLangServerCaptureAdapter:
         out: List[Union[Any, ServerCaptureFailure]] = []
         for task, row in zip(tasks, rows):
             meta = row.get("meta_info") or {}
-            err = meta.get("spec_capture_error")
-            if err:
-                out.append(
-                    ServerCaptureFailure(
-                        task_id=task.task_id,
-                        reason=f"server_capture:{err[0]}",
-                        retryable=True,
-                    )
-                )
-                continue
-            results = meta.get("spec_capture")
-            if not results:
+            # meta_info["spec_capture"] is the per-request result dict (or an
+            # {"error": ...} marker) from the server's dedicated output field.
+            result = meta.get("spec_capture")
+            if not result:
                 out.append(
                     ServerCaptureFailure(
                         task_id=task.task_id,
@@ -331,7 +323,15 @@ class SGLangServerCaptureAdapter:
                     )
                 )
                 continue
-            result = results[0]
+            if result.get("error"):
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id,
+                        reason=f"server_capture:{result['error']}",
+                        retryable=True,
+                    )
+                )
+                continue
             ref = self._ref_from_result(task, result, capture)
             try:
                 verify_feature_contract_specs(

--- a/specforge/runtime/data_plane/feature_dataloader.py
+++ b/specforge/runtime/data_plane/feature_dataloader.py
@@ -16,6 +16,7 @@ the handle immediately, so prefetch can never race a release.
 
 from __future__ import annotations
 
+import time
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
 import torch
@@ -49,6 +50,7 @@ class FeatureDataLoader:
         drop_last: bool = True,
         strategy: str = "eagle3",
         ack: bool = True,
+        gc_interval_s: Optional[float] = 15.0,
     ) -> None:
         if (queue is None) == (refs is None):
             raise ValueError(
@@ -66,6 +68,20 @@ class FeatureDataLoader:
         self.strategy = strategy
         self.ack = ack
         self._seek_batches = 0
+        # Remote stores defer a physical free while the get() read-lease is live
+        # (Mooncake remove -> -706): release() parks it and gc() must retry.
+        # Pump gc on a cadence LONGER than the lease TTL — the store gives up
+        # after max_release_attempts, so rapid retries would leak the object.
+        self.gc_interval_s = gc_interval_s if hasattr(store, "gc") else None
+        self._last_gc = time.monotonic()
+
+    def _maybe_gc(self) -> None:
+        if self.gc_interval_s is None:
+            return
+        now = time.monotonic()
+        if now - self._last_gc >= self.gc_interval_s:
+            self._last_gc = now
+            self.store.gc()
 
     def _validate_refs(self, refs: List[SampleRef]) -> None:
         strategies = {ref.strategy for ref in refs}
@@ -112,6 +128,7 @@ class FeatureDataLoader:
         if self.clone_on_fetch:
             tensors = {k: v.clone() for k, v in tensors.items()}
         self.store.release(handle, reason="loaded")
+        self._maybe_gc()
         if self.per_sample_transform is not None:
             tensors = self.per_sample_transform(tensors)
         return tensors

--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -545,16 +545,29 @@ class MooncakeFeatureStore(FeatureStore):
 
         Zero-copy: one object per tensor, so remove every per-tensor key of the
         sample's current generation. Pickle: a single object.
+
+        Order matters against Mooncake's lease semantics: an is_exist probe
+        GRANTS a read lease, and a remove during any live lease fails (-706).
+        So each key is removed FIRST; the exist probe runs only after a failed
+        remove, purely to classify "already gone" as freed. (A probe on a
+        still-live key re-leases it, which is why gc() spaces retries beyond
+        the lease TTL.)
         """
         if not self._zero_copy:
-            return self._store_remove(self._key(sample_id))
+            if self._store_remove(self._key(sample_id)):
+                return True
+            return not self._store_exists(self._key(sample_id))
         gen = self._generation.get(sample_id)
         if gen is None:
             return True  # nothing tracked to remove (already freed)
         ok = True
         for name in self._sample_names.get(sample_id, []):
-            if not self._store_remove(self._tkey(sample_id, gen, name)):
-                ok = False
+            key = self._tkey(sample_id, gen, name)
+            if self._store_remove(key):
+                continue
+            if not self._store_exists(key):
+                continue  # already gone (freed remotely) counts as freed
+            ok = False
         return ok
 
     def _sample_exists(self, sample_id: str) -> bool:
@@ -632,11 +645,10 @@ class MooncakeFeatureStore(FeatureStore):
                         freed += 1
                     else:
                         self._release_pending.setdefault(sid, 0)
-            # reconcile release-pending: retry the fallible remote free
+            # reconcile release-pending: retry the fallible remote free.
+            # NO exists pre-check here: is_exist grants a read lease that would
+            # make the following remove fail (-706) on every retry.
             for sid in list(self._release_pending):
-                if not self._sample_exists(sid):
-                    freed_bytes += self._free_bookkeeping_locked(sid)
-                    continue
                 attempts = self._release_pending[sid] + 1
                 if self._try_physical_free(sid):
                     freed_bytes += self._free_bookkeeping_locked(sid)

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -389,6 +389,49 @@ class TestServerCaptureAdapter(unittest.TestCase):
             resolve_server_capture_schema("nonexistent")
 
 
+class TestLoaderGcPump(unittest.TestCase):
+    """Consumer-side frees are lease-deferred by Mooncake (remove during the
+    get() read-lease fails, e.g. -706); release() parks them and the LOADER
+    must pump gc() or every consumed sample leaks until the segment fills."""
+
+    def test_loader_gc_pump_frees_lease_deferred_removes(self):
+        from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+
+        backend = _FakeMooncakeStore()
+        backend.lease_active = True
+        original_remove = backend.remove
+
+        def lease_remove(key):
+            if backend.lease_active:
+                return -706
+            return original_remove(key)
+
+        backend.remove = lease_remove
+        store = MooncakeFeatureStore(
+            store=backend, store_id="run0", max_release_attempts=100
+        )
+        refs = [
+            store.put(
+                {"x": torch.ones(2, 2)},
+                sample_id=f"s{i}",
+                metadata={"run_id": "run0", "strategy": "eagle3"},
+            )
+            for i in range(3)
+        ]
+        loader = FeatureDataLoader(
+            store, refs=refs, batch_size=1, strategy="eagle3", gc_interval_s=0.0
+        )
+        for _ in loader:
+            pass
+        # all frees parked (lease active), nothing physically freed
+        self.assertTrue(any(backend._d))
+        self.assertEqual(store.health()["release_pending"], 3)
+        backend.lease_active = False  # lease expired
+        loader._maybe_gc()
+        self.assertFalse(any(backend._d), f"leaked: {list(backend._d)}")
+        self.assertEqual(store.health()["release_pending"], 0)
+
+
 class TestServerCaptureProducerWiring(unittest.TestCase):
     """The example's exact path: build_disagg_online_producer(feature_source=...)."""
 

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -395,18 +395,33 @@ class TestLoaderGcPump(unittest.TestCase):
     must pump gc() or every consumed sample leaks until the segment fills."""
 
     def test_loader_gc_pump_frees_lease_deferred_removes(self):
+        import time as _time
+
         from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
 
-        backend = _FakeMooncakeStore()
-        backend.lease_active = True
-        original_remove = backend.remove
+        TTL = 0.05
 
-        def lease_remove(key):
-            if backend.lease_active:
-                return -706
-            return original_remove(key)
+        class _LeaseFake(_FakeMooncakeStore):
+            """Mooncake lease semantics: is_exist GRANTS a read lease (TTL),
+            and a remove during a live lease fails (-706). get() probes
+            existence, so the release-time remove always fails; a retry frees
+            only if it runs after the TTL and is NOT preceded by another
+            exist probe (the gc() ordering bug this pins)."""
 
-        backend.remove = lease_remove
+            def __init__(self):
+                super().__init__()
+                self._lease_until = {}
+
+            def is_exist(self, key):
+                self._lease_until[key] = _time.monotonic() + TTL
+                return super().is_exist(key)
+
+            def remove(self, key):
+                if _time.monotonic() < self._lease_until.get(key, 0.0):
+                    return -706
+                return super().remove(key)
+
+        backend = _LeaseFake()
         store = MooncakeFeatureStore(
             store=backend, store_id="run0", max_release_attempts=100
         )
@@ -423,11 +438,11 @@ class TestLoaderGcPump(unittest.TestCase):
         )
         for _ in loader:
             pass
-        # all frees parked (lease active), nothing physically freed
+        # release-time frees parked: the get() exist-probe held the lease
         self.assertTrue(any(backend._d))
         self.assertEqual(store.health()["release_pending"], 3)
-        backend.lease_active = False  # lease expired
-        loader._maybe_gc()
+        _time.sleep(TTL * 3)  # pump cadence must exceed the lease TTL
+        loader._maybe_gc()  # retries remove FIRST (no re-leasing pre-check)
         self.assertFalse(any(backend._d), f"leaked: {list(backend._d)}")
         self.assertEqual(store.health()["release_pending"], 0)
 

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -109,7 +109,14 @@ class _StubCaptureServer:
             sid, gen = spec["sample_id"], int(spec["gen"])
             if sid in self.error_sample_ids:
                 rows.append(
-                    {"meta_info": {"spec_capture_error": ["injected sink error"]}}
+                    {
+                        "meta_info": {
+                            "spec_capture": {
+                                "sample_id": sid,
+                                "error": "injected sink error",
+                            }
+                        }
+                    }
                 )
                 continue
             length = len(input_ids)
@@ -144,15 +151,13 @@ class _StubCaptureServer:
             rows.append(
                 {
                     "meta_info": {
-                        "spec_capture": [
-                            {
-                                "sample_id": sid,
-                                "store_id": spec["store_id"],
-                                "gen": gen,
-                                "aux_layer_ids": self.aux_layer_ids,
-                                "features": feats,
-                            }
-                        ]
+                        "spec_capture": {
+                            "sample_id": sid,
+                            "store_id": spec["store_id"],
+                            "gen": gen,
+                            "aux_layer_ids": self.aux_layer_ids,
+                            "features": feats,
+                        }
                     }
                 }
             )


### PR DESCRIPTION
# [Online track] O2 follow-up — fixes from the first real disaggregated run (Qwen3.6-27B DFlash, 5k steps)

Follow-up to #653 (merged before these landed). Running the merged transport end-to-end on a real target surfaced four production bugs; with them fixed, the full disaggregated run completes: **5000 steps, 33 min (~2.6 steps/s), loss 6.66 → 4.59 / acc 0.052 → 0.178 (500-step window means), 5256 samples captured server-side, zero put failures, zero eviction triggers.** Topology: patched server TP=4 (GPUs 0-3) + thin producer (GPU 5) + single-DP trainer (GPU 4), live `mooncake_master`, TCP.

## Fixes (each found by the run, each with a regression test or probe)

1. **`--spec-capture-method {eagle3,dflash}`** — the patch hardcoded the eagle3 capture hook; VL targets (Qwen3.6-27B, `qwen3_vl`) only wire aux capture via `set_dflash_layers_to_capture`, so the dflash server path crashed (`hidden, aux = hidden_states` unpack) on the model the example targets.
2. **Dedicated `spec_capture` output field** (mirrors `output_hidden_states` through streamer → io_struct → detokenizer → tokenizer_manager). The previous `customized_info` return channel has per-TOKEN semantics and misaligns under real batched traffic — crashed the TokenizerManager (`IndexError`) mid-run; the gate's 2-request case couldn't see it.
3. **`mooncake: never probe existence before a remove`** — probed on a live master: `is_exist` **grants a read lease**, so a remove right after fails (-706). `gc()`'s exists pre-check re-leased every pending object before its retry, exhausted `max_release_attempts`, and leaked **100% of consumed samples** — 64GB and 200GB segments both filled at exactly cumulative-produced bytes. Removes now run first; the exist probe only classifies already-gone keys after a failed remove.
4. **Loader pumps `store.gc()` on a lease-aware cadence** (default 15s > lease TTL) — releases are lease-deferred by design but nothing retried the parked frees. Cadence must exceed the TTL or the retries burn while still leased (documented + regression-tested with lease-semantics fake).

Plus example hardening: producer/consumer are **pure Mooncake clients** (`global_segment_size=0`, probe-verified) so committed features never live in a process that exits early; the server sink's segment is the only storage, sized above the in-flight watermark. Producer runs under torchrun on a spare GPU (control plane needs the process group; Mooncake needs a device).

## Validation
- 5k-step e2e run above (previous attempts failed at 142 / 965 / 3076 samples — capacity, producer-exit object loss, and the gc lease bug respectively; each fix moved the wall until it was gone)
- full `tests/test_runtime`: **312 OK** (4 skip, 1 xfail) on sci-h200, sglang 0.5.14 + patch
- known rough edge left for a follow-up: `drive_producer` treats an all-failed round as pool-drained, silently truncating a run instead of surfacing an error burst

🤖 Generated with [Claude Code](https://claude.com/claude-code)
