### PR TITLE
Fix DFlash sglang target backend for sglang 0.5.13+ scheduler/batch API

### DIFF
--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from array import array
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -7,7 +8,7 @@ import torch.distributed as dist
 import torch.nn as nn
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
-from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.dp_attn import prepare_mlp_sync_batch_raw
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.radix_cache import RadixCache
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
@@ -135,18 +136,32 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
             enable_overlap=False,
             spec_algorithm=SpeculativeAlgorithm.NONE,
         )
+        # sglang 0.5.13+: the scheduler's PrefillAdder normally builds fill ids and
+        # sets extend_range; we bypass it, so do it per req (no prefix-cache reuse).
+        for req in reqs:
+            req.init_next_round_input(tree_cache)
+            req.set_extend_range(
+                len(req.prefix_indices), len(req.full_untruncated_fill_ids)
+            )
+        # Capture input lengths before prepare_for_extend, which releases
+        # origin_input_ids (becomes None afterwards).
+        input_lens = [len(req.origin_input_ids) for req in reqs]
         batch.prepare_for_extend()
 
         if require_mlp_sync(self.model_runner.server_args):
-            Scheduler.prepare_mlp_sync_batch_raw(
+            # prepare_mlp_sync_batch_raw is now a module-level function; the
+            # spec_algorithm/speculative_num_draft_tokens args were removed and
+            # attn_cp_size was added.
+            prepare_mlp_sync_batch_raw(
                 batch,
                 dp_size=self.model_runner.server_args.dp_size,
                 attn_tp_size=1,
+                attn_cp_size=getattr(
+                    self.model_runner.server_args, "attn_cp_size", 1
+                ),
                 tp_group=self.model_runner.tp_group,
                 get_idle_batch=None,
                 disable_cuda_graph=self.model_runner.server_args.disable_cuda_graph,
-                spec_algorithm=SpeculativeAlgorithm.NONE,
-                speculative_num_draft_tokens=None,
                 require_mlp_tp_gather=require_mlp_tp_gather(
                     self.model_runner.server_args
                 ),
@@ -154,15 +169,24 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
                 offload_tags=set(),
             )
 
-        model_worker_batch = batch.get_model_worker_batch()
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
+        # prepare_for_extend stages input_ids on pinned CPU and leaves
+        # batch.input_ids=None; the scheduler normally does this H2D copy.
+        if batch.prefill_input_ids_cpu is not None:
+            batch.input_ids = batch.prefill_input_ids_cpu.to(
+                batch.device, non_blocking=True
+            )
+            batch.prefill_input_ids_cpu = None
+
+        # The ModelWorkerBatch step was removed: ForwardBatch.init_new consumes the
+        # ScheduleBatch directly and reads capture_hidden_mode from it.
+        batch.capture_hidden_mode = CaptureHiddenMode.FULL
+        forward_batch = ForwardBatch.init_new(batch, self.model_runner)
         forward_batch.capture_hidden_mode = CaptureHiddenMode.FULL
 
         output = self.model_runner.forward(forward_batch)
         if hasattr(output, "logits_output"):
             output = output.logits_output
 
-        input_lens = [len(req.origin_input_ids) for req in reqs]
         if (
             hasattr(output, "aux_hidden_states")
             and output.aux_hidden_states is not None
@@ -204,8 +228,12 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
                 origin_input_ids=curr_ids.view(-1).tolist(),
                 sampling_params=sampling_params,
             )
-            req.fill_ids = req.origin_input_ids
-            req.extend_input_len = len(req.fill_ids) - len(req.prefix_indices)
+            # sglang 0.5.13+: Req.fill_ids was replaced by full_untruncated_fill_ids
+            # (origin + output ids) plus an integer fill_len.
+            req.full_untruncated_fill_ids = array("q", req.origin_input_ids)
+            req.fill_len = len(req.full_untruncated_fill_ids)
+            req.extend_input_len = req.fill_len - len(req.prefix_indices)
+            req.logprob_start_len = len(req.origin_input_ids) - 1
             data_cache.append((curr_ids, curr_attn, curr_loss))
             reqs.append(req)
 

--- a/specforge/modeling/target/dflash_target_model.py
+++ b/specforge/modeling/target/dflash_target_model.py
@@ -156,9 +156,7 @@ class SGLangDFlashTargetModel(DFlashTargetModel):
                 batch,
                 dp_size=self.model_runner.server_args.dp_size,
                 attn_tp_size=1,
-                attn_cp_size=getattr(
-                    self.model_runner.server_args, "attn_cp_size", 1
-                ),
+                attn_cp_size=getattr(self.model_runner.server_args, "attn_cp_size", 1),
                 tp_group=self.model_runner.tp_group,
                 get_idle_batch=None,
                 disable_cuda_graph=self.model_runner.server_args.disable_cuda_graph,


### PR DESCRIPTION
Updated the dflash_target_model.py to replace deprecated methods and adjust input handling for batch processing.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

The DFlash sglang target backend (`SGLangDFlashTargetModel` in
`specforge/modeling/target/dflash_target_model.py`) still uses the pre-0.5.13
`Req`/`ScheduleBatch` scheduler API. On current sglang (0.5.13/0.5.14) an online
DFlash run crashes at the first `generate_dflash_data` call, before any training
step. This PR updates the request/batch construction to the new API, mirroring
the changes already made to the EAGLE3 target backend (`eagle3_target_model.py`).

## Modifications

All in `specforge/modeling/target/dflash_target_model.py`
(`SGLangDFlashTargetModel` only; the `hf` backend is untouched):

- **Imports:** add `from array import array`; import the module-level
  `prepare_mlp_sync_batch_raw` from
  `sglang.srt.managers.scheduler_components.dp_attn`; drop the now-unused
  `from sglang.srt.managers.scheduler import Scheduler`.
- **`generate_dflash_data` — Req construction:** set
  `full_untruncated_fill_ids` / `fill_len` / `extend_input_len` /
  `logprob_start_len` instead of the removed `fill_ids`.
- **`_extend` — batch prep:** per req call `init_next_round_input(tree_cache)`
  then `set_extend_range(len(prefix_indices), len(full_untruncated_fill_ids))`
  (no prefix-cache reuse); capture `input_lens` before `prepare_for_extend`.
- **`_extend` — mlp sync:** call the module-level `prepare_mlp_sync_batch_raw`
  with `attn_cp_size`, without the removed `spec_algorithm` /
  `speculative_num_draft_tokens`.
- **`_extend` — forward:** materialize `prefill_input_ids_cpu` to device, set
  `batch.capture_hidden_mode`, and call `ForwardBatch.init_new(batch, runner)`
  directly (drop `get_model_worker_batch()`).

These mirror the equivalent, already-merged handling in `eagle3_target_model.py`,
so the two backends stay consistent.

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
