### PR TITLE
feat(training): single-GPU online-mode memory options

### DIFF
--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -1052,6 +1052,12 @@ def main():
     # engine has profiled free memory, so the engine mem fraction does not
     # have to absorb the draft weights (single-GPU online mode).
     draft_model = draft_model.cuda()
+    if args.draft_embedding_cpu or args.optimizer_cpu_offload:
+        if dist.is_initialized() and dist.get_world_size() > 1:
+            raise ValueError(
+                "CPU offloading options (--draft-embedding-cpu, --optimizer-cpu-offload) "
+                "are only supported in single-GPU mode (world_size=1)."
+            )
     if args.draft_embedding_cpu:
         # Frozen vocab x hidden table, used for one lookup per batch; keep it
         # in host memory to free ~2 x hidden x vocab bytes of VRAM

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -4,6 +4,7 @@
 # for them: VLM (--is-vlm), USP sequence parallelism (--attention-backend usp),
 # the eval loop (--eval-*-path), --resume, and experiment trackers (--report-to).
 import argparse
+import contextlib
 import hashlib
 import math
 import os
@@ -184,6 +185,16 @@ def build_parser() -> ArgumentParser:
         type=int,
         default=7,
         help="The length for Test-Time Training (TTT).",
+    )
+    training_group.add_argument(
+        "--draft-embedding-cpu",
+        action="store_true",
+        help="Keep the frozen draft input embedding in host memory (single-GPU online mode).",
+    )
+    training_group.add_argument(
+        "--optimizer-cpu-offload",
+        action="store_true",
+        help="Keep fp32 master params and AdamW state in host memory (single-GPU online mode).",
     )
     training_group.add_argument("--resume", action="store_true")
     training_group.add_argument(
@@ -527,13 +538,13 @@ def build_draft_model(args: Namespace) -> Tuple[AutoDraftModelConfig, nn.Module]
             draft_model_last_checkpoint,
             attention_backend=args.attention_backend,
             torch_dtype=torch.bfloat16,
-        ).cuda()
+        )
     else:
         draft_model = AutoEagle3DraftModel.from_config(
             draft_model_config,
             attention_backend=args.attention_backend,
             torch_dtype=torch.bfloat16,
-        ).cuda()
+        )
 
     # Load training state (optimizer, scheduler, epoch, step) for true resume
     resume_state = None
@@ -701,7 +712,12 @@ def save_checkpoints(
         os.makedirs(epoch_output_dir, exist_ok=True)
     dist.barrier()
 
-    with FSDP.state_dict_type(eagle3_model, StateDictType.FULL_STATE_DICT):
+    sd_ctx = (
+        FSDP.state_dict_type(eagle3_model, StateDictType.FULL_STATE_DICT)
+        if isinstance(eagle3_model, FSDP)
+        else contextlib.nullcontext()
+    )
+    with sd_ctx:
         model_state_dict = eagle3_model.state_dict()
         state_to_save = {
             "epoch": epoch,
@@ -1022,6 +1038,16 @@ def main():
     print_cuda_memory_debug("before build_target_model")
     target_model, processor = build_target_model(args, draft_model_config, is_online)
     print_cuda_memory_debug("after build_target_model")
+    # The draft model is built on CPU and moved to GPU only after the sglang
+    # engine has profiled free memory, so the engine mem fraction does not
+    # have to absorb the draft weights (single-GPU online mode).
+    draft_model = draft_model.cuda()
+    if args.draft_embedding_cpu:
+        # Frozen vocab x hidden table, used for one lookup per batch; keep it
+        # in host memory to free ~2 x hidden x vocab bytes of VRAM
+        # (single-GPU mode only).
+        draft_model.embed_tokens = draft_model.embed_tokens.cpu()
+    print_cuda_memory_debug("after draft_model.cuda()")
 
     # ================================================
     # 3. Build dataloader
@@ -1095,16 +1121,23 @@ def main():
                 kl_scale=args.kl_scale,
                 kl_decay=args.kl_decay,
             )
-    eagle3_model = FSDP(
-        eagle3_model,
-        use_orig_params=True,
-        mixed_precision=MixedPrecision(
-            param_dtype=torch.bfloat16,
-            buffer_dtype=torch.bfloat16,
-        ),
-        sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
-        process_group=dist.group.WORLD,  # the draft model should run dp for all processes
-    )
+    if dist.get_world_size() > 1:
+        eagle3_model = FSDP(
+            eagle3_model,
+            use_orig_params=True,
+            mixed_precision=MixedPrecision(
+                param_dtype=torch.bfloat16,
+                buffer_dtype=torch.bfloat16,
+            ),
+            sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
+            process_group=dist.group.WORLD,  # the draft model should run dp for all processes
+        )
+    else:
+        # Single GPU: FSDP adds no sharding value here and its flat parameter
+        # groups allocate gradient storage even for frozen params (a full
+        # vocab x hidden grad for the frozen embedding), so run the module
+        # directly.
+        print_with_rank("world_size=1: running eagle3 model without FSDP wrap")
     print_with_rank("Initialized Eagle3 FSDP model")
 
     # ================================================
@@ -1116,6 +1149,7 @@ def main():
         max_grad_norm=args.max_grad_norm,
         warmup_ratio=args.warmup_ratio,
         total_steps=args.total_steps,
+        cpu_offload=args.optimizer_cpu_offload,
     )
     print_with_rank("Initialized optimizer and scheduler")
 

--- a/scripts/train_eagle3.py
+++ b/scripts/train_eagle3.py
@@ -471,6 +471,16 @@ def sanity_check(args: Namespace) -> None:
             raise ValueError("shard_target_output is only supported for sglang backend")
         if args.is_vlm:
             raise ValueError("shard_target_output is only supported non vlm model")
+    if (
+        args.optimizer_cpu_offload or args.draft_embedding_cpu
+    ) and dist.get_world_size() > 1:
+        # both options assume unwrapped parameters; under FSDP's flat
+        # parameter groups they would misbehave silently
+        raise ValueError(
+            "--optimizer-cpu-offload and --draft-embedding-cpu are "
+            "single-GPU options (world_size 1); they are incompatible "
+            "with the FSDP wrap used at world_size > 1"
+        )
 
 
 def sp_sanity_check(args: Namespace) -> None:

--- a/specforge/core/lk_loss.py
+++ b/specforge/core/lk_loss.py
@@ -43,10 +43,27 @@ def _masked_mean(
 def _acceptance_rate_per_token_from_logits(
     logits: torch.Tensor,
     target_probs: torch.Tensor,
+    chunk_size: int = 256,
 ) -> torch.Tensor:
-    """Return per-token expected acceptance from draft logits and target probs."""
-    draft_p = F.softmax(logits.to(torch.float32), dim=-1).to(target_probs.dtype)
-    return expected_acceptance_rate(target_probs=target_probs, draft_probs=draft_p)
+    """Return per-token expected acceptance from draft logits and target probs.
+
+    The fp32 softmax over the draft vocab is computed in token chunks so it
+    never materializes for the whole sequence at once; each chunk reduces to
+    one scalar per token, keeping peak memory flat in sequence length.
+    """
+    flat_logits = logits.reshape(-1, logits.shape[-1])
+    flat_target = target_probs.reshape(-1, target_probs.shape[-1])
+    per_token = []
+    for i in range(0, flat_logits.shape[0], chunk_size):
+        draft_p = F.softmax(
+            flat_logits[i : i + chunk_size].to(torch.float32), dim=-1
+        ).to(flat_target.dtype)
+        per_token.append(
+            expected_acceptance_rate(
+                target_probs=flat_target[i : i + chunk_size], draft_probs=draft_p
+            )
+        )
+    return torch.cat(per_token).reshape(logits.shape[:-1])
 
 
 def compute_acceptance_rate(

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -1719,6 +1719,12 @@ class LlamaForCausalLMEagle3(Eagle3DraftModel):
         return hidden_states
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        # The embedding table may be kept in host memory (frozen, one lookup
+        # per batch); run the lookup where the table lives and return the
+        # result on the input device.
+        weight_device = self.embed_tokens.weight.device
+        if input_ids.device != weight_device:
+            return self.embed_tokens(input_ids.to(weight_device)).to(input_ids.device)
         return self.embed_tokens(input_ids)
 
     def project_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/specforge/optimizer.py
+++ b/specforge/optimizer.py
@@ -13,6 +13,7 @@ class BF16Optimizer:
         max_grad_norm=0.5,
         total_steps=800_000,
         warmup_ratio=0.015,
+        cpu_offload=False,
     ):
         # TODO: For now, we only support cosine annealing warmup lr scheduler and AdamW optimizer
         # TODO: We should make these parameters configurable
@@ -21,9 +22,18 @@ class BF16Optimizer:
         self.model = model
         self.model_params = [p for p in model.parameters() if p.requires_grad]
         self.max_grad_norm = max_grad_norm
-        self.fp32_params = [
-            p.detach().clone().to(torch.float32) for p in self.model_params
-        ]
+        self.cpu_offload = cpu_offload
+        if cpu_offload:
+            # Keep fp32 master params and AdamW state in host memory so only
+            # the bf16 params/grads occupy VRAM. The AdamW step runs on CPU.
+            self.fp32_params = [
+                p.detach().to(torch.float32).cpu().pin_memory()
+                for p in self.model_params
+            ]
+        else:
+            self.fp32_params = [
+                p.detach().clone().to(torch.float32) for p in self.model_params
+            ]
         for mp in self.fp32_params:
             mp.requires_grad = True
         self.optimizer = torch.optim.AdamW(
@@ -40,7 +50,9 @@ class BF16Optimizer:
         with torch.no_grad():
             for p, mp in zip(self.model_params, self.fp32_params):
                 mp.grad = (
-                    p.grad.detach().to(torch.float32) if p.grad is not None else None
+                    p.grad.detach().to(device=mp.device, dtype=torch.float32)
+                    if p.grad is not None
+                    else None
                 )
         grad_norm = torch.nn.utils.clip_grad_norm_(self.fp32_params, self.max_grad_norm)
         self.last_grad_norm = grad_norm.detach()
@@ -49,7 +61,7 @@ class BF16Optimizer:
         self.scheduler.step()
         with torch.no_grad():
             for p, mp in zip(self.model_params, self.fp32_params):
-                p.data.copy_(mp.data.to(p.dtype))
+                p.data.copy_(mp.data)
                 p.grad = None
         return self.last_grad_norm
 

--- a/specforge/optimizer.py
+++ b/specforge/optimizer.py
@@ -61,7 +61,7 @@ class BF16Optimizer:
         self.scheduler.step()
         with torch.no_grad():
             for p, mp in zip(self.model_params, self.fp32_params):
-                p.data.copy_(mp.data)
+                p.data.copy_(mp.data, non_blocking=True)
                 p.grad = None
         return self.last_grad_norm
 


### PR DESCRIPTION
## Motivation

Online EAGLE-3 training with a large quantized teacher can fit on one consumer card, but the training side wastes VRAM in four places that matter at 32 GB. With these options, a 36B w4a16 teacher (sglang backend) plus draft training co-reside on one RTX 5090. Related memory issues: #466, #380.

## What this does

Two opt-in flags (default off, no behavior change when off):

- `--optimizer-cpu-offload`: fp32 master params and AdamW state live in pinned host memory and the optimizer step runs on CPU; only bf16 params and grads stay in VRAM. Saved ~8.4 GB for a 1-layer draft head over a 155K vocab. The CPU step cost (~0.5 s) is amortized by the teacher-bound step.
- `--draft-embedding-cpu`: the frozen draft input embedding stays in host memory; it is used for one lookup per batch, and `embed_input_ids` runs the lookup where the table lives. Saved ~1.6 GB.

Two structural changes:

- The draft model is now built on CPU and moved to GPU after the sglang engine has profiled free memory, so `--mem-frac` no longer needs headroom for the draft weights (engine floor 0.784 -> 0.710 in our runs). End state is identical; only the init order changes.
- At `world_size == 1` the FSDP wrap is skipped: FSDP's flat parameter groups allocate gradient storage even for frozen params (a full vocab x hidden grad for the frozen embedding, ~1.5 GB) and provide no sharding value on one rank. `save_checkpoints` handles wrapped and unwrapped models.

One metric fix that becomes necessary at longer sequences:

- The acceptance-rate metric's fp32 softmax over the draft vocab is computed in token chunks, so its peak memory stays flat in sequence length instead of materializing `seq x draft_vocab` fp32 at once.

## Verification

Multiple 7,000-step online training nights on one RTX 5090 (36B w4a16 teacher, max-length 1024 and 2048), rc=0, resume verified across nights; the resulting checkpoints serve normally under sglang EAGLE-3. The numbers above come from `torch.cuda` allocator stats, not nvidia-smi.

## Notes

- The no-FSDP-at-ws1 change affects anyone running world_size 1 today: they get the same model without the wrap. State-dict save/load paths for both cases are exercised by the resume flow.
- pre-commit clean.
