### PR TITLE
feat(data): add validated Qwen ShareGPT regeneration pipelines

### DIFF
--- a/docs/basic_usage/data_preparation.md
+++ b/docs/basic_usage/data_preparation.md
@@ -59,6 +59,96 @@ For reasoning models, add `--reasoning save` to store `reasoning_content` in the
 
 For maximum performance, we recommend to scale the number of GPUs to regenerate the dataset in data parallel mode. To do this, you can simply add more server addresses to the `--server-address` argument, e.g. `--server-address localhost:30000 localhost:30001 localhost:30002 localhost:30003`.
 
+### Qwen ShareGPT recipes
+
+The Qwen recipe wraps regeneration, complete-row accounting, and output
+validation. It expects one or more SGLang servers to already be running; it does
+not launch or stop the servers itself.
+
+For Qwen3-8B non-reasoning regeneration, start a target server in one terminal:
+
+```bash
+python -m sglang.launch_server \
+    --model-path Qwen/Qwen3-8B \
+    --tp-size 1 \
+    --dtype bfloat16 \
+    --mem-fraction-static 0.8 \
+    --host 0.0.0.0 \
+    --port 30000
+```
+
+After `curl --fail http://127.0.0.1:30000/health` succeeds, run the recipe from
+the SpecForge repository root:
+
+```bash
+MODEL_PROFILE=qwen3-8b \
+INPUT_FILE=./cache/dataset/sharegpt_train.jsonl \
+OUTPUT_FILE=./cache/dataset/sharegpt_train_regen_qwen3_8b_temperature0_non_reasoning.jsonl \
+SERVER_ADDRESSES="localhost:30000" \
+bash examples/data_regeneration/run_qwen_sharegpt_regeneration.sh
+```
+
+This profile sets temperature to zero, disables thinking through
+`chat_template_kwargs.enable_thinking=false`, and rejects non-empty structured
+reasoning in successful rows.
+
+For Qwen3.6-27B structured-reasoning regeneration, start SGLang with the Qwen3
+reasoning parser so the OpenAI-compatible response includes
+`reasoning_content`:
+
+```bash
+python -m sglang.launch_server \
+    --model-path Qwen/Qwen3.6-27B \
+    --tp-size 1 \
+    --dtype bfloat16 \
+    --mem-fraction-static 0.8 \
+    --reasoning-parser qwen3 \
+    --host 0.0.0.0 \
+    --port 30000
+```
+
+After `curl --fail http://127.0.0.1:30000/health` succeeds, run:
+
+```bash
+MODEL_PROFILE=qwen3.6-27b \
+INPUT_FILE=./cache/dataset/sharegpt_train.jsonl \
+OUTPUT_FILE=./cache/dataset/sharegpt_train_regen_qwen3.6-27b_temperature0_reasoning.jsonl \
+SERVER_ADDRESSES="localhost:30000" \
+bash examples/data_regeneration/run_qwen_sharegpt_regeneration.sh
+```
+
+The default maximum completion lengths are 4096 tokens for Qwen3-8B and 32768
+tokens for Qwen3.6-27B. The server context length must accommodate both the
+rendered prompt and `MAX_TOKENS`; override `MAX_TOKENS` when using a shorter
+server context.
+
+`INPUT_FILE` may point to another dataset without changing the recipe as long
+as it is JSONL in the conversation format documented below, with a non-empty
+string `id` and alternating `user`/`assistant` messages. Always choose a fresh
+`OUTPUT_FILE`: the recipe deliberately refuses to overwrite or resume an
+existing run.
+
+For an output such as `dataset_regen.jsonl`, the recipe produces:
+
+- `dataset_regen.jsonl`: successful regenerated training rows;
+- `dataset_regen_error.jsonl`: request or generation errors;
+- `dataset_regen_skipped.jsonl`: schema-invalid inputs and outputs excluded by the
+  selected reasoning contract.
+
+The run passes accounting only when
+`success + error + skipped == input`. It prints the success fraction without a
+fixed minimum threshold, then strictly validates every successful row,
+including its conversation structure, reasoning contract, and absence of raw
+`<think>` markers.
+
+To distribute regeneration across independently launched servers, provide all
+addresses as a space-separated list, for example:
+
+```bash
+SERVER_ADDRESSES="localhost:30000 localhost:30010" \
+CONCURRENCY=64 \
+bash examples/data_regeneration/run_qwen_sharegpt_regeneration.sh
+```
 
 ## 🤩 Prepare your own dataset
 

--- a/examples/data_regeneration/run_qwen3_8b_sharegpt_non_reasoning.sh
+++ b/examples/data_regeneration/run_qwen3_8b_sharegpt_non_reasoning.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODEL_PROFILE=qwen3-8b exec bash "${SCRIPT_DIR}/run_qwen_sharegpt_regeneration.sh" "$@"

--- a/examples/data_regeneration/run_qwen_sharegpt_regeneration.sh
+++ b/examples/data_regeneration/run_qwen_sharegpt_regeneration.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+MODEL_PROFILE="${MODEL_PROFILE:-qwen3-8b}"
+case "${MODEL_PROFILE}" in
+    qwen3-8b)
+        DEFAULT_MODEL_PATH="Qwen/Qwen3-8B"
+        DEFAULT_INPUT_FILE="${ROOT_DIR}/cache/dataset/sharegpt_train.jsonl"
+        DEFAULT_OUTPUT_FILE="${ROOT_DIR}/cache/dataset/sharegpt_train_regen_qwen3_8b_temperature0_non_reasoning.jsonl"
+        REASONING_MODE=disable
+        DEFAULT_MAX_TOKENS=4096
+        VALIDATION_MODE=(--expect-non-reasoning)
+        ;;
+    qwen3.6-27b)
+        DEFAULT_MODEL_PATH="Qwen/Qwen3.6-27B"
+        DEFAULT_INPUT_FILE="${ROOT_DIR}/cache/dataset/sharegpt_train.jsonl"
+        DEFAULT_OUTPUT_FILE="${ROOT_DIR}/cache/dataset/sharegpt_train_regen_qwen3.6-27b_temperature0_reasoning.jsonl"
+        REASONING_MODE=save
+        DEFAULT_MAX_TOKENS=32768
+        VALIDATION_MODE=(--expect-reasoning)
+        ;;
+    *)
+        echo "Unsupported MODEL_PROFILE: ${MODEL_PROFILE}" >&2
+        echo "Expected qwen3-8b or qwen3.6-27b." >&2
+        exit 1
+        ;;
+esac
+
+PYTHON="${PYTHON:-python}"
+MODEL_PATH="${MODEL_PATH:-${DEFAULT_MODEL_PATH}}"
+INPUT_FILE="${INPUT_FILE:-${DEFAULT_INPUT_FILE}}"
+OUTPUT_FILE="${OUTPUT_FILE:-${DEFAULT_OUTPUT_FILE}}"
+SERVER_ADDRESSES="${SERVER_ADDRESSES:-localhost:30000}"
+CONCURRENCY="${CONCURRENCY:-64}"
+MAX_TOKENS="${MAX_TOKENS:-${DEFAULT_MAX_TOKENS}}"
+
+if [[ ! -f "${INPUT_FILE}" ]]; then
+    echo "Input dataset does not exist: ${INPUT_FILE}" >&2
+    exit 1
+fi
+if [[ "${OUTPUT_FILE}" != *.jsonl ]]; then
+    echo "OUTPUT_FILE must end in .jsonl: ${OUTPUT_FILE}" >&2
+    exit 1
+fi
+
+ERROR_FILE="${OUTPUT_FILE%.jsonl}_error.jsonl"
+SKIPPED_FILE="${OUTPUT_FILE%.jsonl}_skipped.jsonl"
+for path in "${OUTPUT_FILE}" "${ERROR_FILE}" "${SKIPPED_FILE}"; do
+    if [[ -e "${path}" ]]; then
+        echo "Refusing to reuse an existing regeneration output: ${path}" >&2
+        echo "Choose a fresh OUTPUT_FILE or remove the old run explicitly." >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$(dirname "${OUTPUT_FILE}")"
+read -r -a server_args <<< "${SERVER_ADDRESSES}"
+
+"${PYTHON}" scripts/regenerate_train_data.py \
+    --model "${MODEL_PATH}" \
+    --reasoning "${REASONING_MODE}" \
+    --temperature 0 \
+    --concurrency "${CONCURRENCY}" \
+    --max-tokens "${MAX_TOKENS}" \
+    --server-address "${server_args[@]}" \
+    --input-file-path "${INPUT_FILE}" \
+    --output-file-path "${OUTPUT_FILE}"
+
+INPUT_ROWS=$(awk 'END {print NR}' "${INPUT_FILE}")
+SUCCESS_ROWS=$(awk 'END {print NR}' "${OUTPUT_FILE}")
+ERROR_ROWS=$(awk 'END {print NR}' "${ERROR_FILE}")
+SKIPPED_ROWS=$(awk 'END {print NR}' "${SKIPPED_FILE}")
+
+"${PYTHON}" - \
+    "${INPUT_ROWS}" "${SUCCESS_ROWS}" "${ERROR_ROWS}" "${SKIPPED_ROWS}" <<'PY'
+import sys
+
+input_rows, success_rows, error_rows, skipped_rows = map(int, sys.argv[1:5])
+completed_rows = success_rows + error_rows + skipped_rows
+
+print(f"input rows: {input_rows}")
+print(f"success rows: {success_rows}")
+print(f"error rows: {error_rows}")
+print(f"skipped rows: {skipped_rows}")
+if completed_rows != input_rows:
+    raise SystemExit(
+        "regeneration did not account for every input row: "
+        f"completed={completed_rows}, input={input_rows}"
+    )
+success_fraction = success_rows / completed_rows if completed_rows else 0.0
+print(f"success fraction: {success_fraction:.2%}")
+PY
+
+"${PYTHON}" scripts/validate_regenerated_data.py \
+    --data-path "${OUTPUT_FILE}" \
+    "${VALIDATION_MODE[@]}" \
+    --strict-think-markers

--- a/scripts/conversation_validation.py
+++ b/scripts/conversation_validation.py
@@ -1,0 +1,61 @@
+"""Shared conversation validation helpers for data regeneration scripts."""
+
+from typing import Any
+
+
+def has_think_marker(content: str) -> bool:
+    lowered = content.lower()
+    return "<think>" in lowered or "</think>" in lowered
+
+
+def validate_conversation(
+    messages: Any,
+    *,
+    error_style: str = "validation",
+) -> str | None:
+    if not isinstance(messages, list) or not messages:
+        if error_style == "regeneration":
+            return "Missing or empty conversations list"
+        return "conversations must be a non-empty list"
+
+    expected_role = "user"
+    saw_user = False
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            if error_style == "regeneration":
+                return f"Invalid message at position {index}: expected object"
+            return f"message {index} must be an object"
+        role = message.get("role")
+        content = message.get("content")
+        if not isinstance(content, str) or not content.strip():
+            if error_style == "regeneration":
+                return (
+                    f"Invalid message content at position {index}: "
+                    "expected non-empty string"
+                )
+            return f"message {index} content must be a non-empty string"
+
+        if role == "system" and not saw_user:
+            continue
+        if role not in {"user", "assistant"}:
+            if error_style == "regeneration":
+                return f"Invalid message role: {role}"
+            return f"message {index} has unsupported role {role!r}"
+        if role != expected_role:
+            if error_style == "regeneration":
+                if not saw_user and role == "assistant":
+                    return "Data starts with an assistant message"
+                return (
+                    f"Invalid conversation role order at position {index}: "
+                    f"expected {expected_role}, got {role}"
+                )
+            return f"message {index} expected role {expected_role!r}, got {role!r}"
+
+        saw_user = True
+        expected_role = "assistant" if role == "user" else "user"
+
+    if not saw_user:
+        if error_style == "regeneration":
+            return "Data does not contain a user message"
+        return "conversation has no user message"
+    return None

--- a/scripts/regenerate_train_data.py
+++ b/scripts/regenerate_train_data.py
@@ -40,6 +40,35 @@ from typing import Any, Dict, List
 from openai import OpenAI
 from tqdm import tqdm
 
+try:
+    from scripts.conversation_validation import has_think_marker, validate_conversation
+except ModuleNotFoundError:
+    from conversation_validation import has_think_marker, validate_conversation
+
+
+def validate_regen_input(data: Any) -> str | None:
+    """Return why a ShareGPT row cannot be regenerated, or ``None``."""
+    if not isinstance(data, dict):
+        return "Expected a JSON object"
+
+    return validate_conversation(
+        data.get("conversations"),
+        error_style="regeneration",
+    )
+
+
+def set_skipped(data: Any, error: str) -> Dict[str, Any]:
+    if not isinstance(data, dict):
+        return {"status": "skipped", "error": error, "data": data}
+    data["status"] = "skipped"
+    data["error"] = error
+    return data
+
+
+def count_lines(path: str) -> int:
+    with open(path, encoding="utf-8") as handle:
+        return sum(1 for _ in handle)
+
 
 def parse_arguments():
     """Parse command line arguments"""
@@ -174,9 +203,18 @@ def compute_context_length(conversations: List[Dict[str, Any]]) -> int:
 def build_query_kwargs(args, messages, max_tokens=None):
     effective_max_tokens = max_tokens if max_tokens is not None else args.max_tokens
 
+    query_messages = messages
+    if args.reasoning == "save":
+        query_messages = []
+        for message in messages:
+            query_message = dict(message)
+            if query_message.get("role") == "assistant":
+                query_message.pop("reasoning_content", None)
+            query_messages.append(query_message)
+
     query_kwargs = dict(
         model=args.model,
-        messages=messages,
+        messages=query_messages,
         max_tokens=effective_max_tokens,
         temperature=args.temperature,
         stream=False,
@@ -190,6 +228,8 @@ def build_query_kwargs(args, messages, max_tokens=None):
         extra_body["top_k"] = args.top_k
     if args.reasoning == "disable":
         extra_body["chat_template_kwargs"] = {"enable_thinking": False}
+    elif args.reasoning == "save":
+        extra_body["chat_template_kwargs"] = {"enable_thinking": True}
     if extra_body:
         query_kwargs["extra_body"] = extra_body
     if args.is_gpt_oss:
@@ -232,14 +272,47 @@ def call_sglang(
                 data["error"] = str(e)
                 return data
             response_text = resp.choices[0].message.content
+            if args.reasoning == "disable" and (
+                not isinstance(response_text, str)
+                or not response_text.strip()
+                or has_think_marker(response_text)
+            ):
+                return set_skipped(
+                    data,
+                    "Non-reasoning assistant response is empty or contains a thinking marker",
+                )
             resp_msg = {
                 "role": "assistant",
                 "content": response_text,
             }
             if args.reasoning == "save":
-                resp_msg["reasoning_content"] = resp.choices[
-                    0
-                ].message.reasoning_content
+                response_message = resp.choices[0].message
+                reasoning_content = getattr(response_message, "reasoning_content", None)
+                if reasoning_content is None:
+                    model_extra = getattr(response_message, "model_extra", None)
+                    if isinstance(model_extra, dict):
+                        reasoning_content = model_extra.get("reasoning_content")
+                if max_tokens is None and (
+                    not isinstance(response_text, str)
+                    or not response_text.strip()
+                    or not isinstance(reasoning_content, str)
+                    or not reasoning_content.strip()
+                ):
+                    data["status"] = "error"
+                    data["error"] = (
+                        "Reasoning generation requires non-empty assistant content "
+                        "and reasoning_content"
+                    )
+                    return data
+                if max_tokens is None and (
+                    has_think_marker(response_text)
+                    or has_think_marker(reasoning_content)
+                ):
+                    return set_skipped(
+                        data,
+                        "Reasoning response contains a residual thinking marker",
+                    )
+                resp_msg["reasoning_content"] = reasoning_content
             regenerated_messages.append(resp_msg)
         else:
             data["status"] = "error"
@@ -271,20 +344,25 @@ def main():
     print(f"  Output file: {args.output_file_path}")
     print(f"  Resume mode: {args.resume}")
     print("-" * 50)
-    total_lines = sum(1 for _ in open(args.input_file_path))
+    total_lines = count_lines(args.input_file_path)
 
     skip_lines = 0
     error_file_path = args.output_file_path.replace(".jsonl", "_error.jsonl")
+    skipped_file_path = args.output_file_path.replace(".jsonl", "_skipped.jsonl")
 
     if args.resume and os.path.exists(args.output_file_path):
-        existing_success = sum(1 for _ in open(args.output_file_path))
+        existing_success = count_lines(args.output_file_path)
         existing_error = 0
         if os.path.exists(error_file_path):
-            existing_error = sum(1 for _ in open(error_file_path))
-        skip_lines = existing_success + existing_error
+            existing_error = count_lines(error_file_path)
+        existing_skipped = 0
+        if os.path.exists(skipped_file_path):
+            existing_skipped = count_lines(skipped_file_path)
+        skip_lines = existing_success + existing_error + existing_skipped
         print(f"Resume mode enabled:")
         print(f"  Found {existing_success} successful samples in output file")
         print(f"  Found {existing_error} error samples in error file")
+        print(f"  Found {existing_skipped} skipped samples in skipped file")
         print(f"  Skipping first {skip_lines} input samples")
         print("-" * 50)
 
@@ -304,7 +382,7 @@ def main():
             dummy_data,
             max_tokens=1,
         )
-        if result is not None:
+        if result is not None and result.get("status") == "success":
             valid_server_addresses.append(server_address)
         else:
             print(f"Server {server_address} is not available")
@@ -330,12 +408,15 @@ def main():
     context_token_max = 0
     success_samples = 0
     error_samples = 0
+    skipped_samples = 0
+    submitted_samples = 0
 
     # Create progress bar
     with (
         open(args.input_file_path, "r") as input_file,
         open(args.output_file_path, file_mode) as output_file_handle,
         open(error_file_path, file_mode) as error_file_handle,
+        open(skipped_file_path, file_mode, encoding="utf-8") as skipped_file_handle,
     ):
         executor = ThreadPoolExecutor(
             max_workers=args.concurrency * len(valid_server_addresses)
@@ -353,13 +434,19 @@ def main():
             print(f"Resuming from sample {skip_lines + 1}")
 
         for line in input_file:
-            if (
-                args.num_samples is not None
-                and success_samples + error_samples >= args.num_samples
-            ):
+            if args.num_samples is not None and submitted_samples >= args.num_samples:
                 break
 
             data = json.loads(line.strip())
+            invalid_reason = validate_regen_input(data)
+            if invalid_reason is not None:
+                skipped_file_handle.write(
+                    json.dumps(set_skipped(data, invalid_reason), ensure_ascii=False)
+                    + "\n"
+                )
+                skipped_samples += 1
+                pbar.update(1)
+                continue
 
             # find server address with the least waiting requests
             server_address = valid_server_addresses[start_server_index]
@@ -378,6 +465,11 @@ def main():
                                 json.dumps(regen_data, ensure_ascii=False) + "\n"
                             )
                             error_samples += 1
+                        elif regen_data["status"] == "skipped":
+                            skipped_file_handle.write(
+                                json.dumps(regen_data, ensure_ascii=False) + "\n"
+                            )
+                            skipped_samples += 1
                         else:
                             ctx_len = compute_context_length(
                                 regen_data.get("conversations", [])
@@ -406,6 +498,7 @@ def main():
                 data,
             )
             waiting_queue[server_address].append(req_future)
+            submitted_samples += 1
             pbar.update(1)
 
         # deal with all the remaining requests
@@ -417,6 +510,11 @@ def main():
                         json.dumps(regen_data, ensure_ascii=False) + "\n"
                     )
                     error_samples += 1
+                elif regen_data["status"] == "skipped":
+                    skipped_file_handle.write(
+                        json.dumps(regen_data, ensure_ascii=False) + "\n"
+                    )
+                    skipped_samples += 1
                 else:
                     ctx_len = compute_context_length(
                         regen_data.get("conversations", [])
@@ -444,17 +542,20 @@ def main():
     else:
         print("No successful examples to compute context length statistics.")
 
-    total_processed = success_samples + error_samples
+    total_processed = success_samples + error_samples + skipped_samples
     if skip_lines > 0:
         print(f"\nResume processing completed!")
         print(f"  Previously processed: {skip_lines}")
         print(
-            f"  Newly processed: {total_processed} ({success_samples} success, {error_samples} failed)"
+            f"  Newly processed: {total_processed} "
+            f"({success_samples} success, {error_samples} failed, "
+            f"{skipped_samples} skipped)"
         )
         print(f"  Total: {skip_lines + total_processed}")
     else:
         print(
-            f"\nProcessing completed! {success_samples} samples regenerated, {error_samples} samples failed."
+            f"\nProcessing completed! {success_samples} samples regenerated, "
+            f"{error_samples} samples failed, {skipped_samples} samples skipped."
         )
 
 

--- a/scripts/validate_regenerated_data.py
+++ b/scripts/validate_regenerated_data.py
@@ -1,0 +1,186 @@
+"""Validate regenerated ShareGPT JSONL before training."""
+
+import argparse
+import json
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+try:
+    from scripts.conversation_validation import has_think_marker, validate_conversation
+except ModuleNotFoundError:
+    from conversation_validation import has_think_marker, validate_conversation
+
+
+@dataclass(frozen=True)
+class ValidationSummary:
+    rows: int
+    assistant_messages: int
+    duplicate_rows: int
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate regenerated ShareGPT JSONL before training."
+    )
+    parser.add_argument("--data-path", required=True, type=Path)
+    reasoning_group = parser.add_mutually_exclusive_group()
+    reasoning_group.add_argument(
+        "--expect-non-reasoning",
+        action="store_true",
+        help="Reject non-empty assistant reasoning_content.",
+    )
+    reasoning_group.add_argument(
+        "--expect-reasoning",
+        action="store_true",
+        help="Require non-empty assistant reasoning_content.",
+    )
+    parser.add_argument(
+        "--strict-think-markers",
+        action="store_true",
+        help="Reject <think> and </think> in assistant content or reasoning_content.",
+    )
+    return parser.parse_args()
+
+
+def iter_jsonl(path: Path) -> Iterable[tuple[int, Dict[str, Any]]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"line {line_number}: invalid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"line {line_number}: expected a JSON object")
+            yield line_number, row
+
+
+def validate_row(
+    row: Dict[str, Any],
+    *,
+    expect_non_reasoning: bool,
+    expect_reasoning: bool = False,
+    strict_think_markers: bool,
+) -> int:
+    """Validate one generated training row and return its assistant count."""
+    row_id = row.get("id")
+    if not isinstance(row_id, str) or not row_id.strip():
+        raise ValueError("id must be a non-empty string")
+    if row.get("status") != "success":
+        raise ValueError("status must be 'success'")
+
+    messages = row.get("conversations")
+    conversation_error = validate_conversation(messages)
+    if conversation_error is not None:
+        raise ValueError(conversation_error)
+
+    assistant_count = 0
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if role != "assistant":
+            continue
+
+        content = message["content"]
+        assistant_count += 1
+        reasoning = message.get("reasoning_content")
+        if reasoning is not None and not isinstance(reasoning, str):
+            raise ValueError(
+                f"assistant message {index} reasoning_content must be a string or null"
+            )
+        if expect_non_reasoning and reasoning and reasoning.strip():
+            raise ValueError(
+                f"assistant message {index} has non-empty reasoning_content"
+            )
+        if expect_reasoning and (
+            not isinstance(reasoning, str) or not reasoning.strip()
+        ):
+            raise ValueError(f"assistant message {index} has empty reasoning_content")
+        if strict_think_markers and has_think_marker(content):
+            raise ValueError(f"assistant message {index} contains a thinking marker")
+        if (
+            strict_think_markers
+            and isinstance(reasoning, str)
+            and has_think_marker(reasoning)
+        ):
+            raise ValueError(
+                f"assistant message {index} reasoning_content contains a thinking marker"
+            )
+
+    if assistant_count == 0:
+        raise ValueError("conversation has no assistant message")
+    if messages[-1].get("role") != "assistant":
+        raise ValueError("conversation must end with an assistant message")
+    return assistant_count
+
+
+def validate_dataset(
+    path: Path,
+    *,
+    expect_non_reasoning: bool = False,
+    expect_reasoning: bool = False,
+    strict_think_markers: bool = False,
+) -> ValidationSummary:
+    if expect_non_reasoning and expect_reasoning:
+        raise ValueError(
+            "expect_non_reasoning and expect_reasoning are mutually exclusive"
+        )
+    seen_ids = set()
+    duplicate_rows = 0
+    rows = 0
+    assistant_messages = 0
+
+    for line_number, row in iter_jsonl(path):
+        try:
+            assistant_messages += validate_row(
+                row,
+                expect_non_reasoning=expect_non_reasoning,
+                expect_reasoning=expect_reasoning,
+                strict_think_markers=strict_think_markers,
+            )
+        except ValueError as exc:
+            raise ValueError(f"line {line_number}: {exc}") from exc
+
+        row_id = row["id"]
+        if row_id in seen_ids:
+            duplicate_rows += 1
+        else:
+            seen_ids.add(row_id)
+        rows += 1
+
+    if rows == 0:
+        raise ValueError(f"{path} contains no data rows")
+    if duplicate_rows:
+        warnings.warn(
+            f"found {duplicate_rows} rows with duplicate ids; duplicates are allowed",
+            stacklevel=2,
+        )
+    return ValidationSummary(
+        rows=rows,
+        assistant_messages=assistant_messages,
+        duplicate_rows=duplicate_rows,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        summary = validate_dataset(
+            args.data_path,
+            expect_non_reasoning=args.expect_non_reasoning,
+            expect_reasoning=args.expect_reasoning,
+            strict_think_markers=args.strict_think_markers,
+        )
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"validation failed: {exc}") from exc
+
+    print(f"rows: {summary.rows}")
+    print(f"assistant messages: {summary.assistant_messages}")
+    print(f"duplicate rows (allowed): {summary.duplicate_rows}")
+    print("validation passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scripts/test_validate_regenerated_data.py
+++ b/tests/test_scripts/test_validate_regenerated_data.py
@@ -1,0 +1,478 @@
+import json
+import os
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from scripts.regenerate_train_data import call_sglang
+from scripts.regenerate_train_data import main as regenerate_main
+from scripts.regenerate_train_data import set_skipped, validate_regen_input
+from scripts.validate_regenerated_data import validate_dataset, validate_row
+
+
+def make_row(row_id="row-1", content="answer"):
+    return {
+        "id": row_id,
+        "status": "success",
+        "conversations": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": content},
+        ],
+    }
+
+
+class TestValidateRegeneratedData(TestCase):
+    def test_valid_non_reasoning_dataset_allows_duplicate_ids_with_warning(self):
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "data.jsonl"
+            path.write_text(
+                "".join(json.dumps(make_row("same")) + "\n" for _ in range(2)),
+                encoding="utf-8",
+            )
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                summary = validate_dataset(
+                    path,
+                    expect_non_reasoning=True,
+                    strict_think_markers=True,
+                )
+
+            self.assertEqual(summary.rows, 2)
+            self.assertEqual(summary.assistant_messages, 2)
+            self.assertEqual(summary.duplicate_rows, 1)
+            self.assertEqual(len(caught), 1)
+            self.assertIn("duplicates are allowed", str(caught[0].message))
+
+    def test_rejects_incomplete_training_conversation(self):
+        row = make_row()
+        row["conversations"].append({"role": "user", "content": "follow-up"})
+
+        with self.assertRaisesRegex(ValueError, "must end with an assistant"):
+            validate_row(
+                row,
+                expect_non_reasoning=True,
+                strict_think_markers=True,
+            )
+
+    def test_rejects_nonempty_reasoning_content(self):
+        row = make_row()
+        row["conversations"][-1]["reasoning_content"] = "hidden reasoning"
+
+        with self.assertRaisesRegex(ValueError, "reasoning_content"):
+            validate_row(
+                row,
+                expect_non_reasoning=True,
+                strict_think_markers=False,
+            )
+
+    def test_reasoning_mode_requires_reasoning_content(self):
+        row = make_row()
+
+        with self.assertRaisesRegex(ValueError, "empty reasoning_content"):
+            validate_row(
+                row,
+                expect_non_reasoning=False,
+                expect_reasoning=True,
+                strict_think_markers=True,
+            )
+
+        row["conversations"][-1]["reasoning_content"] = "structured reasoning"
+        self.assertEqual(
+            validate_row(
+                row,
+                expect_non_reasoning=False,
+                expect_reasoning=True,
+                strict_think_markers=True,
+            ),
+            1,
+        )
+
+    def test_strict_mode_rejects_thinking_markers_in_reasoning(self):
+        row = make_row()
+        row["conversations"][-1]["reasoning_content"] = "<think>hidden</think>"
+
+        with self.assertRaisesRegex(ValueError, "reasoning_content"):
+            validate_row(
+                row,
+                expect_non_reasoning=False,
+                expect_reasoning=True,
+                strict_think_markers=True,
+            )
+
+    def test_strict_mode_rejects_thinking_markers(self):
+        row = make_row(content="<THINK>hidden</THINK> visible")
+
+        with self.assertRaisesRegex(ValueError, "thinking marker"):
+            validate_row(
+                row,
+                expect_non_reasoning=True,
+                strict_think_markers=True,
+            )
+
+    def test_rejects_non_success_rows(self):
+        row = make_row()
+        row["status"] = "error"
+
+        with self.assertRaisesRegex(ValueError, "status must be 'success'"):
+            validate_row(
+                row,
+                expect_non_reasoning=False,
+                strict_think_markers=False,
+            )
+
+
+class TestRegenerationGuards(TestCase):
+    def test_input_precheck_rejects_bad_role_order_and_content(self):
+        bad_order = {
+            "conversations": [
+                {"role": "user", "content": "one"},
+                {"role": "user", "content": "two"},
+            ]
+        }
+        empty_content = {"conversations": [{"role": "user", "content": "  "}]}
+
+        self.assertIn("role order", validate_regen_input(bad_order))
+        self.assertIn("non-empty string", validate_regen_input(empty_content))
+
+    def test_non_object_input_can_be_recorded_as_skipped(self):
+        skipped = set_skipped([], "Expected a JSON object")
+
+        self.assertEqual(skipped["status"], "skipped")
+        self.assertEqual(skipped["data"], [])
+
+    def test_disable_reasoning_skips_residual_think_output(self):
+        args = SimpleNamespace(
+            model="Qwen/Qwen3-8B",
+            max_tokens=32,
+            temperature=0,
+            top_p=None,
+            repetition_penalty=None,
+            top_k=None,
+            reasoning="disable",
+            is_gpt_oss=False,
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="<think>hidden</think>answer")
+                )
+            ]
+        )
+        client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+
+        with patch("scripts.regenerate_train_data.OpenAI", return_value=client):
+            result = call_sglang(
+                args,
+                "localhost:30000",
+                {"conversations": [{"role": "user", "content": "question"}]},
+            )
+
+        self.assertEqual(result["status"], "skipped")
+        self.assertIn("thinking marker", result["error"])
+
+    def test_save_reasoning_sets_contract_and_strips_history_reasoning(self):
+        args = SimpleNamespace(
+            model="Qwen/Qwen3.6-27B",
+            max_tokens=32,
+            temperature=0,
+            top_p=None,
+            repetition_penalty=None,
+            top_k=None,
+            reasoning="save",
+            is_gpt_oss=False,
+        )
+        calls = []
+        responses = iter(
+            [
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                content="first answer",
+                                reasoning_content="first reasoning",
+                            )
+                        )
+                    ]
+                ),
+                SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(
+                                content="second answer",
+                                reasoning_content="second reasoning",
+                            )
+                        )
+                    ]
+                ),
+            ]
+        )
+
+        def create(**kwargs):
+            calls.append(kwargs)
+            return next(responses)
+
+        client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+        )
+        data = {
+            "conversations": [
+                {"role": "user", "content": "first question"},
+                {"role": "assistant", "content": "old first answer"},
+                {"role": "user", "content": "second question"},
+            ]
+        }
+
+        with patch("scripts.regenerate_train_data.OpenAI", return_value=client):
+            result = call_sglang(args, "localhost:30000", data)
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(
+            calls[0]["extra_body"]["chat_template_kwargs"]["enable_thinking"],
+            True,
+        )
+        history_assistant = calls[1]["messages"][1]
+        self.assertEqual(history_assistant["content"], "first answer")
+        self.assertNotIn("reasoning_content", history_assistant)
+        self.assertEqual(
+            result["conversations"][-1]["reasoning_content"], "second reasoning"
+        )
+
+    def test_save_reasoning_rejects_missing_reasoning(self):
+        args = SimpleNamespace(
+            model="Qwen/Qwen3.6-27B",
+            max_tokens=32,
+            temperature=0,
+            top_p=None,
+            repetition_penalty=None,
+            top_k=None,
+            reasoning="save",
+            is_gpt_oss=False,
+        )
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="answer"))]
+        )
+        client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+
+        with patch("scripts.regenerate_train_data.OpenAI", return_value=client):
+            result = call_sglang(
+                args,
+                "localhost:30000",
+                {"conversations": [{"role": "user", "content": "question"}]},
+            )
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("reasoning_content", result["error"])
+
+    def test_num_samples_limits_submitted_jobs_under_concurrency(self):
+        with TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.jsonl"
+            output_path = Path(tmpdir) / "output.jsonl"
+            rows = [[]] + [
+                {
+                    "id": str(index),
+                    "conversations": [{"role": "user", "content": f"question {index}"}],
+                }
+                for index in range(4)
+            ]
+            input_path.write_text(
+                "".join(json.dumps(row) + "\n" for row in rows),
+                encoding="utf-8",
+            )
+            submitted = 0
+
+            def fake_call(args, server_address, data, max_tokens=None):
+                nonlocal submitted
+                if max_tokens is not None:
+                    return {"status": "success", "conversations": []}
+                submitted += 1
+                return {
+                    **data,
+                    "status": "success",
+                    "conversations": [
+                        *data["conversations"],
+                        {"role": "assistant", "content": "answer"},
+                    ],
+                }
+
+            argv = [
+                "regenerate_train_data.py",
+                "--model",
+                "Qwen/Qwen3-8B",
+                "--server-address",
+                "localhost:30000",
+                "--input-file-path",
+                str(input_path),
+                "--output-file-path",
+                str(output_path),
+                "--num-samples",
+                "2",
+                "--concurrency",
+                "8",
+            ]
+            with (
+                patch("sys.argv", argv),
+                patch("scripts.regenerate_train_data.call_sglang", fake_call),
+            ):
+                regenerate_main()
+
+            skipped_path = Path(str(output_path).replace(".jsonl", "_skipped.jsonl"))
+            self.assertEqual(submitted, 2)
+            self.assertEqual(len(output_path.read_text().splitlines()), 2)
+            self.assertEqual(len(skipped_path.read_text().splitlines()), 1)
+
+
+class TestQwenRegenerationRecipe(TestCase):
+    def _make_fake_python(self, directory: Path) -> Path:
+        fake_python = directory / "fake_python"
+        fake_python.write_text(
+            f"""#!{sys.executable}
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+if args and args[0].endswith("regenerate_train_data.py"):
+    def value(flag):
+        return args[args.index(flag) + 1]
+
+    input_path = Path(value("--input-file-path"))
+    output_path = Path(value("--output-file-path"))
+    rows = [json.loads(line) for line in input_path.read_text().splitlines() if line]
+    error_rows = int(os.environ.get("FAKE_ERROR_ROWS", "0"))
+    drop_rows = int(os.environ.get("FAKE_DROP_ROWS", "0"))
+    reasoning = value("--reasoning")
+    success_end = len(rows) - drop_rows if drop_rows else len(rows)
+    successes = rows[error_rows:success_end]
+    output_path.write_text("".join(
+        json.dumps({{
+            **row,
+            "status": "success",
+            "conversations": [
+                *row["conversations"],
+                {{
+                    "role": "assistant",
+                    "content": "answer",
+                    **({{"reasoning_content": "reasoning"}} if reasoning == "save" else {{}}),
+                }},
+            ],
+        }}) + "\\n" for row in successes
+    ))
+    Path(str(output_path).replace(".jsonl", "_error.jsonl")).write_text(
+        "".join(json.dumps({{"status": "error"}}) + "\\n" for _ in rows[:error_rows])
+    )
+    Path(str(output_path).replace(".jsonl", "_skipped.jsonl")).write_text("")
+    Path(os.environ["CAPTURE_ARGS"]).write_text(json.dumps(args))
+    raise SystemExit(0)
+
+os.execv(sys.executable, [sys.executable, *args])
+""",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+        return fake_python
+
+    def _run_recipe(
+        self,
+        tmpdir: str,
+        *,
+        error_rows: int = 0,
+        drop_rows: int = 0,
+        trailing_newline: bool = True,
+        entrypoint: str = "run_qwen_sharegpt_regeneration.sh",
+    ):
+        directory = Path(tmpdir)
+        input_path = directory / "input.jsonl"
+        output_path = directory / "output.jsonl"
+        capture_path = directory / "args.json"
+        input_text = "".join(
+            json.dumps(
+                {
+                    "id": str(index),
+                    "conversations": [{"role": "user", "content": f"question {index}"}],
+                }
+            )
+            + "\n"
+            for index in range(2)
+        )
+        input_path.write_text(
+            input_text if trailing_newline else input_text.rstrip("\n"),
+            encoding="utf-8",
+        )
+        env = {
+            **os.environ,
+            "MODEL_PROFILE": "qwen3.6-27b",
+            "PYTHON": str(self._make_fake_python(directory)),
+            "INPUT_FILE": str(input_path),
+            "OUTPUT_FILE": str(output_path),
+            "CAPTURE_ARGS": str(capture_path),
+            "FAKE_ERROR_ROWS": str(error_rows),
+            "FAKE_DROP_ROWS": str(drop_rows),
+        }
+        result = subprocess.run(
+            ["bash", f"examples/data_regeneration/{entrypoint}"],
+            cwd=Path(__file__).resolve().parents[2],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        return result, json.loads(capture_path.read_text(encoding="utf-8"))
+
+    def test_qwen36_profile_uses_reasoning_contract(self):
+        with TemporaryDirectory() as tmpdir:
+            result, args = self._run_recipe(tmpdir)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            args[args.index("--model") + 1],
+            "Qwen/Qwen3.6-27B",
+        )
+        self.assertEqual(args[args.index("--reasoning") + 1], "save")
+        self.assertEqual(args[args.index("--max-tokens") + 1], "32768")
+
+    def test_qwen3_8b_compatibility_wrapper_selects_non_reasoning_profile(self):
+        with TemporaryDirectory() as tmpdir:
+            result, args = self._run_recipe(
+                tmpdir,
+                entrypoint="run_qwen3_8b_sharegpt_non_reasoning.sh",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(args[args.index("--model") + 1], "Qwen/Qwen3-8B")
+        self.assertEqual(args[args.index("--reasoning") + 1], "disable")
+        self.assertEqual(args[args.index("--max-tokens") + 1], "4096")
+
+    def test_recipe_allows_accounted_error_rows(self):
+        with TemporaryDirectory() as tmpdir:
+            result, _ = self._run_recipe(tmpdir, error_rows=1)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("success fraction: 50.00%", result.stdout)
+
+    def test_recipe_counts_input_without_trailing_newline(self):
+        with TemporaryDirectory() as tmpdir:
+            result, _ = self._run_recipe(tmpdir, trailing_newline=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("input rows: 2", result.stdout)
+
+    def test_recipe_fails_when_rows_are_unaccounted_for(self):
+        with TemporaryDirectory() as tmpdir:
+            result, _ = self._run_recipe(tmpdir, drop_rows=1)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not account for every input row", result.stderr)


### PR DESCRIPTION
## Summary

- add a shared ShareGPT regeneration recipe for Qwen3-8B and Qwen3.6-27B
- harden regeneration input/output handling and separate invalid or residual-thinking rows into a skipped JSONL
- validate regenerated training data before it is consumed by training
- document the complete Qwen server, regeneration, accounting, and validation workflow

## Profiles

| Profile | Model | Reasoning | Sampling |
|---|---|---|---|
| `qwen3-8b` | `Qwen/Qwen3-8B` | disabled | temperature 0 |
| `qwen3.6-27b` | `Qwen/Qwen3.6-27B` | structured `reasoning_content` | temperature 0 |

The existing Qwen3-8B entrypoint remains as a compatibility wrapper around the
shared recipe.

## Validation behavior

- reject malformed ShareGPT role/content structure before sending requests
- require non-empty non-reasoning output for Qwen3-8B
- require both visible content and structured reasoning for Qwen3.6-27B
- reject residual `<think>` markers from successful training rows
- require every input row to be accounted for as success, error, or skipped
- print success/error/skipped counts and the success fraction without imposing a fixed success-rate threshold
- refuse to overwrite an existing output/error/skipped run

## Test plan

- [x] `pytest -q tests/test_scripts/test_validate_regenerated_data.py` (`18 passed`)
- [x] `bash -n` on both regeneration entrypoints
- [x] Black check on changed Python files
- [x] repository Ruff/F401 check on changed Python files
- [x] `git diff --check`

## Scope

This PR contains only the data regeneration and validation pipeline. Single-sample
overfit and real-serving gates are kept in a separate PR.
