### PR TITLE
fix(dflash): add sglang 0.5.14 post-load init to the DFlash target model

### DIFF
--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -108,6 +108,10 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
             server_args=server_args,
             nccl_port=None,
         )
+        # sglang 0.5.14 post-load setup; see eagle3_target_model.py for details.
+        model_runner.alloc_memory_pool()
+        model_runner.init_attention_backends()
+        model_runner.init_cuda_graphs()
         return cls(model_runner)
 
     def set_capture_layers(self, layer_ids: List[int]) -> None:


### PR DESCRIPTION
## Summary

On current `main` (which pins `sglang==0.5.14` since #605),
`prepare_hidden_states.py --model-type dflash` crashes immediately:

```
File ".../dflash_target_model.py", line 141, in _extend
    batch = ScheduleBatch.init_new(req_to_token_pool=self.model_runner.req_to_token_pool, ...)
File ".../sglang/srt/managers/schedule_batch.py", line 1866, in init_new
    device=req_to_token_pool.device,
AttributeError: 'NoneType' object has no attribute 'device'
```

## Root cause

sglang 0.5.14 refactored `ModelRunner`: `__init__` no longer allocates the
memory pool. Pool allocation moved to explicit post-load calls
(`alloc_memory_pool()` → `init_memory_pool()` in
`model_runner_kv_cache_mixin.py`), normally invoked by the
Scheduler/TpModelWorker. SpecForge drives the `ModelRunner` directly through
its standalone `SGLangRunner`, so those calls never happen and
`req_to_token_pool` / `token_to_kv_pool_allocator` stay `None`.

#605 fixed exactly this for `eagle3_target_model.py` (added the three
post-load calls with a detailed comment) but did not touch
`dflash_target_model.py`, leaving the DFlash extraction path broken on the
very sglang version the repo now pins.

## Fix

Mirror #605's eagle3 fix in `SGLangDFlashTargetModel.from_pretrained()`:

```python
model_runner.alloc_memory_pool()
model_runner.init_attention_backends()
model_runner.init_cuda_graphs()
```

(`init_cuda_graphs()` captures nothing here because DFlash sets
`disable_cuda_graph=True`; it still builds the EagerRunner that `forward()`
needs.) 4-line diff, identical pattern to the already-merged eagle3 change.

Since this is the second target model needing these exact calls, hoisting
them into `SGLangRunner` itself would prevent a third recurrence — but that
changes the pattern #605 established, so this PR keeps the minimal call-site
fix and leaves that refactor as a possible follow-up.

## Validation

Patched and ran `prepare_hidden_states.py --model-type dflash` on
GLM-5.2-FP8, multi-node tp8, sglang 0.5.14: the generation loop completed
(Processed 176 / Filtered 24 short) and hidden-state `.ckpt.gz` files were
written correctly. Without the patch, the run crashes at the first batch as
shown above.
