### PR TITLE
feat(training): `--vocab-mapping-path` to pin the vocab mapping across resumes

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -473,6 +473,12 @@ def sanity_check(args: Namespace) -> None:
             raise ValueError("shard_target_output is only supported for sglang backend")
         if args.is_vlm:
             raise ValueError("shard_target_output is only supported non vlm model")
+    if args.vocab_mapping_path and not os.path.isfile(args.vocab_mapping_path):
+        # validated here, on every rank, before any distributed barrier:
+        # raising inside rank_0_priority() would hang the other ranks
+        raise FileNotFoundError(
+            f"--vocab-mapping-path {args.vocab_mapping_path} does not exist"
+        )
 
 
 def sp_sanity_check(args: Namespace) -> None:
@@ -600,24 +606,24 @@ def build_dataloaders(
         args.train_data_path is not None and args.train_hidden_states_path is None
     )
     with rank_0_priority():
-        train_eagle3_dataset = build_eagle3_dataset(
-            dataset=train_dataset,
-            tokenizer=tokenizer,
-            chat_template=args.chat_template,
-            max_length=args.max_length,
-            cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
-            cache_key=cache_key,
-            is_vlm=args.is_vlm,
-            is_preformatted=args.is_preformatted,
-            processor=processor,
-            num_proc=args.build_dataset_num_proc,
-            train_only_last_turn=args.train_only_last_turn,
-        )
+        # offline with a pinned mapping consumes neither product of this
+        # build (the offline dataset replaces it below), so skip the work
+        if is_online or not args.vocab_mapping_path:
+            train_eagle3_dataset = build_eagle3_dataset(
+                dataset=train_dataset,
+                tokenizer=tokenizer,
+                chat_template=args.chat_template,
+                max_length=args.max_length,
+                cache_dir=os.path.join(args.cache_dir, "processed_dataset"),
+                cache_key=cache_key,
+                is_vlm=args.is_vlm,
+                is_preformatted=args.is_preformatted,
+                processor=processor,
+                num_proc=args.build_dataset_num_proc,
+                train_only_last_turn=args.train_only_last_turn,
+            )
         if args.vocab_mapping_path:
-            if not os.path.isfile(args.vocab_mapping_path):
-                raise FileNotFoundError(
-                    f"--vocab-mapping-path {args.vocab_mapping_path} does not exist"
-                )
+            # existence validated in sanity_check, on all ranks, pre-barrier
             vocab_mapping_path = args.vocab_mapping_path
             print_on_rank0(f"Using pinned vocab mapping: {vocab_mapping_path}")
         else:

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -266,6 +266,19 @@ def build_parser() -> ArgumentParser:
     other_group = parser.add_argument_group("others")
     other_group.add_argument("--cache-key", type=str, default=None)
     other_group.add_argument("--cache-dir", type=str, default="./cache")
+    other_group.add_argument(
+        "--vocab-mapping-path",
+        type=str,
+        default=None,
+        help=(
+            "Use this existing vocab mapping file instead of generating one "
+            "from the dataset. The generated mapping is keyed on max-length "
+            "(among others), so resuming a checkpoint under a different "
+            "max-length would silently regenerate a shifted d2t/t2d and "
+            "scramble the head's learned vocabulary. Pin the original mapping "
+            "when resuming with changed dataset parameters."
+        ),
+    )
     other_group.add_argument("--output-dir", type=str, required=True)
     other_group.add_argument("--verbose", action="store_true")
     other_group.add_argument(
@@ -600,13 +613,21 @@ def build_dataloaders(
             num_proc=args.build_dataset_num_proc,
             train_only_last_turn=args.train_only_last_turn,
         )
-        vocab_mapping_path = generate_vocab_mapping_file(
-            dataset=train_eagle3_dataset,
-            target_vocab_size=draft_model_config.vocab_size,
-            draft_vocab_size=draft_model_config.draft_vocab_size,
-            cache_dir=os.path.join(args.cache_dir, "vocab_mapping"),
-            cache_key=vocab_cache_key,
-        )
+        if args.vocab_mapping_path:
+            if not os.path.isfile(args.vocab_mapping_path):
+                raise FileNotFoundError(
+                    f"--vocab-mapping-path {args.vocab_mapping_path} does not exist"
+                )
+            vocab_mapping_path = args.vocab_mapping_path
+            print_on_rank0(f"Using pinned vocab mapping: {vocab_mapping_path}")
+        else:
+            vocab_mapping_path = generate_vocab_mapping_file(
+                dataset=train_eagle3_dataset,
+                target_vocab_size=draft_model_config.vocab_size,
+                draft_vocab_size=draft_model_config.draft_vocab_size,
+                cache_dir=os.path.join(args.cache_dir, "vocab_mapping"),
+                cache_key=vocab_cache_key,
+            )
 
         if not is_online:
             train_eagle3_dataset = build_offline_eagle3_dataset(


### PR DESCRIPTION
## The failure mode

The draft-vocab mapping (top `draft_vocab_size` of the target vocab by training-set frequency) is generated with a cache key that includes `max_length` and the other dataset parameters. Resume a checkpoint with any of those changed (e.g. continuing a 1024 run at 2048) and the trainer regenerates a shifted d2t/t2d (the truncation point moves, so tail frequencies reshuffle), then loads it after the head's weights: slot i no longer means the same target token, supervision is scrambled for every shifted slot, and there is no error. Training continues with a plausible loss curve.

## What this does

`--vocab-mapping-path` bypasses generation and uses the given mapping file. Default off; when unset, behavior is unchanged. A missing file raises `FileNotFoundError` up front rather than falling back to regeneration.

## Verification

Resumed a 7,000-step EAGLE-3 head at doubled max-length (1024 -> 2048) with the night-1 mapping pinned, trained another 7,000 steps, and compared a fixed spec-decode eval (same engine config, same prompts, greedy) before and after: no acceptance collapse through the resume (the code workload held at 1.29x speedup / 1.65 accept-len at both points).

## Related

#534 preserves the mapping when fine-tuning from a checkpoint; this flag covers the resume-with-changed-data-parameters case explicitly and gives scripts a way to state the dependency.
