### PR TITLE
fix(train_dflash): atomic per-file checkpoint writes + `_SUCCESS`-gated resume

### DIFF
--- a/specforge/export/checkpoint_io.py
+++ b/specforge/export/checkpoint_io.py
@@ -10,64 +10,27 @@
 
 from __future__ import annotations
 
-import glob
 import os
-import re
 from typing import Any, Dict, Optional
 
 import torch
 
-STATE_FILE = "training_state.pt"
+from specforge.training.checkpoint import STATE_FILE, CheckpointManager
 
 
 def resolve_training_state(checkpoint_path: str) -> Dict[str, Any]:
-    """Load the runtime training state from any checkpoint-shaped path.
+    """Load state from a committed SpecForge runtime checkpoint.
 
     Accepts a ``training_state.pt`` file, a ``{run_id}-step{N}`` checkpoint
-    directory, or a run ``output_dir`` (resolved through its run-scoped
-    ``{run_id}-latest`` pointer — the CheckpointManager layout); a ``file://``
-    URI of any of these (the ``Checkpoint.checkpoint_uri`` form) also works.
+    directory, or a run ``output_dir``; a ``file://`` URI of any of these also
+    works. All forms resolve through ``CheckpointManager`` so a payload without
+    its ``_SUCCESS`` commit marker is never exported.
     """
-    path = checkpoint_path
-    if path.startswith("file://"):
-        path = path[len("file://") :]
-    if os.path.isfile(path):
-        return torch.load(path, map_location="cpu", weights_only=False)
-    state_file = os.path.join(path, STATE_FILE)
-    if os.path.isfile(state_file):
-        return torch.load(state_file, map_location="cpu", weights_only=False)
-    latest = [
-        link
-        for link in sorted(glob.glob(os.path.join(path, "*-latest")))
-        if os.path.isfile(os.path.join(os.path.realpath(link), STATE_FILE))
-    ]
-    if len(latest) > 1:
-        raise ValueError(
-            f"{checkpoint_path!r} holds several runs "
-            f"({[os.path.basename(p) for p in latest]}); pass the "
-            f"{{run_id}}-step{{N}} checkpoint directory explicitly"
-        )
-    if latest:
-        return torch.load(
-            os.path.join(os.path.realpath(latest[0]), STATE_FILE),
-            map_location="cpu",
-            weights_only=False,
-        )
-    # no `{run_id}-latest` pointer (e.g. symlink-free filesystem): fall back to
-    # the highest step directory, mirroring CheckpointManager.latest_dir().
-    steps = []
-    for cand in glob.glob(os.path.join(path, "*-step*")):
-        m = re.search(r"-step(\d+)$", os.path.basename(cand))
-        if m and os.path.isfile(os.path.join(cand, STATE_FILE)):
-            steps.append((int(m.group(1)), cand))
-    if steps:
-        best = max(steps)[1]
-        return torch.load(
-            os.path.join(best, STATE_FILE), map_location="cpu", weights_only=False
-        )
-    raise FileNotFoundError(
-        f"{checkpoint_path!r} is not a training_state.pt, a checkpoint directory, "
-        f"or an output_dir with a '{{run_id}}-latest' pointer / step directories"
+    checkpoint_dir = CheckpointManager.resolve_committed_checkpoint_dir(checkpoint_path)
+    return torch.load(
+        os.path.join(checkpoint_dir, STATE_FILE),
+        map_location="cpu",
+        weights_only=False,
     )
 
 

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -317,19 +317,19 @@ def _resolve_metadata_store(
 
 
 def _checkpoint_global_step(resume_from: str) -> int:
-    """Read the shared checkpoint step without requiring a rank-state file."""
+    """Read the global step from a committed runtime checkpoint."""
     import os
 
     import torch
 
-    from specforge.training.checkpoint import STATE_FILE
+    from specforge.training.checkpoint import STATE_FILE, CheckpointManager
 
-    path = str(resume_from)
-    if path.startswith("file://"):
-        path = path[len("file://") :]
-    if os.path.basename(path) != STATE_FILE:
-        path = os.path.join(path, STATE_FILE)
-    state = torch.load(path, map_location="cpu", weights_only=False)
+    checkpoint_dir = CheckpointManager.resolve_committed_checkpoint_dir(resume_from)
+    state = torch.load(
+        os.path.join(checkpoint_dir, STATE_FILE),
+        map_location="cpu",
+        weights_only=False,
+    )
     return int(state.get("global_step", 0) or 0)
 
 

--- a/specforge/training/checkpoint.py
+++ b/specforge/training/checkpoint.py
@@ -30,6 +30,7 @@ import torch
 logger = logging.getLogger(__name__)
 
 STATE_FILE = "training_state.pt"
+SUCCESS_FILE = "_SUCCESS"
 
 
 class CheckpointManager:
@@ -59,6 +60,16 @@ class CheckpointManager:
         return os.path.join(ckpt_dir, STATE_FILE)
 
     @staticmethod
+    def _success_path(ckpt_dir: str) -> str:
+        return os.path.join(ckpt_dir, SUCCESS_FILE)
+
+    @classmethod
+    def _is_complete_dir(cls, ckpt_dir: str) -> bool:
+        return os.path.isfile(os.path.join(ckpt_dir, STATE_FILE)) and os.path.isfile(
+            cls._success_path(ckpt_dir)
+        )
+
+    @staticmethod
     def _rank_file(rank: int) -> str:
         return f"training_state_rank{rank}.pt"
 
@@ -75,9 +86,11 @@ class CheckpointManager:
         rank_state: Optional[Dict[str, Any]] = None,
     ) -> str:
         """Write ``step``'s checkpoint, first deleting any on-disk steps >= step
-        (fork/rollback semantics), then repoint ``{run_id}-latest`` and rotate.
-        ``state`` is the shared payload (rank0 writes it); ``rank_state`` is
-        written by every rank. Collective: any rank's failure raises on all ranks.
+        (fork/rollback semantics), then publish ``_SUCCESS``, repoint
+        ``{run_id}-latest``, and rotate. ``state`` is the shared payload (rank0
+        writes it); ``rank_state`` is written by every rank. Collective: any
+        rank's failure raises on all ranks, and markerless directories are never
+        considered resumable.
         """
         ckpt_dir = self.checkpoint_dir(step)
         err = ""
@@ -99,6 +112,13 @@ class CheckpointManager:
                     self._atomic_save(state, self._state_path(ckpt_dir))
             except Exception as exc:
                 err = f"{type(exc).__name__}: {exc}"
+        self._all_ok(err)
+        err = ""
+        if self.is_rank0():
+            try:
+                self._mark_complete(ckpt_dir)
+            except Exception as exc:
+                err = f"completion marker failed: {type(exc).__name__}: {exc}"
         self._all_ok(err)
         if self.is_rank0():
             self._point(f"{self.run_id}-latest", ckpt_dir)
@@ -201,7 +221,7 @@ class CheckpointManager:
             or meta.get("metric") != self.best_metric
             or not isinstance(step, int)
             or not isinstance(score, (int, float))
-            or not os.path.isfile(self._state_path(self.checkpoint_dir(step)))
+            or not self._is_complete_dir(self.checkpoint_dir(step))
         ):
             logger.warning(
                 "ignoring best meta %s: run_id/metric mismatch, malformed, or its "
@@ -217,6 +237,10 @@ class CheckpointManager:
         target = self.checkpoint_dir(step) if step is not None else self.latest_dir()
         if target is None:
             raise FileNotFoundError(f"no checkpoint to load under {self.output_dir}")
+        if not self._is_complete_dir(target):
+            raise ValueError(
+                f"checkpoint is incomplete (missing {SUCCESS_FILE}): {target}"
+            )
         return torch.load(
             self._state_path(target), map_location=map_location, weights_only=False
         )
@@ -240,7 +264,7 @@ class CheckpointManager:
         local_error = None
         state = None
         try:
-            path = cls.resolve_resume_dir(path)
+            path = cls.resolve_committed_checkpoint_dir(path)
             state = torch.load(
                 os.path.join(path, STATE_FILE),
                 map_location=map_location,
@@ -320,11 +344,16 @@ class CheckpointManager:
         return state
 
     @classmethod
-    def resolve_resume_dir(cls, path: str) -> str:
-        """Resolve one unambiguous resume target to its checkpoint directory.
+    def resolve_committed_checkpoint_dir(cls, path: str) -> str:
+        """Resolve one unambiguous committed checkpoint directory.
+
+        Every runtime checkpoint consumer — resume, export, and weights-only
+        warm start — must enter through this method. A payload is consumable
+        only after its directory contains both ``training_state.pt`` and the
+        ``_SUCCESS`` marker published by :meth:`save`.
 
         A run output directory is convenient in declarative configs, but it
-        must never choose between unrelated runs silently.  Prefer its single
+        must never choose between unrelated runs silently. Prefer its single
         complete ``*-latest`` pointer; when symlinks are unavailable, fall back
         to the highest complete ``<run-id>-stepN`` directory only if all
         candidates belong to the same run id.
@@ -337,15 +366,19 @@ class CheckpointManager:
             if not os.path.isfile(path):
                 raise FileNotFoundError(f"checkpoint state file does not exist: {path}")
             path = os.path.dirname(path)
-        if os.path.isfile(os.path.join(path, STATE_FILE)):
+        if cls._is_complete_dir(path):
             return path
+        if os.path.isfile(os.path.join(path, STATE_FILE)):
+            raise ValueError(
+                f"checkpoint is incomplete (missing {SUCCESS_FILE}): {path}"
+            )
         if not os.path.isdir(path):
             raise FileNotFoundError(f"checkpoint path does not exist: {path}")
 
         latest = []
         for candidate in glob.glob(os.path.join(glob.escape(path), "*-latest")):
             resolved = os.path.realpath(candidate)
-            if os.path.isfile(os.path.join(resolved, STATE_FILE)):
+            if cls._is_complete_dir(resolved):
                 latest.append(resolved)
         latest = sorted(set(latest))
         if len(latest) == 1:
@@ -360,7 +393,7 @@ class CheckpointManager:
         pattern = re.compile(r"^(.+)-step(\d+)$")
         for candidate in glob.glob(os.path.join(glob.escape(path), "*-step*")):
             match = pattern.match(os.path.basename(candidate))
-            if match and os.path.isfile(os.path.join(candidate, STATE_FILE)):
+            if match and cls._is_complete_dir(candidate):
                 by_run.setdefault(match.group(1), []).append(
                     (int(match.group(2)), candidate)
                 )
@@ -374,12 +407,17 @@ class CheckpointManager:
         candidates = next(iter(by_run.values()))
         return max(candidates, key=lambda item: item[0])[1]
 
+    @classmethod
+    def resolve_resume_dir(cls, path: str) -> str:
+        """Backward-compatible alias for committed checkpoint resolution."""
+        return cls.resolve_committed_checkpoint_dir(path)
+
     def latest_dir(self) -> Optional[str]:
         """Directory of the newest complete checkpoint, or None."""
         link = os.path.join(self.output_dir, f"{self.run_id}-latest")
         if os.path.islink(link):
             target = os.path.realpath(link)
-            if os.path.isfile(self._state_path(target)):
+            if self._is_complete_dir(target):
                 return target
         step = self._max_step_on_disk()
         return self.checkpoint_dir(step) if step is not None else None
@@ -413,17 +451,42 @@ class CheckpointManager:
         return bool(box[0])
 
     @staticmethod
-    def _atomic_save(obj: Any, path: str) -> None:
+    def _fsync_path(path: str) -> None:
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+
+    @classmethod
+    def _atomic_save(cls, obj: Any, path: str) -> None:
         tmp = path + ".tmp"
         torch.save(obj, tmp)
+        cls._fsync_path(tmp)
         os.replace(tmp, path)
+        cls._fsync_path(os.path.dirname(path))
 
-    @staticmethod
-    def _atomic_json(obj: Dict[str, Any], path: str) -> None:
+    @classmethod
+    def _atomic_json(cls, obj: Dict[str, Any], path: str) -> None:
         tmp = path + ".tmp"
         with open(tmp, "w") as fh:
             json.dump(obj, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
         os.replace(tmp, path)
+        cls._fsync_path(os.path.dirname(path))
+
+    @classmethod
+    def _mark_complete(cls, ckpt_dir: str) -> None:
+        if not os.path.isfile(os.path.join(ckpt_dir, STATE_FILE)):
+            raise RuntimeError("rank 0 did not write the shared checkpoint state")
+        path = cls._success_path(ckpt_dir)
+        tmp = path + ".tmp"
+        with open(tmp, "wb") as fh:
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+        cls._fsync_path(ckpt_dir)
 
     def _point(self, name: str, ckpt_dir: str) -> None:
         link = os.path.join(self.output_dir, name)
@@ -466,9 +529,9 @@ class CheckpointManager:
                 yield int(m.group(1)), path
 
     def _all_checkpoints(self) -> Iterator[Tuple[int, str]]:
-        # Only dirs holding STATE_FILE count: a truncated save is never a target.
+        # A checkpoint is resumable only after rank 0 publishes _SUCCESS.
         for step, path in self._step_dirs():
-            if os.path.isfile(self._state_path(path)):
+            if self._is_complete_dir(path):
                 yield step, path
 
     def _max_step_on_disk(self) -> Optional[int]:
@@ -476,4 +539,4 @@ class CheckpointManager:
         return max(steps) if steps else None
 
 
-__all__ = ["CheckpointManager"]
+__all__ = ["CheckpointManager", "STATE_FILE", "SUCCESS_FILE"]

--- a/specforge/training/model_loading.py
+++ b/specforge/training/model_loading.py
@@ -317,27 +317,28 @@ def _has_pretrained_weights(path: str) -> bool:
 
 
 def _runtime_state_file(source: str) -> Optional[str]:
-    """Resolve SpecForge checkpoint storage without loading resume state."""
+    """Resolve a committed SpecForge runtime checkpoint without loading it."""
 
     path = os.path.abspath(os.path.expanduser(_without_file_uri(str(source))))
     if os.path.isfile(path):
-        return path if os.path.basename(path) == _STATE_FILE else None
-    if not os.path.isdir(path):
+        if os.path.basename(path) != _STATE_FILE:
+            return None
+    elif not os.path.isdir(path):
         return None
-
-    direct = os.path.join(path, _STATE_FILE)
-    if os.path.isfile(direct) and not _has_pretrained_weights(path):
-        return direct
-    has_run_pointers = bool(
-        glob.glob(os.path.join(path, "*-latest"))
-        or glob.glob(os.path.join(path, "*-step*"))
-    )
-    if not has_run_pointers:
-        return None
+    else:
+        direct = os.path.join(path, _STATE_FILE)
+        has_run_pointers = bool(
+            glob.glob(os.path.join(path, "*-latest"))
+            or glob.glob(os.path.join(path, "*-step*"))
+        )
+        if not has_run_pointers and (
+            not os.path.isfile(direct) or _has_pretrained_weights(path)
+        ):
+            return None
 
     from specforge.training.checkpoint import CheckpointManager
 
-    checkpoint_dir = CheckpointManager.resolve_resume_dir(path)
+    checkpoint_dir = CheckpointManager.resolve_committed_checkpoint_dir(path)
     return os.path.join(checkpoint_dir, _STATE_FILE)
 
 

--- a/tests/test_runtime/test_checkpoint_manager.py
+++ b/tests/test_runtime/test_checkpoint_manager.py
@@ -48,8 +48,11 @@ class TestLayoutAndAtomicity(unittest.TestCase):
         mgr = _mgr(out)
         mgr.save(_state(1), 1)
         mgr.save(_state(2), 2)
-        # a truncated save: step dir exists but STATE_FILE never landed
-        os.makedirs(os.path.join(out, "run-step5"))
+        # A crash after the shared state lands but before collective completion
+        # must not make a directory discoverable as a checkpoint.
+        truncated = os.path.join(out, "run-step5")
+        os.makedirs(truncated)
+        torch.save(_state(5), os.path.join(truncated, STATE_FILE))
         self.assertEqual(_steps(mgr), [1, 2])
         os.remove(os.path.join(out, "run-latest"))
         self.assertEqual(
@@ -60,6 +63,63 @@ class TestLayoutAndAtomicity(unittest.TestCase):
         ]
         self.assertEqual(leftovers, [], "atomic writes must not leave .tmp files")
         self.assertTrue(os.path.isfile(os.path.join(mgr.checkpoint_dir(2), STATE_FILE)))
+
+    def test_markerless_checkpoint_is_rejected_by_direct_resume(self):
+        from specforge.training.checkpoint import (
+            STATE_FILE,
+            SUCCESS_FILE,
+            CheckpointManager,
+        )
+
+        out = tempfile.mkdtemp(prefix="ckpt_markerless_")
+        ckpt = os.path.join(out, "run-step5")
+        os.makedirs(ckpt)
+        torch.save(_state(5, world_size=1), os.path.join(ckpt, STATE_FILE))
+        torch.save(
+            {"optimizer": {}, "rng": {}}, os.path.join(ckpt, "training_state_rank0.pt")
+        )
+
+        mgr = _mgr(out)
+        self.assertEqual(_steps(mgr), [])
+        self.assertIsNone(mgr.latest_dir())
+        with self.assertRaisesRegex(ValueError, rf"missing {SUCCESS_FILE}"):
+            CheckpointManager.read_resume_state(ckpt)
+        with self.assertRaisesRegex(FileNotFoundError, "no complete checkpoint"):
+            CheckpointManager.read_resume_state(out)
+
+    def test_failed_same_step_rewrite_cannot_retain_completion_marker(self):
+        from specforge.training.checkpoint import SUCCESS_FILE, CheckpointManager
+
+        out = tempfile.mkdtemp(prefix="ckpt_rewrite_failure_")
+        mgr = _mgr(out)
+        mgr.save(_state(1), 1)
+        original = mgr._atomic_save
+        mgr._atomic_save = lambda *_args: (_ for _ in ()).throw(OSError("disk full"))
+        with self.assertRaisesRegex(RuntimeError, "checkpoint save failed"):
+            mgr.save(_state(1), 1)
+
+        ckpt = mgr.checkpoint_dir(1)
+        self.assertFalse(os.path.exists(os.path.join(ckpt, SUCCESS_FILE)))
+        self.assertEqual(_steps(mgr), [])
+        with self.assertRaisesRegex(FileNotFoundError, "no complete checkpoint"):
+            CheckpointManager.read_resume_state(ckpt)
+        mgr._atomic_save = original
+
+    def test_completion_marker_failure_never_publishes_latest(self):
+        from specforge.training.checkpoint import STATE_FILE, SUCCESS_FILE
+
+        out = tempfile.mkdtemp(prefix="ckpt_marker_failure_")
+        mgr = _mgr(out)
+        original = mgr._mark_complete
+        mgr._mark_complete = lambda _path: (_ for _ in ()).throw(OSError("disk full"))
+        with self.assertRaisesRegex(RuntimeError, "completion marker failed"):
+            mgr.save(_state(1), 1)
+        ckpt = mgr.checkpoint_dir(1)
+        self.assertTrue(os.path.isfile(os.path.join(ckpt, STATE_FILE)))
+        self.assertFalse(os.path.exists(os.path.join(ckpt, SUCCESS_FILE)))
+        self.assertFalse(os.path.lexists(os.path.join(out, "run-latest")))
+        self.assertIsNone(mgr.latest_dir())
+        mgr._mark_complete = original
 
     def test_latest_requires_symlink_and_shadow_is_repaired(self):
         from specforge.training.checkpoint import STATE_FILE
@@ -286,12 +346,17 @@ class TestReadResumeState(unittest.TestCase):
         self.assertEqual(loaded["backend"]["rng"]["torch"].item(), 1)
 
     def test_backend_passthrough_and_path_forms(self):
-        from specforge.training.checkpoint import STATE_FILE, CheckpointManager
+        from specforge.training.checkpoint import (
+            STATE_FILE,
+            SUCCESS_FILE,
+            CheckpointManager,
+        )
 
         out = tempfile.mkdtemp(prefix="ckpt_read_")
         rng = torch.get_rng_state()
         rank_state = {"optimizer": {"lr": 0.5}, "rng": {"torch": rng}, "custom": 7}
         ckpt = _mgr(out).save(_state(3, world_size=1), 3, rank_state=rank_state)
+        self.assertTrue(os.path.isfile(os.path.join(ckpt, SUCCESS_FILE)))
 
         for target in (ckpt, os.path.join(ckpt, STATE_FILE), f"file://{ckpt}"):
             st = CheckpointManager.read_resume_state(target)
@@ -304,6 +369,25 @@ class TestReadResumeState(unittest.TestCase):
 
         root_state = CheckpointManager.read_resume_state(out)
         self.assertEqual(root_state["global_step"], 3)
+
+    def test_launch_reads_only_committed_checkpoint_steps(self):
+        from specforge.launch import _checkpoint_global_step
+        from specforge.training.checkpoint import STATE_FILE
+
+        out = tempfile.mkdtemp(prefix="ckpt_launch_step_")
+        ckpt = _mgr(out).save(_state(3), 3)
+        for source in (ckpt, os.path.join(ckpt, STATE_FILE), f"file://{ckpt}", out):
+            with self.subTest(source=source):
+                self.assertEqual(_checkpoint_global_step(source), 3)
+
+        incomplete = os.path.join(out, "run-step5")
+        os.makedirs(incomplete)
+        incomplete_state = os.path.join(incomplete, STATE_FILE)
+        torch.save(_state(5), incomplete_state)
+        for source in (incomplete, incomplete_state, f"file://{incomplete}"):
+            with self.subTest(source=source):
+                with self.assertRaisesRegex(ValueError, "missing _SUCCESS"):
+                    _checkpoint_global_step(source)
 
     def test_run_root_without_symlinks_uses_latest_complete_step(self):
         from specforge.training.checkpoint import CheckpointManager
@@ -451,7 +535,7 @@ class TestDistributedSaveAndResume(unittest.TestCase):
     def test_two_rank_save_and_per_rank_resume(self):
         import torch.multiprocessing as mp
 
-        from specforge.training.checkpoint import STATE_FILE
+        from specforge.training.checkpoint import STATE_FILE, SUCCESS_FILE
 
         out = tempfile.mkdtemp(prefix="ckpt_dist_")
         results = tempfile.mkdtemp(prefix="ckpt_dist_res_")
@@ -465,7 +549,12 @@ class TestDistributedSaveAndResume(unittest.TestCase):
                 loaded.append(json.load(fh))
         self.assertEqual(loaded[0]["ckpt"], loaded[1]["ckpt"])
         expected = sorted(
-            [STATE_FILE, "training_state_rank0.pt", "training_state_rank1.pt"]
+            [
+                STATE_FILE,
+                SUCCESS_FILE,
+                "training_state_rank0.pt",
+                "training_state_rank1.pt",
+            ]
         )
         for r, res in enumerate(loaded):
             self.assertEqual(res["files"], expected)

--- a/tests/test_runtime/test_checkpoint_resume.py
+++ b/tests/test_runtime/test_checkpoint_resume.py
@@ -15,6 +15,8 @@ from unittest import mock
 
 import torch
 
+from specforge.training.checkpoint import SUCCESS_FILE
+
 CUDA = torch.cuda.is_available()
 
 
@@ -313,6 +315,8 @@ class TestTrainerResumeEntrypoint(unittest.TestCase):
                 {"optimizer": None, "rng": {}},
                 os.path.join(d, "training_state_rank0.pt"),
             )
+            with open(os.path.join(d, SUCCESS_FILE), "xb"):
+                pass
             return d
 
         cases = [

--- a/tests/test_runtime/test_disagg_online_shared_plane.py
+++ b/tests/test_runtime/test_disagg_online_shared_plane.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
@@ -80,6 +81,7 @@ class TestSharedPlaneConsumerResume(unittest.TestCase):
         path = os.path.join(self.work, f"run0-step{step}")
         os.makedirs(path, exist_ok=True)
         torch.save({"global_step": step}, os.path.join(path, STATE_FILE))
+        Path(path, "_SUCCESS").touch()
         return path
 
     def _seed_ledger(self, *, acked=(), step=None) -> None:

--- a/tests/test_runtime/test_export.py
+++ b/tests/test_runtime/test_export.py
@@ -13,10 +13,50 @@ round trips require GPU and can be run on the H200 box via rcli.
 import os
 import tempfile
 import unittest
+from pathlib import Path
 
 import torch
 
 CUDA = torch.cuda.is_available()
+
+
+class TestCommittedCheckpointResolution(unittest.TestCase):
+    def test_committed_checkpoint_is_resolved_from_all_supported_forms(self):
+        from specforge.export.checkpoint_io import resolve_training_state
+        from specforge.training.checkpoint import STATE_FILE, CheckpointManager
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            checkpoint_dir = CheckpointManager(output_dir, "run").save(
+                {"global_step": 5, "draft_state_dict": {}}, 5
+            )
+            for source in (
+                checkpoint_dir,
+                os.path.join(checkpoint_dir, STATE_FILE),
+                f"file://{checkpoint_dir}",
+                output_dir,
+            ):
+                self.assertEqual(resolve_training_state(source)["global_step"], 5)
+
+    def test_markerless_checkpoint_is_not_exportable(self):
+        from specforge.export.checkpoint_io import resolve_training_state
+        from specforge.training.checkpoint import STATE_FILE
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            checkpoint_dir = Path(output_dir, "run-step5")
+            checkpoint_dir.mkdir()
+            state_file = checkpoint_dir / STATE_FILE
+            torch.save({"global_step": 5, "draft_state_dict": {}}, state_file)
+
+            for source in (
+                str(checkpoint_dir),
+                str(state_file),
+                f"file://{checkpoint_dir}",
+            ):
+                with self.subTest(source=source):
+                    with self.assertRaisesRegex(ValueError, "missing _SUCCESS"):
+                        resolve_training_state(source)
+            with self.assertRaisesRegex(FileNotFoundError, "no complete checkpoint"):
+                resolve_training_state(output_dir)
 
 
 class TestLegacyVocabMappingCompatibility(unittest.TestCase):

--- a/tests/test_runtime/test_model_loading.py
+++ b/tests/test_runtime/test_model_loading.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import torch
@@ -248,7 +249,24 @@ class WarmStartTest(unittest.TestCase):
             },
             path,
         )
+        Path(directory, "_SUCCESS").touch()
         return path
+
+    def test_markerless_runtime_checkpoint_is_rejected(self):
+        source = _TinyDraft()
+        destination = _TinyDraft()
+        with tempfile.TemporaryDirectory() as directory:
+            torch.save(
+                {"draft_state_dict": source.state_dict(), "strategy": "dflash"},
+                os.path.join(directory, "training_state.pt"),
+            )
+            with self.assertRaisesRegex(ValueError, "missing _SUCCESS"):
+                warm_start_draft_model(
+                    destination,
+                    os.path.join(directory, "training_state.pt"),
+                    draft_config=object(),
+                    strategy="dflash",
+                )
 
     def test_specforge_checkpoint_loads_only_draft_weights(self):
         torch.manual_seed(1)


### PR DESCRIPTION
A runtime checkpoint is now consumable only after its `_SUCCESS` marker is published. Resume, export, runtime warm start, online checkpoint reconciliation, and training gates share that rule, so an interrupted save cannot be selected or consumed through a side path.

`_SUCCESS` is published only after every rank has written its payload, the write is confirmed collectively, and rank 0's publish is itself confirmed — before the `*-latest` pointer moves. Payloads, the marker, and the parent directory are fsynced so a crash cannot leave a marked-but-partial checkpoint.
