### PR TITLE
feat(training): gradient checkpointing for the TTT unroll (`--draft-gradient-checkpointing`)

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -261,6 +261,18 @@ def build_parser() -> ArgumentParser:
         default="flex_attention",
         help="The attention backend for the draft model",
     )
+    optimization_group.add_argument(
+        "--draft-gradient-checkpointing",
+        action="store_true",
+        help=(
+            "Recompute each TTT step during backward instead of retaining its "
+            "activations. Cuts the retained graph from ~O(ttt_length * "
+            "seq * vocab/intermediate) to just the per-step hidden states and "
+            "cached k/v, at the cost of one extra draft forward per step. "
+            "Enables longer --max-length on a single card. Not supported with "
+            "the usp attention backend."
+        ),
+    )
 
     # other args
     other_group = parser.add_argument_group("others")
@@ -1064,6 +1076,11 @@ def main():
         and args.tp_size == 1
         and args.target_model_backend != "sglang"
     ):
+        if args.draft_gradient_checkpointing:
+            raise ValueError(
+                "--draft-gradient-checkpointing is not supported for the "
+                "QwenVL online path"
+            )
         eagle3_model = QwenVLOnlineEagle3Model(
             target_model=target_model,
             draft_model=draft_model,
@@ -1084,6 +1101,7 @@ def main():
                 lk_loss_type=args.lk_loss_type,
                 kl_scale=args.kl_scale,
                 kl_decay=args.kl_decay,
+                gradient_checkpointing=args.draft_gradient_checkpointing,
             )
         else:
             # offline: the target_model is TargetHead not a model
@@ -1094,6 +1112,7 @@ def main():
                 lk_loss_type=args.lk_loss_type,
                 kl_scale=args.kl_scale,
                 kl_decay=args.kl_decay,
+                gradient_checkpointing=args.draft_gradient_checkpointing,
             )
     eagle3_model = FSDP(
         eagle3_model,

--- a/specforge/core/eagle3.py
+++ b/specforge/core/eagle3.py
@@ -25,6 +25,7 @@ from typing import Callable, List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.utils.checkpoint
 from transformers.cache_utils import DynamicCache
 
 from specforge.core.compact_teacher import (
@@ -40,6 +41,13 @@ from specforge.utils import padding
 
 class Eagle3Model(nn.Module):
     pass
+
+
+def _dynamic_cache_kv(cache: DynamicCache) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return the layer-0 key/value tensors across transformers versions."""
+    if hasattr(cache, "layers"):  # transformers >= 5
+        return cache.layers[0].keys, cache.layers[0].values
+    return cache.key_cache[0], cache.value_cache[0]
 
 
 def _compute_loss_and_acceptance_rate(
@@ -116,6 +124,7 @@ class OnlineEagle3Model(Eagle3Model):
         lk_loss_type: Optional[str] = None,
         kl_scale: float = 1.0,
         kl_decay: float = 1.0,
+        gradient_checkpointing: bool = False,
     ):
         """
         Args:
@@ -125,6 +134,12 @@ class OnlineEagle3Model(Eagle3Model):
             lk_loss_type: LK loss objective type. One of {"lambda", "alpha"}.
             kl_scale: Initial KL weight scale for lambda LK loss.
             kl_decay: Decay factor for adaptive KL weight in lambda LK loss.
+            gradient_checkpointing: recompute each TTT step in backward instead
+                of retaining its activations (attention probs, MLP intermediates,
+                logits, per-step teacher-p slices). Only the per-step hidden
+                states and cached k/v survive the forward, which is what makes
+                longer max_length fit on a single card. Not supported for usp:
+                it runs collectives inside the step, which is not replay-safe.
         """
         super().__init__()
         self.draft_model = draft_model
@@ -134,6 +149,12 @@ class OnlineEagle3Model(Eagle3Model):
         self.lk_loss_type = lk_loss_type
         self.kl_scale = kl_scale
         self.kl_decay = kl_decay
+        if gradient_checkpointing and attention_backend == "usp":
+            raise ValueError(
+                "gradient_checkpointing is not supported with the usp attention "
+                "backend (collectives inside the checkpointed step)"
+            )
+        self.gradient_checkpointing = gradient_checkpointing
 
     def _make_adapter(self) -> BackendAdapter:
         if self.attention_backend == "usp":
@@ -231,6 +252,105 @@ class OnlineEagle3Model(Eagle3Model):
 
         position_ids = position_ids.long()
         return position_ids.view(-1, seq_length)
+
+    def _run_ttt_step(
+        self,
+        idx: int,
+        seq_length: int,
+        n_prev: int,
+        adapter: BackendAdapter,
+        global_input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        target_p_padded: torch.Tensor,
+        target_p_on_draft_padded: Optional[torch.Tensor],
+        target_token_ids_padded: Optional[torch.Tensor],
+        position_mask: torch.Tensor,
+        *prev_kv: torch.Tensor,
+    ) -> Tuple[torch.Tensor, ...]:
+        """One TTT step as a replay-safe function for activation checkpointing.
+
+        Prior steps' cached k/v enter as flat tensor args (autograd inputs, so
+        the cross-step gradient chain survives recompute) and a fresh local
+        cache — cache_hidden lists for sdpa/fa, a seeded DynamicCache for
+        flex_attention — is built per invocation, so replaying never
+        double-appends. The padded teacher tensors are sliced in here so the
+        per-step .contiguous() copies stay recompute-transient instead of being
+        retained by the loss graph.
+
+        For sdpa/fa, prev_kv is (*per_step_keys, *per_step_values) with n_prev
+        keys; for flex_attention it is the running concatenated (key, value)
+        pair with n_prev == 1, or empty on the first step.
+        """
+        if self.attention_backend == "flex_attention":
+            cache_hidden = None
+            past_key_values = DynamicCache()
+            if n_prev:
+                past_key_values.update(prev_kv[0], prev_kv[n_prev], layer_idx=0)
+        else:
+            cache_hidden = [list(prev_kv[:n_prev]), list(prev_kv[n_prev:])]
+            past_key_values = None
+        state = adapter.step_view(
+            idx=idx,
+            ttt_length=self.length,
+            global_input_ids=global_input_ids,
+            attention_mask=attention_mask,
+            loss_mask=loss_mask,
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            target_p_padded=target_p_padded,
+            target_p_on_draft_padded=target_p_on_draft_padded,
+            target_token_ids_padded=target_token_ids_padded,
+            position_mask=position_mask,
+            seq_length=seq_length,
+        )
+        inputs_embeds = self.draft_model.embed_input_ids(state.input_ids)
+        inputs_embeds = inputs_embeds.to(state.hidden_states.dtype)
+        hidden_states_out = self.draft_model.backbone(
+            input_embeds=inputs_embeds,
+            hidden_states=state.hidden_states,
+            cache_hidden=cache_hidden,
+            attention_mask=state.attention_mask,
+            position_ids=state.position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+        )
+        if self.attention_backend == "flex_attention":
+            new_key, new_value = _dynamic_cache_kv(past_key_values)
+        else:
+            new_key, new_value = cache_hidden[0][-1], cache_hidden[1][-1]
+        logits = self.draft_model.compute_logits(hidden_states_out)
+        (
+            acc,
+            acceptance_rate,
+            loss,
+            correct,
+            denom,
+            metric_loss,
+            loss_denom,
+        ) = self._acc_and_loss(
+            logits=logits,
+            target_p=state.target_p,
+            target_p_on_draft=state.target_p_on_draft,
+            target_token_ids=state.target_token_ids,
+            position_mask=state.position_mask,
+            loss_mask=state.loss_mask,
+            adapter=adapter,
+        )
+        return (
+            hidden_states_out,
+            new_key,
+            new_value,
+            loss,
+            acc,
+            acceptance_rate,
+            correct,
+            denom,
+            metric_loss,
+            loss_denom,
+        )
 
     def forward(
         self,
@@ -358,7 +478,66 @@ class OnlineEagle3Model(Eagle3Model):
         else:
             raise ValueError(f"Unknown attention backend: {self.attention_backend}")
 
+        use_ckpt = (
+            self.gradient_checkpointing and self.training and torch.is_grad_enabled()
+        )
+        ckpt_keys: List[torch.Tensor] = []
+        ckpt_values: List[torch.Tensor] = []
         for idx in range(self.length):
+            is_last = idx == self.length - 1
+
+            if use_ckpt:
+                # Steps 5.1-5.6 replayed in backward; only step outputs retained.
+                (
+                    hidden_states,
+                    new_k,
+                    new_v,
+                    loss,
+                    acc,
+                    acceptance_rate,
+                    correct,
+                    denom,
+                    metric_loss,
+                    loss_denom,
+                ) = torch.utils.checkpoint.checkpoint(
+                    self._run_ttt_step,
+                    idx,
+                    seq_length,
+                    len(ckpt_keys),
+                    adapter,
+                    global_input_ids,
+                    attention_mask,
+                    loss_mask,
+                    position_ids,
+                    hidden_states,
+                    target_p_padded,
+                    target_p_on_draft_padded,
+                    target_token_ids_padded,
+                    position_mask,
+                    *ckpt_keys,
+                    *ckpt_values,
+                    use_reentrant=False,
+                )
+                if self.attention_backend == "flex_attention":
+                    # running concatenated cache: replace, don't append
+                    ckpt_keys, ckpt_values = [new_k], [new_v]
+                else:
+                    ckpt_keys = ckpt_keys + [new_k]
+                    ckpt_values = ckpt_values + [new_v]
+                acces.append(acc)
+                acceptance_rates.append(acceptance_rate)
+                plosses.append(loss)
+                metric_corrects.append(correct)
+                metric_denoms.append(denom)
+                metric_losses.append(metric_loss)
+                metric_loss_denoms.append(loss_denom)
+
+                if not is_last:
+                    global_input_ids = padding(global_input_ids, left=False)
+                    position_mask = padding(position_mask, left=False)
+                    loss_mask = padding(loss_mask, left=False)
+                continue
+
             state = adapter.step_view(
                 idx=idx,
                 ttt_length=self.length,
@@ -373,7 +552,6 @@ class OnlineEagle3Model(Eagle3Model):
                 position_mask=position_mask,
                 seq_length=seq_length,
             )
-            is_last = idx == self.length - 1
 
             # Step 5.1: embed the input ids
             inputs_embeds = self.draft_model.embed_input_ids(state.input_ids)


### PR DESCRIPTION
## Motivation

The TTT loop unrolls `ttt_length` draft forwards and retains every step's activations until backward: attention probs, MLP intermediates, the per-step `seq x draft_vocab` logits (131 MB per step at max-length 2048 with a 32K draft vocab), and the per-step teacher-p slices (~262 MB fp32 per step). At longer max-length this retained graph, not the weights, is what OOMs online training on a single card. Related memory asks: #466, #528, #558 (#581 addressed the teacher side, offline only).

## What this does

`--draft-gradient-checkpointing` (default off, no behavior change when off) recomputes each TTT step during backward instead of retaining it. Naive `torch.utils.checkpoint` around a step is incorrect here, not a speed tradeoff: backward replays the forward, and a replay that appends to a shared KV cache appends a second time, corrupting every later step. The step function is made replay-safe:

- Prior steps' cached k/v enter the checkpointed function as explicit tensor arguments, so the cross-step gradient chain survives recompute.
- A fresh local cache is built per invocation (`cache_hidden` lists for sdpa/fa; a `DynamicCache` seeded via `.update()` for flex_attention, with the transformers>=5 `cache.layers[i]` API and legacy fallback), so a replay can never double-append.
- The loss is computed inside the checkpointed region, so the per-step logits and teacher-p slices stay recompute-transient instead of being retained by the loss graph.

`usp` is rejected with a `ValueError` (it runs collectives inside the step, which is not replay-safe). The QwenVL online path rejects the flag rather than silently ignoring it. The online and offline text paths both go through `OnlineEagle3Model` and both support it.

## Verification

The equivalence bar is bitwise, not a tolerance:

1. Run the unpatched path twice on identical inputs to measure the backward noise floor: 0.0.
2. Require checkpointed-vs-unpatched gradient diff <= that floor.

Result on a real 1-layer draft head (155K target vocab / 32K draft vocab, flex_attention): all 7 step losses and every parameter gradient bitwise identical (diff exactly 0.0). Anything above the floor would mean the replay is not reproducing the forward.

Production evidence: a 7,000-step online training night at max-length 2048 on one RTX 5090 (36B w4a16 teacher via the sglang backend), rc=0, ~3.7 s/step vs ~3.5 s/step at 1024: the extra draft forward per step drowns under a teacher-bound step. Retained graph dropped ~85%; 2048 previously missed single-card fit by ~250 MB with every other memory option enabled, and now fits with headroom. A spec-decode eval of the resulting checkpoint served normally in sglang EAGLE-3.

## Checklist notes

- pre-commit clean.
- I have the equivalence A/B as a standalone script and can adapt it into a GPU unit test in this PR if you want it in CI.
