### PR TITLE
[Online track] O4: multi-server producer — fan the disagg producer out over N capture servers

### DIFF
--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -153,3 +153,23 @@ train step, with aux parity vs an HF reference) in
 `tests/test_runtime/test_server_capture_gate.py`
 (`SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1`, GPU); the contract/ref/adapter logic is
 covered on CPU in `tests/test_runtime/test_server_capture.py`.
+
+## Multi-server (scale the inference pool)
+
+```bash
+bash examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh   # 2x TP=2 + DP=2
+```
+
+`DISAGG_SERVER_URLS` (comma-separated) fans the producer out: one
+`SGLangServerCaptureAdapter` + one `RolloutWorker` *per server*, each on its own
+thread, leasing **disjoint** prompts from the one controller — N servers prefill
+concurrently into the same Mooncake namespace (every server registers a segment
+with the one master; the trainer fetches by key, oblivious to which server
+captured). All servers must run the same model + capture flags.
+
+Failure semantics (`specforge/launch.py:build_disagg_online_producer`): a dead
+server's worker fails its leases retryable (survivors re-lease them) and is
+dropped after `max_worker_failures` consecutive errors; all workers dead with
+prompts remaining raises instead of truncating; a prompt the pool rejects every
+time goes terminal after `max_prompt_attempts`. CPU coverage:
+`tests/test_runtime/test_disagg_multiserver.py`.

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -28,6 +28,10 @@ Config is environment-driven so one wrapper drives both roles; role is
 
     DISAGG_ROLE=producer|consumer      # else rank 0 -> producer, else consumer
     DISAGG_SERVER_URL=http://host:30000   # the patched SGLang server (producer)
+    DISAGG_SERVER_URLS=http://h1:30000,http://h2:30000  # MULTI-server fan-out
+                                       # (comma-separated; overrides SERVER_URL;
+                                       #  one adapter+worker per server, driven
+                                       #  concurrently over disjoint prompts)
     DISAGG_STORE_ID=qwen36-dflash-disagg  # Mooncake key namespace (both roles)
     DISAGG_REF_CHANNEL=/root/disagg/refs.jsonl   # tiny ref manifest (both roles)
     DISAGG_DB=/root/disagg/run.db      # consumer rank-0 ledger (trainer-side ONLY)
@@ -162,8 +166,18 @@ def _resolve_mask_token(args, tokenizer) -> int:
     return tokenizer.mask_token_id
 
 
+def _server_urls() -> list:
+    """The patched-server pool: DISAGG_SERVER_URLS (comma list) or the single
+    DISAGG_SERVER_URL. Every server must run the SAME model/patch flags (the
+    FeatureContract check fails loud per-sample on a heterogeneous pool)."""
+    urls = os.environ.get("DISAGG_SERVER_URLS")
+    if urls:
+        return [u.strip() for u in urls.split(",") if u.strip()]
+    return [os.environ["DISAGG_SERVER_URL"]]
+
+
 def run_producer(args) -> None:
-    """Thin CPU driver: prompts -> patched server (captures to Mooncake) -> refs."""
+    """Thin CPU driver: prompts -> patched server(s) (capture to Mooncake) -> refs."""
     tokenizer = AutoTokenizer.from_pretrained(
         args.target_model_path, trust_remote_code=args.trust_remote_code
     )
@@ -180,14 +194,21 @@ def run_producer(args) -> None:
 
     store = _mooncake_store()
     channel = _ref_channel()
-    adapter = SGLangServerCaptureAdapter(
-        os.environ["DISAGG_SERVER_URL"],
-        store,
-        run_id=RUN_ID,
-        strategy="dflash",
-        target_model_version=args.target_model_path,
-    )
-    print(f"[producer] {len(prompts)} prompts -> {os.environ['DISAGG_SERVER_URL']}")
+    # One adapter per server, all over the ONE store instance (thread-safe):
+    # each adapter gets its own RolloutWorker leasing disjoint prompts, so N
+    # servers prefill concurrently into the same Mooncake namespace.
+    urls = _server_urls()
+    adapters = [
+        SGLangServerCaptureAdapter(
+            url,
+            store,
+            run_id=RUN_ID,
+            strategy="dflash",
+            target_model_version=args.target_model_path,
+        )
+        for url in urls
+    ]
+    print(f"[producer] {len(prompts)} prompts -> {len(urls)} server(s): {urls}")
 
     # NO shared db: the trainer-side ledger (DISAGG_DB) is the run's single
     # book-keeper; committed rows from the producer would make the consumer
@@ -195,7 +216,7 @@ def run_producer(args) -> None:
     # in-memory store still dedups within its own process.
     _workers, drive_producer = build_disagg_online_producer(
         strategy="dflash",
-        feature_source=adapter,
+        feature_source=adapters if len(adapters) > 1 else adapters[0],
         prompts=prompts,
         feature_store=store,
         channel=channel,

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Qwen3.6-27B DFlash, ONLINE disaggregated, MULTI-SERVER on one 8-GPU node:
+#   mooncake master           -> CPU  (RDMA/TCP object store)
+#   patched SGLang server 0   -> GPUs 0,1 (TP=2, frozen 27B target -> mooncake)
+#   patched SGLang server 1   -> GPUs 2,3 (TP=2, same model + capture flags)
+#   producer (HTTP driver)    -> CPU  (fans prompts out to BOTH servers)
+#   consumer (DFlash trainer) -> GPUs 4,5 (DP=2 over per-rank inboxes)
+#
+# Multi-server sibling of run_qwen3.6_27b_dflash_disagg.sh. The producer builds
+# one SGLangServerCaptureAdapter per URL in DISAGG_SERVER_URLS; each adapter is
+# driven by its own RolloutWorker on its own thread, leasing DISJOINT prompts
+# from the one controller — both servers prefill concurrently. Every server
+# registers a segment with the ONE mooncake master, so the trainer fetches any
+# sample by key regardless of which server captured it. A server that dies is
+# dropped after its in-flight prompts are returned to the pool; the survivor
+# finishes the run.
+#
+# Both servers MUST be launched with identical model + capture flags (the
+# producer's FeatureContract check fails loudly per-sample otherwise).
+#
+# Prereqs: identical to run_qwen3.6_27b_dflash_disagg.sh (patched sglang 0.5.14,
+# mooncake_master on PATH, dataset + weights cached, WANDB_API_KEY or
+# --report-to none).
+set -uxo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
+cd "$ROOT_DIR"
+
+# --- topology: 2 servers x TP=2 + DP=2 trainer (override via env) ---
+SERVER0_GPUS=${SERVER0_GPUS:-"0,1"}
+SERVER1_GPUS=${SERVER1_GPUS:-"2,3"}
+SERVER_TP=${SERVER_TP:-2}
+SERVER0_PORT=${SERVER0_PORT:-30000}
+SERVER1_PORT=${SERVER1_PORT:-30001}
+TRAIN_DP=${TRAIN_DP:-2}
+CONSUMER_GPUS=${CONSUMER_GPUS:-"4,5"}
+# DFlash target capture layers — must match dflash_config.target_layer_ids in
+# the draft config below, on BOTH servers.
+AUX_LAYER_IDS=${AUX_LAYER_IDS:-"1 16 31 46 61"}
+
+# --- mooncake connection (server sinks + producer + consumer share these) ---
+export MOONCAKE_LOCAL_HOSTNAME=${MOONCAKE_LOCAL_HOSTNAME:-127.0.0.1}
+export MOONCAKE_MASTER_SERVER_ADDR=${MOONCAKE_MASTER_SERVER_ADDR:-127.0.0.1:50051}
+export MOONCAKE_METADATA_SERVER=${MOONCAKE_METADATA_SERVER:-http://127.0.0.1:8080/metadata}
+export MOONCAKE_PROTOCOL=${MOONCAKE_PROTOCOL:-tcp}
+# EACH server contributes a segment of this size to the one master; objects are
+# hard-pinned (undersizing fails puts rather than evicting). The producer
+# watermark's in-flight bytes now spread across N segments, but placement is
+# not balanced — keep per-server headroom above watermark/N (skew margin).
+export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((48 << 30))}
+# Producer/consumer are pure clients (no segment): objects must not live in a
+# process that exits before training finishes.
+export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
+
+export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg-2srv}
+export DISAGG_SERVER_URLS="http://127.0.0.1:$SERVER0_PORT,http://127.0.0.1:$SERVER1_PORT"
+export DISAGG_REF_CHANNEL=${DISAGG_REF_CHANNEL:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/refs.jsonl}
+# Trainer-side ONLY (rank-0 ledger + per-rank inboxes); the producer must not
+# see the db — the launcher below passes it just to the consumer.
+DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+DISAGG_INBOX_DIR=${DISAGG_INBOX_DIR:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/inboxes}
+export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-400}
+export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}
+export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
+REPORT_TO=${REPORT_TO:-wandb}  # set REPORT_TO=none to run without W&B
+
+rm -rf "$(dirname "$DISAGG_REF_CHANNEL")" "$DISAGG_DB"
+mkdir -p "$(dirname "$DISAGG_REF_CHANNEL")"
+: > "$DISAGG_REF_CHANNEL"
+
+cleanup() { kill "${MASTER_PID:-}" "${SERVER0_PID:-}" "${SERVER1_PID:-}" "${PRODUCER_PID:-}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- mooncake master ---
+mooncake_master --enable-http-metadata-server=true &
+MASTER_PID=$!
+sleep 3
+
+# --- patched SGLang servers: frozen 27B target, TP=2 each, spec-capture on ---
+launch_server() { # $1=gpus $2=port
+    CUDA_VISIBLE_DEVICES=$1 MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAME \
+        python -m sglang.launch_server \
+            --model-path Qwen/Qwen3.6-27B \
+            --trust-remote-code \
+            --skip-tokenizer-init \
+            --tp-size "$SERVER_TP" \
+            --mem-fraction-static 0.85 \
+            --chunked-prefill-size -1 \
+            --disable-radix-cache \
+            --enable-spec-capture \
+            --spec-capture-method dflash \
+            --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
+            --port "$2" &
+}
+launch_server "$SERVER0_GPUS" "$SERVER0_PORT"
+SERVER0_PID=$!
+launch_server "$SERVER1_GPUS" "$SERVER1_PORT"
+SERVER1_PID=$!
+
+# wait for BOTH servers before driving prompts (die fast if either dies)
+for port_pid in "$SERVER0_PORT:$SERVER0_PID" "$SERVER1_PORT:$SERVER1_PID"; do
+    port=${port_pid%%:*}; pid=${port_pid##*:}
+    until curl -sf "http://127.0.0.1:$port/health" > /dev/null; do
+        if ! kill -0 "$pid" 2>/dev/null; then echo "server on :$port died"; exit 1; fi
+        sleep 5
+    done
+done
+
+# recipe matches run_qwen3.6_27b_dflash_disagg.sh; max-length 2048 for a bounded
+# single-node demo. batch-size is PER RANK: global batch = batch_size * TRAIN_DP.
+ARGS=(
+    --target-model-path Qwen/Qwen3.6-27B
+    --target-model-backend hf
+    --trust-remote-code
+    --draft-config-path "$ROOT_DIR/configs/qwen3.6-27b-dflash.json"
+    --embedding-key model.language_model.embed_tokens.weight
+    --lm-head-key lm_head.weight
+    --mask-token-id 248070
+    --train-data-path "$ROOT_DIR/cache/dataset/nemotron_v2_train.jsonl"
+    --chat-template qwen3.5
+    --max-length 2048
+    --batch-size 1
+    --learning-rate 6e-4
+    --warmup-ratio 0.04
+    --max-grad-norm 1.0
+    --attention-backend flex_attention
+    --block-size 16
+    --num-anchors 512
+    --loss-decay-gamma 7.0
+    --num-epochs 1
+    --seed 42
+    --save-interval 1000000
+)
+
+LAUNCHER=$SCRIPT_DIR/run_disagg_dflash.py
+
+# --- producer: CPU-only HTTP driver fanning out to both servers ---
+DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
+    python "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$ROOT_DIR/outputs/qwen36-disagg-2srv-producer" &
+PRODUCER_PID=$!
+
+# --- consumer: DP=$TRAIN_DP trainer pool; rank 0 = distributor + ledger ---
+CUDA_VISIBLE_DEVICES=$CONSUMER_GPUS DISAGG_ROLE=consumer \
+    DISAGG_DB=$DISAGG_DB DISAGG_INBOX_DIR=$DISAGG_INBOX_DIR \
+    torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29702 \
+        --nnodes 1 --nproc_per_node "$TRAIN_DP" "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$ROOT_DIR/outputs/qwen36-disagg-2srv-consumer" \
+        --report-to "$REPORT_TO" \
+        --wandb-project qwen36-dflash-disagg \
+        --wandb-name qwen36-27b-dflash-2srv-tp2-dp$TRAIN_DP
+
+wait $PRODUCER_PID
+echo "DISAGG36-2SRV-DONE"

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -274,6 +274,7 @@ class SGLangServerCaptureAdapter:
                 "target_repr": contract.target_repr,
                 "vocab_map_version": contract.vocab_map_version,
                 "transport": "sglang_server_capture",
+                "server": self.base_url,  # which server captured it (provenance)
                 "generation": gen,  # the zero-copy get() locator
             },
         )

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -16,6 +16,7 @@ is a registry entry, not a new ``build_*`` family.
 
 from __future__ import annotations
 
+import logging
 from typing import List, Optional, Tuple
 
 from specforge.runtime.contracts import DeploymentMode, SampleRef
@@ -30,6 +31,8 @@ from specforge.runtime.control_plane.metadata_store import (
 )
 from specforge.runtime.data_plane import FeatureStore, LocalFeatureStore
 from specforge.training.strategies.registry import StrategySpec, resolve_strategy
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Shared assemblers — strategy- and topology-agnostic.
@@ -225,6 +228,12 @@ def _assemble_rollout_workers(
     SGLang server writes features straight to the store — no ``target_model``
     is loaded here). Otherwise an in-process adapter is built over
     ``target_model``.
+
+    A *sequence* of feature sources fans out to one worker per source (the
+    multi-server topology: 1 server : 1 adapter : 1 worker). All workers share
+    the one controller, whose per-``worker_id`` leases keep their prompt slices
+    disjoint. A single source keeps the legacy shape: ``num_rollout_workers``
+    workers sharing it.
     """
     if not spec.supports_online:
         raise NotImplementedError(
@@ -239,22 +248,35 @@ def _assemble_rollout_workers(
         aux_hidden_state_layer_ids = tuple(
             getattr(target_model, "aux_hidden_states_layers", ()) or ()
         )
-    if feature_source is not None:
-        adapter = feature_source
+    if isinstance(feature_source, (list, tuple)):
+        if not feature_source:
+            raise ValueError("feature_source sequence is empty")
+        if num_rollout_workers not in (1, len(feature_source)):
+            raise ValueError(
+                f"num_rollout_workers={num_rollout_workers} conflicts with "
+                f"{len(feature_source)} feature sources (one worker per source)"
+            )
+        adapters = list(feature_source)
+    elif feature_source is not None:
+        adapters = [feature_source] * num_rollout_workers
     elif spec.make_adapter is not None:
-        adapter = spec.make_adapter(target_model, device=device, t2d=t2d)
+        adapters = [
+            spec.make_adapter(target_model, device=device, t2d=t2d)
+        ] * num_rollout_workers
     else:
         from specforge.inference.adapters.policy import (
             EAGLE3_FEATURE_SCHEMA,
             PolicyFeatureAdapter,
         )
 
-        adapter = PolicyFeatureAdapter(
-            target_model,
-            schema=spec.feature_schema or EAGLE3_FEATURE_SCHEMA,
-            device=device,
-            t2d=t2d,
-        )
+        adapters = [
+            PolicyFeatureAdapter(
+                target_model,
+                schema=spec.feature_schema or EAGLE3_FEATURE_SCHEMA,
+                device=device,
+                t2d=t2d,
+            )
+        ] * num_rollout_workers
     feature_contract = FeatureContract.from_strategy(
         required_features=spec.required_features,
         aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
@@ -275,7 +297,7 @@ def _assemble_rollout_workers(
             worker_id=f"rollout-{i}",
             strategy=spec.name,
         )
-        for i in range(num_rollout_workers)
+        for i, adapter in enumerate(adapters)
     ]
 
 
@@ -565,6 +587,8 @@ def build_disagg_online_producer(
     lease: int = 8,
     in_flight_high_watermark: int = 256,
     backpressure_poll_s: float = 0.2,
+    max_worker_failures: int = 3,
+    max_prompt_attempts: Optional[int] = 5,
     metadata_store: Optional[MetadataStore] = None,
     metadata_db_path: Optional[str] = None,
     sleep=None,
@@ -574,12 +598,27 @@ def build_disagg_online_producer(
     Workers put() into a cross-node ``feature_store``; committed refs stream to
     the consumer via ``channel``. Pass ``feature_source`` for the server-capture
     transport (live SGLang server writes to the store; ``target_model`` stays
-    None). ``metadata_store``/``metadata_db_path`` must be the same durable store
+    None) — a *sequence* of sources fans out to one worker per source (the
+    multi-server topology; each worker drives its own server concurrently).
+    ``metadata_store``/``metadata_db_path`` must be the same durable store
     the consumer opens. Returns ``(workers, drive_producer)``:
     ``drive_producer(should_stop=...)`` runs until the prompt pool drains, pauses
     above ``in_flight_high_watermark``, and always closes the channel on exit
     (EOF terminates the consumer's loader).
+
+    Failure semantics: a worker whose source raises (dead/unreachable server)
+    has already failed its leases retryable — the surviving workers re-lease
+    those prompts. After ``max_worker_failures`` *consecutive* failures the
+    worker is dropped from rotation (its health is logged); if every worker is
+    dropped while prompts remain, ``drive_producer`` raises instead of silently
+    truncating the run. Per-task retryable failures are bounded by
+    ``max_prompt_attempts`` (a poisoned prompt goes terminal, not infinite).
+    The pool counts as drained only when no prompt is pending *or leased* —
+    an all-failed round no longer reads as end-of-data. With N workers the
+    watermark can overshoot by up to N * lease (each worker checks it
+    independently before leasing).
     """
+    import threading
     import time
 
     spec = resolve_strategy(strategy)
@@ -587,6 +626,7 @@ def build_disagg_online_producer(
     controller = DataFlowController(
         run_id,
         metadata_store=_resolve_metadata_store(metadata_store, metadata_db_path),
+        max_prompt_attempts=max_prompt_attempts,
     )
     controller.ingest_prompts(prompts)
 
@@ -609,26 +649,113 @@ def build_disagg_online_producer(
     )
 
     def drive_producer(max_rounds: int = 1_000_000, should_stop=None) -> int:
+        """Drive all workers until the pool drains; returns refs published.
+
+        One worker runs inline; N workers run one thread each (the blocking
+        HTTP prefill call releases the GIL, so servers genuinely overlap).
+        The controller and feature store are lock-protected; the channel is
+        not, so publishes serialize through ``publish_lock``.
+        """
         for w in workers:
             w.start()
-        produced = 0
-        try:
+        publish_lock = threading.Lock()
+        state = {"produced": 0}
+        dead: dict = {}  # worker_id -> last failure reason
+
+        def pool_drained() -> bool:
+            st = controller.status()
+            # leased counts too: a peer's in-flight lease may fail retryable
+            # and come back — leaving then would strand it.
+            return st["prompts_pending"] == 0 and st["prompts_leased"] == 0
+
+        def run_worker(w) -> None:
+            failures = 0
             for _ in range(max_rounds):
                 if should_stop is not None and should_stop():
-                    break  # caller asked us to wind down (e.g. trainer finished)
+                    return
                 # backpressure: in_flight = published - consumer-acked
                 while channel.in_flight_remote() >= in_flight_high_watermark:
                     if should_stop is not None and should_stop():
-                        return produced  # don't block on the watermark forever
+                        return
                     sleep(backpressure_poll_s)
-                refs = []
-                for w in workers:
-                    refs.extend(w.run_once(max_tasks=lease))
-                if not refs:
-                    break  # prompt pool drained
-                channel.publish_many(refs)
-                produced += len(refs)
-            return produced
+                try:
+                    refs = w.run_once(max_tasks=lease)
+                except Exception as exc:
+                    # the worker already failed its leases retryable; peers
+                    # (or this worker, next round) will re-lease them.
+                    failures += 1
+                    logger.warning(
+                        "rollout worker %s failed (%d/%d): %s",
+                        w.worker_id,
+                        failures,
+                        max_worker_failures,
+                        exc,
+                    )
+                    if failures >= max_worker_failures:
+                        dead[w.worker_id] = str(exc)
+                        logger.error(
+                            "dropping rollout worker %s after %d consecutive "
+                            "failures; health=%s",
+                            w.worker_id,
+                            failures,
+                            w.health(),
+                        )
+                        return
+                    sleep(backpressure_poll_s)
+                    continue
+                failures = 0
+                if refs:
+                    with publish_lock:
+                        channel.publish_many(refs)
+                        state["produced"] += len(refs)
+                elif pool_drained():
+                    return
+                else:
+                    # leased nothing: peers hold the remaining prompts (their
+                    # leases may yet fail back into the pool) — wait, retry.
+                    sleep(backpressure_poll_s)
+
+        fatal: list = []  # non-transport errors escaping a worker thread
+
+        def run_worker_guarded(w) -> None:
+            try:
+                run_worker(w)
+            except BaseException as exc:  # e.g. a channel publish failure
+                fatal.append((w.worker_id, exc))
+
+        try:
+            if len(workers) == 1:
+                run_worker(workers[0])
+            else:
+                threads = [
+                    threading.Thread(
+                        target=run_worker_guarded,
+                        args=(w,),
+                        name=f"drive-{w.worker_id}",
+                        daemon=True,
+                    )
+                    for w in workers
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+            if fatal:
+                raise fatal[0][1]
+            stopped = should_stop is not None and should_stop()
+            if dead and not stopped and not pool_drained():
+                raise RuntimeError(
+                    f"all rollout workers exited with {len(dead)} dropped as "
+                    f"dead and prompts remaining — dead workers: {dead}"
+                )
+            st = controller.status()
+            if st["prompts_failed"]:
+                logger.warning(
+                    "producer finished with %d terminally failed prompts "
+                    "(see controller status for reasons)",
+                    st["prompts_failed"],
+                )
+            return state["produced"]
         finally:
             channel.close()  # EOF -> the consumer's loader terminates once drained
 

--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -89,6 +89,7 @@ class DataFlowController:
         sample_queue: Optional[SampleRefQueue] = None,
         metadata_store: Optional[MetadataStore] = None,
         backpressure: Optional[BackpressureController] = None,
+        max_prompt_attempts: Optional[int] = None,
     ) -> None:
         self.run_id = run_id
         self.sample_queue = sample_queue or SampleRefQueue()
@@ -97,6 +98,10 @@ class DataFlowController:
         # behavior). The controller owns the pause decision; the policy only
         # reads capacity (FeatureStore.health) — no tensors cross this seam.
         self.backpressure = backpressure
+        # Retryable-failure bound: a task failed this many attempts goes
+        # terminal instead of requeueing (None = retry forever). Bounds a
+        # poisoned prompt that would otherwise pin the pool non-empty forever.
+        self.max_prompt_attempts = max_prompt_attempts
         self._prompts: "OrderedDict[str, PromptTask]" = OrderedDict()
         self._prompt_pending: Deque[str] = deque()
         self._prompt_leased: Dict[str, str] = {}  # task_id -> worker_id
@@ -193,12 +198,20 @@ class DataFlowController:
                 task = self._prompts.get(task_id)
                 if task is None:
                     continue
-                if retryable:
+                attempts_left = (
+                    self.max_prompt_attempts is None
+                    or task.attempt + 1 < self.max_prompt_attempts
+                )
+                if retryable and attempts_left:
                     self._prompts[task_id] = dataclasses.replace(
                         task, attempt=task.attempt + 1
                     )
                     if task_id not in self._prompt_pending:
                         self._prompt_pending.append(task_id)
+                elif retryable:
+                    self._prompt_failed[task_id] = (
+                        f"{reason} (attempts exhausted: {task.attempt + 1})"
+                    )
                 else:
                     self._prompt_failed[task_id] = reason
 

--- a/tests/test_runtime/test_disagg_multiserver.py
+++ b/tests/test_runtime/test_disagg_multiserver.py
@@ -1,0 +1,213 @@
+# coding=utf-8
+"""Multi-server producer fan-out (no GPU, no server, no mooncake master).
+
+The multi-server topology: ``build_disagg_online_producer(feature_source=[...])``
+builds one RolloutWorker per SGLangServerCaptureAdapter (1 server : 1 adapter :
+1 worker), all leasing DISJOINT prompts from the one controller and publishing
+into the one channel, concurrently. Each stub ``post_fn`` stands in for one
+patched SGLang server writing into the SHARED fake Mooncake backend — exactly
+the shape of ``examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh``.
+
+Covers the failure matrix the single-server path never hits:
+- disjoint + complete production across two live servers;
+- one dead server: its leases fail retryable, the survivor re-leases and
+  finishes the pool (no truncation, no hang);
+- all servers dead: loud RuntimeError, channel still closed;
+- a poisoned prompt (server rejects it every time): terminal after
+  ``max_prompt_attempts`` instead of spinning the drained-detection loop.
+"""
+
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+from specforge.inference.adapters.server_capture import SGLangServerCaptureAdapter
+from specforge.launch import build_disagg_online_producer
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+from tests.test_runtime.test_server_capture import (
+    AUX_LAYERS,
+    HIDDEN,
+    _FakeMooncakeStore,
+    _StubCaptureServer,
+)
+
+
+def _SLEEP(_s):  # injected drive sleep: keep retry/backpressure spins bounded
+    time.sleep(0.001)
+
+
+def _prompts(n, seq=6):
+    return [
+        {
+            "task_id": f"p{i}",
+            "payload": {
+                "input_ids": list(range(1, seq + 1 + i)),
+                "loss_mask": [1] * (seq + i),
+            },
+        }
+        for i in range(n)
+    ]
+
+
+def _adapter(store, post_fn, url="http://server:30000"):
+    return SGLangServerCaptureAdapter(
+        url, store, run_id="run0", strategy="dflash", post_fn=post_fn
+    )
+
+
+def _build(adapters, prompts, store, channel, **kw):
+    return build_disagg_online_producer(
+        strategy="dflash",
+        feature_source=adapters,
+        prompts=prompts,
+        feature_store=store,
+        channel=channel,
+        run_id="run0",
+        target_hidden_size=HIDDEN,
+        target_repr=None,
+        aux_hidden_state_layer_ids=AUX_LAYERS,
+        sleep=_SLEEP,
+        **kw,
+    )
+
+
+def _published_refs(path):
+    return StreamingRefChannel(path).poll()
+
+
+def _published_sample_ids(path):
+    return [r.sample_id for r in _published_refs(path)]
+
+
+class TestMultiServerProducer(unittest.TestCase):
+    def _workdir(self):
+        return tempfile.mkdtemp(prefix="disagg_multisrv_")
+
+    def test_two_servers_disjoint_and_complete(self):
+        backend = _FakeMooncakeStore()
+        stubs = [_StubCaptureServer(backend), _StubCaptureServer(backend)]
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        adapters = [
+            _adapter(store, stubs[i], url=f"http://server{i}:3000{i}") for i in range(2)
+        ]
+        N = 12
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        workers, drive = _build(adapters, _prompts(N), store, channel, lease=2)
+        self.assertEqual(len(workers), 2)
+
+        produced = drive()
+        self.assertEqual(produced, N)
+        self.assertTrue(channel.is_closed())
+
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(len(ids), N)
+        self.assertEqual(len(set(ids)), N)  # no duplicate publishes
+
+        seen0, seen1 = set(stubs[0].expected), set(stubs[1].expected)
+        self.assertEqual(seen0 | seen1, {f"run0:p{i}" for i in range(N)})
+        self.assertEqual(seen0 & seen1, set())  # disjoint prompt slices
+        # concurrency is real: both servers captured (lease=2 over 12 prompts
+        # leaves plenty for the peer even in the worst interleaving)
+        self.assertTrue(seen0 and seen1)
+
+        # ref-level provenance mirrors the stub-level split (the post-hoc
+        # audit trail a real multi-server run relies on)
+        by_server = {}
+        for r in _published_refs(channel.path):
+            by_server.setdefault(r.metadata["server"], set()).add(r.sample_id)
+        self.assertEqual(by_server.get("http://server0:30000"), seen0)
+        self.assertEqual(by_server.get("http://server1:30001"), seen1)
+
+    def test_one_dead_server_survivor_completes_pool(self):
+        backend = _FakeMooncakeStore()
+        healthy = _StubCaptureServer(backend)
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+
+        dead_leased = threading.Event()
+
+        def dead_post(url, json_body, timeout):
+            dead_leased.set()  # it held leases when it died
+            raise ConnectionError("server 1 unreachable")
+
+        def healthy_post(url, json_body, timeout):
+            dead_leased.wait(5)  # let the dead server lease + fail first
+            return healthy(url, json_body, timeout)
+
+        adapters = [
+            _adapter(store, healthy_post, url="http://server0:30000"),
+            _adapter(store, dead_post, url="http://server1:30001"),
+        ]
+        N = 8
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        workers, drive = _build(adapters, _prompts(N), store, channel, lease=2)
+
+        produced = drive(max_rounds=10_000)
+        # the dead worker's leases were failed retryable and re-leased by the
+        # survivor: every prompt still becomes exactly one ref.
+        self.assertEqual(produced, N)
+        self.assertTrue(dead_leased.is_set())
+        self.assertEqual(set(healthy.expected), {f"run0:p{i}" for i in range(N)})
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(sorted(ids), sorted(set(ids)))
+        self.assertTrue(channel.is_closed())
+        self.assertTrue(workers[1].health()["recent_failures"])
+
+    def test_all_servers_dead_raises_loudly(self):
+        backend = _FakeMooncakeStore()
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+
+        def dead_post(url, json_body, timeout):
+            raise ConnectionError("pool down")
+
+        adapters = [
+            _adapter(store, dead_post, url=f"http://server{i}:3000{i}")
+            for i in range(2)
+        ]
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        _workers, drive = _build(
+            adapters, _prompts(4), store, channel, lease=2, max_worker_failures=2
+        )
+        with self.assertRaises(RuntimeError):
+            drive(max_rounds=10_000)
+        # EOF still reaches the consumer — a crashed producer must not hang it.
+        self.assertTrue(channel.is_closed())
+
+    def test_poisoned_prompt_goes_terminal_not_infinite(self):
+        # PR654 known rough edge: an all-failed round used to read as
+        # pool-drained (silent truncation); with drained = pending==0 AND
+        # leased==0 the loop instead retries — so a prompt the server rejects
+        # every time must go terminal via max_prompt_attempts, not spin.
+        backend = _FakeMooncakeStore()
+        stub = _StubCaptureServer(backend, error_sample_ids={"run0:p0"})
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        N = 5
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        _workers, drive = _build(
+            [_adapter(store, stub)],
+            _prompts(N),
+            store,
+            channel,
+            lease=2,
+            max_prompt_attempts=3,
+        )
+        produced = drive(max_rounds=10_000)
+        self.assertEqual(produced, N - 1)  # p0 terminal, everything else through
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(set(ids), {f"run0:p{i}" for i in range(1, N)})
+        self.assertTrue(channel.is_closed())
+
+    def test_source_count_worker_count_conflict_raises(self):
+        backend = _FakeMooncakeStore()
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        stub = _StubCaptureServer(backend)
+        adapters = [_adapter(store, stub), _adapter(store, stub)]
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        with self.assertRaises(ValueError):
+            _build(adapters, _prompts(2), store, channel, num_rollout_workers=3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacks on #655** — merge #655 first; until then this diff includes its commits.

## What

Scale the inference side of the online disaggregated run: `build_disagg_online_producer(feature_source=[...])` now fans out to **N patched SGLang servers** — one `SGLangServerCaptureAdapter` + one `RolloutWorker` + one driver thread per server, all leasing **disjoint** prompts from the one controller and publishing into the one ref channel / Mooncake namespace.

```
                          ┌── worker0/adapter0 ─HTTP─▶ server0 (TP=k) ─┐  every server registers
controller ──disjoint────┼── worker1/adapter1 ─HTTP─▶ server1 (TP=k) ─┼─▶ a segment with the ONE
  leases (worker_id)      └── workerN/adapterN ─HTTP─▶ serverN (TP=k) ─┘  mooncake master
        ▲ commit                    │ refs (tensor-free, per-server provenance in metadata)
        └───────────── driver ──publish (lock)──▶ StreamingRefChannel ──▶ DP consumer (#655)
```

The control plane needed **no** changes for the fan-out itself — per-`worker_id` leases were already disjoint and the controller/metadata-store/queue were already lock-protected. The channel is not, so publishes serialize through a driver-side lock. Each ref records its capture server in `metadata["server"]` (post-hoc provenance audit from the ref channel).

## Failure semantics (replaces the truncating `if not refs: break`)

- **Drained means drained**: end-of-data = no prompt *pending or leased* (via `controller.status()`). An all-failed round no longer reads as EOF — the known rough edge from #654.
- **Dead server**: its worker fails its leases retryable (survivors re-lease them) and is dropped after `max_worker_failures` consecutive errors; **all** workers dead with prompts remaining **raises** instead of silently truncating.
- **Poisoned prompt**: per-task retryable failures are bounded by a new `DataFlowController(max_prompt_attempts=…)` knob (producer default 5) — required now that the drained check retries instead of truncating; an unbounded retry would spin forever.
- Watermark backpressure can overshoot by ≤ N×lease (each worker checks independently) — documented.

Single-source calls keep the legacy shape (`num_rollout_workers` workers sharing one adapter, inline drive loop).

## Example

`examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh` — one 8-GPU node: 2 patched servers TP=2 (GPUs 0-1 / 2-3), CPU producer over `DISAGG_SERVER_URLS`, DP=2 trainer (GPUs 4-5, #655's RefDistributor). Servers must share model + capture flags (the FeatureContract check fails loud per-sample otherwise).

## Validation (sci-h200, 8×H200, sglang 0.5.14 + patch)

- `tests/test_runtime`: **331 OK** (4 skip, 1 xfail) — 5 new CPU tests in `test_disagg_multiserver.py`: disjoint+complete 2-server production (incl. ref-level provenance vs stub-level split), dead-server failover (survivor re-leases and finishes the pool), all-dead → RuntimeError with channel still closed, poisoned-prompt goes terminal not infinite, source/worker-count conflict.
- **e2e (2×TP2 + DP2)**: 400 prompts → 400 samples, 200 steps/rank; asserted post-run: ledger `acked = 400 = 2×200` exactly, inboxes 200/200 **disjoint & equal**, zero worker failures, both server segments pooled on the one master (96 GB).
- **provenance e2e** (40 prompts): per-server split `{server0: 16, server1: 24}`, disjoint, union 40 — both servers demonstrably captured concurrently.

Note: #655's example got a one-line fix pushed to its branch (`--spec-capture-method dflash`; the VL target crashes on the default eagle3 capture hook — #654 fix #1's flag was never wired into the example scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)