### PR TITLE
[Online track] O3: DP online consumer — centralized RefDistributor + single-ledger ack

### DIFF
--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -42,6 +42,15 @@ sides land on one master. Export ``WANDB_API_KEY`` for consumer W&B logging.
 import hashlib
 import json
 import os
+import sys
+
+import torch
+
+if not torch.cuda.is_available():
+    # GPU-less process (the CPU producer): yunchang probes CUDA at import time
+    # whenever flashinfer is importable (yunchang.globals.get_cuda_arch) and
+    # raises; hiding flashinfer trips its clean ImportError fallback instead.
+    sys.modules["flashinfer"] = None
 
 from accelerate.utils import set_seed
 from train_dflash import build_models, parse_args

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -288,6 +288,8 @@ def run_consumer(args) -> None:
         logger=logger,
         log_interval=_max("DISAGG_LOG_INTERVAL", 1),
         inbox_dir=os.environ.get("DISAGG_INBOX_DIR") or None,
+        # liveness guard against a dead producer/server (DP default: 1800s)
+        idle_timeout_s=float(os.environ.get("DISAGG_IDLE_TIMEOUT", 0)) or None,
     )
     try:
         trainer.fit(loader)

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -18,6 +18,11 @@ and ran staged, since DFlash's HF capture is not thread-safe): the server does
 the capture, so a single prefill per prompt feeds training directly. It is the
 disaggregated sibling of ``examples/run_qwen3.6_27b_dflash_online.sh``.
 
+The producer is CPU-only (no torch.distributed, no GPU); the consumer runs
+under torchrun and data-parallel-shards the stream across its ranks: rank 0
+hosts the RefDistributor (the run's single ledger + round-robin dispatch to
+per-rank inboxes), gradients sync via FSDP.
+
 Config is environment-driven so one wrapper drives both roles; role is
 ``DISAGG_ROLE`` (``producer``/``consumer``) or derived from ``RCLI_NODE_RANK``:
 
@@ -25,7 +30,7 @@ Config is environment-driven so one wrapper drives both roles; role is
     DISAGG_SERVER_URL=http://host:30000   # the patched SGLang server (producer)
     DISAGG_STORE_ID=qwen36-dflash-disagg  # Mooncake key namespace (both roles)
     DISAGG_REF_CHANNEL=/root/disagg/refs.jsonl   # tiny ref manifest (both roles)
-    DISAGG_DB=/root/disagg/run.db      # shared durable metadata store
+    DISAGG_DB=/root/disagg/run.db      # consumer rank-0 ledger (trainer-side ONLY)
     DISAGG_MAX_PROMPTS=400             # cap the prompt pool (0 = all)
     DISAGG_MAX_STEPS=0                 # trainer max optimizer steps (0 = all)
 
@@ -34,11 +39,12 @@ Mooncake connection uses the standard ``MOONCAKE_*`` env vars (see
 sides land on one master. Export ``WANDB_API_KEY`` for consumer W&B logging.
 """
 
+import hashlib
 import json
 import os
 
 from accelerate.utils import set_seed
-from train_dflash import build_dataloader, build_models, parse_args
+from train_dflash import build_models, parse_args
 from transformers import AutoTokenizer
 
 from specforge.core.dflash import OnlineDFlashModel
@@ -94,22 +100,47 @@ def _mooncake_store() -> MooncakeFeatureStore:
     )
 
 
-def _extract_prompts(train_dataloader):
+def _producer_prompts(args, tokenizer):
+    """Tokenized prompts straight off the dataset — no DataLoader, no dist.
+
+    The producer only feeds prompts to the server, so it skips
+    ``prepare_dp_dataloaders`` (whose DistributedSampler needs a process group)
+    and stays CPU-only. Same tokenize/template/cache + min-loss filter as
+    ``train_dflash.build_dataloader``.
+    """
+    from datasets import load_dataset
+    from specforge.data import build_eagle3_dataset
+
+    cache_key = hashlib.md5(
+        f"{args.train_data_path}-{args.max_length}-{args.chat_template}-"
+        f"{args.target_model_path}".encode()
+    ).hexdigest()
+    dataset = load_dataset("json", data_files=args.train_data_path)["train"]
+    dataset = build_eagle3_dataset(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        chat_template=args.chat_template,
+        max_length=args.max_length,
+        is_preformatted=args.is_preformatted,
+        cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
+        cache_key=cache_key,
+        num_proc=args.build_dataset_num_proc,
+    )
+    dataset = dataset.filter(lambda x: x["loss_mask"].sum() >= 2 * args.block_size)
+
     prompts = []
-    for batch in train_dataloader:
-        input_ids = batch["input_ids"]
-        loss_mask = batch["loss_mask"]
-        attn = batch.get("attention_mask")
-        for i in range(input_ids.shape[0]):
-            n = int(attn[i].sum().item()) if attn is not None else input_ids.shape[1]
-            prompts.append(
-                {
-                    "payload": {
-                        "input_ids": input_ids[i, :n].tolist(),
-                        "loss_mask": loss_mask[i, :n].tolist(),
-                    }
+    for row in dataset:  # rows are (1, L) tensors
+        input_ids, loss_mask = row["input_ids"][0], row["loss_mask"][0]
+        attn = row.get("attention_mask")
+        n = int(attn[0].sum().item()) if attn is not None else input_ids.shape[0]
+        prompts.append(
+            {
+                "payload": {
+                    "input_ids": input_ids[:n].tolist(),
+                    "loss_mask": loss_mask[:n].tolist(),
                 }
-            )
+            }
+        )
     return prompts
 
 
@@ -123,12 +154,11 @@ def _resolve_mask_token(args, tokenizer) -> int:
 
 
 def run_producer(args) -> None:
-    """Thin driver: prompts -> patched server (captures to Mooncake) -> refs."""
+    """Thin CPU driver: prompts -> patched server (captures to Mooncake) -> refs."""
     tokenizer = AutoTokenizer.from_pretrained(
         args.target_model_path, trust_remote_code=args.trust_remote_code
     )
-    train_dataloader, _eval = build_dataloader(args, tokenizer)
-    prompts = _extract_prompts(train_dataloader)
+    prompts = _producer_prompts(args, tokenizer)
     max_prompts = _max("DISAGG_MAX_PROMPTS", 0)
     if max_prompts:
         prompts = prompts[:max_prompts]
@@ -150,6 +180,10 @@ def run_producer(args) -> None:
     )
     print(f"[producer] {len(prompts)} prompts -> {os.environ['DISAGG_SERVER_URL']}")
 
+    # NO shared db: the trainer-side ledger (DISAGG_DB) is the run's single
+    # book-keeper; committed rows from the producer would make the consumer
+    # distributor's commit-dedup drop every ref. The producer's private
+    # in-memory store still dedups within its own process.
     _workers, drive_producer = build_disagg_online_producer(
         strategy="dflash",
         feature_source=adapter,
@@ -160,7 +194,6 @@ def run_producer(args) -> None:
         target_hidden_size=target_hidden,
         target_repr=None,  # DFlash trains on captured hidden states, no target dist.
         aux_hidden_state_layer_ids=aux_layer_ids,
-        metadata_db_path=os.environ.get("DISAGG_DB") or None,
     )
     produced = drive_producer()
     print(f"[producer] streamed {produced} samples; channel closed", flush=True)
@@ -226,6 +259,8 @@ def run_consumer(args) -> None:
             print(f"[consumer] step {step} {summary}", flush=True)
 
     print(f"[consumer] training from mooncake://{RUN_ID}", flush=True)
+    # dp_rank/dp_size default from the torchrun world: rank 0 hosts the
+    # RefDistributor (single ledger + per-rank inbox dispatch).
     trainer, loader = build_disagg_online_consumer(
         strategy="dflash",
         feature_store=_mooncake_store(),
@@ -243,8 +278,13 @@ def run_consumer(args) -> None:
         metadata_db_path=os.environ.get("DISAGG_DB") or None,
         logger=logger,
         log_interval=_max("DISAGG_LOG_INTERVAL", 1),
+        inbox_dir=os.environ.get("DISAGG_INBOX_DIR") or None,
     )
-    trainer.fit(loader)
+    try:
+        trainer.fit(loader)
+    finally:
+        if getattr(trainer, "ref_distributor", None) is not None:
+            trainer.ref_distributor.stop()  # clean wind-down on max_steps exit
     print(f"[consumer] DONE ({RUN_ID})", flush=True)
 
 
@@ -253,15 +293,13 @@ def main() -> None:
     set_seed(args.seed)
     role = _role()
     print(f"[disagg-dflash] role={role} run_id={RUN_ID}", flush=True)
-    # Both roles need the process group: the producer loads no model, but the
-    # control plane / feature store query dist rank. Launch each under torchrun
-    # (the producer on a spare GPU, its own rendezvous endpoint).
+    if role == "producer":
+        # CPU-only: no model, no collectives — plain `python`, no torchrun.
+        run_producer(args)
+        return
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     try:
-        if role == "producer":
-            run_producer(args)
-        else:
-            run_consumer(args)
+        run_consumer(args)
     finally:
         destroy_distributed()
 

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -81,6 +81,7 @@ CUDA_VISIBLE_DEVICES=$SERVER_GPU MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAM
         --chunked-prefill-size -1 \
         --disable-radix-cache \
         --enable-spec-capture \
+        --spec-capture-method dflash \
         --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
         --port $SERVER_PORT &
 SERVER_PID=$!

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -79,6 +79,7 @@ CUDA_VISIBLE_DEVICES=$SERVER_GPU MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAM
         --skip-tokenizer-init \
         --mem-fraction-static 0.85 \
         --chunked-prefill-size -1 \
+        --disable-radix-cache \
         --enable-spec-capture \
         --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
         --port $SERVER_PORT &

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Qwen3.6-27B DFlash, ONLINE disaggregated via server-capture on one 8-GPU node:
-#   mooncake master        -> CPU (RDMA/TCP object store)
-#   patched SGLang server   -> GPU 0   (frozen 27B target, captures to mooncake)
-#   producer (HTTP driver)  -> CPU     (prompts -> server, streams refs)
-#   consumer (DFlash trainer)-> GPU 1  (trains from mooncake, zero-copy)
+#   mooncake master          -> CPU (RDMA/TCP object store)
+#   patched SGLang server    -> SERVER_GPU     (frozen 27B target -> mooncake)
+#   producer (HTTP driver)   -> CPU            (prompts -> server, streams refs)
+#   consumer (DFlash trainer)-> CONSUMER_GPUS  (DP=TRAIN_DP over per-rank inboxes)
+#
+# The consumer is DATA-PARALLEL: torchrun spawns TRAIN_DP ranks; rank 0 hosts the
+# RefDistributor — the run's single book-keeper (one SQLite ledger, one channel
+# reader) — and round-robin dispatches refs to per-rank inboxes; gradients sync
+# via FSDP. The producer never touches the ledger (trainer-side only).
 #
 # The server is sglang 0.5.14 patched with patches/sglang/v0.5.14/spec-capture.patch
 # (apply with scripts/apply_sglang_spec_capture_patch.sh). Feature tensors travel
@@ -23,7 +28,8 @@ export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
 cd "$ROOT_DIR"
 
 SERVER_GPU=${SERVER_GPU:-0}
-CONSUMER_GPU=${CONSUMER_GPU:-1}
+TRAIN_DP=${TRAIN_DP:-2}
+CONSUMER_GPUS=${CONSUMER_GPUS:-"1,2"}
 SERVER_PORT=${SERVER_PORT:-30000}
 # DFlash target capture layers — must match dflash_config.target_layer_ids in
 # the draft config below.
@@ -45,7 +51,10 @@ export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
 export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg}
 export DISAGG_SERVER_URL=http://127.0.0.1:$SERVER_PORT
 export DISAGG_REF_CHANNEL=${DISAGG_REF_CHANNEL:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/refs.jsonl}
-export DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+# Trainer-side ONLY (rank-0 ledger + per-rank inboxes); the producer must not
+# see the db — the launcher below passes it just to the consumer.
+DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+DISAGG_INBOX_DIR=${DISAGG_INBOX_DIR:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/inboxes}
 export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-400}
 export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}
 export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
@@ -82,7 +91,7 @@ until curl -sf "http://127.0.0.1:$SERVER_PORT/health" > /dev/null; do
 done
 
 # recipe matches run_qwen3.6_27b_dflash_online.sh; max-length 2048 for a bounded
-# single-node demo (online disagg is consume-once / single-DP-rank).
+# single-node demo. batch-size is PER RANK: global batch = batch_size * TRAIN_DP.
 ARGS=(
     --target-model-path Qwen/Qwen3.6-27B
     --target-model-backend hf
@@ -109,20 +118,21 @@ ARGS=(
 
 LAUNCHER=$SCRIPT_DIR/run_disagg_dflash.py
 
-# --- producer: HTTP driver (no torch model; shares the box, no GPU model) ---
+# --- producer: CPU-only HTTP driver (no torch model, no process group) ---
 DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
     python "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-producer" &
 PRODUCER_PID=$!
 
-# --- consumer: trainer pool (GPU $CONSUMER_GPU), logs the curve to W&B ---
-CUDA_VISIBLE_DEVICES=$CONSUMER_GPU DISAGG_ROLE=consumer \
+# --- consumer: DP=$TRAIN_DP trainer pool; rank 0 = distributor + ledger ---
+CUDA_VISIBLE_DEVICES=$CONSUMER_GPUS DISAGG_ROLE=consumer \
+    DISAGG_DB=$DISAGG_DB DISAGG_INBOX_DIR=$DISAGG_INBOX_DIR \
     torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29702 \
-        --nnodes 1 --nproc_per_node 1 "$LAUNCHER" "${ARGS[@]}" \
+        --nnodes 1 --nproc_per_node "$TRAIN_DP" "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-consumer" \
         --report-to wandb \
         --wandb-project qwen36-dflash-disagg \
-        --wandb-name qwen36-27b-dflash-nemotron-server-capture
+        --wandb-name qwen36-27b-dflash-server-capture-dp$TRAIN_DP
 
 wait $PRODUCER_PID
 echo "DISAGG36-DONE"

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -137,7 +137,7 @@ diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/manager
 index abba37441..3018b8247 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -576,6 +576,19 @@ class Scheduler(
+@@ -576,6 +576,25 @@ class Scheduler(
  
          self.init_batch_result_processor()
  
@@ -149,6 +149,12 @@ index abba37441..3018b8247 100644
 +                    "--enable-spec-capture requires --chunked-prefill-size -1 "
 +                    "(single-pass prefill) so captured hidden states cover the "
 +                    "whole sequence"
++                )
++            if not server_args.disable_radix_cache:
++                raise ValueError(
++                    "--enable-spec-capture requires --disable-radix-cache: a "
++                    "prefix-cache hit skips prefilling (and capturing) the "
++                    "cached tokens, silently truncating the stored hidden states"
 +                )
 +            from sglang.srt import spec_capture_sink
 +

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -333,6 +333,30 @@ class SGLangServerCaptureAdapter:
                 )
                 continue
             ref = self._ref_from_result(task, result, capture)
+            # A capture shorter than the prompt is corrupt (classic cause: a
+            # radix-cache prefix hit skips prefilling — and capturing — the
+            # cached tokens; the patched scheduler refuses that config).
+            expected_len = len(task.payload["input_ids"])
+            short = {
+                name: spec.shape
+                for name, spec in ref.feature_specs.items()
+                if len(spec.shape) >= 2 and spec.shape[1] != expected_len
+            }
+            if short:
+                self.store.adopt(ref)
+                self.store.abort(ref.sample_id, reason="seq-len-mismatch")
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id,
+                        reason=(
+                            f"server_capture: captured seq len != prompt len "
+                            f"{expected_len} for {short} — was the server "
+                            f"started without --disable-radix-cache?"
+                        ),
+                        retryable=False,
+                    )
+                )
+                continue
             try:
                 verify_feature_contract_specs(
                     ref.feature_specs,

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -685,13 +685,12 @@ def build_disagg_online_consumer(
     rows), and round-robin dispatches aligned windows to per-rank inboxes under
     ``inbox_dir`` (default ``<channel>.inboxes``, trainer-local). Every rank
     consumes only its own inbox; durable acks gather to rank 0
-    (:class:`DPAckController`), which also advances the producer's backpressure
-    counter. Single-rank runs keep the original direct-channel path.
+    (:class:`DPAckController`) while the distributor mirrors the per-rank inbox
+    acks onto the producer's backpressure counter. Passing ``inbox_dir``
+    explicitly opts a single-rank run into the same distributor path;
+    otherwise ``dp_size == 1`` keeps the original direct-channel path.
     """
-    from specforge.runtime.data_plane.streaming_ref_channel import (
-        StreamingRefChannel,
-        StreamingRefQueue,
-    )
+    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
 
     if resume_from and not resume:
         raise ValueError(
@@ -732,7 +731,8 @@ def build_disagg_online_consumer(
         return set(reconciled["released"])
 
     distributor = None
-    if dp_size == 1:
+    if dp_size == 1 and inbox_dir is None:
+        # Legacy direct-channel path, unchanged.
         store = _resolve_metadata_store(metadata_store, metadata_db_path)
         controller = DataFlowController(run_id, metadata_store=store)
         skip_ids = _reconcile(controller, store) if resume else None
@@ -740,23 +740,57 @@ def build_disagg_online_consumer(
             channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids
         )
     else:
+        import torch.distributed as dist
+
         from specforge.runtime.control_plane.dp_ack import DPAckController
-        from specforge.runtime.data_plane.ref_distributor import RefDistributor
+        from specforge.runtime.control_plane.metadata_store import NoOpMetadataStore
+        from specforge.runtime.data_plane.ref_distributor import (
+            InboxChannel,
+            RefDistributor,
+        )
 
         if inbox_dir is None:
             inbox_dir = channel.path + ".inboxes"
+        # Symmetric preconditions (ALL ranks) — a rank-0-only raise would strand
+        # the other ranks in the barrier below.
+        if metadata_store is None and metadata_db_path is None:
+            raise ValueError(
+                "DP online consumer needs a durable metadata_store/"
+                "metadata_db_path — the rank-0 distributor is the run's single "
+                "ledger"
+            )
+        if dist.is_available() and dist.is_initialized():
+            world = dist.get_world_size()
+            if world != dp_size:
+                raise ValueError(
+                    f"DP online consumer: dp_size={dp_size} but the process "
+                    f"group has {world} ranks — every rank must own exactly one "
+                    f"inbox"
+                )
+        # Liveness default: a dead producer/distributor must never hang the
+        # ranks silently. Generous enough for a cold server load before the
+        # first ref.
+        if idle_timeout_s is None:
+            idle_timeout_s = 1800.0
         if dp_rank == 0:
             store = _resolve_metadata_store(metadata_store, metadata_db_path)
-            if store is None:
+            if isinstance(store, NoOpMetadataStore):
                 raise ValueError(
-                    "DP online consumer needs a durable metadata_store/"
-                    "metadata_db_path on rank 0 — the distributor is the run's "
-                    "single ledger"
+                    "DP online consumer needs a RETAINING metadata store: the "
+                    "ledger is what dedups commits and reconciles restarts"
                 )
             controller = DPAckController(
                 run_id, is_authority=True, metadata_store=store
             )
             skip_ids = _reconcile(controller, store) if resume else None
+            if not resume and store.committed_count() > 0:
+                raise ValueError(
+                    f"metadata store already holds {store.committed_count()} "
+                    f"committed samples from a previous run; the distributor's "
+                    f"commit-dedup would silently drop the whole re-streamed "
+                    f"channel. Pass resume=True (+ resume_from) to reconcile, or "
+                    f"start fresh (new metadata_db_path / delete the db)"
+                )
             distributor = RefDistributor(
                 channel,
                 controller,
@@ -765,7 +799,6 @@ def build_disagg_online_consumer(
                 skip_ids=skip_ids,
                 idle_timeout_s=idle_timeout_s,
             )
-            controller.ack_sink = lambda ids: distributor.note_acked(len(ids))
         else:
             # Gather-participant only: throwaway store, records nothing.
             controller = DPAckController(
@@ -774,7 +807,7 @@ def build_disagg_online_consumer(
         # Inboxes must be re-created (rank 0, in RefDistributor.__init__) before
         # any rank opens a reader on a stale previous-attempt file.
         _dp_barrier()
-        inbox = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
+        inbox = InboxChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
         queue = StreamingRefQueue(inbox, idle_timeout_s=idle_timeout_s)
         if distributor is not None:
             distributor.start()

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -16,7 +16,7 @@ is a registry entry, not a new ``build_*`` family.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from specforge.runtime.contracts import DeploymentMode, SampleRef
 from specforge.runtime.control_plane import (
@@ -142,6 +142,44 @@ def _resolve_metadata_store(
     if metadata_db_path is not None:
         return SQLiteMetadataStore(metadata_db_path)
     return None
+
+
+def _dp_consumer_layout(
+    dp_rank: Optional[int],
+    dp_size: Optional[int],
+    tp_size: int,
+    sp_ulysses_size: int,
+    sp_ring_size: int,
+) -> Tuple[int, int]:
+    """Resolve the online consumer's (dp_rank, dp_size), defaulting from dist.
+
+    The DP online consumer shards DATA across ranks (one inbox each), so its DP
+    width is the whole trainer world; tp/sp replication inside a shard is not
+    wired yet and is rejected rather than silently double-training.
+    """
+    import torch.distributed as dist
+
+    initialized = dist.is_available() and dist.is_initialized()
+    if dp_size is None:
+        dp_size = dist.get_world_size() if initialized else 1
+    if dp_rank is None:
+        dp_rank = dist.get_rank() if initialized else 0
+    if dp_size > 1 and (tp_size != 1 or sp_ulysses_size != 1 or sp_ring_size != 1):
+        raise NotImplementedError(
+            "DP online consumer shards refs across dp ranks; tp/sp inside a DP "
+            f"shard is not wired yet (got tp={tp_size}, sp_ulysses="
+            f"{sp_ulysses_size}, sp_ring={sp_ring_size})"
+        )
+    if not 0 <= dp_rank < dp_size:
+        raise ValueError(f"dp_rank {dp_rank} out of range for dp_size {dp_size}")
+    return dp_rank, dp_size
+
+
+def _dp_barrier() -> None:
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        dist.barrier()
 
 
 def _checkpoint_global_step(resume_from: str) -> int:
@@ -625,19 +663,35 @@ def build_disagg_online_consumer(
     log_interval: int = 50,
     resume_from: Optional[str] = None,
     max_checkpoints: int = 0,
+    dp_rank: Optional[int] = None,
+    dp_size: Optional[int] = None,
+    inbox_dir: Optional[str] = None,
 ):
     """Consumer (trainer) side of an ONLINE disaggregated run.
 
     Trains from a streamed ref ``channel`` + a consume-once ``feature_store``
-    produced by another pool; ``metadata_store``/``metadata_db_path`` must be the
-    durable store the producer commits to. Online resume needs BOTH knobs:
-    ``resume=True`` reconciles the durable marker (already-trained refs are
-    skipped on the channel re-read) and ``resume_from`` restores the trainer
-    state those acks correspond to. ``resume_from`` alone raises; a marker ahead
-    of the checkpoint raises (the skipped samples' weight updates were rolled
-    back — silent data loss).
+    produced by another pool. Online resume needs BOTH knobs: ``resume=True``
+    reconciles the durable marker (already-trained refs are skipped on the
+    channel re-read) and ``resume_from`` restores the trainer state those acks
+    correspond to. ``resume_from`` alone raises; a marker ahead of the
+    checkpoint raises (the skipped samples' weight updates were rolled back —
+    silent data loss).
+
+    **Data-parallel trainer** (``dp_size > 1``, defaulting to the torchrun
+    world): rank 0 runs the :class:`RefDistributor` — the run's single
+    book-keeper. It alone reads ``channel``, commits into the ONE durable
+    ``metadata_store``/``metadata_db_path`` (required on rank 0; the producer
+    must NOT share this db — the distributor's commit-dedup would drop its
+    rows), and round-robin dispatches aligned windows to per-rank inboxes under
+    ``inbox_dir`` (default ``<channel>.inboxes``, trainer-local). Every rank
+    consumes only its own inbox; durable acks gather to rank 0
+    (:class:`DPAckController`), which also advances the producer's backpressure
+    counter. Single-rank runs keep the original direct-channel path.
     """
-    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
+    from specforge.runtime.data_plane.streaming_ref_channel import (
+        StreamingRefChannel,
+        StreamingRefQueue,
+    )
 
     if resume_from and not resume:
         raise ValueError(
@@ -648,12 +702,13 @@ def build_disagg_online_consumer(
             "alone would re-train the whole re-streamed channel"
         )
     spec = resolve_strategy(strategy)
-    store = _resolve_metadata_store(metadata_store, metadata_db_path)
-    controller = DataFlowController(run_id, metadata_store=store)
+    dp_rank, dp_size = _dp_consumer_layout(
+        dp_rank, dp_size, tp_size, sp_ulysses_size, sp_ring_size
+    )
 
-    skip_ids = None
-    if resume:
-        if store is None:
+    def _reconcile(controller, resolved_store):
+        """resume=True -> skip already-released refs; guard marker vs checkpoint."""
+        if resolved_store is None:
             raise ValueError(
                 "resume=True needs a durable metadata_store/metadata_db_path; an "
                 "in-process store has no committed/ack history to reconcile against"
@@ -661,7 +716,6 @@ def build_disagg_online_consumer(
         # Released == durably acked AND optimizer-step committed: skip exactly
         # those on the channel re-read; the committed-unacked tail re-trains.
         reconciled = controller.reconcile_on_restart(feature_store)
-        skip_ids = set(reconciled["released"])
         if resume_from:
             marker_step = reconciled["global_step"]
             ckpt_step = _checkpoint_global_step(resume_from)
@@ -675,9 +729,57 @@ def build_disagg_online_consumer(
                     f"latest), or start a fresh run_id + metadata store to re-train "
                     f"from scratch"
                 )
+        return set(reconciled["released"])
 
-    queue = StreamingRefQueue(channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids)
-    return _assemble_trainer(
+    distributor = None
+    if dp_size == 1:
+        store = _resolve_metadata_store(metadata_store, metadata_db_path)
+        controller = DataFlowController(run_id, metadata_store=store)
+        skip_ids = _reconcile(controller, store) if resume else None
+        queue = StreamingRefQueue(
+            channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids
+        )
+    else:
+        from specforge.runtime.control_plane.dp_ack import DPAckController
+        from specforge.runtime.data_plane.ref_distributor import RefDistributor
+
+        if inbox_dir is None:
+            inbox_dir = channel.path + ".inboxes"
+        if dp_rank == 0:
+            store = _resolve_metadata_store(metadata_store, metadata_db_path)
+            if store is None:
+                raise ValueError(
+                    "DP online consumer needs a durable metadata_store/"
+                    "metadata_db_path on rank 0 — the distributor is the run's "
+                    "single ledger"
+                )
+            controller = DPAckController(
+                run_id, is_authority=True, metadata_store=store
+            )
+            skip_ids = _reconcile(controller, store) if resume else None
+            distributor = RefDistributor(
+                channel,
+                controller,
+                inbox_dir,
+                dp_size,
+                skip_ids=skip_ids,
+                idle_timeout_s=idle_timeout_s,
+            )
+            controller.ack_sink = lambda ids: distributor.note_acked(len(ids))
+        else:
+            # Gather-participant only: throwaway store, records nothing.
+            controller = DPAckController(
+                run_id, is_authority=False, metadata_store=InMemoryMetadataStore()
+            )
+        # Inboxes must be re-created (rank 0, in RefDistributor.__init__) before
+        # any rank opens a reader on a stale previous-attempt file.
+        _dp_barrier()
+        inbox = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
+        queue = StreamingRefQueue(inbox, idle_timeout_s=idle_timeout_s)
+        if distributor is not None:
+            distributor.start()
+
+    trainer, loader = _assemble_trainer(
         spec=spec,
         controller=controller,
         store=feature_store,
@@ -704,6 +806,10 @@ def build_disagg_online_consumer(
         resume_from=resume_from,
         max_checkpoints=max_checkpoints,
     )
+    #: rank 0's RefDistributor handle in DP mode (None elsewhere) — callers may
+    #: stop() it after fit for a clean early (max_steps) shutdown.
+    trainer.ref_distributor = distributor
+    return trainer, loader
 
 
 def run_disagg_online_interleaved(

--- a/specforge/runtime/control_plane/__init__.py
+++ b/specforge/runtime/control_plane/__init__.py
@@ -10,6 +10,7 @@ from specforge.runtime.control_plane.controller import (
     TrainLease,
     build_control_plane_for_mode,
 )
+from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
 from specforge.runtime.control_plane.metadata_store import (
     InMemoryMetadataStore,
     MetadataStore,
@@ -19,6 +20,8 @@ from specforge.runtime.control_plane.metadata_store import (
 
 __all__ = [
     "DataFlowController",
+    "DPAckController",
+    "gather_id_union",
     "TrainLease",
     "build_control_plane_for_mode",
     "MetadataStore",

--- a/specforge/runtime/control_plane/dp_ack.py
+++ b/specforge/runtime/control_plane/dp_ack.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DP-aware durable ack: gather every rank's sample_ids, record ONCE.
+
+With data-parallel consumers each rank trains a disjoint shard, but the durable
+``{acked, global_step, optimizer_durable}`` marker must have a single writer —
+otherwise N ranks interleave partial ack sets into one ledger.
+:class:`DPAckController` keeps the write single-authority without giving up the
+existing trainer seam: ``TrainerController.fit`` already calls ``ack_fn`` on
+EVERY rank at EVERY optimizer boundary (in lockstep), so ``ack_train_refs``
+becomes a collective — all ranks contribute their shard's ids
+(``all_gather_object``), only the authority (DP rank 0) records the union and
+drives the ``ack_sink`` (the producer-backpressure counter).
+
+Correctness rests on the lockstep invariant the :class:`RefDistributor`
+enforces (equal per-rank ref counts): a rank that skipped a boundary would hang
+the gather.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+from specforge.runtime.control_plane.controller import DataFlowController
+
+
+def gather_id_union(ids: List[str]) -> List[str]:
+    """All-gather each rank's sample_ids; return the rank-ordered, deduped union.
+
+    Identity when torch.distributed is absent/uninitialized/world=1. Dedup keeps
+    first occurrence so SP-replicated shards (same ids on sp peers) collapse.
+    """
+    import torch.distributed as dist
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return list(ids)
+    world = dist.get_world_size()
+    if world == 1:
+        return list(ids)
+    gathered: List[Optional[List[str]]] = [None] * world
+    dist.all_gather_object(gathered, list(ids))
+    out: List[str] = []
+    seen = set()
+    for rank_ids in gathered:
+        for sid in rank_ids or ():
+            if sid not in seen:
+                seen.add(sid)
+                out.append(sid)
+    return out
+
+
+class DPAckController(DataFlowController):
+    """A :class:`DataFlowController` whose ``ack_train_refs`` is a DP collective.
+
+    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store,
+      records the gathered union, then calls ``ack_sink(union_ids)`` — the
+      launcher points that at the distributor's consumed counter.
+    * ``is_authority=False`` (other ranks): participates in the gather (the
+      collective needs every rank) and records nothing; give it a throwaway
+      in-memory store.
+
+    Every rank must call ``ack_train_refs`` at every optimizer boundary — the
+    trainer's ``ack_fn`` already does exactly that.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        is_authority: bool = True,
+        gather: Callable[[List[str]], List[str]] = gather_id_union,
+        ack_sink: Optional[Callable[[List[str]], None]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(run_id, **kwargs)
+        self.is_authority = is_authority
+        self._gather = gather
+        #: post-ack hook fed the gathered union (assignable after construction
+        #: because the distributor needs the controller first).
+        self.ack_sink = ack_sink
+
+    def ack_train_refs(
+        self,
+        trainer_id: str,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        union = self._gather(list(sample_ids))
+        if not self.is_authority:
+            return
+        super().ack_train_refs(
+            trainer_id,
+            union,
+            global_step=global_step,
+            optimizer_durable=optimizer_durable,
+        )
+        if self.ack_sink is not None and union:
+            self.ack_sink(union)
+
+
+__all__ = ["DPAckController", "gather_id_union"]

--- a/specforge/runtime/control_plane/dp_ack.py
+++ b/specforge/runtime/control_plane/dp_ack.py
@@ -58,15 +58,16 @@ def gather_id_union(ids: List[str]) -> List[str]:
 class DPAckController(DataFlowController):
     """A :class:`DataFlowController` whose ``ack_train_refs`` is a DP collective.
 
-    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store,
-      records the gathered union, then calls ``ack_sink(union_ids)`` — the
-      launcher points that at the distributor's consumed counter.
+    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store and
+      records the gathered union.
     * ``is_authority=False`` (other ranks): participates in the gather (the
       collective needs every rank) and records nothing; give it a throwaway
       in-memory store.
 
     Every rank must call ``ack_train_refs`` at every optimizer boundary — the
-    trainer's ``ack_fn`` already does exactly that.
+    trainer's ``ack_fn`` already does exactly that. Producer backpressure is
+    NOT this class's job: the distributor mirrors the per-rank inbox acks onto
+    the source counter at micro-batch granularity.
     """
 
     def __init__(
@@ -75,15 +76,11 @@ class DPAckController(DataFlowController):
         *,
         is_authority: bool = True,
         gather: Callable[[List[str]], List[str]] = gather_id_union,
-        ack_sink: Optional[Callable[[List[str]], None]] = None,
         **kwargs,
     ) -> None:
         super().__init__(run_id, **kwargs)
         self.is_authority = is_authority
         self._gather = gather
-        #: post-ack hook fed the gathered union (assignable after construction
-        #: because the distributor needs the controller first).
-        self.ack_sink = ack_sink
 
     def ack_train_refs(
         self,
@@ -102,8 +99,6 @@ class DPAckController(DataFlowController):
             global_step=global_step,
             optimizer_durable=optimizer_durable,
         )
-        if self.ack_sink is not None and union:
-            self.ack_sink(union)
 
 
 __all__ = ["DPAckController", "gather_id_union"]

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -14,6 +14,7 @@ from specforge.runtime.data_plane.offline_reader import (
     OfflineManifestReader,
     list_feature_files,
 )
+from specforge.runtime.data_plane.ref_distributor import RefDistributor
 from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue, dp_partition
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "spec_from_tensor",
     "SampleRefQueue",
     "dp_partition",
+    "RefDistributor",
     "FeatureDataLoader",
     "OfflineManifestReader",
     "list_feature_files",

--- a/specforge/runtime/data_plane/ref_distributor.py
+++ b/specforge/runtime/data_plane/ref_distributor.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""RefDistributor: the centralized dispatcher for DP online consumers.
+
+One distributor per run (it lives on trainer DP rank 0). It is the ONLY reader
+of the producer's ref channel and the only holder of consume book-keeping:
+
+    source channel -> commit (ONE ledger, dedup) -> aligned round-robin -> per-rank inbox
+
+Each rank reads a private inbox (a plain consume-once :class:`StreamingRefQueue`)
+and holds no channel offset, no partition math, no ledger — the design goal is a
+single book-keeping authority, not N. Refs are dispatched in windows of exactly
+``dp_size`` (one ref per rank per window) so every rank sees the SAME count:
+the lockstep invariant FSDP collectives require. Anything less than a full
+window at end-of-stream is dropped (logged; it stays committed-unacked in the
+ledger, so a restart re-trains it).
+
+The consumed counter on the source channel (the producer's backpressure signal)
+is advanced by exactly two events, both through this object: restart-skips of
+already-released refs, and the authority's durable ack
+(``DPAckController.ack_sink -> note_acked``). Dispatch itself does NOT count —
+in-flight must keep covering everything not yet trained.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Iterable, List, Optional
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+
+logger = logging.getLogger(__name__)
+
+_INBOX_SUFFIXES = ("", ".closed", ".consumed_count", ".consumed_count.tmp")
+
+
+class RefDistributor:
+    """Single-authority push dispatcher: source channel -> per-rank inboxes."""
+
+    def __init__(
+        self,
+        source: StreamingRefChannel,
+        controller,  # DataFlowController (rank 0's, with the run's durable store)
+        inbox_dir: str,
+        dp_size: int,
+        *,
+        skip_ids: Optional[Iterable[str]] = None,
+        worker_id: str = "ref-distributor",
+        poll_s: float = 0.05,
+        idle_timeout_s: Optional[float] = None,
+        clock=time.monotonic,
+        sleep=time.sleep,
+    ) -> None:
+        if dp_size < 1:
+            raise ValueError(f"dp_size must be >= 1, got {dp_size}")
+        self.source = source
+        self.controller = controller
+        self.dp_size = dp_size
+        self.worker_id = worker_id
+        self.poll_s = poll_s
+        self.idle_timeout_s = idle_timeout_s
+        self._clock = clock
+        self._sleep = sleep
+        self._skip = set(skip_ids) if skip_ids else None
+        # Inboxes are EPHEMERAL (the ledger is the durable state): recreate them
+        # fresh so a restarted run cannot replay a previous attempt's dispatch.
+        # The launcher barriers ranks AFTER construction, before readers open.
+        os.makedirs(inbox_dir, exist_ok=True)
+        for rank in range(dp_size):
+            base = self.inbox_path(inbox_dir, rank)
+            for suffix in _INBOX_SUFFIXES:
+                try:
+                    os.remove(base + suffix)
+                except FileNotFoundError:
+                    pass
+        self._inboxes = [
+            StreamingRefChannel(self.inbox_path(inbox_dir, rank))
+            for rank in range(dp_size)
+        ]
+        # A restarted consumer must not rewind the producer's counter.
+        self.source.seed_consumed()
+        # mark_consumed is not thread-safe; acks (trainer thread) and skips
+        # (this thread) serialize here.
+        self._consume_lock = threading.Lock()
+        self._window: List[SampleRef] = []  # leased, awaiting a full dp_size window
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.finished = False
+        self.error: Optional[BaseException] = None
+        self.stats = {"dispatched": 0, "skipped": 0, "duplicates": 0, "dropped": 0}
+
+    @staticmethod
+    def inbox_path(inbox_dir: str, dp_rank: int) -> str:
+        return os.path.join(inbox_dir, f"inbox-rank{dp_rank}.jsonl")
+
+    def note_acked(self, n: int) -> None:
+        """Advance the producer's backpressure counter for n durably-acked refs."""
+        if n:
+            with self._consume_lock:
+                self.source.mark_consumed(n)
+
+    def pump(self) -> bool:
+        """One non-blocking cycle: ingest + dispatch. Returns True on progress.
+
+        Sets :attr:`finished` (and closes the inboxes) once the source is
+        closed-and-drained and no full window remains.
+        """
+        if self.finished:
+            return False
+        progress = False
+
+        raw = self.source.poll()
+        if raw:
+            progress = True
+            skipped = 0
+            for ref in raw:
+                if self._skip and ref.sample_id in self._skip:
+                    self._skip.discard(ref.sample_id)
+                    skipped += 1
+                    if not self._skip:
+                        self._skip = None
+                    continue
+                before = self.controller.store.committed_count()
+                self.controller.commit_samples(self.worker_id, [ref])
+                if self.controller.store.committed_count() == before:
+                    # duplicate publication (e.g. producer restart); a
+                    # reconcile-requeued ref also lands here and trains later.
+                    self.stats["duplicates"] += 1
+            if skipped:
+                self.stats["skipped"] += skipped
+                self.note_acked(skipped)  # already trained: keep in-flight exact
+
+        # Dispatch every full window: one ref per rank, round-robin — per-rank
+        # counts stay exactly equal, which is what keeps DP ranks in lockstep.
+        queue = self.controller.sample_queue
+        while True:
+            need = self.dp_size - len(self._window)
+            if need:
+                self._window.extend(queue.get(need, timeout_s=0.0))
+            if len(self._window) < self.dp_size:
+                break
+            for rank, ref in enumerate(self._window):
+                self._inboxes[rank].publish(ref)
+            self.stats["dispatched"] += self.dp_size
+            self._window = []
+            progress = True
+
+        if not raw and self.source.is_closed() and queue.depth() == 0:
+            self._finish()
+        return progress
+
+    def _finish(self) -> None:
+        if self._window:
+            # Committed-but-unacked in the ledger: a restart re-trains them.
+            self.stats["dropped"] = len(self._window)
+            logger.warning(
+                "ref-distributor: dropping %d end-of-stream refs (< dp_size=%d "
+                "window); they stay committed-unacked and replay on restart",
+                len(self._window),
+                self.dp_size,
+            )
+            self._window = []
+        for inbox in self._inboxes:
+            inbox.close()
+        self.finished = True
+        logger.info("ref-distributor: finished %s", self.stats)
+
+    def run(self) -> None:
+        """Blocking loop; ends when the source is closed-and-drained or stop().
+
+        On error the inboxes are deliberately NOT closed: a clean close would
+        read as a normal end-of-stream and let ranks finish "successfully" on
+        partial data — instead they surface a loud idle TimeoutError.
+        """
+        last_progress = self._clock()
+        while not self._stop.is_set() and not self.finished:
+            progress = self.pump()
+            now = self._clock()
+            if progress:
+                last_progress = now
+                continue
+            if (
+                self.idle_timeout_s is not None
+                and now - last_progress > self.idle_timeout_s
+            ):
+                raise TimeoutError(
+                    f"ref-distributor: no refs for {self.idle_timeout_s:.0f}s and "
+                    f"the source channel is still open (producer dead?)"
+                )
+            self._sleep(self.poll_s)
+
+    def _run_guarded(self) -> None:
+        try:
+            self.run()
+        except BaseException as exc:  # noqa: BLE001 - surfaced via self.error
+            self.error = exc
+            logger.exception("ref-distributor: died; DP ranks will idle-timeout")
+
+    def start(self) -> "RefDistributor":
+        self._thread = threading.Thread(
+            target=self._run_guarded, name="ref-distributor", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def stop(self, join_timeout_s: float = 10.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=join_timeout_s)
+
+
+__all__ = ["RefDistributor"]

--- a/specforge/runtime/data_plane/ref_distributor.py
+++ b/specforge/runtime/data_plane/ref_distributor.py
@@ -22,10 +22,18 @@ window at end-of-stream is dropped (logged; it stays committed-unacked in the
 ledger, so a restart re-trains it).
 
 The consumed counter on the source channel (the producer's backpressure signal)
-is advanced by exactly two events, both through this object: restart-skips of
-already-released refs, and the authority's durable ack
-(``DPAckController.ack_sink -> note_acked``). Dispatch itself does NOT count —
-in-flight must keep covering everything not yet trained.
+mirrors what the ranks actually consumed: each rank's loader acks its OWN inbox
+per micro-batch, and the distributor forwards the sum of the inbox sidecars to
+the source counter. Per-micro-batch granularity means the producer watermark
+never has to cover a whole ``dp_size * batch * accumulation`` optimizer window.
+Dispatch itself does NOT count — in-flight must keep covering everything not
+yet trained. On restart the counter is seeded from the sidecar (released refs
+were already counted by the prior run, so skips add nothing).
+
+If the distributor dies it drops a ``.failed`` sentinel (with the traceback)
+into every inbox; :class:`InboxChannel` readers raise on it at the next poll —
+a loud, immediate all-rank failure instead of a silent hang, and distinct from
+the clean ``.closed`` end-of-stream.
 """
 
 from __future__ import annotations
@@ -34,6 +42,7 @@ import logging
 import os
 import threading
 import time
+import traceback
 from typing import Iterable, List, Optional
 
 from specforge.runtime.contracts import SampleRef
@@ -41,7 +50,32 @@ from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChann
 
 logger = logging.getLogger(__name__)
 
-_INBOX_SUFFIXES = ("", ".closed", ".consumed_count", ".consumed_count.tmp")
+_FAILED_SUFFIX = ".failed"
+_INBOX_SUFFIXES = (
+    "",
+    ".closed",
+    ".consumed_count",
+    ".consumed_count.tmp",
+    _FAILED_SUFFIX,
+)
+
+
+class InboxChannel(StreamingRefChannel):
+    """Reader view of a distributor inbox: fails loudly if the distributor died.
+
+    ``StreamingRefQueue.get`` consults ``is_closed()`` every poll cycle, so a
+    ``.failed`` sentinel converts "distributor thread died" from an unbounded
+    hang into an immediate RuntimeError on every rank.
+    """
+
+    def is_closed(self) -> bool:
+        failed = self.path + _FAILED_SUFFIX
+        if os.path.exists(failed):
+            with open(failed) as f:
+                raise RuntimeError(f"ref-distributor died:\n{f.read()}")
+        return super().is_closed()
+
+    _is_closed = is_closed
 
 
 class RefDistributor:
@@ -87,11 +121,11 @@ class RefDistributor:
             StreamingRefChannel(self.inbox_path(inbox_dir, rank))
             for rank in range(dp_size)
         ]
-        # A restarted consumer must not rewind the producer's counter.
+        # A restarted consumer must not rewind the producer's counter. The seed
+        # already covers everything the prior run counted (incl. released refs,
+        # which the skip filter therefore does NOT count again).
         self.source.seed_consumed()
-        # mark_consumed is not thread-safe; acks (trainer thread) and skips
-        # (this thread) serialize here.
-        self._consume_lock = threading.Lock()
+        self._inbox_consumed = 0  # last forwarded sum of the inbox sidecars
         self._window: List[SampleRef] = []  # leased, awaiting a full dp_size window
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -103,14 +137,23 @@ class RefDistributor:
     def inbox_path(inbox_dir: str, dp_rank: int) -> str:
         return os.path.join(inbox_dir, f"inbox-rank{dp_rank}.jsonl")
 
-    def note_acked(self, n: int) -> None:
-        """Advance the producer's backpressure counter for n durably-acked refs."""
-        if n:
-            with self._consume_lock:
-                self.source.mark_consumed(n)
+    def _forward_consumed(self) -> bool:
+        """Mirror the ranks' inbox acks onto the source counter (backpressure).
+
+        Per-micro-batch granularity: the producer's watermark only ever has to
+        cover the dispatch pipeline, not a whole optimizer window — a watermark
+        smaller than ``dp_size * batch * accumulation`` must not deadlock.
+        """
+        consumed = sum(inbox.consumed_remote() for inbox in self._inboxes)
+        delta = consumed - self._inbox_consumed
+        if delta <= 0:
+            return False
+        self._inbox_consumed = consumed
+        self.source.mark_consumed(delta)
+        return True
 
     def pump(self) -> bool:
-        """One non-blocking cycle: ingest + dispatch. Returns True on progress.
+        """One non-blocking cycle: ingest + dispatch + counter. True on progress.
 
         Sets :attr:`finished` (and closes the inboxes) once the source is
         closed-and-drained and no full window remains.
@@ -122,11 +165,12 @@ class RefDistributor:
         raw = self.source.poll()
         if raw:
             progress = True
-            skipped = 0
             for ref in raw:
                 if self._skip and ref.sample_id in self._skip:
+                    # released in a prior run: already counted by that run's
+                    # acks (covered by the seed), so just don't re-dispatch.
                     self._skip.discard(ref.sample_id)
-                    skipped += 1
+                    self.stats["skipped"] += 1
                     if not self._skip:
                         self._skip = None
                     continue
@@ -136,9 +180,6 @@ class RefDistributor:
                     # duplicate publication (e.g. producer restart); a
                     # reconcile-requeued ref also lands here and trains later.
                     self.stats["duplicates"] += 1
-            if skipped:
-                self.stats["skipped"] += skipped
-                self.note_acked(skipped)  # already trained: keep in-flight exact
 
         # Dispatch every full window: one ref per rank, round-robin — per-rank
         # counts stay exactly equal, which is what keeps DP ranks in lockstep.
@@ -155,19 +196,28 @@ class RefDistributor:
             self._window = []
             progress = True
 
+        if self._forward_consumed():
+            progress = True
+
         if not raw and self.source.is_closed() and queue.depth() == 0:
             self._finish()
         return progress
 
     def _finish(self) -> None:
         if self._window:
-            # Committed-but-unacked in the ledger: a restart re-trains them.
+            # Less than one aligned window left at end-of-stream: dropped for
+            # THIS run (lockstep needs equal counts). They stay committed-
+            # unacked in the ledger; only a resume=True restart re-queues them.
             self.stats["dropped"] = len(self._window)
             logger.warning(
                 "ref-distributor: dropping %d end-of-stream refs (< dp_size=%d "
-                "window); they stay committed-unacked and replay on restart",
+                "window); committed-unacked in the ledger, re-queued only on a "
+                "resume=True restart",
                 len(self._window),
                 self.dp_size,
+            )
+            self.controller.sample_queue.fail(
+                self._window, reason="eos-partial-window", retryable=False
             )
             self._window = []
         for inbox in self._inboxes:
@@ -178,9 +228,10 @@ class RefDistributor:
     def run(self) -> None:
         """Blocking loop; ends when the source is closed-and-drained or stop().
 
-        On error the inboxes are deliberately NOT closed: a clean close would
-        read as a normal end-of-stream and let ranks finish "successfully" on
-        partial data — instead they surface a loud idle TimeoutError.
+        On error the inboxes are NOT closed (a clean close would read as a
+        normal end-of-stream and let ranks finish "successfully" on partial
+        data) — ``_run_guarded`` drops a ``.failed`` sentinel instead, which
+        every rank's :class:`InboxChannel` raises on at its next poll.
         """
         last_progress = self._clock()
         while not self._stop.is_set() and not self.finished:
@@ -199,12 +250,24 @@ class RefDistributor:
                 )
             self._sleep(self.poll_s)
 
+    def _fail_inboxes(self, exc: BaseException) -> None:
+        """Poison every inbox so all ranks fail loudly (never a silent hang —
+        and never a clean close that would masquerade as end-of-stream)."""
+        text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        for inbox in self._inboxes:
+            try:
+                with open(inbox.path + _FAILED_SUFFIX, "w") as f:
+                    f.write(text)
+            except OSError:  # best effort; ranks still have idle_timeout_s
+                logger.exception("ref-distributor: could not poison %s", inbox.path)
+
     def _run_guarded(self) -> None:
         try:
             self.run()
         except BaseException as exc:  # noqa: BLE001 - surfaced via self.error
             self.error = exc
-            logger.exception("ref-distributor: died; DP ranks will idle-timeout")
+            logger.exception("ref-distributor: died; poisoning inboxes")
+            self._fail_inboxes(exc)
 
     def start(self) -> "RefDistributor":
         self._thread = threading.Thread(
@@ -219,4 +282,4 @@ class RefDistributor:
             self._thread.join(timeout=join_timeout_s)
 
 
-__all__ = ["RefDistributor"]
+__all__ = ["InboxChannel", "RefDistributor"]

--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -143,6 +143,17 @@ class StreamingRefChannel:
             f.write(str(self._consumed))
         os.replace(tmp, self.path + _CONSUMED_SUFFIX)  # atomic counter publish
 
+    def seed_consumed(self) -> int:
+        """Adopt the sidecar's persisted count as this instance's baseline.
+
+        ``mark_consumed`` publishes this instance's cumulative in-memory count,
+        so a restarted consumer (fresh instance, ``_consumed=0``) would rewind
+        the sidecar and inflate the producer's ``in_flight_remote`` forever.
+        Call once on restart, before the first ``mark_consumed``.
+        """
+        self._consumed = self.consumed_remote()
+        return self._consumed
+
     def stream(
         self,
         *,

--- a/tests/test_runtime/test_ref_distributor.py
+++ b/tests/test_runtime/test_ref_distributor.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+"""Tests for RefDistributor + DPAckController: the DP online consumer's
+single-authority dispatch/book-keeping path (CPU only, no torch.distributed)."""
+
+import os
+import tempfile
+import unittest
+
+from specforge.runtime.contracts import FeatureSpec, SampleRef
+from specforge.runtime.control_plane.controller import DataFlowController
+from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
+from specforge.runtime.control_plane.metadata_store import SQLiteMetadataStore
+from specforge.runtime.data_plane.ref_distributor import RefDistributor
+from specforge.runtime.data_plane.streaming_ref_channel import (
+    StreamingRefChannel,
+    StreamingRefQueue,
+)
+
+
+def _ref(sid):
+    spec = FeatureSpec(name="hidden_state", shape=(4, 8), dtype="float32")
+    return SampleRef(
+        sample_id=sid,
+        run_id="run0",
+        source_task_id=None,
+        feature_store_uri=f"mooncake://run0/{sid}",
+        feature_keys={"hidden_state": f"{sid}/hidden_state"},
+        feature_specs={"hidden_state": spec},
+        strategy="eagle3",
+        num_tokens=4,
+    )
+
+
+def _pump_until_quiet(dist, max_rounds=20):
+    for _ in range(max_rounds):
+        if not dist.pump():
+            return
+    raise AssertionError("distributor never went quiet")
+
+
+def _inbox_ids(inbox_dir, rank):
+    reader = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, rank))
+    return [r.sample_id for r in reader.poll()]
+
+
+class TestRefDistributor(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="refdist_")
+        self.src_path = os.path.join(self.dir, "refs.jsonl")
+        self.inbox_dir = os.path.join(self.dir, "inboxes")
+        self.producer = StreamingRefChannel(self.src_path)
+        self.source = StreamingRefChannel(self.src_path)  # consumer-side view
+
+    def _distributor(self, dp_size=2, controller=None, **kwargs):
+        controller = controller or DataFlowController("run0")
+        return RefDistributor(
+            self.source, controller, self.inbox_dir, dp_size, **kwargs
+        )
+
+    def test_round_robin_equal_counts_and_unaligned_tail_dropped(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(7):
+            self.producer.publish(_ref(f"s{i}"))
+        _pump_until_quiet(dist)
+        # 3 full windows of dp_size=2 dispatched; s6 held (not a full window)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s2", "s4"])
+        self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s1", "s3", "s5"])
+        self.assertFalse(dist.finished)
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertTrue(dist.finished)
+        self.assertEqual(dist.stats["dropped"], 1)  # s6: replayed on restart
+        for rank in range(2):
+            reader = StreamingRefChannel(
+                RefDistributor.inbox_path(self.inbox_dir, rank)
+            )
+            self.assertTrue(reader.is_closed())
+
+    def test_inbox_readers_get_disjoint_shards_via_queue(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        q0 = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 0))
+        )
+        q1 = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 1))
+        )
+        ids0 = {r.sample_id for r in q0.get(2)}
+        ids1 = {r.sample_id for r in q1.get(2)}
+        self.assertEqual(ids0 & ids1, set())
+        self.assertEqual(ids0 | ids1, {"s0", "s1", "s2", "s3"})
+        # closed-and-drained: both readers terminate identically
+        self.assertEqual(q0.get(1), [])
+        self.assertEqual(q1.get(1), [])
+
+    def test_duplicate_publication_dispatched_once(self):
+        dist = self._distributor(dp_size=1)
+        self.producer.publish(_ref("s0"))
+        self.producer.publish(_ref("s0"))  # producer-restart republication
+        self.producer.publish(_ref("s1"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s1"])
+        self.assertEqual(dist.stats["duplicates"], 1)
+
+    def test_skip_ids_marks_consumed_and_never_dispatches(self):
+        dist = self._distributor(dp_size=2, skip_ids={"s0", "s1"})
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s2"])
+        self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s3"])
+        # skips count as consumed so the producer's in-flight stays exact
+        self.assertEqual(self.producer.consumed_remote(), 2)
+        dist.note_acked(2)  # the durable-ack path adds the trained ones
+        self.assertEqual(self.producer.consumed_remote(), 4)
+
+    def test_consumed_counter_survives_restart(self):
+        # First consumer attempt marks 3 consumed, then dies.
+        first = StreamingRefChannel(self.src_path)
+        first.mark_consumed(3)
+        self.assertEqual(self.producer.consumed_remote(), 3)
+        # A restarted distributor must seed from the sidecar, not rewind it.
+        dist = self._distributor(dp_size=1)
+        dist.note_acked(1)
+        self.assertEqual(self.producer.consumed_remote(), 4)
+
+    def test_stale_inbox_files_recreated_fresh(self):
+        os.makedirs(self.inbox_dir, exist_ok=True)
+        stale = RefDistributor.inbox_path(self.inbox_dir, 0)
+        StreamingRefChannel(stale).publish(_ref("stale"))
+        open(stale + ".closed", "w").close()
+        dist = self._distributor(dp_size=1)
+        self.producer.publish(_ref("fresh"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        reader = StreamingRefChannel(stale)
+        self.assertEqual([r.sample_id for r in reader.poll()], ["fresh"])
+
+    def test_resume_requeues_committed_unacked_and_skips_released(self):
+        db = os.path.join(self.dir, "run.db")
+        # Prior attempt: committed s0..s3; s0,s1 durably acked (released).
+        prior = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        prior.commit_samples("w0", [_ref(f"s{i}") for i in range(4)])
+        prior.ack_train_refs("t0", ["s0", "s1"], global_step=1, optimizer_durable=True)
+        prior.store.close()
+        # Restart: reconcile requeues committed-unacked (s2, s3) into the new
+        # controller's queue; released (s0, s1) become skip_ids.
+        controller = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        reconciled = controller.reconcile_on_restart()
+        self.assertEqual(sorted(reconciled["released"]), ["s0", "s1"])
+        self.assertEqual(sorted(reconciled["requeued"]), ["s2", "s3"])
+        dist = self._distributor(
+            dp_size=2, controller=controller, skip_ids=set(reconciled["released"])
+        )
+        # The channel replays everything from offset 0 (restart re-read).
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        ids0, ids1 = _inbox_ids(self.inbox_dir, 0), _inbox_ids(self.inbox_dir, 1)
+        # exactly the unacked tail trains again, split evenly, no duplicates
+        self.assertEqual(sorted(ids0 + ids1), ["s2", "s3"])
+        self.assertEqual(len(ids0), len(ids1))
+        self.assertEqual(self.producer.consumed_remote(), 2)  # the two skips
+        controller.store.close()
+
+    def test_idle_timeout_raises_when_producer_silent(self):
+        clock = {"t": 0.0}
+        dist = self._distributor(
+            dp_size=1,
+            idle_timeout_s=5.0,
+            clock=lambda: clock["t"],
+            sleep=lambda s: clock.__setitem__("t", clock["t"] + s),
+        )
+        with self.assertRaises(TimeoutError):
+            dist.run()
+
+
+class TestDPAckController(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="dpack_")
+
+    def test_authority_records_gathered_union_and_drives_sink(self):
+        gathered = lambda ids: ids + ["s-other-rank"]  # noqa: E731
+        sunk = []
+        controller = DPAckController(
+            "run0",
+            is_authority=True,
+            gather=gathered,
+            metadata_store=SQLiteMetadataStore(os.path.join(self.dir, "run.db")),
+        )
+        controller.ack_sink = lambda ids: sunk.extend(ids)
+        controller.commit_samples("w0", [_ref("s0"), _ref("s-other-rank")])
+        controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
+        marker = controller.store.durable_marker()
+        self.assertEqual(sorted(marker["acked"]), ["s-other-rank", "s0"])
+        self.assertTrue(marker["optimizer_durable"])
+        self.assertEqual(sorted(sunk), ["s-other-rank", "s0"])
+        controller.store.close()
+
+    def test_non_authority_participates_but_records_nothing(self):
+        calls = []
+
+        def gather(ids):
+            calls.append(list(ids))
+            return ids
+
+        controller = DPAckController("run0", is_authority=False, gather=gather)
+        controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
+        self.assertEqual(calls, [["s0"]])  # joined the collective
+        self.assertEqual(controller.store.durable_marker()["acked"], set())
+
+    def test_gather_id_union_without_dist_is_identity(self):
+        self.assertEqual(gather_id_union(["a", "b"]), ["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_ref_distributor.py
+++ b/tests/test_runtime/test_ref_distributor.py
@@ -10,7 +10,7 @@ from specforge.runtime.contracts import FeatureSpec, SampleRef
 from specforge.runtime.control_plane.controller import DataFlowController
 from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
 from specforge.runtime.control_plane.metadata_store import SQLiteMetadataStore
-from specforge.runtime.data_plane.ref_distributor import RefDistributor
+from specforge.runtime.data_plane.ref_distributor import InboxChannel, RefDistributor
 from specforge.runtime.data_plane.streaming_ref_channel import (
     StreamingRefChannel,
     StreamingRefQueue,
@@ -106,7 +106,11 @@ class TestRefDistributor(unittest.TestCase):
         self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s1"])
         self.assertEqual(dist.stats["duplicates"], 1)
 
-    def test_skip_ids_marks_consumed_and_never_dispatches(self):
+    def test_skip_ids_never_dispatch_and_are_not_recounted(self):
+        # Released refs were already counted by the prior run's acks (the
+        # sidecar seed); the skip filter must not count them again.
+        prior = StreamingRefChannel(self.src_path)
+        prior.mark_consumed(2)  # run 1 counted s0, s1
         dist = self._distributor(dp_size=2, skip_ids={"s0", "s1"})
         for i in range(4):
             self.producer.publish(_ref(f"s{i}"))
@@ -114,9 +118,22 @@ class TestRefDistributor(unittest.TestCase):
         _pump_until_quiet(dist)
         self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s2"])
         self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s3"])
-        # skips count as consumed so the producer's in-flight stays exact
-        self.assertEqual(self.producer.consumed_remote(), 2)
-        dist.note_acked(2)  # the durable-ack path adds the trained ones
+        self.assertEqual(dist.stats["skipped"], 2)
+        self.assertEqual(self.producer.consumed_remote(), 2)  # seed only, no double
+
+    def test_inbox_acks_forward_to_source_counter(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        _pump_until_quiet(dist)
+        self.assertEqual(self.producer.consumed_remote(), 0)  # dispatch != consumed
+        # rank readers ack their inboxes per micro-batch (loader behavior)
+        for rank in range(2):
+            q = StreamingRefQueue(
+                StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, rank))
+            )
+            q.ack(q.get(2))
+        _pump_until_quiet(dist)
         self.assertEqual(self.producer.consumed_remote(), 4)
 
     def test_consumed_counter_survives_restart(self):
@@ -124,9 +141,16 @@ class TestRefDistributor(unittest.TestCase):
         first = StreamingRefChannel(self.src_path)
         first.mark_consumed(3)
         self.assertEqual(self.producer.consumed_remote(), 3)
-        # A restarted distributor must seed from the sidecar, not rewind it.
+        # A restarted distributor must seed from the sidecar, not rewind it:
+        # one new inbox ack lands on top of the seed.
         dist = self._distributor(dp_size=1)
-        dist.note_acked(1)
+        self.producer.publish(_ref("s9"))
+        _pump_until_quiet(dist)
+        q = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 0))
+        )
+        q.ack(q.get(1))
+        _pump_until_quiet(dist)
         self.assertEqual(self.producer.consumed_remote(), 4)
 
     def test_stale_inbox_files_recreated_fresh(self):
@@ -166,8 +190,36 @@ class TestRefDistributor(unittest.TestCase):
         # exactly the unacked tail trains again, split evenly, no duplicates
         self.assertEqual(sorted(ids0 + ids1), ["s2", "s3"])
         self.assertEqual(len(ids0), len(ids1))
-        self.assertEqual(self.producer.consumed_remote(), 2)  # the two skips
+        self.assertEqual(dist.stats["skipped"], 2)
         controller.store.close()
+
+    def test_end_of_stream_partial_window_releases_leases(self):
+        controller = DataFlowController("run0")
+        dist = self._distributor(dp_size=2, controller=controller)
+        for i in range(3):  # one full window + one leftover
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertTrue(dist.finished)
+        self.assertEqual(dist.stats["dropped"], 1)
+        # the dropped ref's lease is released, not leaked
+        self.assertEqual(controller.sample_queue.in_flight(), 2)  # dispatched only
+        self.assertEqual(controller.sample_queue.depth(), 0)
+
+    def test_distributor_death_poisons_inboxes(self):
+        clock = {"t": 0.0}
+        dist = self._distributor(
+            dp_size=2,
+            idle_timeout_s=5.0,
+            clock=lambda: clock["t"],
+            sleep=lambda s: clock.__setitem__("t", clock["t"] + s),
+        )
+        dist._run_guarded()  # idle-timeout kills it (producer silent)
+        self.assertIsInstance(dist.error, TimeoutError)
+        for rank in range(2):
+            reader = InboxChannel(RefDistributor.inbox_path(self.inbox_dir, rank))
+            with self.assertRaisesRegex(RuntimeError, "ref-distributor died"):
+                StreamingRefQueue(reader).get(1)
 
     def test_idle_timeout_raises_when_producer_silent(self):
         clock = {"t": 0.0}
@@ -185,22 +237,19 @@ class TestDPAckController(unittest.TestCase):
     def setUp(self):
         self.dir = tempfile.mkdtemp(prefix="dpack_")
 
-    def test_authority_records_gathered_union_and_drives_sink(self):
+    def test_authority_records_gathered_union(self):
         gathered = lambda ids: ids + ["s-other-rank"]  # noqa: E731
-        sunk = []
         controller = DPAckController(
             "run0",
             is_authority=True,
             gather=gathered,
             metadata_store=SQLiteMetadataStore(os.path.join(self.dir, "run.db")),
         )
-        controller.ack_sink = lambda ids: sunk.extend(ids)
         controller.commit_samples("w0", [_ref("s0"), _ref("s-other-rank")])
         controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
         marker = controller.store.durable_marker()
         self.assertEqual(sorted(marker["acked"]), ["s-other-rank", "s0"])
         self.assertTrue(marker["optimizer_durable"])
-        self.assertEqual(sorted(sunk), ["s-other-rank", "s0"])
         controller.store.close()
 
     def test_non_authority_participates_but_records_nothing(self):


### PR DESCRIPTION
> **Stacks on #654** — merge #654 first; until then this diff includes its commits.

## What

Data-parallel training for the online disaggregated consumer: `torchrun --nproc_per_node N` now shards the captured-feature stream across N FSDP ranks, with **one** book-keeping authority instead of N.

```
source ref channel ──> RefDistributor (trainer rank 0)          ranks 1..N-1
                        │  the ONLY channel reader               │
                        │  commits into the ONE SQLite ledger    │
                        │  round-robin, windows of exactly N ────┼──> per-rank inbox
                        └  mirrors inbox acks -> producer counter┘    (consume-once queue)
gradients: plain FSDP all-reduce (untouched)
durable ack: all ranks all_gather ids at the optimizer boundary; rank 0 records the union
```

## Design

- **Centralized push, not per-rank hash-filtering**: ranks hold no channel offset, no partition math, no ledger. `RefDistributor` dispatches aligned windows (one ref per rank per window) so every rank yields the **same batch count** — the lockstep invariant FSDP collectives require.
- **`DPAckController`**: `ack_train_refs` becomes a DP collective at the existing `ack_fn` seam — every rank gathers, only rank 0 writes the durable `{acked, global_step, optimizer_durable}` marker. Single writer, no interleaved partial acks.
- **Backpressure at micro-batch granularity**: each rank's loader acks its own inbox sidecar; the distributor mirrors the sum onto the source channel counter. The producer watermark never has to cover a whole `dp × batch × accum` optimizer window (a boundary-granularity counter deadlocks when that product exceeds the watermark).
- **Loud failure, never a silent hang**: a dying distributor poisons every inbox with a `.failed` sentinel (traceback included); `InboxChannel` readers raise immediately. Distinct from the clean `.closed` end-of-stream. DP path defaults `idle_timeout_s=1800`.
- **Restart guards**: stale ledger without `resume=True` raises (commit-dedup would silently swallow the re-streamed channel); released refs skip without double-counting the consumed counter (`seed_consumed()`); committed-unacked refs re-dispatch via `reconcile_on_restart`.
- **CPU-only producer**: the HTTP driver runs as plain `python` — no GPU, no torchrun, no process group (needed for cross-node where the inference node's GPUs are all serving).
- Single-rank (`dp_size==1`, no `inbox_dir`) keeps the exact legacy path.

## Server-capture bug found & fixed (affects #653 too)

The first 5k DP run crashed at step 1570: **one prefill batch hit a 64-token radix-cache prefix**, so the server captured hidden states 64 tokens short of the prompt → rope shape mismatch in the dflash draft. 427 other batches had zero cache hits — earlier single-DP runs survived on luck.

- patch: scheduler startup now also requires `--disable-radix-cache` (same guard style as the chunked-prefill check);
- adapter: rejects any capture whose seq len ≠ prompt len (frees the corrupt keys, fails just that sample);
- the new `.failed` poisoning turned what would have been a silent multi-rank hang into a diagnosable traceback.

## Validation (sci-h200, 8×H200)

- `tests/test_runtime`: **326 OK** (4 skip, 1 xfail) — 14 new CPU tests (round-robin alignment, shard disjointness, dedup, resume/reconcile, counter seeding, inbox poisoning, EOS lease release, gather-union ack).
- Adversarial review workflow over the diff: 8 confirmed findings, all fixed (backpressure deadlock, restart double-count, silent-hang, stale-ledger swallow, EOS lease leak, NoOp-store guard, barrier stranding, dp1-example ledger).
- **DP=2 e2e, 5000 steps** (server TP=4 on GPU 0–3, CPU producer, DP=2 trainer on GPU 4–5, Qwen3.6-27B dflash): loss 6.6→3.15, acc→0.237; asserted post-run: inboxes 5128/5128 **disjoint & equal**, ledger **acked = 10000 = 2×5000 exactly**, marker `global_step=5000 optimizer_durable=true`, `acked ⊆ dispatched ⊆ committed`, zero cache hits, zero sink failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)