### PR TITLE
[Online track] Roll up O3/O4 into up-16

### DIFF
--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -153,3 +153,23 @@ train step, with aux parity vs an HF reference) in
 `tests/test_runtime/test_server_capture_gate.py`
 (`SPECFORGE_RUN_SERVER_CAPTURE_TESTS=1`, GPU); the contract/ref/adapter logic is
 covered on CPU in `tests/test_runtime/test_server_capture.py`.
+
+## Multi-server (scale the inference pool)
+
+```bash
+bash examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh   # 2x TP=2 + DP=2
+```
+
+`DISAGG_SERVER_URLS` (comma-separated) fans the producer out: one
+`SGLangServerCaptureAdapter` + one `RolloutWorker` *per server*, each on its own
+thread, leasing **disjoint** prompts from the one controller — N servers prefill
+concurrently into the same Mooncake namespace (every server registers a segment
+with the one master; the trainer fetches by key, oblivious to which server
+captured). All servers must run the same model + capture flags.
+
+Failure semantics (`specforge/launch.py:build_disagg_online_producer`): a dead
+server's worker fails its leases retryable (survivors re-lease them) and is
+dropped after `max_worker_failures` consecutive errors; all workers dead with
+prompts remaining raises instead of truncating; a prompt the pool rejects every
+time goes terminal after `max_prompt_attempts`. CPU coverage:
+`tests/test_runtime/test_disagg_multiserver.py`.

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -28,6 +28,10 @@ Config is environment-driven so one wrapper drives both roles; role is
 
     DISAGG_ROLE=producer|consumer      # else rank 0 -> producer, else consumer
     DISAGG_SERVER_URL=http://host:30000   # the patched SGLang server (producer)
+    DISAGG_SERVER_URLS=http://h1:30000,http://h2:30000  # MULTI-server fan-out
+                                       # (comma-separated; overrides SERVER_URL;
+                                       #  one adapter+worker per server, driven
+                                       #  concurrently over disjoint prompts)
     DISAGG_STORE_ID=qwen36-dflash-disagg  # Mooncake key namespace (both roles)
     DISAGG_REF_CHANNEL=/root/disagg/refs.jsonl   # tiny ref manifest (both roles)
     DISAGG_DB=/root/disagg/run.db      # consumer rank-0 ledger (trainer-side ONLY)
@@ -162,8 +166,18 @@ def _resolve_mask_token(args, tokenizer) -> int:
     return tokenizer.mask_token_id
 
 
+def _server_urls() -> list:
+    """The patched-server pool: DISAGG_SERVER_URLS (comma list) or the single
+    DISAGG_SERVER_URL. Every server must run the SAME model/patch flags (the
+    FeatureContract check fails loud per-sample on a heterogeneous pool)."""
+    urls = os.environ.get("DISAGG_SERVER_URLS")
+    if urls:
+        return [u.strip() for u in urls.split(",") if u.strip()]
+    return [os.environ["DISAGG_SERVER_URL"]]
+
+
 def run_producer(args) -> None:
-    """Thin CPU driver: prompts -> patched server (captures to Mooncake) -> refs."""
+    """Thin CPU driver: prompts -> patched server(s) (capture to Mooncake) -> refs."""
     tokenizer = AutoTokenizer.from_pretrained(
         args.target_model_path, trust_remote_code=args.trust_remote_code
     )
@@ -180,14 +194,21 @@ def run_producer(args) -> None:
 
     store = _mooncake_store()
     channel = _ref_channel()
-    adapter = SGLangServerCaptureAdapter(
-        os.environ["DISAGG_SERVER_URL"],
-        store,
-        run_id=RUN_ID,
-        strategy="dflash",
-        target_model_version=args.target_model_path,
-    )
-    print(f"[producer] {len(prompts)} prompts -> {os.environ['DISAGG_SERVER_URL']}")
+    # One adapter per server, all over the ONE store instance (thread-safe):
+    # each adapter gets its own RolloutWorker leasing disjoint prompts, so N
+    # servers prefill concurrently into the same Mooncake namespace.
+    urls = _server_urls()
+    adapters = [
+        SGLangServerCaptureAdapter(
+            url,
+            store,
+            run_id=RUN_ID,
+            strategy="dflash",
+            target_model_version=args.target_model_path,
+        )
+        for url in urls
+    ]
+    print(f"[producer] {len(prompts)} prompts -> {len(urls)} server(s): {urls}")
 
     # NO shared db: the trainer-side ledger (DISAGG_DB) is the run's single
     # book-keeper; committed rows from the producer would make the consumer
@@ -195,7 +216,7 @@ def run_producer(args) -> None:
     # in-memory store still dedups within its own process.
     _workers, drive_producer = build_disagg_online_producer(
         strategy="dflash",
-        feature_source=adapter,
+        feature_source=adapters if len(adapters) > 1 else adapters[0],
         prompts=prompts,
         feature_store=store,
         channel=channel,

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -42,6 +42,15 @@ sides land on one master. Export ``WANDB_API_KEY`` for consumer W&B logging.
 import hashlib
 import json
 import os
+import sys
+
+import torch
+
+if not torch.cuda.is_available():
+    # GPU-less process (the CPU producer): yunchang probes CUDA at import time
+    # whenever flashinfer is importable (yunchang.globals.get_cuda_arch) and
+    # raises; hiding flashinfer trips its clean ImportError fallback instead.
+    sys.modules["flashinfer"] = None
 
 from accelerate.utils import set_seed
 from train_dflash import build_models, parse_args

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -288,6 +288,8 @@ def run_consumer(args) -> None:
         logger=logger,
         log_interval=_max("DISAGG_LOG_INTERVAL", 1),
         inbox_dir=os.environ.get("DISAGG_INBOX_DIR") or None,
+        # liveness guard against a dead producer/server (DP default: 1800s)
+        idle_timeout_s=float(os.environ.get("DISAGG_IDLE_TIMEOUT", 0)) or None,
     )
     try:
         trainer.fit(loader)

--- a/examples/disagg/run_disagg_dflash.py
+++ b/examples/disagg/run_disagg_dflash.py
@@ -18,6 +18,11 @@ and ran staged, since DFlash's HF capture is not thread-safe): the server does
 the capture, so a single prefill per prompt feeds training directly. It is the
 disaggregated sibling of ``examples/run_qwen3.6_27b_dflash_online.sh``.
 
+The producer is CPU-only (no torch.distributed, no GPU); the consumer runs
+under torchrun and data-parallel-shards the stream across its ranks: rank 0
+hosts the RefDistributor (the run's single ledger + round-robin dispatch to
+per-rank inboxes), gradients sync via FSDP.
+
 Config is environment-driven so one wrapper drives both roles; role is
 ``DISAGG_ROLE`` (``producer``/``consumer``) or derived from ``RCLI_NODE_RANK``:
 
@@ -25,7 +30,7 @@ Config is environment-driven so one wrapper drives both roles; role is
     DISAGG_SERVER_URL=http://host:30000   # the patched SGLang server (producer)
     DISAGG_STORE_ID=qwen36-dflash-disagg  # Mooncake key namespace (both roles)
     DISAGG_REF_CHANNEL=/root/disagg/refs.jsonl   # tiny ref manifest (both roles)
-    DISAGG_DB=/root/disagg/run.db      # shared durable metadata store
+    DISAGG_DB=/root/disagg/run.db      # consumer rank-0 ledger (trainer-side ONLY)
     DISAGG_MAX_PROMPTS=400             # cap the prompt pool (0 = all)
     DISAGG_MAX_STEPS=0                 # trainer max optimizer steps (0 = all)
 
@@ -34,11 +39,12 @@ Mooncake connection uses the standard ``MOONCAKE_*`` env vars (see
 sides land on one master. Export ``WANDB_API_KEY`` for consumer W&B logging.
 """
 
+import hashlib
 import json
 import os
 
 from accelerate.utils import set_seed
-from train_dflash import build_dataloader, build_models, parse_args
+from train_dflash import build_models, parse_args
 from transformers import AutoTokenizer
 
 from specforge.core.dflash import OnlineDFlashModel
@@ -94,22 +100,47 @@ def _mooncake_store() -> MooncakeFeatureStore:
     )
 
 
-def _extract_prompts(train_dataloader):
+def _producer_prompts(args, tokenizer):
+    """Tokenized prompts straight off the dataset — no DataLoader, no dist.
+
+    The producer only feeds prompts to the server, so it skips
+    ``prepare_dp_dataloaders`` (whose DistributedSampler needs a process group)
+    and stays CPU-only. Same tokenize/template/cache + min-loss filter as
+    ``train_dflash.build_dataloader``.
+    """
+    from datasets import load_dataset
+    from specforge.data import build_eagle3_dataset
+
+    cache_key = hashlib.md5(
+        f"{args.train_data_path}-{args.max_length}-{args.chat_template}-"
+        f"{args.target_model_path}".encode()
+    ).hexdigest()
+    dataset = load_dataset("json", data_files=args.train_data_path)["train"]
+    dataset = build_eagle3_dataset(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        chat_template=args.chat_template,
+        max_length=args.max_length,
+        is_preformatted=args.is_preformatted,
+        cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
+        cache_key=cache_key,
+        num_proc=args.build_dataset_num_proc,
+    )
+    dataset = dataset.filter(lambda x: x["loss_mask"].sum() >= 2 * args.block_size)
+
     prompts = []
-    for batch in train_dataloader:
-        input_ids = batch["input_ids"]
-        loss_mask = batch["loss_mask"]
-        attn = batch.get("attention_mask")
-        for i in range(input_ids.shape[0]):
-            n = int(attn[i].sum().item()) if attn is not None else input_ids.shape[1]
-            prompts.append(
-                {
-                    "payload": {
-                        "input_ids": input_ids[i, :n].tolist(),
-                        "loss_mask": loss_mask[i, :n].tolist(),
-                    }
+    for row in dataset:  # rows are (1, L) tensors
+        input_ids, loss_mask = row["input_ids"][0], row["loss_mask"][0]
+        attn = row.get("attention_mask")
+        n = int(attn[0].sum().item()) if attn is not None else input_ids.shape[0]
+        prompts.append(
+            {
+                "payload": {
+                    "input_ids": input_ids[:n].tolist(),
+                    "loss_mask": loss_mask[:n].tolist(),
                 }
-            )
+            }
+        )
     return prompts
 
 
@@ -123,12 +154,11 @@ def _resolve_mask_token(args, tokenizer) -> int:
 
 
 def run_producer(args) -> None:
-    """Thin driver: prompts -> patched server (captures to Mooncake) -> refs."""
+    """Thin CPU driver: prompts -> patched server (captures to Mooncake) -> refs."""
     tokenizer = AutoTokenizer.from_pretrained(
         args.target_model_path, trust_remote_code=args.trust_remote_code
     )
-    train_dataloader, _eval = build_dataloader(args, tokenizer)
-    prompts = _extract_prompts(train_dataloader)
+    prompts = _producer_prompts(args, tokenizer)
     max_prompts = _max("DISAGG_MAX_PROMPTS", 0)
     if max_prompts:
         prompts = prompts[:max_prompts]
@@ -150,6 +180,10 @@ def run_producer(args) -> None:
     )
     print(f"[producer] {len(prompts)} prompts -> {os.environ['DISAGG_SERVER_URL']}")
 
+    # NO shared db: the trainer-side ledger (DISAGG_DB) is the run's single
+    # book-keeper; committed rows from the producer would make the consumer
+    # distributor's commit-dedup drop every ref. The producer's private
+    # in-memory store still dedups within its own process.
     _workers, drive_producer = build_disagg_online_producer(
         strategy="dflash",
         feature_source=adapter,
@@ -160,7 +194,6 @@ def run_producer(args) -> None:
         target_hidden_size=target_hidden,
         target_repr=None,  # DFlash trains on captured hidden states, no target dist.
         aux_hidden_state_layer_ids=aux_layer_ids,
-        metadata_db_path=os.environ.get("DISAGG_DB") or None,
     )
     produced = drive_producer()
     print(f"[producer] streamed {produced} samples; channel closed", flush=True)
@@ -226,6 +259,8 @@ def run_consumer(args) -> None:
             print(f"[consumer] step {step} {summary}", flush=True)
 
     print(f"[consumer] training from mooncake://{RUN_ID}", flush=True)
+    # dp_rank/dp_size default from the torchrun world: rank 0 hosts the
+    # RefDistributor (single ledger + per-rank inbox dispatch).
     trainer, loader = build_disagg_online_consumer(
         strategy="dflash",
         feature_store=_mooncake_store(),
@@ -243,8 +278,13 @@ def run_consumer(args) -> None:
         metadata_db_path=os.environ.get("DISAGG_DB") or None,
         logger=logger,
         log_interval=_max("DISAGG_LOG_INTERVAL", 1),
+        inbox_dir=os.environ.get("DISAGG_INBOX_DIR") or None,
     )
-    trainer.fit(loader)
+    try:
+        trainer.fit(loader)
+    finally:
+        if getattr(trainer, "ref_distributor", None) is not None:
+            trainer.ref_distributor.stop()  # clean wind-down on max_steps exit
     print(f"[consumer] DONE ({RUN_ID})", flush=True)
 
 
@@ -253,15 +293,13 @@ def main() -> None:
     set_seed(args.seed)
     role = _role()
     print(f"[disagg-dflash] role={role} run_id={RUN_ID}", flush=True)
-    # Both roles need the process group: the producer loads no model, but the
-    # control plane / feature store query dist rank. Launch each under torchrun
-    # (the producer on a spare GPU, its own rendezvous endpoint).
+    if role == "producer":
+        # CPU-only: no model, no collectives — plain `python`, no torchrun.
+        run_producer(args)
+        return
     init_distributed(timeout=args.dist_timeout, tp_size=args.tp_size)
     try:
-        if role == "producer":
-            run_producer(args)
-        else:
-            run_consumer(args)
+        run_consumer(args)
     finally:
         destroy_distributed()
 

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -81,6 +81,7 @@ CUDA_VISIBLE_DEVICES=$SERVER_GPU MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAM
         --chunked-prefill-size -1 \
         --disable-radix-cache \
         --enable-spec-capture \
+        --spec-capture-method dflash \
         --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
         --port $SERVER_PORT &
 SERVER_PID=$!

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -79,6 +79,7 @@ CUDA_VISIBLE_DEVICES=$SERVER_GPU MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAM
         --skip-tokenizer-init \
         --mem-fraction-static 0.85 \
         --chunked-prefill-size -1 \
+        --disable-radix-cache \
         --enable-spec-capture \
         --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
         --port $SERVER_PORT &

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Qwen3.6-27B DFlash, ONLINE disaggregated via server-capture on one 8-GPU node:
-#   mooncake master        -> CPU (RDMA/TCP object store)
-#   patched SGLang server   -> GPU 0   (frozen 27B target, captures to mooncake)
-#   producer (HTTP driver)  -> CPU     (prompts -> server, streams refs)
-#   consumer (DFlash trainer)-> GPU 1  (trains from mooncake, zero-copy)
+#   mooncake master          -> CPU (RDMA/TCP object store)
+#   patched SGLang server    -> SERVER_GPU     (frozen 27B target -> mooncake)
+#   producer (HTTP driver)   -> CPU            (prompts -> server, streams refs)
+#   consumer (DFlash trainer)-> CONSUMER_GPUS  (DP=TRAIN_DP over per-rank inboxes)
+#
+# The consumer is DATA-PARALLEL: torchrun spawns TRAIN_DP ranks; rank 0 hosts the
+# RefDistributor — the run's single book-keeper (one SQLite ledger, one channel
+# reader) — and round-robin dispatches refs to per-rank inboxes; gradients sync
+# via FSDP. The producer never touches the ledger (trainer-side only).
 #
 # The server is sglang 0.5.14 patched with patches/sglang/v0.5.14/spec-capture.patch
 # (apply with scripts/apply_sglang_spec_capture_patch.sh). Feature tensors travel
@@ -23,7 +28,8 @@ export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
 cd "$ROOT_DIR"
 
 SERVER_GPU=${SERVER_GPU:-0}
-CONSUMER_GPU=${CONSUMER_GPU:-1}
+TRAIN_DP=${TRAIN_DP:-2}
+CONSUMER_GPUS=${CONSUMER_GPUS:-"1,2"}
 SERVER_PORT=${SERVER_PORT:-30000}
 # DFlash target capture layers — must match dflash_config.target_layer_ids in
 # the draft config below.
@@ -45,7 +51,10 @@ export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
 export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg}
 export DISAGG_SERVER_URL=http://127.0.0.1:$SERVER_PORT
 export DISAGG_REF_CHANNEL=${DISAGG_REF_CHANNEL:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/refs.jsonl}
-export DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+# Trainer-side ONLY (rank-0 ledger + per-rank inboxes); the producer must not
+# see the db — the launcher below passes it just to the consumer.
+DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+DISAGG_INBOX_DIR=${DISAGG_INBOX_DIR:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/inboxes}
 export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-400}
 export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}
 export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
@@ -82,7 +91,7 @@ until curl -sf "http://127.0.0.1:$SERVER_PORT/health" > /dev/null; do
 done
 
 # recipe matches run_qwen3.6_27b_dflash_online.sh; max-length 2048 for a bounded
-# single-node demo (online disagg is consume-once / single-DP-rank).
+# single-node demo. batch-size is PER RANK: global batch = batch_size * TRAIN_DP.
 ARGS=(
     --target-model-path Qwen/Qwen3.6-27B
     --target-model-backend hf
@@ -109,20 +118,21 @@ ARGS=(
 
 LAUNCHER=$SCRIPT_DIR/run_disagg_dflash.py
 
-# --- producer: HTTP driver (no torch model; shares the box, no GPU model) ---
+# --- producer: CPU-only HTTP driver (no torch model, no process group) ---
 DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
     python "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-producer" &
 PRODUCER_PID=$!
 
-# --- consumer: trainer pool (GPU $CONSUMER_GPU), logs the curve to W&B ---
-CUDA_VISIBLE_DEVICES=$CONSUMER_GPU DISAGG_ROLE=consumer \
+# --- consumer: DP=$TRAIN_DP trainer pool; rank 0 = distributor + ledger ---
+CUDA_VISIBLE_DEVICES=$CONSUMER_GPUS DISAGG_ROLE=consumer \
+    DISAGG_DB=$DISAGG_DB DISAGG_INBOX_DIR=$DISAGG_INBOX_DIR \
     torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29702 \
-        --nnodes 1 --nproc_per_node 1 "$LAUNCHER" "${ARGS[@]}" \
+        --nnodes 1 --nproc_per_node "$TRAIN_DP" "$LAUNCHER" "${ARGS[@]}" \
         --output-dir "$ROOT_DIR/outputs/qwen36-disagg-consumer" \
         --report-to wandb \
         --wandb-project qwen36-dflash-disagg \
-        --wandb-name qwen36-27b-dflash-nemotron-server-capture
+        --wandb-name qwen36-27b-dflash-server-capture-dp$TRAIN_DP
 
 wait $PRODUCER_PID
 echo "DISAGG36-DONE"

--- a/examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh
+++ b/examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Qwen3.6-27B DFlash, ONLINE disaggregated, MULTI-SERVER on one 8-GPU node:
+#   mooncake master           -> CPU  (RDMA/TCP object store)
+#   patched SGLang server 0   -> GPUs 0,1 (TP=2, frozen 27B target -> mooncake)
+#   patched SGLang server 1   -> GPUs 2,3 (TP=2, same model + capture flags)
+#   producer (HTTP driver)    -> CPU  (fans prompts out to BOTH servers)
+#   consumer (DFlash trainer) -> GPUs 4,5 (DP=2 over per-rank inboxes)
+#
+# Multi-server sibling of run_qwen3.6_27b_dflash_disagg.sh. The producer builds
+# one SGLangServerCaptureAdapter per URL in DISAGG_SERVER_URLS; each adapter is
+# driven by its own RolloutWorker on its own thread, leasing DISJOINT prompts
+# from the one controller — both servers prefill concurrently. Every server
+# registers a segment with the ONE mooncake master, so the trainer fetches any
+# sample by key regardless of which server captured it. A server that dies is
+# dropped after its in-flight prompts are returned to the pool; the survivor
+# finishes the run.
+#
+# Both servers MUST be launched with identical model + capture flags (the
+# producer's FeatureContract check fails loudly per-sample otherwise).
+#
+# Prereqs: identical to run_qwen3.6_27b_dflash_disagg.sh (patched sglang 0.5.14,
+# mooncake_master on PATH, dataset + weights cached, WANDB_API_KEY or
+# --report-to none).
+set -uxo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
+cd "$ROOT_DIR"
+
+# --- topology: 2 servers x TP=2 + DP=2 trainer (override via env) ---
+SERVER0_GPUS=${SERVER0_GPUS:-"0,1"}
+SERVER1_GPUS=${SERVER1_GPUS:-"2,3"}
+SERVER_TP=${SERVER_TP:-2}
+SERVER0_PORT=${SERVER0_PORT:-30000}
+SERVER1_PORT=${SERVER1_PORT:-30001}
+TRAIN_DP=${TRAIN_DP:-2}
+CONSUMER_GPUS=${CONSUMER_GPUS:-"4,5"}
+# DFlash target capture layers — must match dflash_config.target_layer_ids in
+# the draft config below, on BOTH servers.
+AUX_LAYER_IDS=${AUX_LAYER_IDS:-"1 16 31 46 61"}
+
+# --- mooncake connection (server sinks + producer + consumer share these) ---
+export MOONCAKE_LOCAL_HOSTNAME=${MOONCAKE_LOCAL_HOSTNAME:-127.0.0.1}
+export MOONCAKE_MASTER_SERVER_ADDR=${MOONCAKE_MASTER_SERVER_ADDR:-127.0.0.1:50051}
+export MOONCAKE_METADATA_SERVER=${MOONCAKE_METADATA_SERVER:-http://127.0.0.1:8080/metadata}
+export MOONCAKE_PROTOCOL=${MOONCAKE_PROTOCOL:-tcp}
+# EACH server contributes a segment of this size to the one master; objects are
+# hard-pinned (undersizing fails puts rather than evicting). The producer
+# watermark's in-flight bytes now spread across N segments, but placement is
+# not balanced — keep per-server headroom above watermark/N (skew margin).
+export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((48 << 30))}
+# Producer/consumer are pure clients (no segment): objects must not live in a
+# process that exits before training finishes.
+export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
+
+export DISAGG_STORE_ID=${DISAGG_STORE_ID:-qwen36-dflash-disagg-2srv}
+export DISAGG_SERVER_URLS="http://127.0.0.1:$SERVER0_PORT,http://127.0.0.1:$SERVER1_PORT"
+export DISAGG_REF_CHANNEL=${DISAGG_REF_CHANNEL:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/refs.jsonl}
+# Trainer-side ONLY (rank-0 ledger + per-rank inboxes); the producer must not
+# see the db — the launcher below passes it just to the consumer.
+DISAGG_DB=${DISAGG_DB:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/run.db}
+DISAGG_INBOX_DIR=${DISAGG_INBOX_DIR:-$ROOT_DIR/outputs/$DISAGG_STORE_ID/inboxes}
+export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-400}
+export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-0}
+export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
+REPORT_TO=${REPORT_TO:-wandb}  # set REPORT_TO=none to run without W&B
+
+rm -rf "$(dirname "$DISAGG_REF_CHANNEL")" "$DISAGG_DB"
+mkdir -p "$(dirname "$DISAGG_REF_CHANNEL")"
+: > "$DISAGG_REF_CHANNEL"
+
+cleanup() { kill "${MASTER_PID:-}" "${SERVER0_PID:-}" "${SERVER1_PID:-}" "${PRODUCER_PID:-}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# --- mooncake master ---
+mooncake_master --enable-http-metadata-server=true &
+MASTER_PID=$!
+sleep 3
+
+# --- patched SGLang servers: frozen 27B target, TP=2 each, spec-capture on ---
+launch_server() { # $1=gpus $2=port
+    CUDA_VISIBLE_DEVICES=$1 MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_LOCAL_HOSTNAME \
+        python -m sglang.launch_server \
+            --model-path Qwen/Qwen3.6-27B \
+            --trust-remote-code \
+            --skip-tokenizer-init \
+            --tp-size "$SERVER_TP" \
+            --mem-fraction-static 0.85 \
+            --chunked-prefill-size -1 \
+            --disable-radix-cache \
+            --enable-spec-capture \
+            --spec-capture-method dflash \
+            --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
+            --port "$2" &
+}
+launch_server "$SERVER0_GPUS" "$SERVER0_PORT"
+SERVER0_PID=$!
+launch_server "$SERVER1_GPUS" "$SERVER1_PORT"
+SERVER1_PID=$!
+
+# wait for BOTH servers before driving prompts (die fast if either dies)
+for port_pid in "$SERVER0_PORT:$SERVER0_PID" "$SERVER1_PORT:$SERVER1_PID"; do
+    port=${port_pid%%:*}; pid=${port_pid##*:}
+    until curl -sf "http://127.0.0.1:$port/health" > /dev/null; do
+        if ! kill -0 "$pid" 2>/dev/null; then echo "server on :$port died"; exit 1; fi
+        sleep 5
+    done
+done
+
+# recipe matches run_qwen3.6_27b_dflash_disagg.sh; max-length 2048 for a bounded
+# single-node demo. batch-size is PER RANK: global batch = batch_size * TRAIN_DP.
+ARGS=(
+    --target-model-path Qwen/Qwen3.6-27B
+    --target-model-backend hf
+    --trust-remote-code
+    --draft-config-path "$ROOT_DIR/configs/qwen3.6-27b-dflash.json"
+    --embedding-key model.language_model.embed_tokens.weight
+    --lm-head-key lm_head.weight
+    --mask-token-id 248070
+    --train-data-path "$ROOT_DIR/cache/dataset/nemotron_v2_train.jsonl"
+    --chat-template qwen3.5
+    --max-length 2048
+    --batch-size 1
+    --learning-rate 6e-4
+    --warmup-ratio 0.04
+    --max-grad-norm 1.0
+    --attention-backend flex_attention
+    --block-size 16
+    --num-anchors 512
+    --loss-decay-gamma 7.0
+    --num-epochs 1
+    --seed 42
+    --save-interval 1000000
+)
+
+LAUNCHER=$SCRIPT_DIR/run_disagg_dflash.py
+
+# --- producer: CPU-only HTTP driver fanning out to both servers ---
+DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
+    python "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$ROOT_DIR/outputs/qwen36-disagg-2srv-producer" &
+PRODUCER_PID=$!
+
+# --- consumer: DP=$TRAIN_DP trainer pool; rank 0 = distributor + ledger ---
+CUDA_VISIBLE_DEVICES=$CONSUMER_GPUS DISAGG_ROLE=consumer \
+    DISAGG_DB=$DISAGG_DB DISAGG_INBOX_DIR=$DISAGG_INBOX_DIR \
+    torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29702 \
+        --nnodes 1 --nproc_per_node "$TRAIN_DP" "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$ROOT_DIR/outputs/qwen36-disagg-2srv-consumer" \
+        --report-to "$REPORT_TO" \
+        --wandb-project qwen36-dflash-disagg \
+        --wandb-name qwen36-27b-dflash-2srv-tp2-dp$TRAIN_DP
+
+wait $PRODUCER_PID
+echo "DISAGG36-2SRV-DONE"

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -137,7 +137,7 @@ diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/manager
 index abba37441..3018b8247 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -576,6 +576,19 @@ class Scheduler(
+@@ -576,6 +576,25 @@ class Scheduler(
  
          self.init_batch_result_processor()
  
@@ -149,6 +149,12 @@ index abba37441..3018b8247 100644
 +                    "--enable-spec-capture requires --chunked-prefill-size -1 "
 +                    "(single-pass prefill) so captured hidden states cover the "
 +                    "whole sequence"
++                )
++            if not server_args.disable_radix_cache:
++                raise ValueError(
++                    "--enable-spec-capture requires --disable-radix-cache: a "
++                    "prefix-cache hit skips prefilling (and capturing) the "
++                    "cached tokens, silently truncating the stored hidden states"
 +                )
 +            from sglang.srt import spec_capture_sink
 +

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -274,6 +274,7 @@ class SGLangServerCaptureAdapter:
                 "target_repr": contract.target_repr,
                 "vocab_map_version": contract.vocab_map_version,
                 "transport": "sglang_server_capture",
+                "server": self.base_url,  # which server captured it (provenance)
                 "generation": gen,  # the zero-copy get() locator
             },
         )

--- a/specforge/inference/adapters/server_capture.py
+++ b/specforge/inference/adapters/server_capture.py
@@ -333,6 +333,30 @@ class SGLangServerCaptureAdapter:
                 )
                 continue
             ref = self._ref_from_result(task, result, capture)
+            # A capture shorter than the prompt is corrupt (classic cause: a
+            # radix-cache prefix hit skips prefilling — and capturing — the
+            # cached tokens; the patched scheduler refuses that config).
+            expected_len = len(task.payload["input_ids"])
+            short = {
+                name: spec.shape
+                for name, spec in ref.feature_specs.items()
+                if len(spec.shape) >= 2 and spec.shape[1] != expected_len
+            }
+            if short:
+                self.store.adopt(ref)
+                self.store.abort(ref.sample_id, reason="seq-len-mismatch")
+                out.append(
+                    ServerCaptureFailure(
+                        task_id=task.task_id,
+                        reason=(
+                            f"server_capture: captured seq len != prompt len "
+                            f"{expected_len} for {short} — was the server "
+                            f"started without --disable-radix-cache?"
+                        ),
+                        retryable=False,
+                    )
+                )
+                continue
             try:
                 verify_feature_contract_specs(
                     ref.feature_specs,

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -16,6 +16,7 @@ is a registry entry, not a new ``build_*`` family.
 
 from __future__ import annotations
 
+import logging
 from typing import List, Optional, Tuple
 
 from specforge.runtime.contracts import DeploymentMode, SampleRef
@@ -30,6 +31,8 @@ from specforge.runtime.control_plane.metadata_store import (
 )
 from specforge.runtime.data_plane import FeatureStore, LocalFeatureStore
 from specforge.training.strategies.registry import StrategySpec, resolve_strategy
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Shared assemblers — strategy- and topology-agnostic.
@@ -225,6 +228,12 @@ def _assemble_rollout_workers(
     SGLang server writes features straight to the store — no ``target_model``
     is loaded here). Otherwise an in-process adapter is built over
     ``target_model``.
+
+    A *sequence* of feature sources fans out to one worker per source (the
+    multi-server topology: 1 server : 1 adapter : 1 worker). All workers share
+    the one controller, whose per-``worker_id`` leases keep their prompt slices
+    disjoint. A single source keeps the legacy shape: ``num_rollout_workers``
+    workers sharing it.
     """
     if not spec.supports_online:
         raise NotImplementedError(
@@ -239,22 +248,35 @@ def _assemble_rollout_workers(
         aux_hidden_state_layer_ids = tuple(
             getattr(target_model, "aux_hidden_states_layers", ()) or ()
         )
-    if feature_source is not None:
-        adapter = feature_source
+    if isinstance(feature_source, (list, tuple)):
+        if not feature_source:
+            raise ValueError("feature_source sequence is empty")
+        if num_rollout_workers not in (1, len(feature_source)):
+            raise ValueError(
+                f"num_rollout_workers={num_rollout_workers} conflicts with "
+                f"{len(feature_source)} feature sources (one worker per source)"
+            )
+        adapters = list(feature_source)
+    elif feature_source is not None:
+        adapters = [feature_source] * num_rollout_workers
     elif spec.make_adapter is not None:
-        adapter = spec.make_adapter(target_model, device=device, t2d=t2d)
+        adapters = [
+            spec.make_adapter(target_model, device=device, t2d=t2d)
+        ] * num_rollout_workers
     else:
         from specforge.inference.adapters.policy import (
             EAGLE3_FEATURE_SCHEMA,
             PolicyFeatureAdapter,
         )
 
-        adapter = PolicyFeatureAdapter(
-            target_model,
-            schema=spec.feature_schema or EAGLE3_FEATURE_SCHEMA,
-            device=device,
-            t2d=t2d,
-        )
+        adapters = [
+            PolicyFeatureAdapter(
+                target_model,
+                schema=spec.feature_schema or EAGLE3_FEATURE_SCHEMA,
+                device=device,
+                t2d=t2d,
+            )
+        ] * num_rollout_workers
     feature_contract = FeatureContract.from_strategy(
         required_features=spec.required_features,
         aux_hidden_state_layer_ids=tuple(aux_hidden_state_layer_ids),
@@ -275,7 +297,7 @@ def _assemble_rollout_workers(
             worker_id=f"rollout-{i}",
             strategy=spec.name,
         )
-        for i in range(num_rollout_workers)
+        for i, adapter in enumerate(adapters)
     ]
 
 
@@ -565,6 +587,8 @@ def build_disagg_online_producer(
     lease: int = 8,
     in_flight_high_watermark: int = 256,
     backpressure_poll_s: float = 0.2,
+    max_worker_failures: int = 3,
+    max_prompt_attempts: Optional[int] = 5,
     metadata_store: Optional[MetadataStore] = None,
     metadata_db_path: Optional[str] = None,
     sleep=None,
@@ -574,12 +598,27 @@ def build_disagg_online_producer(
     Workers put() into a cross-node ``feature_store``; committed refs stream to
     the consumer via ``channel``. Pass ``feature_source`` for the server-capture
     transport (live SGLang server writes to the store; ``target_model`` stays
-    None). ``metadata_store``/``metadata_db_path`` must be the same durable store
+    None) — a *sequence* of sources fans out to one worker per source (the
+    multi-server topology; each worker drives its own server concurrently).
+    ``metadata_store``/``metadata_db_path`` must be the same durable store
     the consumer opens. Returns ``(workers, drive_producer)``:
     ``drive_producer(should_stop=...)`` runs until the prompt pool drains, pauses
     above ``in_flight_high_watermark``, and always closes the channel on exit
     (EOF terminates the consumer's loader).
+
+    Failure semantics: a worker whose source raises (dead/unreachable server)
+    has already failed its leases retryable — the surviving workers re-lease
+    those prompts. After ``max_worker_failures`` *consecutive* failures the
+    worker is dropped from rotation (its health is logged); if every worker is
+    dropped while prompts remain, ``drive_producer`` raises instead of silently
+    truncating the run. Per-task retryable failures are bounded by
+    ``max_prompt_attempts`` (a poisoned prompt goes terminal, not infinite).
+    The pool counts as drained only when no prompt is pending *or leased* —
+    an all-failed round no longer reads as end-of-data. With N workers the
+    watermark can overshoot by up to N * lease (each worker checks it
+    independently before leasing).
     """
+    import threading
     import time
 
     spec = resolve_strategy(strategy)
@@ -587,6 +626,7 @@ def build_disagg_online_producer(
     controller = DataFlowController(
         run_id,
         metadata_store=_resolve_metadata_store(metadata_store, metadata_db_path),
+        max_prompt_attempts=max_prompt_attempts,
     )
     controller.ingest_prompts(prompts)
 
@@ -609,26 +649,113 @@ def build_disagg_online_producer(
     )
 
     def drive_producer(max_rounds: int = 1_000_000, should_stop=None) -> int:
+        """Drive all workers until the pool drains; returns refs published.
+
+        One worker runs inline; N workers run one thread each (the blocking
+        HTTP prefill call releases the GIL, so servers genuinely overlap).
+        The controller and feature store are lock-protected; the channel is
+        not, so publishes serialize through ``publish_lock``.
+        """
         for w in workers:
             w.start()
-        produced = 0
-        try:
+        publish_lock = threading.Lock()
+        state = {"produced": 0}
+        dead: dict = {}  # worker_id -> last failure reason
+
+        def pool_drained() -> bool:
+            st = controller.status()
+            # leased counts too: a peer's in-flight lease may fail retryable
+            # and come back — leaving then would strand it.
+            return st["prompts_pending"] == 0 and st["prompts_leased"] == 0
+
+        def run_worker(w) -> None:
+            failures = 0
             for _ in range(max_rounds):
                 if should_stop is not None and should_stop():
-                    break  # caller asked us to wind down (e.g. trainer finished)
+                    return
                 # backpressure: in_flight = published - consumer-acked
                 while channel.in_flight_remote() >= in_flight_high_watermark:
                     if should_stop is not None and should_stop():
-                        return produced  # don't block on the watermark forever
+                        return
                     sleep(backpressure_poll_s)
-                refs = []
-                for w in workers:
-                    refs.extend(w.run_once(max_tasks=lease))
-                if not refs:
-                    break  # prompt pool drained
-                channel.publish_many(refs)
-                produced += len(refs)
-            return produced
+                try:
+                    refs = w.run_once(max_tasks=lease)
+                except Exception as exc:
+                    # the worker already failed its leases retryable; peers
+                    # (or this worker, next round) will re-lease them.
+                    failures += 1
+                    logger.warning(
+                        "rollout worker %s failed (%d/%d): %s",
+                        w.worker_id,
+                        failures,
+                        max_worker_failures,
+                        exc,
+                    )
+                    if failures >= max_worker_failures:
+                        dead[w.worker_id] = str(exc)
+                        logger.error(
+                            "dropping rollout worker %s after %d consecutive "
+                            "failures; health=%s",
+                            w.worker_id,
+                            failures,
+                            w.health(),
+                        )
+                        return
+                    sleep(backpressure_poll_s)
+                    continue
+                failures = 0
+                if refs:
+                    with publish_lock:
+                        channel.publish_many(refs)
+                        state["produced"] += len(refs)
+                elif pool_drained():
+                    return
+                else:
+                    # leased nothing: peers hold the remaining prompts (their
+                    # leases may yet fail back into the pool) — wait, retry.
+                    sleep(backpressure_poll_s)
+
+        fatal: list = []  # non-transport errors escaping a worker thread
+
+        def run_worker_guarded(w) -> None:
+            try:
+                run_worker(w)
+            except BaseException as exc:  # e.g. a channel publish failure
+                fatal.append((w.worker_id, exc))
+
+        try:
+            if len(workers) == 1:
+                run_worker(workers[0])
+            else:
+                threads = [
+                    threading.Thread(
+                        target=run_worker_guarded,
+                        args=(w,),
+                        name=f"drive-{w.worker_id}",
+                        daemon=True,
+                    )
+                    for w in workers
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join()
+            if fatal:
+                raise fatal[0][1]
+            stopped = should_stop is not None and should_stop()
+            if dead and not stopped and not pool_drained():
+                raise RuntimeError(
+                    f"all rollout workers exited with {len(dead)} dropped as "
+                    f"dead and prompts remaining — dead workers: {dead}"
+                )
+            st = controller.status()
+            if st["prompts_failed"]:
+                logger.warning(
+                    "producer finished with %d terminally failed prompts "
+                    "(see controller status for reasons)",
+                    st["prompts_failed"],
+                )
+            return state["produced"]
         finally:
             channel.close()  # EOF -> the consumer's loader terminates once drained
 

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -685,13 +685,12 @@ def build_disagg_online_consumer(
     rows), and round-robin dispatches aligned windows to per-rank inboxes under
     ``inbox_dir`` (default ``<channel>.inboxes``, trainer-local). Every rank
     consumes only its own inbox; durable acks gather to rank 0
-    (:class:`DPAckController`), which also advances the producer's backpressure
-    counter. Single-rank runs keep the original direct-channel path.
+    (:class:`DPAckController`) while the distributor mirrors the per-rank inbox
+    acks onto the producer's backpressure counter. Passing ``inbox_dir``
+    explicitly opts a single-rank run into the same distributor path;
+    otherwise ``dp_size == 1`` keeps the original direct-channel path.
     """
-    from specforge.runtime.data_plane.streaming_ref_channel import (
-        StreamingRefChannel,
-        StreamingRefQueue,
-    )
+    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
 
     if resume_from and not resume:
         raise ValueError(
@@ -732,7 +731,8 @@ def build_disagg_online_consumer(
         return set(reconciled["released"])
 
     distributor = None
-    if dp_size == 1:
+    if dp_size == 1 and inbox_dir is None:
+        # Legacy direct-channel path, unchanged.
         store = _resolve_metadata_store(metadata_store, metadata_db_path)
         controller = DataFlowController(run_id, metadata_store=store)
         skip_ids = _reconcile(controller, store) if resume else None
@@ -740,23 +740,57 @@ def build_disagg_online_consumer(
             channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids
         )
     else:
+        import torch.distributed as dist
+
         from specforge.runtime.control_plane.dp_ack import DPAckController
-        from specforge.runtime.data_plane.ref_distributor import RefDistributor
+        from specforge.runtime.control_plane.metadata_store import NoOpMetadataStore
+        from specforge.runtime.data_plane.ref_distributor import (
+            InboxChannel,
+            RefDistributor,
+        )
 
         if inbox_dir is None:
             inbox_dir = channel.path + ".inboxes"
+        # Symmetric preconditions (ALL ranks) — a rank-0-only raise would strand
+        # the other ranks in the barrier below.
+        if metadata_store is None and metadata_db_path is None:
+            raise ValueError(
+                "DP online consumer needs a durable metadata_store/"
+                "metadata_db_path — the rank-0 distributor is the run's single "
+                "ledger"
+            )
+        if dist.is_available() and dist.is_initialized():
+            world = dist.get_world_size()
+            if world != dp_size:
+                raise ValueError(
+                    f"DP online consumer: dp_size={dp_size} but the process "
+                    f"group has {world} ranks — every rank must own exactly one "
+                    f"inbox"
+                )
+        # Liveness default: a dead producer/distributor must never hang the
+        # ranks silently. Generous enough for a cold server load before the
+        # first ref.
+        if idle_timeout_s is None:
+            idle_timeout_s = 1800.0
         if dp_rank == 0:
             store = _resolve_metadata_store(metadata_store, metadata_db_path)
-            if store is None:
+            if isinstance(store, NoOpMetadataStore):
                 raise ValueError(
-                    "DP online consumer needs a durable metadata_store/"
-                    "metadata_db_path on rank 0 — the distributor is the run's "
-                    "single ledger"
+                    "DP online consumer needs a RETAINING metadata store: the "
+                    "ledger is what dedups commits and reconciles restarts"
                 )
             controller = DPAckController(
                 run_id, is_authority=True, metadata_store=store
             )
             skip_ids = _reconcile(controller, store) if resume else None
+            if not resume and store.committed_count() > 0:
+                raise ValueError(
+                    f"metadata store already holds {store.committed_count()} "
+                    f"committed samples from a previous run; the distributor's "
+                    f"commit-dedup would silently drop the whole re-streamed "
+                    f"channel. Pass resume=True (+ resume_from) to reconcile, or "
+                    f"start fresh (new metadata_db_path / delete the db)"
+                )
             distributor = RefDistributor(
                 channel,
                 controller,
@@ -765,7 +799,6 @@ def build_disagg_online_consumer(
                 skip_ids=skip_ids,
                 idle_timeout_s=idle_timeout_s,
             )
-            controller.ack_sink = lambda ids: distributor.note_acked(len(ids))
         else:
             # Gather-participant only: throwaway store, records nothing.
             controller = DPAckController(
@@ -774,7 +807,7 @@ def build_disagg_online_consumer(
         # Inboxes must be re-created (rank 0, in RefDistributor.__init__) before
         # any rank opens a reader on a stale previous-attempt file.
         _dp_barrier()
-        inbox = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
+        inbox = InboxChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
         queue = StreamingRefQueue(inbox, idle_timeout_s=idle_timeout_s)
         if distributor is not None:
             distributor.start()

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -16,7 +16,7 @@ is a registry entry, not a new ``build_*`` family.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from specforge.runtime.contracts import DeploymentMode, SampleRef
 from specforge.runtime.control_plane import (
@@ -142,6 +142,44 @@ def _resolve_metadata_store(
     if metadata_db_path is not None:
         return SQLiteMetadataStore(metadata_db_path)
     return None
+
+
+def _dp_consumer_layout(
+    dp_rank: Optional[int],
+    dp_size: Optional[int],
+    tp_size: int,
+    sp_ulysses_size: int,
+    sp_ring_size: int,
+) -> Tuple[int, int]:
+    """Resolve the online consumer's (dp_rank, dp_size), defaulting from dist.
+
+    The DP online consumer shards DATA across ranks (one inbox each), so its DP
+    width is the whole trainer world; tp/sp replication inside a shard is not
+    wired yet and is rejected rather than silently double-training.
+    """
+    import torch.distributed as dist
+
+    initialized = dist.is_available() and dist.is_initialized()
+    if dp_size is None:
+        dp_size = dist.get_world_size() if initialized else 1
+    if dp_rank is None:
+        dp_rank = dist.get_rank() if initialized else 0
+    if dp_size > 1 and (tp_size != 1 or sp_ulysses_size != 1 or sp_ring_size != 1):
+        raise NotImplementedError(
+            "DP online consumer shards refs across dp ranks; tp/sp inside a DP "
+            f"shard is not wired yet (got tp={tp_size}, sp_ulysses="
+            f"{sp_ulysses_size}, sp_ring={sp_ring_size})"
+        )
+    if not 0 <= dp_rank < dp_size:
+        raise ValueError(f"dp_rank {dp_rank} out of range for dp_size {dp_size}")
+    return dp_rank, dp_size
+
+
+def _dp_barrier() -> None:
+    import torch.distributed as dist
+
+    if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+        dist.barrier()
 
 
 def _checkpoint_global_step(resume_from: str) -> int:
@@ -625,19 +663,35 @@ def build_disagg_online_consumer(
     log_interval: int = 50,
     resume_from: Optional[str] = None,
     max_checkpoints: int = 0,
+    dp_rank: Optional[int] = None,
+    dp_size: Optional[int] = None,
+    inbox_dir: Optional[str] = None,
 ):
     """Consumer (trainer) side of an ONLINE disaggregated run.
 
     Trains from a streamed ref ``channel`` + a consume-once ``feature_store``
-    produced by another pool; ``metadata_store``/``metadata_db_path`` must be the
-    durable store the producer commits to. Online resume needs BOTH knobs:
-    ``resume=True`` reconciles the durable marker (already-trained refs are
-    skipped on the channel re-read) and ``resume_from`` restores the trainer
-    state those acks correspond to. ``resume_from`` alone raises; a marker ahead
-    of the checkpoint raises (the skipped samples' weight updates were rolled
-    back — silent data loss).
+    produced by another pool. Online resume needs BOTH knobs: ``resume=True``
+    reconciles the durable marker (already-trained refs are skipped on the
+    channel re-read) and ``resume_from`` restores the trainer state those acks
+    correspond to. ``resume_from`` alone raises; a marker ahead of the
+    checkpoint raises (the skipped samples' weight updates were rolled back —
+    silent data loss).
+
+    **Data-parallel trainer** (``dp_size > 1``, defaulting to the torchrun
+    world): rank 0 runs the :class:`RefDistributor` — the run's single
+    book-keeper. It alone reads ``channel``, commits into the ONE durable
+    ``metadata_store``/``metadata_db_path`` (required on rank 0; the producer
+    must NOT share this db — the distributor's commit-dedup would drop its
+    rows), and round-robin dispatches aligned windows to per-rank inboxes under
+    ``inbox_dir`` (default ``<channel>.inboxes``, trainer-local). Every rank
+    consumes only its own inbox; durable acks gather to rank 0
+    (:class:`DPAckController`), which also advances the producer's backpressure
+    counter. Single-rank runs keep the original direct-channel path.
     """
-    from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefQueue
+    from specforge.runtime.data_plane.streaming_ref_channel import (
+        StreamingRefChannel,
+        StreamingRefQueue,
+    )
 
     if resume_from and not resume:
         raise ValueError(
@@ -648,12 +702,13 @@ def build_disagg_online_consumer(
             "alone would re-train the whole re-streamed channel"
         )
     spec = resolve_strategy(strategy)
-    store = _resolve_metadata_store(metadata_store, metadata_db_path)
-    controller = DataFlowController(run_id, metadata_store=store)
+    dp_rank, dp_size = _dp_consumer_layout(
+        dp_rank, dp_size, tp_size, sp_ulysses_size, sp_ring_size
+    )
 
-    skip_ids = None
-    if resume:
-        if store is None:
+    def _reconcile(controller, resolved_store):
+        """resume=True -> skip already-released refs; guard marker vs checkpoint."""
+        if resolved_store is None:
             raise ValueError(
                 "resume=True needs a durable metadata_store/metadata_db_path; an "
                 "in-process store has no committed/ack history to reconcile against"
@@ -661,7 +716,6 @@ def build_disagg_online_consumer(
         # Released == durably acked AND optimizer-step committed: skip exactly
         # those on the channel re-read; the committed-unacked tail re-trains.
         reconciled = controller.reconcile_on_restart(feature_store)
-        skip_ids = set(reconciled["released"])
         if resume_from:
             marker_step = reconciled["global_step"]
             ckpt_step = _checkpoint_global_step(resume_from)
@@ -675,9 +729,57 @@ def build_disagg_online_consumer(
                     f"latest), or start a fresh run_id + metadata store to re-train "
                     f"from scratch"
                 )
+        return set(reconciled["released"])
 
-    queue = StreamingRefQueue(channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids)
-    return _assemble_trainer(
+    distributor = None
+    if dp_size == 1:
+        store = _resolve_metadata_store(metadata_store, metadata_db_path)
+        controller = DataFlowController(run_id, metadata_store=store)
+        skip_ids = _reconcile(controller, store) if resume else None
+        queue = StreamingRefQueue(
+            channel, idle_timeout_s=idle_timeout_s, skip_ids=skip_ids
+        )
+    else:
+        from specforge.runtime.control_plane.dp_ack import DPAckController
+        from specforge.runtime.data_plane.ref_distributor import RefDistributor
+
+        if inbox_dir is None:
+            inbox_dir = channel.path + ".inboxes"
+        if dp_rank == 0:
+            store = _resolve_metadata_store(metadata_store, metadata_db_path)
+            if store is None:
+                raise ValueError(
+                    "DP online consumer needs a durable metadata_store/"
+                    "metadata_db_path on rank 0 — the distributor is the run's "
+                    "single ledger"
+                )
+            controller = DPAckController(
+                run_id, is_authority=True, metadata_store=store
+            )
+            skip_ids = _reconcile(controller, store) if resume else None
+            distributor = RefDistributor(
+                channel,
+                controller,
+                inbox_dir,
+                dp_size,
+                skip_ids=skip_ids,
+                idle_timeout_s=idle_timeout_s,
+            )
+            controller.ack_sink = lambda ids: distributor.note_acked(len(ids))
+        else:
+            # Gather-participant only: throwaway store, records nothing.
+            controller = DPAckController(
+                run_id, is_authority=False, metadata_store=InMemoryMetadataStore()
+            )
+        # Inboxes must be re-created (rank 0, in RefDistributor.__init__) before
+        # any rank opens a reader on a stale previous-attempt file.
+        _dp_barrier()
+        inbox = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, dp_rank))
+        queue = StreamingRefQueue(inbox, idle_timeout_s=idle_timeout_s)
+        if distributor is not None:
+            distributor.start()
+
+    trainer, loader = _assemble_trainer(
         spec=spec,
         controller=controller,
         store=feature_store,
@@ -704,6 +806,10 @@ def build_disagg_online_consumer(
         resume_from=resume_from,
         max_checkpoints=max_checkpoints,
     )
+    #: rank 0's RefDistributor handle in DP mode (None elsewhere) — callers may
+    #: stop() it after fit for a clean early (max_steps) shutdown.
+    trainer.ref_distributor = distributor
+    return trainer, loader
 
 
 def run_disagg_online_interleaved(

--- a/specforge/runtime/control_plane/__init__.py
+++ b/specforge/runtime/control_plane/__init__.py
@@ -10,6 +10,7 @@ from specforge.runtime.control_plane.controller import (
     TrainLease,
     build_control_plane_for_mode,
 )
+from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
 from specforge.runtime.control_plane.metadata_store import (
     InMemoryMetadataStore,
     MetadataStore,
@@ -19,6 +20,8 @@ from specforge.runtime.control_plane.metadata_store import (
 
 __all__ = [
     "DataFlowController",
+    "DPAckController",
+    "gather_id_union",
     "TrainLease",
     "build_control_plane_for_mode",
     "MetadataStore",

--- a/specforge/runtime/control_plane/controller.py
+++ b/specforge/runtime/control_plane/controller.py
@@ -89,6 +89,7 @@ class DataFlowController:
         sample_queue: Optional[SampleRefQueue] = None,
         metadata_store: Optional[MetadataStore] = None,
         backpressure: Optional[BackpressureController] = None,
+        max_prompt_attempts: Optional[int] = None,
     ) -> None:
         self.run_id = run_id
         self.sample_queue = sample_queue or SampleRefQueue()
@@ -97,6 +98,10 @@ class DataFlowController:
         # behavior). The controller owns the pause decision; the policy only
         # reads capacity (FeatureStore.health) — no tensors cross this seam.
         self.backpressure = backpressure
+        # Retryable-failure bound: a task failed this many attempts goes
+        # terminal instead of requeueing (None = retry forever). Bounds a
+        # poisoned prompt that would otherwise pin the pool non-empty forever.
+        self.max_prompt_attempts = max_prompt_attempts
         self._prompts: "OrderedDict[str, PromptTask]" = OrderedDict()
         self._prompt_pending: Deque[str] = deque()
         self._prompt_leased: Dict[str, str] = {}  # task_id -> worker_id
@@ -193,12 +198,20 @@ class DataFlowController:
                 task = self._prompts.get(task_id)
                 if task is None:
                     continue
-                if retryable:
+                attempts_left = (
+                    self.max_prompt_attempts is None
+                    or task.attempt + 1 < self.max_prompt_attempts
+                )
+                if retryable and attempts_left:
                     self._prompts[task_id] = dataclasses.replace(
                         task, attempt=task.attempt + 1
                     )
                     if task_id not in self._prompt_pending:
                         self._prompt_pending.append(task_id)
+                elif retryable:
+                    self._prompt_failed[task_id] = (
+                        f"{reason} (attempts exhausted: {task.attempt + 1})"
+                    )
                 else:
                     self._prompt_failed[task_id] = reason
 

--- a/specforge/runtime/control_plane/dp_ack.py
+++ b/specforge/runtime/control_plane/dp_ack.py
@@ -1,0 +1,109 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""DP-aware durable ack: gather every rank's sample_ids, record ONCE.
+
+With data-parallel consumers each rank trains a disjoint shard, but the durable
+``{acked, global_step, optimizer_durable}`` marker must have a single writer —
+otherwise N ranks interleave partial ack sets into one ledger.
+:class:`DPAckController` keeps the write single-authority without giving up the
+existing trainer seam: ``TrainerController.fit`` already calls ``ack_fn`` on
+EVERY rank at EVERY optimizer boundary (in lockstep), so ``ack_train_refs``
+becomes a collective — all ranks contribute their shard's ids
+(``all_gather_object``), only the authority (DP rank 0) records the union and
+drives the ``ack_sink`` (the producer-backpressure counter).
+
+Correctness rests on the lockstep invariant the :class:`RefDistributor`
+enforces (equal per-rank ref counts): a rank that skipped a boundary would hang
+the gather.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional
+
+from specforge.runtime.control_plane.controller import DataFlowController
+
+
+def gather_id_union(ids: List[str]) -> List[str]:
+    """All-gather each rank's sample_ids; return the rank-ordered, deduped union.
+
+    Identity when torch.distributed is absent/uninitialized/world=1. Dedup keeps
+    first occurrence so SP-replicated shards (same ids on sp peers) collapse.
+    """
+    import torch.distributed as dist
+
+    if not (dist.is_available() and dist.is_initialized()):
+        return list(ids)
+    world = dist.get_world_size()
+    if world == 1:
+        return list(ids)
+    gathered: List[Optional[List[str]]] = [None] * world
+    dist.all_gather_object(gathered, list(ids))
+    out: List[str] = []
+    seen = set()
+    for rank_ids in gathered:
+        for sid in rank_ids or ():
+            if sid not in seen:
+                seen.add(sid)
+                out.append(sid)
+    return out
+
+
+class DPAckController(DataFlowController):
+    """A :class:`DataFlowController` whose ``ack_train_refs`` is a DP collective.
+
+    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store,
+      records the gathered union, then calls ``ack_sink(union_ids)`` — the
+      launcher points that at the distributor's consumed counter.
+    * ``is_authority=False`` (other ranks): participates in the gather (the
+      collective needs every rank) and records nothing; give it a throwaway
+      in-memory store.
+
+    Every rank must call ``ack_train_refs`` at every optimizer boundary — the
+    trainer's ``ack_fn`` already does exactly that.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        is_authority: bool = True,
+        gather: Callable[[List[str]], List[str]] = gather_id_union,
+        ack_sink: Optional[Callable[[List[str]], None]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(run_id, **kwargs)
+        self.is_authority = is_authority
+        self._gather = gather
+        #: post-ack hook fed the gathered union (assignable after construction
+        #: because the distributor needs the controller first).
+        self.ack_sink = ack_sink
+
+    def ack_train_refs(
+        self,
+        trainer_id: str,
+        sample_ids: List[str],
+        *,
+        global_step: Optional[int] = None,
+        optimizer_durable: bool = False,
+    ) -> None:
+        union = self._gather(list(sample_ids))
+        if not self.is_authority:
+            return
+        super().ack_train_refs(
+            trainer_id,
+            union,
+            global_step=global_step,
+            optimizer_durable=optimizer_durable,
+        )
+        if self.ack_sink is not None and union:
+            self.ack_sink(union)
+
+
+__all__ = ["DPAckController", "gather_id_union"]

--- a/specforge/runtime/control_plane/dp_ack.py
+++ b/specforge/runtime/control_plane/dp_ack.py
@@ -58,15 +58,16 @@ def gather_id_union(ids: List[str]) -> List[str]:
 class DPAckController(DataFlowController):
     """A :class:`DataFlowController` whose ``ack_train_refs`` is a DP collective.
 
-    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store,
-      records the gathered union, then calls ``ack_sink(union_ids)`` — the
-      launcher points that at the distributor's consumed counter.
+    * ``is_authority=True`` (DP rank 0): holds the run's ONE durable store and
+      records the gathered union.
     * ``is_authority=False`` (other ranks): participates in the gather (the
       collective needs every rank) and records nothing; give it a throwaway
       in-memory store.
 
     Every rank must call ``ack_train_refs`` at every optimizer boundary — the
-    trainer's ``ack_fn`` already does exactly that.
+    trainer's ``ack_fn`` already does exactly that. Producer backpressure is
+    NOT this class's job: the distributor mirrors the per-rank inbox acks onto
+    the source counter at micro-batch granularity.
     """
 
     def __init__(
@@ -75,15 +76,11 @@ class DPAckController(DataFlowController):
         *,
         is_authority: bool = True,
         gather: Callable[[List[str]], List[str]] = gather_id_union,
-        ack_sink: Optional[Callable[[List[str]], None]] = None,
         **kwargs,
     ) -> None:
         super().__init__(run_id, **kwargs)
         self.is_authority = is_authority
         self._gather = gather
-        #: post-ack hook fed the gathered union (assignable after construction
-        #: because the distributor needs the controller first).
-        self.ack_sink = ack_sink
 
     def ack_train_refs(
         self,
@@ -102,8 +99,6 @@ class DPAckController(DataFlowController):
             global_step=global_step,
             optimizer_durable=optimizer_durable,
         )
-        if self.ack_sink is not None and union:
-            self.ack_sink(union)
 
 
 __all__ = ["DPAckController", "gather_id_union"]

--- a/specforge/runtime/data_plane/__init__.py
+++ b/specforge/runtime/data_plane/__init__.py
@@ -14,6 +14,7 @@ from specforge.runtime.data_plane.offline_reader import (
     OfflineManifestReader,
     list_feature_files,
 )
+from specforge.runtime.data_plane.ref_distributor import RefDistributor
 from specforge.runtime.data_plane.sample_ref_queue import SampleRefQueue, dp_partition
 
 __all__ = [
@@ -23,6 +24,7 @@ __all__ = [
     "spec_from_tensor",
     "SampleRefQueue",
     "dp_partition",
+    "RefDistributor",
     "FeatureDataLoader",
     "OfflineManifestReader",
     "list_feature_files",

--- a/specforge/runtime/data_plane/ref_distributor.py
+++ b/specforge/runtime/data_plane/ref_distributor.py
@@ -1,0 +1,222 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""RefDistributor: the centralized dispatcher for DP online consumers.
+
+One distributor per run (it lives on trainer DP rank 0). It is the ONLY reader
+of the producer's ref channel and the only holder of consume book-keeping:
+
+    source channel -> commit (ONE ledger, dedup) -> aligned round-robin -> per-rank inbox
+
+Each rank reads a private inbox (a plain consume-once :class:`StreamingRefQueue`)
+and holds no channel offset, no partition math, no ledger — the design goal is a
+single book-keeping authority, not N. Refs are dispatched in windows of exactly
+``dp_size`` (one ref per rank per window) so every rank sees the SAME count:
+the lockstep invariant FSDP collectives require. Anything less than a full
+window at end-of-stream is dropped (logged; it stays committed-unacked in the
+ledger, so a restart re-trains it).
+
+The consumed counter on the source channel (the producer's backpressure signal)
+is advanced by exactly two events, both through this object: restart-skips of
+already-released refs, and the authority's durable ack
+(``DPAckController.ack_sink -> note_acked``). Dispatch itself does NOT count —
+in-flight must keep covering everything not yet trained.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Iterable, List, Optional
+
+from specforge.runtime.contracts import SampleRef
+from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+
+logger = logging.getLogger(__name__)
+
+_INBOX_SUFFIXES = ("", ".closed", ".consumed_count", ".consumed_count.tmp")
+
+
+class RefDistributor:
+    """Single-authority push dispatcher: source channel -> per-rank inboxes."""
+
+    def __init__(
+        self,
+        source: StreamingRefChannel,
+        controller,  # DataFlowController (rank 0's, with the run's durable store)
+        inbox_dir: str,
+        dp_size: int,
+        *,
+        skip_ids: Optional[Iterable[str]] = None,
+        worker_id: str = "ref-distributor",
+        poll_s: float = 0.05,
+        idle_timeout_s: Optional[float] = None,
+        clock=time.monotonic,
+        sleep=time.sleep,
+    ) -> None:
+        if dp_size < 1:
+            raise ValueError(f"dp_size must be >= 1, got {dp_size}")
+        self.source = source
+        self.controller = controller
+        self.dp_size = dp_size
+        self.worker_id = worker_id
+        self.poll_s = poll_s
+        self.idle_timeout_s = idle_timeout_s
+        self._clock = clock
+        self._sleep = sleep
+        self._skip = set(skip_ids) if skip_ids else None
+        # Inboxes are EPHEMERAL (the ledger is the durable state): recreate them
+        # fresh so a restarted run cannot replay a previous attempt's dispatch.
+        # The launcher barriers ranks AFTER construction, before readers open.
+        os.makedirs(inbox_dir, exist_ok=True)
+        for rank in range(dp_size):
+            base = self.inbox_path(inbox_dir, rank)
+            for suffix in _INBOX_SUFFIXES:
+                try:
+                    os.remove(base + suffix)
+                except FileNotFoundError:
+                    pass
+        self._inboxes = [
+            StreamingRefChannel(self.inbox_path(inbox_dir, rank))
+            for rank in range(dp_size)
+        ]
+        # A restarted consumer must not rewind the producer's counter.
+        self.source.seed_consumed()
+        # mark_consumed is not thread-safe; acks (trainer thread) and skips
+        # (this thread) serialize here.
+        self._consume_lock = threading.Lock()
+        self._window: List[SampleRef] = []  # leased, awaiting a full dp_size window
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self.finished = False
+        self.error: Optional[BaseException] = None
+        self.stats = {"dispatched": 0, "skipped": 0, "duplicates": 0, "dropped": 0}
+
+    @staticmethod
+    def inbox_path(inbox_dir: str, dp_rank: int) -> str:
+        return os.path.join(inbox_dir, f"inbox-rank{dp_rank}.jsonl")
+
+    def note_acked(self, n: int) -> None:
+        """Advance the producer's backpressure counter for n durably-acked refs."""
+        if n:
+            with self._consume_lock:
+                self.source.mark_consumed(n)
+
+    def pump(self) -> bool:
+        """One non-blocking cycle: ingest + dispatch. Returns True on progress.
+
+        Sets :attr:`finished` (and closes the inboxes) once the source is
+        closed-and-drained and no full window remains.
+        """
+        if self.finished:
+            return False
+        progress = False
+
+        raw = self.source.poll()
+        if raw:
+            progress = True
+            skipped = 0
+            for ref in raw:
+                if self._skip and ref.sample_id in self._skip:
+                    self._skip.discard(ref.sample_id)
+                    skipped += 1
+                    if not self._skip:
+                        self._skip = None
+                    continue
+                before = self.controller.store.committed_count()
+                self.controller.commit_samples(self.worker_id, [ref])
+                if self.controller.store.committed_count() == before:
+                    # duplicate publication (e.g. producer restart); a
+                    # reconcile-requeued ref also lands here and trains later.
+                    self.stats["duplicates"] += 1
+            if skipped:
+                self.stats["skipped"] += skipped
+                self.note_acked(skipped)  # already trained: keep in-flight exact
+
+        # Dispatch every full window: one ref per rank, round-robin — per-rank
+        # counts stay exactly equal, which is what keeps DP ranks in lockstep.
+        queue = self.controller.sample_queue
+        while True:
+            need = self.dp_size - len(self._window)
+            if need:
+                self._window.extend(queue.get(need, timeout_s=0.0))
+            if len(self._window) < self.dp_size:
+                break
+            for rank, ref in enumerate(self._window):
+                self._inboxes[rank].publish(ref)
+            self.stats["dispatched"] += self.dp_size
+            self._window = []
+            progress = True
+
+        if not raw and self.source.is_closed() and queue.depth() == 0:
+            self._finish()
+        return progress
+
+    def _finish(self) -> None:
+        if self._window:
+            # Committed-but-unacked in the ledger: a restart re-trains them.
+            self.stats["dropped"] = len(self._window)
+            logger.warning(
+                "ref-distributor: dropping %d end-of-stream refs (< dp_size=%d "
+                "window); they stay committed-unacked and replay on restart",
+                len(self._window),
+                self.dp_size,
+            )
+            self._window = []
+        for inbox in self._inboxes:
+            inbox.close()
+        self.finished = True
+        logger.info("ref-distributor: finished %s", self.stats)
+
+    def run(self) -> None:
+        """Blocking loop; ends when the source is closed-and-drained or stop().
+
+        On error the inboxes are deliberately NOT closed: a clean close would
+        read as a normal end-of-stream and let ranks finish "successfully" on
+        partial data — instead they surface a loud idle TimeoutError.
+        """
+        last_progress = self._clock()
+        while not self._stop.is_set() and not self.finished:
+            progress = self.pump()
+            now = self._clock()
+            if progress:
+                last_progress = now
+                continue
+            if (
+                self.idle_timeout_s is not None
+                and now - last_progress > self.idle_timeout_s
+            ):
+                raise TimeoutError(
+                    f"ref-distributor: no refs for {self.idle_timeout_s:.0f}s and "
+                    f"the source channel is still open (producer dead?)"
+                )
+            self._sleep(self.poll_s)
+
+    def _run_guarded(self) -> None:
+        try:
+            self.run()
+        except BaseException as exc:  # noqa: BLE001 - surfaced via self.error
+            self.error = exc
+            logger.exception("ref-distributor: died; DP ranks will idle-timeout")
+
+    def start(self) -> "RefDistributor":
+        self._thread = threading.Thread(
+            target=self._run_guarded, name="ref-distributor", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def stop(self, join_timeout_s: float = 10.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=join_timeout_s)
+
+
+__all__ = ["RefDistributor"]

--- a/specforge/runtime/data_plane/ref_distributor.py
+++ b/specforge/runtime/data_plane/ref_distributor.py
@@ -22,10 +22,18 @@ window at end-of-stream is dropped (logged; it stays committed-unacked in the
 ledger, so a restart re-trains it).
 
 The consumed counter on the source channel (the producer's backpressure signal)
-is advanced by exactly two events, both through this object: restart-skips of
-already-released refs, and the authority's durable ack
-(``DPAckController.ack_sink -> note_acked``). Dispatch itself does NOT count —
-in-flight must keep covering everything not yet trained.
+mirrors what the ranks actually consumed: each rank's loader acks its OWN inbox
+per micro-batch, and the distributor forwards the sum of the inbox sidecars to
+the source counter. Per-micro-batch granularity means the producer watermark
+never has to cover a whole ``dp_size * batch * accumulation`` optimizer window.
+Dispatch itself does NOT count — in-flight must keep covering everything not
+yet trained. On restart the counter is seeded from the sidecar (released refs
+were already counted by the prior run, so skips add nothing).
+
+If the distributor dies it drops a ``.failed`` sentinel (with the traceback)
+into every inbox; :class:`InboxChannel` readers raise on it at the next poll —
+a loud, immediate all-rank failure instead of a silent hang, and distinct from
+the clean ``.closed`` end-of-stream.
 """
 
 from __future__ import annotations
@@ -34,6 +42,7 @@ import logging
 import os
 import threading
 import time
+import traceback
 from typing import Iterable, List, Optional
 
 from specforge.runtime.contracts import SampleRef
@@ -41,7 +50,32 @@ from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChann
 
 logger = logging.getLogger(__name__)
 
-_INBOX_SUFFIXES = ("", ".closed", ".consumed_count", ".consumed_count.tmp")
+_FAILED_SUFFIX = ".failed"
+_INBOX_SUFFIXES = (
+    "",
+    ".closed",
+    ".consumed_count",
+    ".consumed_count.tmp",
+    _FAILED_SUFFIX,
+)
+
+
+class InboxChannel(StreamingRefChannel):
+    """Reader view of a distributor inbox: fails loudly if the distributor died.
+
+    ``StreamingRefQueue.get`` consults ``is_closed()`` every poll cycle, so a
+    ``.failed`` sentinel converts "distributor thread died" from an unbounded
+    hang into an immediate RuntimeError on every rank.
+    """
+
+    def is_closed(self) -> bool:
+        failed = self.path + _FAILED_SUFFIX
+        if os.path.exists(failed):
+            with open(failed) as f:
+                raise RuntimeError(f"ref-distributor died:\n{f.read()}")
+        return super().is_closed()
+
+    _is_closed = is_closed
 
 
 class RefDistributor:
@@ -87,11 +121,11 @@ class RefDistributor:
             StreamingRefChannel(self.inbox_path(inbox_dir, rank))
             for rank in range(dp_size)
         ]
-        # A restarted consumer must not rewind the producer's counter.
+        # A restarted consumer must not rewind the producer's counter. The seed
+        # already covers everything the prior run counted (incl. released refs,
+        # which the skip filter therefore does NOT count again).
         self.source.seed_consumed()
-        # mark_consumed is not thread-safe; acks (trainer thread) and skips
-        # (this thread) serialize here.
-        self._consume_lock = threading.Lock()
+        self._inbox_consumed = 0  # last forwarded sum of the inbox sidecars
         self._window: List[SampleRef] = []  # leased, awaiting a full dp_size window
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -103,14 +137,23 @@ class RefDistributor:
     def inbox_path(inbox_dir: str, dp_rank: int) -> str:
         return os.path.join(inbox_dir, f"inbox-rank{dp_rank}.jsonl")
 
-    def note_acked(self, n: int) -> None:
-        """Advance the producer's backpressure counter for n durably-acked refs."""
-        if n:
-            with self._consume_lock:
-                self.source.mark_consumed(n)
+    def _forward_consumed(self) -> bool:
+        """Mirror the ranks' inbox acks onto the source counter (backpressure).
+
+        Per-micro-batch granularity: the producer's watermark only ever has to
+        cover the dispatch pipeline, not a whole optimizer window — a watermark
+        smaller than ``dp_size * batch * accumulation`` must not deadlock.
+        """
+        consumed = sum(inbox.consumed_remote() for inbox in self._inboxes)
+        delta = consumed - self._inbox_consumed
+        if delta <= 0:
+            return False
+        self._inbox_consumed = consumed
+        self.source.mark_consumed(delta)
+        return True
 
     def pump(self) -> bool:
-        """One non-blocking cycle: ingest + dispatch. Returns True on progress.
+        """One non-blocking cycle: ingest + dispatch + counter. True on progress.
 
         Sets :attr:`finished` (and closes the inboxes) once the source is
         closed-and-drained and no full window remains.
@@ -122,11 +165,12 @@ class RefDistributor:
         raw = self.source.poll()
         if raw:
             progress = True
-            skipped = 0
             for ref in raw:
                 if self._skip and ref.sample_id in self._skip:
+                    # released in a prior run: already counted by that run's
+                    # acks (covered by the seed), so just don't re-dispatch.
                     self._skip.discard(ref.sample_id)
-                    skipped += 1
+                    self.stats["skipped"] += 1
                     if not self._skip:
                         self._skip = None
                     continue
@@ -136,9 +180,6 @@ class RefDistributor:
                     # duplicate publication (e.g. producer restart); a
                     # reconcile-requeued ref also lands here and trains later.
                     self.stats["duplicates"] += 1
-            if skipped:
-                self.stats["skipped"] += skipped
-                self.note_acked(skipped)  # already trained: keep in-flight exact
 
         # Dispatch every full window: one ref per rank, round-robin — per-rank
         # counts stay exactly equal, which is what keeps DP ranks in lockstep.
@@ -155,19 +196,28 @@ class RefDistributor:
             self._window = []
             progress = True
 
+        if self._forward_consumed():
+            progress = True
+
         if not raw and self.source.is_closed() and queue.depth() == 0:
             self._finish()
         return progress
 
     def _finish(self) -> None:
         if self._window:
-            # Committed-but-unacked in the ledger: a restart re-trains them.
+            # Less than one aligned window left at end-of-stream: dropped for
+            # THIS run (lockstep needs equal counts). They stay committed-
+            # unacked in the ledger; only a resume=True restart re-queues them.
             self.stats["dropped"] = len(self._window)
             logger.warning(
                 "ref-distributor: dropping %d end-of-stream refs (< dp_size=%d "
-                "window); they stay committed-unacked and replay on restart",
+                "window); committed-unacked in the ledger, re-queued only on a "
+                "resume=True restart",
                 len(self._window),
                 self.dp_size,
+            )
+            self.controller.sample_queue.fail(
+                self._window, reason="eos-partial-window", retryable=False
             )
             self._window = []
         for inbox in self._inboxes:
@@ -178,9 +228,10 @@ class RefDistributor:
     def run(self) -> None:
         """Blocking loop; ends when the source is closed-and-drained or stop().
 
-        On error the inboxes are deliberately NOT closed: a clean close would
-        read as a normal end-of-stream and let ranks finish "successfully" on
-        partial data — instead they surface a loud idle TimeoutError.
+        On error the inboxes are NOT closed (a clean close would read as a
+        normal end-of-stream and let ranks finish "successfully" on partial
+        data) — ``_run_guarded`` drops a ``.failed`` sentinel instead, which
+        every rank's :class:`InboxChannel` raises on at its next poll.
         """
         last_progress = self._clock()
         while not self._stop.is_set() and not self.finished:
@@ -199,12 +250,24 @@ class RefDistributor:
                 )
             self._sleep(self.poll_s)
 
+    def _fail_inboxes(self, exc: BaseException) -> None:
+        """Poison every inbox so all ranks fail loudly (never a silent hang —
+        and never a clean close that would masquerade as end-of-stream)."""
+        text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        for inbox in self._inboxes:
+            try:
+                with open(inbox.path + _FAILED_SUFFIX, "w") as f:
+                    f.write(text)
+            except OSError:  # best effort; ranks still have idle_timeout_s
+                logger.exception("ref-distributor: could not poison %s", inbox.path)
+
     def _run_guarded(self) -> None:
         try:
             self.run()
         except BaseException as exc:  # noqa: BLE001 - surfaced via self.error
             self.error = exc
-            logger.exception("ref-distributor: died; DP ranks will idle-timeout")
+            logger.exception("ref-distributor: died; poisoning inboxes")
+            self._fail_inboxes(exc)
 
     def start(self) -> "RefDistributor":
         self._thread = threading.Thread(
@@ -219,4 +282,4 @@ class RefDistributor:
             self._thread.join(timeout=join_timeout_s)
 
 
-__all__ = ["RefDistributor"]
+__all__ = ["InboxChannel", "RefDistributor"]

--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -143,6 +143,17 @@ class StreamingRefChannel:
             f.write(str(self._consumed))
         os.replace(tmp, self.path + _CONSUMED_SUFFIX)  # atomic counter publish
 
+    def seed_consumed(self) -> int:
+        """Adopt the sidecar's persisted count as this instance's baseline.
+
+        ``mark_consumed`` publishes this instance's cumulative in-memory count,
+        so a restarted consumer (fresh instance, ``_consumed=0``) would rewind
+        the sidecar and inflate the producer's ``in_flight_remote`` forever.
+        Call once on restart, before the first ``mark_consumed``.
+        """
+        self._consumed = self.consumed_remote()
+        return self._consumed
+
     def stream(
         self,
         *,

--- a/tests/test_runtime/test_disagg_multiserver.py
+++ b/tests/test_runtime/test_disagg_multiserver.py
@@ -1,0 +1,213 @@
+# coding=utf-8
+"""Multi-server producer fan-out (no GPU, no server, no mooncake master).
+
+The multi-server topology: ``build_disagg_online_producer(feature_source=[...])``
+builds one RolloutWorker per SGLangServerCaptureAdapter (1 server : 1 adapter :
+1 worker), all leasing DISJOINT prompts from the one controller and publishing
+into the one channel, concurrently. Each stub ``post_fn`` stands in for one
+patched SGLang server writing into the SHARED fake Mooncake backend — exactly
+the shape of ``examples/disagg/run_qwen3.6_27b_dflash_disagg_multiserver.sh``.
+
+Covers the failure matrix the single-server path never hits:
+- disjoint + complete production across two live servers;
+- one dead server: its leases fail retryable, the survivor re-leases and
+  finishes the pool (no truncation, no hang);
+- all servers dead: loud RuntimeError, channel still closed;
+- a poisoned prompt (server rejects it every time): terminal after
+  ``max_prompt_attempts`` instead of spinning the drained-detection loop.
+"""
+
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+from specforge.inference.adapters.server_capture import SGLangServerCaptureAdapter
+from specforge.launch import build_disagg_online_producer
+from specforge.runtime.data_plane.mooncake_store import MooncakeFeatureStore
+from specforge.runtime.data_plane.streaming_ref_channel import StreamingRefChannel
+from tests.test_runtime.test_server_capture import (
+    AUX_LAYERS,
+    HIDDEN,
+    _FakeMooncakeStore,
+    _StubCaptureServer,
+)
+
+
+def _SLEEP(_s):  # injected drive sleep: keep retry/backpressure spins bounded
+    time.sleep(0.001)
+
+
+def _prompts(n, seq=6):
+    return [
+        {
+            "task_id": f"p{i}",
+            "payload": {
+                "input_ids": list(range(1, seq + 1 + i)),
+                "loss_mask": [1] * (seq + i),
+            },
+        }
+        for i in range(n)
+    ]
+
+
+def _adapter(store, post_fn, url="http://server:30000"):
+    return SGLangServerCaptureAdapter(
+        url, store, run_id="run0", strategy="dflash", post_fn=post_fn
+    )
+
+
+def _build(adapters, prompts, store, channel, **kw):
+    return build_disagg_online_producer(
+        strategy="dflash",
+        feature_source=adapters,
+        prompts=prompts,
+        feature_store=store,
+        channel=channel,
+        run_id="run0",
+        target_hidden_size=HIDDEN,
+        target_repr=None,
+        aux_hidden_state_layer_ids=AUX_LAYERS,
+        sleep=_SLEEP,
+        **kw,
+    )
+
+
+def _published_refs(path):
+    return StreamingRefChannel(path).poll()
+
+
+def _published_sample_ids(path):
+    return [r.sample_id for r in _published_refs(path)]
+
+
+class TestMultiServerProducer(unittest.TestCase):
+    def _workdir(self):
+        return tempfile.mkdtemp(prefix="disagg_multisrv_")
+
+    def test_two_servers_disjoint_and_complete(self):
+        backend = _FakeMooncakeStore()
+        stubs = [_StubCaptureServer(backend), _StubCaptureServer(backend)]
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        adapters = [
+            _adapter(store, stubs[i], url=f"http://server{i}:3000{i}") for i in range(2)
+        ]
+        N = 12
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        workers, drive = _build(adapters, _prompts(N), store, channel, lease=2)
+        self.assertEqual(len(workers), 2)
+
+        produced = drive()
+        self.assertEqual(produced, N)
+        self.assertTrue(channel.is_closed())
+
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(len(ids), N)
+        self.assertEqual(len(set(ids)), N)  # no duplicate publishes
+
+        seen0, seen1 = set(stubs[0].expected), set(stubs[1].expected)
+        self.assertEqual(seen0 | seen1, {f"run0:p{i}" for i in range(N)})
+        self.assertEqual(seen0 & seen1, set())  # disjoint prompt slices
+        # concurrency is real: both servers captured (lease=2 over 12 prompts
+        # leaves plenty for the peer even in the worst interleaving)
+        self.assertTrue(seen0 and seen1)
+
+        # ref-level provenance mirrors the stub-level split (the post-hoc
+        # audit trail a real multi-server run relies on)
+        by_server = {}
+        for r in _published_refs(channel.path):
+            by_server.setdefault(r.metadata["server"], set()).add(r.sample_id)
+        self.assertEqual(by_server.get("http://server0:30000"), seen0)
+        self.assertEqual(by_server.get("http://server1:30001"), seen1)
+
+    def test_one_dead_server_survivor_completes_pool(self):
+        backend = _FakeMooncakeStore()
+        healthy = _StubCaptureServer(backend)
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+
+        dead_leased = threading.Event()
+
+        def dead_post(url, json_body, timeout):
+            dead_leased.set()  # it held leases when it died
+            raise ConnectionError("server 1 unreachable")
+
+        def healthy_post(url, json_body, timeout):
+            dead_leased.wait(5)  # let the dead server lease + fail first
+            return healthy(url, json_body, timeout)
+
+        adapters = [
+            _adapter(store, healthy_post, url="http://server0:30000"),
+            _adapter(store, dead_post, url="http://server1:30001"),
+        ]
+        N = 8
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        workers, drive = _build(adapters, _prompts(N), store, channel, lease=2)
+
+        produced = drive(max_rounds=10_000)
+        # the dead worker's leases were failed retryable and re-leased by the
+        # survivor: every prompt still becomes exactly one ref.
+        self.assertEqual(produced, N)
+        self.assertTrue(dead_leased.is_set())
+        self.assertEqual(set(healthy.expected), {f"run0:p{i}" for i in range(N)})
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(sorted(ids), sorted(set(ids)))
+        self.assertTrue(channel.is_closed())
+        self.assertTrue(workers[1].health()["recent_failures"])
+
+    def test_all_servers_dead_raises_loudly(self):
+        backend = _FakeMooncakeStore()
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+
+        def dead_post(url, json_body, timeout):
+            raise ConnectionError("pool down")
+
+        adapters = [
+            _adapter(store, dead_post, url=f"http://server{i}:3000{i}")
+            for i in range(2)
+        ]
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        _workers, drive = _build(
+            adapters, _prompts(4), store, channel, lease=2, max_worker_failures=2
+        )
+        with self.assertRaises(RuntimeError):
+            drive(max_rounds=10_000)
+        # EOF still reaches the consumer — a crashed producer must not hang it.
+        self.assertTrue(channel.is_closed())
+
+    def test_poisoned_prompt_goes_terminal_not_infinite(self):
+        # PR654 known rough edge: an all-failed round used to read as
+        # pool-drained (silent truncation); with drained = pending==0 AND
+        # leased==0 the loop instead retries — so a prompt the server rejects
+        # every time must go terminal via max_prompt_attempts, not spin.
+        backend = _FakeMooncakeStore()
+        stub = _StubCaptureServer(backend, error_sample_ids={"run0:p0"})
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        N = 5
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        _workers, drive = _build(
+            [_adapter(store, stub)],
+            _prompts(N),
+            store,
+            channel,
+            lease=2,
+            max_prompt_attempts=3,
+        )
+        produced = drive(max_rounds=10_000)
+        self.assertEqual(produced, N - 1)  # p0 terminal, everything else through
+        ids = _published_sample_ids(channel.path)
+        self.assertEqual(set(ids), {f"run0:p{i}" for i in range(1, N)})
+        self.assertTrue(channel.is_closed())
+
+    def test_source_count_worker_count_conflict_raises(self):
+        backend = _FakeMooncakeStore()
+        store = MooncakeFeatureStore(store=backend, store_id="run0")
+        stub = _StubCaptureServer(backend)
+        adapters = [_adapter(store, stub), _adapter(store, stub)]
+        channel = StreamingRefChannel(os.path.join(self._workdir(), "refs.jsonl"))
+        with self.assertRaises(ValueError):
+            _build(adapters, _prompts(2), store, channel, num_rollout_workers=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_ref_distributor.py
+++ b/tests/test_runtime/test_ref_distributor.py
@@ -1,0 +1,223 @@
+# coding=utf-8
+"""Tests for RefDistributor + DPAckController: the DP online consumer's
+single-authority dispatch/book-keeping path (CPU only, no torch.distributed)."""
+
+import os
+import tempfile
+import unittest
+
+from specforge.runtime.contracts import FeatureSpec, SampleRef
+from specforge.runtime.control_plane.controller import DataFlowController
+from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
+from specforge.runtime.control_plane.metadata_store import SQLiteMetadataStore
+from specforge.runtime.data_plane.ref_distributor import RefDistributor
+from specforge.runtime.data_plane.streaming_ref_channel import (
+    StreamingRefChannel,
+    StreamingRefQueue,
+)
+
+
+def _ref(sid):
+    spec = FeatureSpec(name="hidden_state", shape=(4, 8), dtype="float32")
+    return SampleRef(
+        sample_id=sid,
+        run_id="run0",
+        source_task_id=None,
+        feature_store_uri=f"mooncake://run0/{sid}",
+        feature_keys={"hidden_state": f"{sid}/hidden_state"},
+        feature_specs={"hidden_state": spec},
+        strategy="eagle3",
+        num_tokens=4,
+    )
+
+
+def _pump_until_quiet(dist, max_rounds=20):
+    for _ in range(max_rounds):
+        if not dist.pump():
+            return
+    raise AssertionError("distributor never went quiet")
+
+
+def _inbox_ids(inbox_dir, rank):
+    reader = StreamingRefChannel(RefDistributor.inbox_path(inbox_dir, rank))
+    return [r.sample_id for r in reader.poll()]
+
+
+class TestRefDistributor(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="refdist_")
+        self.src_path = os.path.join(self.dir, "refs.jsonl")
+        self.inbox_dir = os.path.join(self.dir, "inboxes")
+        self.producer = StreamingRefChannel(self.src_path)
+        self.source = StreamingRefChannel(self.src_path)  # consumer-side view
+
+    def _distributor(self, dp_size=2, controller=None, **kwargs):
+        controller = controller or DataFlowController("run0")
+        return RefDistributor(
+            self.source, controller, self.inbox_dir, dp_size, **kwargs
+        )
+
+    def test_round_robin_equal_counts_and_unaligned_tail_dropped(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(7):
+            self.producer.publish(_ref(f"s{i}"))
+        _pump_until_quiet(dist)
+        # 3 full windows of dp_size=2 dispatched; s6 held (not a full window)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s2", "s4"])
+        self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s1", "s3", "s5"])
+        self.assertFalse(dist.finished)
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertTrue(dist.finished)
+        self.assertEqual(dist.stats["dropped"], 1)  # s6: replayed on restart
+        for rank in range(2):
+            reader = StreamingRefChannel(
+                RefDistributor.inbox_path(self.inbox_dir, rank)
+            )
+            self.assertTrue(reader.is_closed())
+
+    def test_inbox_readers_get_disjoint_shards_via_queue(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        q0 = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 0))
+        )
+        q1 = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 1))
+        )
+        ids0 = {r.sample_id for r in q0.get(2)}
+        ids1 = {r.sample_id for r in q1.get(2)}
+        self.assertEqual(ids0 & ids1, set())
+        self.assertEqual(ids0 | ids1, {"s0", "s1", "s2", "s3"})
+        # closed-and-drained: both readers terminate identically
+        self.assertEqual(q0.get(1), [])
+        self.assertEqual(q1.get(1), [])
+
+    def test_duplicate_publication_dispatched_once(self):
+        dist = self._distributor(dp_size=1)
+        self.producer.publish(_ref("s0"))
+        self.producer.publish(_ref("s0"))  # producer-restart republication
+        self.producer.publish(_ref("s1"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s1"])
+        self.assertEqual(dist.stats["duplicates"], 1)
+
+    def test_skip_ids_marks_consumed_and_never_dispatches(self):
+        dist = self._distributor(dp_size=2, skip_ids={"s0", "s1"})
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s2"])
+        self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s3"])
+        # skips count as consumed so the producer's in-flight stays exact
+        self.assertEqual(self.producer.consumed_remote(), 2)
+        dist.note_acked(2)  # the durable-ack path adds the trained ones
+        self.assertEqual(self.producer.consumed_remote(), 4)
+
+    def test_consumed_counter_survives_restart(self):
+        # First consumer attempt marks 3 consumed, then dies.
+        first = StreamingRefChannel(self.src_path)
+        first.mark_consumed(3)
+        self.assertEqual(self.producer.consumed_remote(), 3)
+        # A restarted distributor must seed from the sidecar, not rewind it.
+        dist = self._distributor(dp_size=1)
+        dist.note_acked(1)
+        self.assertEqual(self.producer.consumed_remote(), 4)
+
+    def test_stale_inbox_files_recreated_fresh(self):
+        os.makedirs(self.inbox_dir, exist_ok=True)
+        stale = RefDistributor.inbox_path(self.inbox_dir, 0)
+        StreamingRefChannel(stale).publish(_ref("stale"))
+        open(stale + ".closed", "w").close()
+        dist = self._distributor(dp_size=1)
+        self.producer.publish(_ref("fresh"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        reader = StreamingRefChannel(stale)
+        self.assertEqual([r.sample_id for r in reader.poll()], ["fresh"])
+
+    def test_resume_requeues_committed_unacked_and_skips_released(self):
+        db = os.path.join(self.dir, "run.db")
+        # Prior attempt: committed s0..s3; s0,s1 durably acked (released).
+        prior = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        prior.commit_samples("w0", [_ref(f"s{i}") for i in range(4)])
+        prior.ack_train_refs("t0", ["s0", "s1"], global_step=1, optimizer_durable=True)
+        prior.store.close()
+        # Restart: reconcile requeues committed-unacked (s2, s3) into the new
+        # controller's queue; released (s0, s1) become skip_ids.
+        controller = DataFlowController("run0", metadata_store=SQLiteMetadataStore(db))
+        reconciled = controller.reconcile_on_restart()
+        self.assertEqual(sorted(reconciled["released"]), ["s0", "s1"])
+        self.assertEqual(sorted(reconciled["requeued"]), ["s2", "s3"])
+        dist = self._distributor(
+            dp_size=2, controller=controller, skip_ids=set(reconciled["released"])
+        )
+        # The channel replays everything from offset 0 (restart re-read).
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        ids0, ids1 = _inbox_ids(self.inbox_dir, 0), _inbox_ids(self.inbox_dir, 1)
+        # exactly the unacked tail trains again, split evenly, no duplicates
+        self.assertEqual(sorted(ids0 + ids1), ["s2", "s3"])
+        self.assertEqual(len(ids0), len(ids1))
+        self.assertEqual(self.producer.consumed_remote(), 2)  # the two skips
+        controller.store.close()
+
+    def test_idle_timeout_raises_when_producer_silent(self):
+        clock = {"t": 0.0}
+        dist = self._distributor(
+            dp_size=1,
+            idle_timeout_s=5.0,
+            clock=lambda: clock["t"],
+            sleep=lambda s: clock.__setitem__("t", clock["t"] + s),
+        )
+        with self.assertRaises(TimeoutError):
+            dist.run()
+
+
+class TestDPAckController(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="dpack_")
+
+    def test_authority_records_gathered_union_and_drives_sink(self):
+        gathered = lambda ids: ids + ["s-other-rank"]  # noqa: E731
+        sunk = []
+        controller = DPAckController(
+            "run0",
+            is_authority=True,
+            gather=gathered,
+            metadata_store=SQLiteMetadataStore(os.path.join(self.dir, "run.db")),
+        )
+        controller.ack_sink = lambda ids: sunk.extend(ids)
+        controller.commit_samples("w0", [_ref("s0"), _ref("s-other-rank")])
+        controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
+        marker = controller.store.durable_marker()
+        self.assertEqual(sorted(marker["acked"]), ["s-other-rank", "s0"])
+        self.assertTrue(marker["optimizer_durable"])
+        self.assertEqual(sorted(sunk), ["s-other-rank", "s0"])
+        controller.store.close()
+
+    def test_non_authority_participates_but_records_nothing(self):
+        calls = []
+
+        def gather(ids):
+            calls.append(list(ids))
+            return ids
+
+        controller = DPAckController("run0", is_authority=False, gather=gather)
+        controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
+        self.assertEqual(calls, [["s0"]])  # joined the collective
+        self.assertEqual(controller.store.durable_marker()["acked"], set())
+
+    def test_gather_id_union_without_dist_is_identity(self):
+        self.assertEqual(gather_id_union(["a", "b"]), ["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime/test_ref_distributor.py
+++ b/tests/test_runtime/test_ref_distributor.py
@@ -10,7 +10,7 @@ from specforge.runtime.contracts import FeatureSpec, SampleRef
 from specforge.runtime.control_plane.controller import DataFlowController
 from specforge.runtime.control_plane.dp_ack import DPAckController, gather_id_union
 from specforge.runtime.control_plane.metadata_store import SQLiteMetadataStore
-from specforge.runtime.data_plane.ref_distributor import RefDistributor
+from specforge.runtime.data_plane.ref_distributor import InboxChannel, RefDistributor
 from specforge.runtime.data_plane.streaming_ref_channel import (
     StreamingRefChannel,
     StreamingRefQueue,
@@ -106,7 +106,11 @@ class TestRefDistributor(unittest.TestCase):
         self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s0", "s1"])
         self.assertEqual(dist.stats["duplicates"], 1)
 
-    def test_skip_ids_marks_consumed_and_never_dispatches(self):
+    def test_skip_ids_never_dispatch_and_are_not_recounted(self):
+        # Released refs were already counted by the prior run's acks (the
+        # sidecar seed); the skip filter must not count them again.
+        prior = StreamingRefChannel(self.src_path)
+        prior.mark_consumed(2)  # run 1 counted s0, s1
         dist = self._distributor(dp_size=2, skip_ids={"s0", "s1"})
         for i in range(4):
             self.producer.publish(_ref(f"s{i}"))
@@ -114,9 +118,22 @@ class TestRefDistributor(unittest.TestCase):
         _pump_until_quiet(dist)
         self.assertEqual(_inbox_ids(self.inbox_dir, 0), ["s2"])
         self.assertEqual(_inbox_ids(self.inbox_dir, 1), ["s3"])
-        # skips count as consumed so the producer's in-flight stays exact
-        self.assertEqual(self.producer.consumed_remote(), 2)
-        dist.note_acked(2)  # the durable-ack path adds the trained ones
+        self.assertEqual(dist.stats["skipped"], 2)
+        self.assertEqual(self.producer.consumed_remote(), 2)  # seed only, no double
+
+    def test_inbox_acks_forward_to_source_counter(self):
+        dist = self._distributor(dp_size=2)
+        for i in range(4):
+            self.producer.publish(_ref(f"s{i}"))
+        _pump_until_quiet(dist)
+        self.assertEqual(self.producer.consumed_remote(), 0)  # dispatch != consumed
+        # rank readers ack their inboxes per micro-batch (loader behavior)
+        for rank in range(2):
+            q = StreamingRefQueue(
+                StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, rank))
+            )
+            q.ack(q.get(2))
+        _pump_until_quiet(dist)
         self.assertEqual(self.producer.consumed_remote(), 4)
 
     def test_consumed_counter_survives_restart(self):
@@ -124,9 +141,16 @@ class TestRefDistributor(unittest.TestCase):
         first = StreamingRefChannel(self.src_path)
         first.mark_consumed(3)
         self.assertEqual(self.producer.consumed_remote(), 3)
-        # A restarted distributor must seed from the sidecar, not rewind it.
+        # A restarted distributor must seed from the sidecar, not rewind it:
+        # one new inbox ack lands on top of the seed.
         dist = self._distributor(dp_size=1)
-        dist.note_acked(1)
+        self.producer.publish(_ref("s9"))
+        _pump_until_quiet(dist)
+        q = StreamingRefQueue(
+            StreamingRefChannel(RefDistributor.inbox_path(self.inbox_dir, 0))
+        )
+        q.ack(q.get(1))
+        _pump_until_quiet(dist)
         self.assertEqual(self.producer.consumed_remote(), 4)
 
     def test_stale_inbox_files_recreated_fresh(self):
@@ -166,8 +190,36 @@ class TestRefDistributor(unittest.TestCase):
         # exactly the unacked tail trains again, split evenly, no duplicates
         self.assertEqual(sorted(ids0 + ids1), ["s2", "s3"])
         self.assertEqual(len(ids0), len(ids1))
-        self.assertEqual(self.producer.consumed_remote(), 2)  # the two skips
+        self.assertEqual(dist.stats["skipped"], 2)
         controller.store.close()
+
+    def test_end_of_stream_partial_window_releases_leases(self):
+        controller = DataFlowController("run0")
+        dist = self._distributor(dp_size=2, controller=controller)
+        for i in range(3):  # one full window + one leftover
+            self.producer.publish(_ref(f"s{i}"))
+        self.producer.close()
+        _pump_until_quiet(dist)
+        self.assertTrue(dist.finished)
+        self.assertEqual(dist.stats["dropped"], 1)
+        # the dropped ref's lease is released, not leaked
+        self.assertEqual(controller.sample_queue.in_flight(), 2)  # dispatched only
+        self.assertEqual(controller.sample_queue.depth(), 0)
+
+    def test_distributor_death_poisons_inboxes(self):
+        clock = {"t": 0.0}
+        dist = self._distributor(
+            dp_size=2,
+            idle_timeout_s=5.0,
+            clock=lambda: clock["t"],
+            sleep=lambda s: clock.__setitem__("t", clock["t"] + s),
+        )
+        dist._run_guarded()  # idle-timeout kills it (producer silent)
+        self.assertIsInstance(dist.error, TimeoutError)
+        for rank in range(2):
+            reader = InboxChannel(RefDistributor.inbox_path(self.inbox_dir, rank))
+            with self.assertRaisesRegex(RuntimeError, "ref-distributor died"):
+                StreamingRefQueue(reader).get(1)
 
     def test_idle_timeout_raises_when_producer_silent(self):
         clock = {"t": 0.0}
@@ -185,22 +237,19 @@ class TestDPAckController(unittest.TestCase):
     def setUp(self):
         self.dir = tempfile.mkdtemp(prefix="dpack_")
 
-    def test_authority_records_gathered_union_and_drives_sink(self):
+    def test_authority_records_gathered_union(self):
         gathered = lambda ids: ids + ["s-other-rank"]  # noqa: E731
-        sunk = []
         controller = DPAckController(
             "run0",
             is_authority=True,
             gather=gathered,
             metadata_store=SQLiteMetadataStore(os.path.join(self.dir, "run.db")),
         )
-        controller.ack_sink = lambda ids: sunk.extend(ids)
         controller.commit_samples("w0", [_ref("s0"), _ref("s-other-rank")])
         controller.ack_train_refs("t0", ["s0"], global_step=1, optimizer_durable=True)
         marker = controller.store.durable_marker()
         self.assertEqual(sorted(marker["acked"]), ["s-other-rank", "s0"])
         self.assertTrue(marker["optimizer_durable"])
-        self.assertEqual(sorted(sunk), ["s-other-rank", "s0"])
         controller.store.close()
 
     def test_non_authority_participates_but_records_nothing(self):


### PR DESCRIPTION
## Summary
- Roll up #655 (DP online consumer / RefDistributor + single-ledger ack) into `dataflow-up-16-zerocopy`.
- Roll up #656 (multi-server producer fan-out) into `dataflow-up-16-zerocopy`.
- Preserves the original stacked merge history by merging `origin/dataflow-o3-dp-distributor` onto current `dataflow-up-16-zerocopy`.

## Verification
- `git diff --check origin/dataflow-up-16-zerocopy...HEAD`
- `python -m compileall specforge/runtime/control_plane/dp_ack.py specforge/runtime/data_plane/ref_distributor.py specforge/launch.py specforge/inference/adapters/server_capture.py tests/test_runtime/test_disagg_multiserver.py tests/test_runtime/test_ref_distributor.py`
- `USE_TF=0 TRANSFORMERS_NO_TF=1 python -m pytest tests/test_runtime/test_ref_distributor.py tests/test_runtime/test_disagg_multiserver.py` was attempted locally, but collection fails before running tests because this machine has `transformers==4.54.1`, which does not export `GptOssConfig`; repo `pyproject.toml` requires `transformers==4.57.1`.

Closes follow-up coverage gap for #655 and #656.