### PR TITLE
test(domino): add generic overfit and DFLASH serving gates

### DIFF
--- a/configs/qwen3.6-27b-domino-full-attention.json
+++ b/configs/qwen3.6-27b-domino-full-attention.json
@@ -1,0 +1,52 @@
+{
+  "architectures": [
+    "DFlashDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "dflash.DFlashDraftModel"
+  },
+  "block_size": 16,
+  "bos_token_id": null,
+  "dflash_config": {
+    "mask_token_id": 248070,
+    "target_layer_ids": [1, 16, 31, 46, 61],
+    "projector_type": "domino",
+    "pure_draft_prefix_len": 1,
+    "emb_dim": 256,
+    "gru_hidden_dim": 1024,
+    "shift_label": false
+  },
+  "dtype": "bfloat16",
+  "eos_token_id": 248044,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 5120,
+  "initializer_range": 0.02,
+  "intermediate_size": 17408,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "max_position_embeddings": 262144,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 64,
+  "pad_token_id": 248044,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 10000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "transformers_version": "5.5.3",
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 248320
+}

--- a/docs/examples/domino-disagg-overfit-serving-gate.md
+++ b/docs/examples/domino-disagg-overfit-serving-gate.md
@@ -1,0 +1,146 @@
+# Domino disaggregated overfit and DFLASH serving gate
+
+This gate checks the smallest end-to-end Domino disaggregated training path:
+one patched SGLang capture server captures target features for one ShareGPT
+row, and a separate DP trainer repeatedly consumes that row. A companion
+post-training gate exports the resulting checkpoint and loads it in real
+SGLang DFLASH speculative serving. Every target model uses these same entry
+points; model-specific paths, templates, tensor keys, and reasoning behavior
+are inputs rather than separate test implementations.
+
+Domino is a DFLASH draft architecture with its own GRU logit correction, not a
+second serving algorithm. Training therefore needs a Domino architecture
+config, while SGLang serves the resulting draft through the common `DFLASH`
+algorithm.
+
+| Example | Dataset contract | `CHAT_TEMPLATE` | Reasoning inputs |
+| --- | --- | --- | --- |
+| Qwen3-8B | non-reasoning | `qwen` | `REASONING_POLICY=forbidden`, `ENABLE_THINKING=0` |
+| Qwen3.6-27B | structured reasoning | `qwen3.5` | `REASONING_POLICY=required`, `ENABLE_THINKING=1` |
+
+Mask token, capture layers, and block size are read from the selected draft
+config so the launch command does not duplicate model metadata.
+
+`SOURCE_DATA_PATH` is the only data input. It must point to validated,
+ShareGPT-compatible JSONL; data regeneration is intentionally outside this
+gate. See [Data Preparation](../basic_usage/data_preparation.md) for the general
+regeneration workflow. Before starting a server or trainer, this gate enforces
+the requested reasoning contract and the real post-tokenization loss-mask
+threshold.
+
+`DRAFT_CONFIG_PATH` describes the Domino draft architecture to initialize and
+train, including its block size, mask token, and captured target layers. The
+overfit stage does not require an existing draft checkpoint. The real serving
+stage necessarily consumes the checkpoint produced by that overfit run because
+DFLASH serving verifies proposals from the trained draft against the target.
+
+Run from the repository root on an eight-GPU host with Mooncake and a patched
+SGLang capture server installed:
+
+```bash
+SOURCE_DATA_PATH=/path/to/validated_sharegpt.jsonl \
+TARGET_MODEL_PATH=Qwen/Qwen3-8B \
+DRAFT_CONFIG_PATH=configs/qwen3-8b-domino.json \
+CHAT_TEMPLATE=qwen \
+EMBEDDING_KEY=model.embed_tokens.weight \
+REASONING_POLICY=forbidden ENABLE_THINKING=0 MAX_LENGTH=512 \
+SERVER_GPUS=0 \
+CONSUMER_GPUS=1,2,3,4,5,6,7 \
+TRAIN_DP=7 \
+bash examples/disagg/run_domino_disagg_overfit_gate.sh
+```
+
+For the validated Qwen3.6-27B reasoning dataset and full-attention Domino config:
+
+```bash
+SOURCE_DATA_PATH=/path/to/validated_qwen36_reasoning.jsonl \
+TARGET_MODEL_PATH=Qwen/Qwen3.6-27B \
+DRAFT_CONFIG_PATH=configs/qwen3.6-27b-domino-full-attention.json \
+CHAT_TEMPLATE=qwen3.5 \
+EMBEDDING_KEY=model.language_model.embed_tokens.weight \
+REASONING_POLICY=required ENABLE_THINKING=1 MAX_LENGTH=2048 \
+SERVER_GPUS=0 SERVER_TP=1 \
+CONSUMER_GPUS=1,2,3,4,5,6,7 TRAIN_DP=7 \
+bash examples/disagg/run_domino_disagg_overfit_gate.sh
+```
+
+The launcher intentionally refuses an existing `WORK_DIR`; choose a new path
+for every run. It selects one clean single-turn row into `single_sample.jsonl`
+and runs the selected target tokenizer and SpecForge preprocessing used by the
+producer. Selection succeeds only when the resulting loss mask has at least 32
+tokens, matching the producer's `2 * block_size` filter, and the rendered row
+fits without truncation. Selection also writes `prompt_artifact.json`, which
+records the exact rendered prompt/target suffix.
+The serving client uses that artifact instead of reconstructing a target from
+visible content; this preserves structured reasoning while stripping hidden
+reasoning fields from request history.
+
+`DISAGG_MAX_PROMPTS=1` limits the producer input to that one source row.
+`NUM_EPOCHS` is then set to `DISAGG_MAX_STEPS * TRAIN_DP`, so replay produces
+exactly enough sample references for every DP rank at every bounded optimizer
+step. The default gate stops at `DISAGG_MAX_STEPS=400`.
+
+Useful bounded overrides are:
+
+```bash
+WORK_DIR=outputs/domino-overfit-$(date +%Y%m%dT%H%M%S) \
+DISAGG_MAX_STEPS=600 \
+bash examples/disagg/run_domino_disagg_overfit_gate.sh
+```
+
+The command exits successfully only when all three conditions hold:
+
+- the final logged loss is at most `0.0001` (displayed as approximately
+  `0.0000`);
+- final token accuracy is exactly `1.0000` by default;
+- a `training_state.pt` checkpoint exists under the fresh consumer output.
+
+The final JSON emitted by `scripts/gates/check_overfit_metrics.py` records the step,
+loss, token accuracy, and checkpoint path. A nonzero exit means this gate did
+not pass even if the trainer process itself exited cleanly.
+
+## Real DFLASH serving gate
+
+Run the strict serving check against the fresh overfit checkpoint and its
+`prompt_artifact.json`:
+
+```bash
+CHECKPOINT_PATH=/path/to/consumer/<run-id>-step400 \
+PROMPT_ARTIFACT_PATH=/path/to/run/prompt_artifact.json \
+TARGET_MODEL_PATH=Qwen/Qwen3-8B \
+DRAFT_CONFIG_PATH=configs/qwen3-8b-domino.json \
+EMBEDDING_KEY=model.embed_tokens.weight \
+SERVED_MODEL=qwen3-8b \
+SGLANG_ROOT=/path/to/domino-capable/sglang \
+SGLANG_PYTHON=/path/to/sglang-env/bin/python \
+bash examples/disagg/run_domino_dflash_serving_gate.sh
+```
+
+Alternatively, set `RUN_REAL_SERVING_GATE=1` on the training wrapper and set
+`SERVING_SGLANG_ROOT` / `SERVING_PYTHON` when serving uses a separate SGLang
+environment. The wrapper releases the capture server and trainer GPUs before
+starting the real serving process.
+
+The runner exports the runtime checkpoint with the target embedding, changes
+the exported architecture to SGLang's `DFlashDraftModel`, and launches a real
+server with `--speculative-algorithm DFLASH` and block size 16. Its client only
+uses `/v1/chat/completions`, removes `reasoning_content` from request history,
+and takes `enable_thinking` from the prompt artifact. It combines response
+`reasoning_content + content` and compares that text with the artifact's
+rendered target suffix. Reasoning parsers, TP, and serving context are ordinary
+launcher inputs (`REASONING_PARSER`, `SERVING_TP`, and
+`SERVING_CONTEXT_LENGTH`).
+
+This is a strict per-request gate. The SGLang checkout must support
+`return_meta_info=true` on the OpenAI chat API and expose
+`choices[0].meta_info.spec_accept_length`; aggregate `/server_info` acceptance
+statistics are not accepted as a substitute. The result passes only when:
+
+- `/server_info.speculative_algorithm` is `DFLASH`;
+- the request contains no `reasoning_content`;
+- the choice reports `spec_accept_length >= 16`;
+- the generated output matches at least the first 16 target tokens.
+
+The auditable result is written to `serving_gate.json`. An older SGLang checkout
+that omits choice metadata fails explicitly instead of being reported as real
+per-request serving success.

--- a/examples/disagg/_dflash_family_disagg.py
+++ b/examples/disagg/_dflash_family_disagg.py
@@ -453,7 +453,10 @@ def _make_logger(args, holder: Optional[Dict] = None):
                 pass
         if logdict:
             tracker.log(logdict, step=step)
-            summary = {k.split("/")[-1]: round(v, 4) for k, v in logdict.items()}
+            # Keep machine-readable gate metrics at full float precision. Rounding
+            # here can turn loss=1.49e-4 into 1e-4 or accuracy=0.99996 into 1.0,
+            # allowing a strict overfit threshold to pass on the displayed value.
+            summary = {k.split("/")[-1]: v for k, v in logdict.items()}
             print(f"[consumer] step {step} {summary}", flush=True)
 
     return logger

--- a/examples/disagg/run_domino_dflash_serving_gate.sh
+++ b/examples/disagg/run_domino_dflash_serving_gate.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Export one Domino overfit checkpoint and gate it through real SGLang DFLASH.
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
+
+: "${CHECKPOINT_PATH:?set CHECKPOINT_PATH to the overfit checkpoint directory}"
+: "${TARGET_MODEL_PATH:?set TARGET_MODEL_PATH to the target model}"
+: "${DRAFT_CONFIG_PATH:?set DRAFT_CONFIG_PATH to the matching Domino config}"
+: "${EMBEDDING_KEY:?set EMBEDDING_KEY to the target embedding tensor key}"
+SERVED_MODEL=${SERVED_MODEL:-domino-target}
+SERVING_GPUS=${SERVING_GPUS:-${SERVING_GPU:-0}}
+SERVING_TP=${SERVING_TP:-1}
+REASONING_PARSER=${REASONING_PARSER:-}
+SERVING_CONTEXT_LENGTH=${SERVING_CONTEXT_LENGTH:-512}
+SERVING_MAX_TOTAL_TOKENS=${SERVING_MAX_TOTAL_TOKENS:-1024}
+: "${PROMPT_ARTIFACT_PATH:?set PROMPT_ARTIFACT_PATH to prompt_artifact.json}"
+SPECFORGE_PYTHON=${SPECFORGE_PYTHON:-python}
+SGLANG_PYTHON=${SGLANG_PYTHON:-python}
+SGLANG_ROOT=${SGLANG_ROOT:-}
+SERVING_PORT=${SERVING_PORT:-30001}
+WORK_DIR=${WORK_DIR:-$ROOT_DIR/outputs/domino-real-serving-$(date +%Y%m%dT%H%M%S)}
+EXPORT_DIR=$WORK_DIR/draft_hf
+RESULT_PATH=$WORK_DIR/serving_gate.json
+SERVER_LOG=$WORK_DIR/server.log
+
+for path in "$CHECKPOINT_PATH" "$PROMPT_ARTIFACT_PATH" "$DRAFT_CONFIG_PATH"; do
+    if [[ ! -e "$path" ]]; then
+        echo "Required path does not exist: $path" >&2
+        exit 2
+    fi
+done
+if timeout 1 bash -c "</dev/tcp/127.0.0.1/$SERVING_PORT" 2>/dev/null; then
+    echo "SERVING_PORT is already occupied; refusing to probe an existing server: $SERVING_PORT" >&2
+    exit 2
+fi
+if [[ -e "$WORK_DIR" ]]; then
+    echo "WORK_DIR already exists; serving gates require a fresh output: $WORK_DIR" >&2
+    exit 2
+fi
+mkdir -p "$WORK_DIR"
+
+mapfile -t DRAFT_VALUES < <("$SPECFORGE_PYTHON" - "$DRAFT_CONFIG_PATH" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+dflash = config.get("dflash_config") or {}
+if dflash.get("projector_type") != "domino":
+    raise SystemExit("draft config must set dflash_config.projector_type='domino'")
+print(config["block_size"])
+PY
+)
+BLOCK_SIZE=${BLOCK_SIZE:-${DRAFT_VALUES[0]}}
+
+PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+    "$SPECFORGE_PYTHON" -m specforge.export.to_hf \
+    --checkpoint "$CHECKPOINT_PATH" \
+    --draft-config "$DRAFT_CONFIG_PATH" \
+    --output-dir "$EXPORT_DIR" \
+    --embedding-source "$TARGET_MODEL_PATH" \
+    --embedding-key "$EMBEDDING_KEY"
+
+# SGLang dispatches this compatible HF artifact through its DFLASH loader.
+"$SPECFORGE_PYTHON" - "$EXPORT_DIR/config.json" "$BLOCK_SIZE" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+block_size = int(sys.argv[2])
+with open(path, encoding="utf-8") as handle:
+    config = json.load(handle)
+config["architectures"] = ["DFlashDraftModel"]
+config.pop("auto_map", None)
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2)
+    handle.write("\n")
+dflash = config.get("dflash_config") or {}
+if config.get("block_size") != block_size or dflash.get("projector_type") != "domino":
+    raise SystemExit(f"exported checkpoint is not a block-{block_size} Domino draft")
+PY
+
+cleanup() {
+    if [[ -n "${SERVER_PID:-}" ]]; then
+        kill -TERM -- "-$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+SGLANG_PYTHONPATH=()
+if [[ -n "$SGLANG_ROOT" ]]; then
+    SGLANG_PYTHONPATH=(PYTHONPATH="$SGLANG_ROOT/python${PYTHONPATH:+:$PYTHONPATH}")
+fi
+REASONING_PARSER_ARGS=()
+if [[ -n "$REASONING_PARSER" ]]; then
+    REASONING_PARSER_ARGS=(--reasoning-parser "$REASONING_PARSER")
+fi
+env \\
+    CUDA_VISIBLE_DEVICES="$SERVING_GPUS" \
+    PYTHONUNBUFFERED=1 \
+    "${SGLANG_PYTHONPATH[@]}" \
+    "$SGLANG_PYTHON" -m sglang.launch_server \
+    --model-path "$TARGET_MODEL_PATH" \
+    --served-model-name "$SERVED_MODEL" \
+    --tp-size "$SERVING_TP" \
+    --dtype bfloat16 \
+    --attention-backend "${SERVING_ATTENTION_BACKEND:-triton}" \
+    --mem-fraction-static "${SERVING_MEM_FRACTION:-0.8}" \
+    --context-length "$SERVING_CONTEXT_LENGTH" \
+    --max-running-requests 1 \
+    --max-total-tokens "$SERVING_MAX_TOTAL_TOKENS" \
+    --chunked-prefill-size -1 \
+    --disable-radix-cache \
+    --disable-cuda-graph \
+    --trust-remote-code \
+    --host 127.0.0.1 \
+    --port "$SERVING_PORT" \
+    --speculative-algorithm DFLASH \
+    --speculative-draft-model-path "$EXPORT_DIR" \
+    --speculative-num-draft-tokens "$BLOCK_SIZE" \
+    --speculative-dflash-block-size "$BLOCK_SIZE" \
+    "${REASONING_PARSER_ARGS[@]}" \
+    >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 300); do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "SGLang server exited during startup; see $SERVER_LOG" >&2
+        exit 1
+    fi
+    if curl -fsS "http://127.0.0.1:$SERVING_PORT/v1/models" >/dev/null; then
+        break
+    fi
+    sleep 2
+done
+if ! curl -fsS "http://127.0.0.1:$SERVING_PORT/v1/models" >/dev/null; then
+    echo "SGLang server did not become ready; see $SERVER_LOG" >&2
+    exit 1
+fi
+
+PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}" \
+    "$SGLANG_PYTHON" "$ROOT_DIR/scripts/gates/run_dflash_chat_serving_gate.py" \
+    --server-url "http://127.0.0.1:$SERVING_PORT" \
+    --model-path "$TARGET_MODEL_PATH" \
+    --served-model "$SERVED_MODEL" \
+    --prompt-json-path "$PROMPT_ARTIFACT_PATH" \
+    --output-path "$RESULT_PATH" \
+    --block-size "$BLOCK_SIZE" \
+    --max-tokens "$BLOCK_SIZE"
+
+echo "DOMINO-REAL-DFLASH-SERVING-PASSED: $RESULT_PATH"

--- a/examples/disagg/run_domino_disagg_overfit_gate.sh
+++ b/examples/disagg/run_domino_disagg_overfit_gate.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# Strict model-parameterized, one-sample Domino disaggregated overfit gate:
+# one SGLang capture server and one Domino trainer.
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
+cd "$ROOT_DIR"
+
+export PYTHONPATH="$ROOT_DIR:$ROOT_DIR/scripts:${PYTHONPATH:-}"
+export TORCHINDUCTOR_CACHE_DIR=${TORCHINDUCTOR_CACHE_DIR:-$ROOT_DIR/cache/compiled_kernels}
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+
+PYTHON=${PYTHON:-python}
+: "${TARGET_MODEL_PATH:?set TARGET_MODEL_PATH to the target model}"
+: "${DRAFT_CONFIG_PATH:?set DRAFT_CONFIG_PATH to a Domino draft config}"
+: "${SOURCE_DATA_PATH:?set SOURCE_DATA_PATH to validated ShareGPT JSONL}"
+CHAT_TEMPLATE=${CHAT_TEMPLATE:-qwen}
+EMBEDDING_KEY=${EMBEDDING_KEY:-model.embed_tokens.weight}
+LM_HEAD_KEY=${LM_HEAD_KEY:-lm_head.weight}
+REASONING_POLICY=${REASONING_POLICY:-allow}
+ENABLE_THINKING=${ENABLE_THINKING:-0}
+MAX_LENGTH=${MAX_LENGTH:-512}
+SERVER_GPUS=${SERVER_GPUS:-0}
+SERVER_TP=${SERVER_TP:-1}
+REAL_SERVING_GPUS=${REAL_SERVING_GPUS:-0}
+REAL_SERVING_TP=${REAL_SERVING_TP:-1}
+
+SERVER_PORT=${SERVER_PORT:-30000}
+TRAIN_DP=${TRAIN_DP:-7}
+CONSUMER_GPUS=${CONSUMER_GPUS:-"1,2,3,4,5,6,7"}
+
+RUN_TAG=${RUN_TAG:-$(date +%Y%m%dT%H%M%S)}
+export DISAGG_STORE_ID=${DISAGG_STORE_ID:-domino-overfit-$RUN_TAG}
+WORK_DIR=${WORK_DIR:-$ROOT_DIR/outputs/$DISAGG_STORE_ID}
+PRODUCER_OUTPUT_DIR=$WORK_DIR/producer
+CONSUMER_OUTPUT_DIR=$WORK_DIR/consumer
+SINGLE_DATA_PATH=$WORK_DIR/single_sample.jsonl
+PROMPT_ARTIFACT_PATH=$WORK_DIR/prompt_artifact.json
+TRAIN_LOG=$WORK_DIR/train.log
+
+for path in "$SOURCE_DATA_PATH" "$DRAFT_CONFIG_PATH"; do
+    if [[ ! -e "$path" ]]; then
+        echo "Required path does not exist: $path" >&2
+        exit 2
+    fi
+done
+if timeout 1 bash -c "</dev/tcp/127.0.0.1/$SERVER_PORT" 2>/dev/null; then
+    echo "SERVER_PORT is already occupied; refusing to use an existing capture server: $SERVER_PORT" >&2
+    exit 2
+fi
+if [[ -e "$WORK_DIR" ]]; then
+    echo "WORK_DIR already exists; overfit gates require a fresh output: $WORK_DIR" >&2
+    exit 2
+fi
+mkdir -p "$WORK_DIR"
+
+mapfile -t DRAFT_VALUES < <("$PYTHON" - "$DRAFT_CONFIG_PATH" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    config = json.load(handle)
+dflash = config.get("dflash_config") or {}
+if dflash.get("projector_type") != "domino":
+    raise SystemExit("draft config must set dflash_config.projector_type='domino'")
+print(dflash["mask_token_id"])
+print(config["block_size"])
+print(" ".join(str(layer) for layer in dflash["target_layer_ids"]))
+PY
+)
+MASK_TOKEN_ID=${MASK_TOKEN_ID:-${DRAFT_VALUES[0]}}
+BLOCK_SIZE=${BLOCK_SIZE:-${DRAFT_VALUES[1]}}
+AUX_LAYER_IDS=${AUX_LAYER_IDS:-${DRAFT_VALUES[2]}}
+MIN_LOSS_TOKENS=$((2 * BLOCK_SIZE))
+
+SELECT_ARGS=()
+if [[ "$ENABLE_THINKING" == "1" || "$ENABLE_THINKING" == "true" ]]; then
+    SELECT_ARGS+=(--enable-thinking)
+fi
+"$PYTHON" "$ROOT_DIR/scripts/gates/select_overfit_sample.py" \
+    --input-data-path "$SOURCE_DATA_PATH" \
+    --output-data-path "$SINGLE_DATA_PATH" \
+    --model-path "$TARGET_MODEL_PATH" \
+    --chat-template "$CHAT_TEMPLATE" \
+    --max-length "$MAX_LENGTH" \
+    --min-loss-tokens "$MIN_LOSS_TOKENS" \
+    --reasoning-policy "$REASONING_POLICY" \
+    --prompt-output-path "$PROMPT_ARTIFACT_PATH" \
+    --require-untruncated \
+    "${SELECT_ARGS[@]}"
+
+export DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-1}
+export DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-400}
+if [[ "$DISAGG_MAX_PROMPTS" -ne 1 || "$DISAGG_MAX_STEPS" -le 0 ]]; then
+    echo "overfit requires DISAGG_MAX_PROMPTS=1 and DISAGG_MAX_STEPS>0" >&2
+    exit 2
+fi
+# Each optimizer step consumes one batch on every DP rank. Replaying the one
+# prompt MAX_STEPS*TRAIN_DP times keeps the producer alive for the whole gate.
+NUM_EPOCHS=$((DISAGG_MAX_STEPS * TRAIN_DP))
+export DISAGG_TOTAL_STEPS=$DISAGG_MAX_STEPS
+export DISAGG_LOG_INTERVAL=${DISAGG_LOG_INTERVAL:-1}
+
+MAX_LOSS=${MAX_LOSS:-0.0001}
+MIN_ACCURACY=${MIN_ACCURACY:-1.0}
+
+MOONCAKE_HOST=${MOONCAKE_HOST:-127.0.0.1}
+MOONCAKE_RPC_PORT=${MOONCAKE_RPC_PORT:-35551}
+MOONCAKE_HTTP_PORT=${MOONCAKE_HTTP_PORT:-35880}
+MOONCAKE_METRICS_PORT=${MOONCAKE_METRICS_PORT:-35903}
+export MOONCAKE_LOCAL_HOSTNAME=$MOONCAKE_HOST
+export MOONCAKE_MASTER_SERVER_ADDR=$MOONCAKE_HOST:$MOONCAKE_RPC_PORT
+export MOONCAKE_METADATA_SERVER=http://$MOONCAKE_HOST:$MOONCAKE_HTTP_PORT/metadata
+export MOONCAKE_PROTOCOL=${MOONCAKE_PROTOCOL:-tcp}
+export MOONCAKE_GLOBAL_SEGMENT_SIZE=${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((32 << 30))}
+export DISAGG_CLIENT_SEGMENT_SIZE=${DISAGG_CLIENT_SEGMENT_SIZE:-0}
+export DISAGG_CLIENT_BUFFER_SIZE=${DISAGG_CLIENT_BUFFER_SIZE:-$((256 << 20))}
+if [[ "$DISAGG_CLIENT_SEGMENT_SIZE" -ne 0 ]]; then
+    echo "DISAGG_CLIENT_SEGMENT_SIZE must be 0 for server-owned captures" >&2
+    exit 2
+fi
+
+export DISAGG_SERVER_URLS=http://127.0.0.1:$SERVER_PORT
+export DISAGG_REF_CHANNEL=$WORK_DIR/refs.jsonl
+DISAGG_DB=$WORK_DIR/run.db
+DISAGG_INBOX_DIR=$WORK_DIR/inboxes
+MOONCAKE_LOG=$WORK_DIR/mooncake.log
+: > "$DISAGG_REF_CHANNEL"
+
+cleanup() {
+    kill "${SERVER_PID:-}" "${PRODUCER_PID:-}" 2>/dev/null || true
+    if [[ -n "${MASTER_PID:-}" ]]; then
+        kill -- "-$MASTER_PID" 2>/dev/null || kill "$MASTER_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+setsid mooncake_master \
+    --enable_http_metadata_server=true \
+    --rpc_port="$MOONCAKE_RPC_PORT" \
+    --http_metadata_server_port="$MOONCAKE_HTTP_PORT" \
+    --metrics_port="$MOONCAKE_METRICS_PORT" \
+    >"$MOONCAKE_LOG" 2>&1 &
+MASTER_PID=$!
+
+for _ in $(seq 1 30); do
+    if ! kill -0 "$MASTER_PID" 2>/dev/null; then
+        echo "Mooncake master exited during startup; see $MOONCAKE_LOG" >&2
+        exit 1
+    fi
+    if curl -sS --max-time 1 -o /dev/null \
+        "$MOONCAKE_METADATA_SERVER?key=specforge-health-check" \
+        && timeout 1 bash -c \
+            "</dev/tcp/$MOONCAKE_HOST/$MOONCAKE_RPC_PORT" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+if ! timeout 1 bash -c "</dev/tcp/$MOONCAKE_HOST/$MOONCAKE_RPC_PORT" 2>/dev/null; then
+    echo "Mooncake master did not become ready; see $MOONCAKE_LOG" >&2
+    exit 1
+fi
+
+CUDA_VISIBLE_DEVICES=$SERVER_GPUS \
+    "$PYTHON" -m sglang.launch_server \
+        --model-path "$TARGET_MODEL_PATH" \
+        --trust-remote-code \
+        --skip-tokenizer-init \
+        --tp-size "$SERVER_TP" \
+        --context-length "$MAX_LENGTH" \
+        --mem-fraction-static "${SERVER_MEM_FRACTION:-0.85}" \
+        --chunked-prefill-size -1 \
+        --disable-radix-cache \
+        --enable-spec-capture \
+        --spec-capture-method dflash \
+        --spec-capture-aux-layer-ids $AUX_LAYER_IDS \
+        --port "$SERVER_PORT" &
+SERVER_PID=$!
+
+until curl -sf "http://127.0.0.1:$SERVER_PORT/health" >/dev/null; do
+    if ! kill -0 "$MASTER_PID" 2>/dev/null; then
+        echo "Mooncake master died while SGLang was starting" >&2
+        exit 1
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "SGLang server on :$SERVER_PORT died" >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+ARGS=(
+    --target-model-path "$TARGET_MODEL_PATH"
+    --target-model-backend hf
+    --trust-remote-code
+    --draft-config-path "$DRAFT_CONFIG_PATH"
+    --embedding-key "$EMBEDDING_KEY"
+    --lm-head-key "$LM_HEAD_KEY"
+    --mask-token-id "$MASK_TOKEN_ID"
+    --train-data-path "$SINGLE_DATA_PATH"
+    --chat-template "$CHAT_TEMPLATE"
+    --max-length "$MAX_LENGTH"
+    --batch-size 1
+    --accumulation-steps 1
+    --learning-rate "${LEARNING_RATE:-6e-4}"
+    --warmup-ratio "${WARMUP_RATIO:-0.04}"
+    --max-grad-norm 1.0
+    --attention-backend "${ATTENTION_BACKEND:-flex_attention}"
+    --block-size "$BLOCK_SIZE"
+    --num-anchors "${NUM_ANCHORS:-256}"
+    --loss-decay-gamma 7.0
+    --num-epochs "$NUM_EPOCHS"
+    --seed 42
+    --save-interval "$DISAGG_MAX_STEPS"
+    --lambda-base-start 1.0
+    --lambda-base-decay-ratio 1.0
+)
+LAUNCHER=$SCRIPT_DIR/run_disagg_domino.py
+
+DISAGG_ROLE=producer CUDA_VISIBLE_DEVICES="" \
+    "$PYTHON" "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$PRODUCER_OUTPUT_DIR" &
+PRODUCER_PID=$!
+
+CUDA_VISIBLE_DEVICES=$CONSUMER_GPUS DISAGG_ROLE=consumer \
+    DISAGG_DB=$DISAGG_DB DISAGG_INBOX_DIR=$DISAGG_INBOX_DIR \
+    torchrun --rdzv-backend c10d --rdzv-endpoint localhost:29702 \
+        --nnodes 1 --nproc_per_node "$TRAIN_DP" "$LAUNCHER" "${ARGS[@]}" \
+        --output-dir "$CONSUMER_OUTPUT_DIR" \
+        --report-to none 2>&1 | tee "$TRAIN_LOG"
+
+wait "$PRODUCER_PID"
+"$PYTHON" "$ROOT_DIR/scripts/gates/check_overfit_metrics.py" \
+    --log-path "$TRAIN_LOG" \
+    --checkpoint-root "$CONSUMER_OUTPUT_DIR" \
+    --expected-step "$DISAGG_MAX_STEPS" \
+    --max-loss "$MAX_LOSS" \
+    --min-accuracy "$MIN_ACCURACY"
+
+LATEST_CHECKPOINT="$CONSUMER_OUTPUT_DIR/$DISAGG_STORE_ID-step$DISAGG_MAX_STEPS"
+if [[ ! -f "$LATEST_CHECKPOINT/training_state.pt" ]]; then
+    echo "Expected final checkpoint is missing: $LATEST_CHECKPOINT/training_state.pt" >&2
+    exit 1
+fi
+if [[ "${RUN_REAL_SERVING_GATE:-0}" == "1" ]]; then
+    # Release the capture/training stack before loading target + draft serving.
+    kill "$SERVER_PID" 2>/dev/null || true
+    kill -- "-$MASTER_PID" 2>/dev/null || kill "$MASTER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" "$MASTER_PID" 2>/dev/null || true
+    SERVER_PID=""
+    MASTER_PID=""
+    CHECKPOINT_PATH="$LATEST_CHECKPOINT" \
+    PROMPT_ARTIFACT_PATH="$PROMPT_ARTIFACT_PATH" \
+    TARGET_MODEL_PATH="$TARGET_MODEL_PATH" \
+    DRAFT_CONFIG_PATH="$DRAFT_CONFIG_PATH" \
+    EMBEDDING_KEY="$EMBEDDING_KEY" \
+    SPECFORGE_PYTHON="$PYTHON" \
+    SGLANG_PYTHON="${SERVING_PYTHON:-$PYTHON}" \
+    SGLANG_ROOT="${SERVING_SGLANG_ROOT:-}" \
+    SERVING_GPUS="$REAL_SERVING_GPUS" \
+    SERVING_TP="$REAL_SERVING_TP" \
+    SERVING_CONTEXT_LENGTH="$MAX_LENGTH" \
+    WORK_DIR="$WORK_DIR/real_serving" \
+        bash "$ROOT_DIR/examples/disagg/run_domino_dflash_serving_gate.sh"
+else
+    echo "Real serving is a separate strict gate. Run it with:"
+    echo "CHECKPOINT_PATH=$LATEST_CHECKPOINT \\"
+    echo "  PROMPT_ARTIFACT_PATH=$PROMPT_ARTIFACT_PATH \\"
+    echo "  bash examples/disagg/run_domino_dflash_serving_gate.sh"
+fi
+
+echo "DOMINO-DISAGG-OVERFIT-PASSED: $WORK_DIR"

--- a/scripts/gates/check_overfit_metrics.py
+++ b/scripts/gates/check_overfit_metrics.py
@@ -1,0 +1,110 @@
+"""Gate an overfit run on its final loss, accuracy, and checkpoint.
+
+Assumptions about the trainer log and output structure:
+
+- Metric lines match: ``[consumer] step <N> {<dict>}``
+  This is the disaggregated Domino consumer log format. A new method whose trainer
+  uses a different prefix or schema must either emit the same pattern or supply its
+  own checker; update ``METRIC_LINE`` accordingly.
+- The checkpoint tree layout is: ``<checkpoint_root>/<run-id>-step<N>/training_state.pt``
+  If a new method saves checkpoints under a different layout, adjust
+  ``checkpoint_paths()`` to match.
+- The gate thresholds ``--max-loss`` and ``--min-accuracy`` are method-agnostic
+  CLI arguments; every future overfit gate can pass the values appropriate for that
+  method without modifying this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import glob
+import json
+import os
+import re
+from typing import Dict, Tuple
+
+METRIC_LINE = re.compile(r"\[consumer\] step (\d+) (\{.*\})\s*$")
+
+
+def final_metrics(log_path: str) -> Tuple[int, Dict[str, float]]:
+    matches = []
+    with open(log_path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            match = METRIC_LINE.search(line)
+            if match:
+                metrics = ast.literal_eval(match.group(2))
+                matches.append((int(match.group(1)), metrics))
+    if not matches:
+        raise ValueError(f"no consumer metric lines found in {log_path}")
+    return matches[-1]
+
+
+def checkpoint_paths(checkpoint_root: str):
+    pattern = os.path.join(checkpoint_root, "*-step*", "training_state.pt")
+    paths = glob.glob(pattern)
+
+    def get_step(path: str) -> int:
+        match = re.search(r"-step(\\d+)", path)
+        return int(match.group(1)) if match else 0
+
+    return sorted(paths, key=get_step)
+
+
+def check_overfit(
+    log_path: str,
+    checkpoint_root: str,
+    *,
+    expected_step: int,
+    max_loss: float,
+    min_accuracy: float,
+) -> Dict[str, object]:
+    step, metrics = final_metrics(log_path)
+    loss = float(metrics["loss"])
+    accuracy = float(metrics["accuracy"])
+    checkpoints = checkpoint_paths(checkpoint_root)
+    errors = []
+    if step != expected_step:
+        errors.append(f"final logged step {step} != expected {expected_step}")
+    if loss > max_loss:
+        errors.append(f"final loss {loss} > {max_loss}")
+    if accuracy < min_accuracy:
+        errors.append(f"final token accuracy {accuracy} < {min_accuracy}")
+    if not checkpoints:
+        errors.append(f"no training_state.pt checkpoint under {checkpoint_root}")
+    result = {
+        "step": step,
+        "loss": loss,
+        "token_accuracy": accuracy,
+        "checkpoint": checkpoints[-1] if checkpoints else None,
+        "passed": not errors,
+    }
+    if errors:
+        raise ValueError("; ".join(errors))
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-path", required=True)
+    parser.add_argument("--checkpoint-root", required=True)
+    parser.add_argument("--expected-step", type=int, required=True)
+    parser.add_argument("--max-loss", type=float, default=1e-4)
+    parser.add_argument("--min-accuracy", type=float, default=1.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = check_overfit(
+        args.log_path,
+        args.checkpoint_root,
+        expected_step=args.expected_step,
+        max_loss=args.max_loss,
+        min_accuracy=args.min_accuracy,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/run_dflash_chat_serving_gate.py
+++ b/scripts/gates/run_dflash_chat_serving_gate.py
@@ -1,0 +1,193 @@
+"""Gate one overfit draft artifact through real SGLang DFLASH chat serving.
+
+This script is tied to the SGLang DFLASH serving API, not to a particular draft
+architecture. A method-specific launcher should export its checkpoint into an
+SGLang-compatible draft artifact, start the server with ``--speculative-algorithm
+DFLASH``, then call this checker with the prompt artifact produced by
+``select_overfit_sample.py``.
+
+Future DFLASH draft methods can reuse this checker when they expose the same
+OpenAI chat endpoint behavior and per-choice ``spec_accept_length`` metadata. If a
+method needs a different request shape, acceptance metric, or output comparison,
+add a sibling checker under this directory instead of weakening this strict gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any, Dict, List, Sequence
+
+import requests
+
+
+def longest_prefix_match(left: Sequence[int], right: Sequence[int]) -> int:
+    for index, (left_id, right_id) in enumerate(zip(left, right)):
+        if left_id != right_id:
+            return index
+    return min(len(left), len(right))
+
+
+def load_prompt_artifact(path: str) -> Dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        artifact = json.load(handle)
+    messages = artifact.get("prompt_messages")
+    target = artifact.get("target_suffix")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("prompt artifact must contain nonempty prompt_messages")
+    if not isinstance(target, str) or not target:
+        raise ValueError("prompt artifact must contain nonempty target_suffix")
+    return artifact
+
+
+def build_chat_payload(
+    artifact: Dict[str, Any], model: str, max_tokens: int
+) -> Dict[str, Any]:
+    messages: List[Dict[str, Any]] = []
+    for message in artifact["prompt_messages"]:
+        clean = dict(message)
+        clean.pop("reasoning_content", None)
+        messages.append(clean)
+    return {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "stream": False,
+        "return_meta_info": True,
+        "separate_reasoning": True,
+        "chat_template_kwargs": {
+            "enable_thinking": bool(artifact.get("enable_thinking", False))
+        },
+    }
+
+
+def request_messages_with_reasoning_content(payload: Dict[str, Any]) -> int:
+    return sum("reasoning_content" in message for message in payload["messages"])
+
+
+def evaluate_response(
+    *,
+    response_json: Dict[str, Any],
+    server_info: Dict[str, Any],
+    payload: Dict[str, Any],
+    target_ids: Sequence[int],
+    encode,
+    block_size: int,
+) -> Dict[str, Any]:
+    choices = response_json.get("choices") or []
+    choice = choices[0] if choices and isinstance(choices[0], dict) else {}
+    message = choice.get("message") or {}
+    generated_reasoning = message.get("reasoning_content") or ""
+    generated_content = message.get("content") or ""
+    generated_text = generated_reasoning + generated_content
+    generated_ids = encode(generated_text)
+
+    # This is intentionally choice metadata, not aggregate /server_info metrics.
+    choice_meta_info = choice.get("meta_info")
+    spec_accept_length = (
+        choice_meta_info.get("spec_accept_length")
+        if isinstance(choice_meta_info, dict)
+        else None
+    )
+    prefix_match = longest_prefix_match(generated_ids, target_ids)
+    algorithm = server_info.get("speculative_algorithm")
+    reasoning_count = request_messages_with_reasoning_content(payload)
+
+    errors = []
+    if algorithm != "DFLASH":
+        errors.append(
+            f"server speculative_algorithm is {algorithm!r}, expected 'DFLASH'"
+        )
+    if reasoning_count:
+        errors.append("request history contains reasoning_content")
+    if spec_accept_length is None:
+        errors.append("missing choices[0].meta_info.spec_accept_length")
+    elif float(spec_accept_length) < block_size:
+        errors.append(
+            f"spec_accept_length {spec_accept_length} < block_size {block_size}"
+        )
+    if prefix_match < block_size:
+        errors.append(f"target prefix match {prefix_match} < block_size {block_size}")
+
+    return {
+        "passed": not errors,
+        "endpoint": "/v1/chat/completions",
+        "request_messages_with_reasoning_content": reasoning_count,
+        "sglang_server_info_before": server_info,
+        "choice_meta_info": choice_meta_info,
+        "spec_accept_length": spec_accept_length,
+        "target_prefix_match_tokens": prefix_match,
+        "generated_tokens": len(generated_ids),
+        "generated_reasoning": generated_reasoning,
+        "generated_content": generated_content,
+        "target_tokens": len(target_ids),
+        "clean_block_tokens": block_size if not errors else 0,
+        "errors": errors,
+        "request_payload": payload,
+        "sglang_response": response_json,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--server-url", required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--served-model", required=True)
+    parser.add_argument("--prompt-json-path", required=True)
+    parser.add_argument("--output-path", required=True)
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--timeout", type=float, default=1800.0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.block_size <= 0 or args.max_tokens < args.block_size:
+        raise SystemExit("--block-size must be positive and --max-tokens >= block size")
+
+    from transformers import AutoTokenizer
+
+    artifact = load_prompt_artifact(args.prompt_json_path)
+    payload = build_chat_payload(artifact, args.served_model, args.max_tokens)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
+
+    def encode(text):
+        return tokenizer.encode(text, add_special_tokens=False)
+
+    target_ids = encode(artifact["target_suffix"])
+
+    server_url = args.server_url.rstrip("/")
+    info_response = requests.get(f"{server_url}/server_info", timeout=30)
+    info_response.raise_for_status()
+    response = requests.post(
+        f"{server_url}/v1/chat/completions", json=payload, timeout=args.timeout
+    )
+    response.raise_for_status()
+    result = evaluate_response(
+        response_json=response.json(),
+        server_info=info_response.json(),
+        payload=payload,
+        target_ids=target_ids,
+        encode=encode,
+        block_size=args.block_size,
+    )
+    result["server_url"] = server_url
+    result["endpoint"] = f"{server_url}/v1/chat/completions"
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.output_path)), exist_ok=True)
+    with open(args.output_path, "w", encoding="utf-8") as handle:
+        json.dump(result, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if not result["passed"]:
+        raise SystemExit(
+            "real SGLang DFLASH serving gate failed: " + "; ".join(result["errors"])
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gates/select_overfit_sample.py
+++ b/scripts/gates/select_overfit_sample.py
@@ -1,0 +1,274 @@
+"""Select one clean single-turn overfit sample and record its serving contract.
+
+This helper is method-agnostic: it only validates ShareGPT-style data, applies the
+selected tokenizer/template preprocessing, and writes the prompt artifact consumed
+by serving gates. New draft methods should reuse this script when they can train
+from the same single-turn conversation and `target_suffix` contract; method-specific
+constraints such as block size or minimum loss-token count should stay in the
+launcher that calls this helper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import types
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+
+def iter_jsonl(path: str) -> Iterable[Tuple[int, Dict[str, Any]]]:
+    with open(path, encoding="utf-8") as handle:
+        for index, line in enumerate(handle):
+            if line.strip():
+                yield index, json.loads(line)
+
+
+def single_turn_candidate(
+    row: Dict[str, Any],
+    reasoning_policy: str = "allow",
+) -> Optional[Dict[str, Any]]:
+    conversations = row.get("conversations")
+    if not isinstance(conversations, list) or len(conversations) != 2:
+        return None
+    user, assistant = conversations
+    if user.get("role") != "user" or assistant.get("role") != "assistant":
+        return None
+    user_content = user.get("content")
+    assistant_content = assistant.get("content")
+    if not isinstance(user_content, str) or not user_content.strip():
+        return None
+    if not isinstance(assistant_content, str):
+        return None
+    reasoning_content = assistant.get("reasoning_content", "")
+    if not isinstance(reasoning_content, str):
+        return None
+    if not assistant_content.strip() and not reasoning_content.strip():
+        return None
+    has_reasoning = bool(reasoning_content.strip())
+    if reasoning_policy == "forbidden" and has_reasoning:
+        return None
+    if reasoning_policy == "required" and not has_reasoning:
+        return None
+    return {
+        "id": row.get("id"),
+        "conversations": [dict(user), dict(assistant)],
+    }
+
+
+def load_processing_stack(model_path: str, chat_template: str):
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    package_name = "_specforge_domino_overfit"
+    root_package = types.ModuleType(package_name)
+    root_package.__path__ = []
+    sys.modules[package_name] = root_package
+
+    data_package_name = f"{package_name}.data"
+    data_package = types.ModuleType(data_package_name)
+    data_package.__path__ = []
+    sys.modules[data_package_name] = data_package
+
+    distributed_module = types.ModuleType(f"{package_name}.distributed")
+    distributed_module.get_draft_sp_group = lambda: None
+    distributed_module.get_sp_ring_group = lambda: None
+    sys.modules[f"{package_name}.distributed"] = distributed_module
+
+    for module_name in ("template", "parse", "preprocessing"):
+        full_name = f"{data_package_name}.{module_name}"
+        module_path = os.path.join(root_dir, "specforge", "data", f"{module_name}.py")
+        spec = importlib.util.spec_from_file_location(full_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full_name] = module
+        spec.loader.exec_module(module)
+
+    template_module = sys.modules[f"{data_package_name}.template"]
+    preprocessing_module = sys.modules[f"{data_package_name}.preprocessing"]
+    return (
+        tokenizer,
+        template_module.TEMPLATE_REGISTRY.get(chat_template),
+        preprocessing_module.preprocess_conversations,
+    )
+
+
+def loss_token_count(
+    candidate: Dict[str, Any],
+    processing_stack,
+    *,
+    max_length: int,
+) -> int:
+    tokenizer, template, preprocess_conversations = processing_stack
+    processed = preprocess_conversations(
+        tokenizer,
+        [candidate["conversations"]],
+        template,
+        max_length=max_length,
+    )
+    if len(processed["loss_mask"]) != 1:
+        raise ValueError("preprocessing did not return exactly one loss mask")
+    return int(processed["loss_mask"][0].sum().item())
+
+
+def build_prompt_artifact(
+    candidate: Dict[str, Any],
+    processing_stack,
+    *,
+    enable_thinking: bool,
+    source_row_index: int,
+    loss_tokens: int,
+) -> Dict[str, Any]:
+    """Render the exact chat prompt/target boundary used by real serving."""
+    tokenizer = processing_stack[0]
+    messages = candidate["conversations"]
+    prompt_messages = []
+    for message in messages[:-1]:
+        clean = dict(message)
+        clean.pop("reasoning_content", None)
+        prompt_messages.append(clean)
+    template_kwargs = {
+        "tokenize": False,
+        "add_special_tokens": False,
+        "enable_thinking": enable_thinking,
+    }
+    flat_prompt = tokenizer.apply_chat_template(
+        prompt_messages, add_generation_prompt=True, **template_kwargs
+    )
+    flat_train_text = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=False, **template_kwargs
+    )
+    if not flat_train_text.startswith(flat_prompt):
+        raise ValueError("flattened train text does not start with flattened prompt")
+    full_input_tokens = len(tokenizer.encode(flat_train_text, add_special_tokens=False))
+    return {
+        "source_row_index": source_row_index,
+        "id": candidate.get("id"),
+        "prompt_messages": prompt_messages,
+        "target_suffix": flat_train_text[len(flat_prompt) :],
+        "enable_thinking": enable_thinking,
+        "loss_tokens": loss_tokens,
+        "full_input_tokens": full_input_tokens,
+    }
+
+
+def create_single_sample(
+    input_path: str,
+    output_path: str,
+    *,
+    model_path: str,
+    chat_template: str = "qwen",
+    max_length: int = 512,
+    min_loss_tokens: int = 32,
+    reasoning_policy: str = "allow",
+    prompt_output_path: Optional[str] = None,
+    enable_thinking: bool = False,
+    require_untruncated: bool = False,
+    processing_stack=None,
+) -> Tuple[int, Dict[str, Any], int]:
+    if os.path.exists(output_path):
+        raise FileExistsError(f"refusing to overwrite existing output: {output_path}")
+    if prompt_output_path and os.path.exists(prompt_output_path):
+        raise FileExistsError(
+            f"refusing to overwrite existing prompt artifact: {prompt_output_path}"
+        )
+    if reasoning_policy not in {"forbidden", "required", "allow"}:
+        raise ValueError(f"unknown reasoning policy: {reasoning_policy}")
+    if processing_stack is None:
+        processing_stack = load_processing_stack(model_path, chat_template)
+    for index, row in iter_jsonl(input_path):
+        candidate = single_turn_candidate(row, reasoning_policy=reasoning_policy)
+        if candidate is None:
+            continue
+        loss_tokens = loss_token_count(
+            candidate,
+            processing_stack,
+            max_length=max_length,
+        )
+        if loss_tokens < min_loss_tokens:
+            continue
+        artifact = None
+        if prompt_output_path:
+            artifact = build_prompt_artifact(
+                candidate,
+                processing_stack,
+                enable_thinking=enable_thinking,
+                source_row_index=index,
+                loss_tokens=loss_tokens,
+            )
+            if require_untruncated and artifact["full_input_tokens"] > max_length:
+                continue
+        parent = os.path.dirname(os.path.abspath(output_path))
+        os.makedirs(parent, exist_ok=True)
+        with open(output_path, "x", encoding="utf-8") as handle:
+            handle.write(json.dumps(candidate, ensure_ascii=False) + "\n")
+        if prompt_output_path and artifact is not None:
+            prompt_parent = os.path.dirname(os.path.abspath(prompt_output_path))
+            os.makedirs(prompt_parent, exist_ok=True)
+            with open(prompt_output_path, "x", encoding="utf-8") as handle:
+                json.dump(artifact, handle, ensure_ascii=False, indent=2)
+                handle.write("\n")
+        return index, candidate, loss_tokens
+    raise ValueError(
+        "no trainable single-turn sample found; expected a user/assistant row "
+        f"with reasoning_policy={reasoning_policy!r} and at least "
+        f"{min_loss_tokens} post-preprocessing loss tokens"
+        + (f", without exceeding {max_length} tokens" if require_untruncated else "")
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-data-path", required=True)
+    parser.add_argument("--output-data-path", required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--chat-template", default="qwen")
+    parser.add_argument("--max-length", type=int, default=512)
+    parser.add_argument("--min-loss-tokens", type=int, default=32)
+    parser.add_argument(
+        "--reasoning-policy",
+        choices=["forbidden", "required", "allow"],
+        default="allow",
+    )
+    parser.add_argument("--prompt-output-path")
+    parser.add_argument("--enable-thinking", action="store_true")
+    parser.add_argument("--require-untruncated", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    index, row, loss_tokens = create_single_sample(
+        args.input_data_path,
+        args.output_data_path,
+        model_path=args.model_path,
+        chat_template=args.chat_template,
+        max_length=args.max_length,
+        min_loss_tokens=args.min_loss_tokens,
+        reasoning_policy=args.reasoning_policy,
+        prompt_output_path=args.prompt_output_path,
+        enable_thinking=args.enable_thinking,
+        require_untruncated=args.require_untruncated,
+    )
+    print(
+        json.dumps(
+            {
+                "source_row_index": index,
+                "id": row.get("id"),
+                "loss_tokens": loss_tokens,
+                "output_data_path": os.path.abspath(args.output_data_path),
+                "prompt_output_path": (
+                    os.path.abspath(args.prompt_output_path)
+                    if args.prompt_output_path
+                    else None
+                ),
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/export/to_hf.py
+++ b/specforge/export/to_hf.py
@@ -16,9 +16,48 @@ the target via ``load_embedding``.
 from __future__ import annotations
 
 import argparse
+import glob
+import json
+import os
 from typing import Optional
 
+import torch
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+
 from specforge.export.checkpoint_io import materialize_draft, resolve_training_state
+
+
+def _load_embedding_tensor(source: str, key: str) -> torch.Tensor:
+    """Read one target embedding without materializing the target lm_head."""
+    root = source if os.path.exists(source) else snapshot_download(repo_id=source)
+    index_paths = glob.glob(os.path.join(root, "*.index.json"))
+    if len(index_paths) > 1:
+        raise FileNotFoundError(f"multiple index files found under {root}")
+    if index_paths:
+        with open(index_paths[0], encoding="utf-8") as handle:
+            weight_file = json.load(handle).get("weight_map", {}).get(key)
+        if not weight_file:
+            raise KeyError(f"embedding key {key!r} is absent from {index_paths[0]}")
+        path = os.path.join(root, weight_file)
+    else:
+        candidates = glob.glob(os.path.join(root, "*.safetensors"))
+        candidates += glob.glob(os.path.join(root, "*.bin"))
+        if len(candidates) != 1:
+            raise FileNotFoundError(
+                f"expected one model weight file under {root}, found {len(candidates)}"
+            )
+        path = candidates[0]
+
+    if path.endswith(".safetensors"):
+        with safe_open(path, framework="pt") as handle:
+            if key not in handle.keys():
+                raise KeyError(f"embedding key {key!r} is absent from {path}")
+            return handle.get_tensor(key)
+    state = torch.load(path, map_location="cpu", weights_only=True)
+    if key not in state:
+        raise KeyError(f"embedding key {key!r} is absent from {path}")
+    return state[key]
 
 
 def export_to_hf(
@@ -50,8 +89,22 @@ def export_to_hf(
                 "exclude the frozen embedding); pass embedding_source=<target "
                 "model path> so the export ships the real embedding"
             )
-        model.load_embedding(embedding_source, embedding_key=embedding_key)
+        load_embedding = getattr(model, "load_embedding", None)
+        if load_embedding is not None:
+            load_embedding(embedding_source, embedding_key=embedding_key)
     full_state = dict(model.state_dict())
+    if (
+        "embed_tokens.weight" not in full_state
+        and "embed_tokens.weight" not in state["draft_state_dict"]
+    ):
+        if not embedding_source:
+            raise ValueError(
+                "checkpoint does not contain embed_tokens.weight; pass "
+                "embedding_source=<target model path>"
+            )
+        full_state["embed_tokens.weight"] = _load_embedding_tensor(
+            embedding_source, embedding_key
+        )
     full_state.update(state["draft_state_dict"])  # trained keys win
     model.save_pretrained(output_dir, state_dict=full_state)
     return output_dir

--- a/tests/test_scripts/test_dflash_serving_gate.py
+++ b/tests/test_scripts/test_dflash_serving_gate.py
@@ -1,0 +1,219 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import save_file
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "gates" / "run_dflash_chat_serving_gate.py"
+SPEC = importlib.util.spec_from_file_location("dflash_serving_gate", SCRIPT)
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+
+def load_hf_exporter():
+    names = ("specforge", "specforge.export", "specforge.export.checkpoint_io")
+    saved = {name: sys.modules.get(name) for name in names}
+    try:
+        for name in names[:2]:
+            package = types.ModuleType(name)
+            package.__path__ = []
+            sys.modules[name] = package
+        checkpoint_io = types.ModuleType(names[2])
+        checkpoint_io.materialize_draft = None
+        checkpoint_io.resolve_training_state = None
+        sys.modules[names[2]] = checkpoint_io
+        path = ROOT / "specforge" / "export" / "to_hf.py"
+        spec = importlib.util.spec_from_file_location("_test_to_hf", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+hf_exporter = load_hf_exporter()
+
+
+def encode(text):
+    return [ord(char) for char in text]
+
+
+class TestDflashServingGate(unittest.TestCase):
+    def setUp(self):
+        self.target = "abcdefghijklmnop target continuation"
+        self.artifact = {
+            "prompt_messages": [
+                {
+                    "role": "user",
+                    "content": "question",
+                    "reasoning_content": "must not be sent",
+                }
+            ],
+            "target_suffix": self.target,
+            "enable_thinking": False,
+        }
+        self.payload = gate.build_chat_payload(self.artifact, "test-model", 16)
+
+    def evaluate(self, response, server_info=None):
+        return gate.evaluate_response(
+            response_json=response,
+            server_info=server_info or {"speculative_algorithm": "DFLASH"},
+            payload=self.payload,
+            target_ids=encode(self.target),
+            encode=encode,
+            block_size=16,
+        )
+
+    def test_payload_is_non_reasoning_chat_history(self):
+        self.assertEqual(
+            self.payload["chat_template_kwargs"], {"enable_thinking": False}
+        )
+        self.assertTrue(self.payload["return_meta_info"])
+        self.assertEqual(gate.request_messages_with_reasoning_content(self.payload), 0)
+        self.assertNotIn("reasoning_content", self.payload["messages"][0])
+
+    def test_passes_clean_choice_meta_info_block(self):
+        result = self.evaluate(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": self.target[:16]},
+                        "meta_info": {"spec_accept_length": 16.0},
+                    }
+                ]
+            }
+        )
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["target_prefix_match_tokens"], 16)
+        self.assertEqual(result["clean_block_tokens"], 16)
+
+    def test_reasoning_and_content_are_combined_for_structured_target(self):
+        target = "reasoning answer"
+        payload = gate.build_chat_payload(
+            {
+                "prompt_messages": [{"role": "user", "content": "question"}],
+                "target_suffix": target,
+                "enable_thinking": True,
+            },
+            "test-reasoning-model",
+            16,
+        )
+        result = gate.evaluate_response(
+            response_json={
+                "choices": [
+                    {
+                        "message": {
+                            "reasoning_content": "reasoning ",
+                            "content": "answer",
+                        },
+                        "meta_info": {"spec_accept_length": 16.0},
+                    }
+                ]
+            },
+            server_info={"speculative_algorithm": "DFLASH"},
+            payload=payload,
+            target_ids=encode(target),
+            encode=encode,
+            block_size=16,
+        )
+        self.assertTrue(result["passed"])
+        self.assertTrue(payload["chat_template_kwargs"]["enable_thinking"])
+
+    def test_rejects_root_meta_info_instead_of_choice_meta_info(self):
+        result = self.evaluate(
+            {
+                "meta_info": {"spec_accept_length": 16.0},
+                "choices": [
+                    {"message": {"role": "assistant", "content": self.target[:16]}}
+                ],
+            }
+        )
+        self.assertFalse(result["passed"])
+        self.assertIn(
+            "missing choices[0].meta_info.spec_accept_length", result["errors"]
+        )
+
+    def test_rejects_non_dflash_or_diverged_prefix(self):
+        result = self.evaluate(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "wrong"},
+                        "meta_info": {"spec_accept_length": 16.0},
+                    }
+                ]
+            },
+            {"speculative_algorithm": None},
+        )
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("expected 'DFLASH'" in error for error in result["errors"]))
+        self.assertTrue(
+            any("target prefix match" in error for error in result["errors"])
+        )
+
+    def test_shell_launcher_uses_matching_dflash_block_flags(self):
+        launcher = ROOT / "examples/disagg/run_domino_dflash_serving_gate.sh"
+        subprocess.run(["bash", "-n", str(launcher)], check=True)
+        text = launcher.read_text()
+        self.assertIn('--speculative-num-draft-tokens "$BLOCK_SIZE"', text)
+        self.assertIn('--speculative-dflash-block-size "$BLOCK_SIZE"', text)
+        self.assertIn('--tp-size "$SERVING_TP"', text)
+        self.assertIn("REASONING_PARSER_ARGS=(--reasoning-parser", text)
+        self.assertIn("SERVING_PORT is already occupied", text)
+
+
+class TestDominoHfExport(unittest.TestCase):
+    def test_model_without_load_embedding_gets_target_embedding_in_state(self):
+        embedding = torch.arange(12, dtype=torch.bfloat16).reshape(4, 3)
+        source_key = "model.embed_tokens.weight"
+        state = {"draft_state_dict": {"draft.weight": torch.ones(1)}}
+        saved_state = {}
+
+        class DominoLikeModel:
+            def state_dict(self):
+                return {"draft.weight": torch.zeros(1)}
+
+            def save_pretrained(self, output_dir, *, state_dict):
+                saved_state.update(state_dict)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            shard = Path(tmp) / "model-00001-of-00001.safetensors"
+            save_file({source_key: embedding}, shard)
+            (Path(tmp) / "model.safetensors.index.json").write_text(
+                json.dumps({"weight_map": {source_key: shard.name}}),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(hf_exporter, "resolve_training_state", return_value=state),
+                patch.object(
+                    hf_exporter,
+                    "materialize_draft",
+                    return_value=DominoLikeModel(),
+                ),
+            ):
+                hf_exporter.export_to_hf(
+                    "checkpoint",
+                    "config",
+                    str(Path(tmp) / "out"),
+                    embedding_source=tmp,
+                    embedding_key=source_key,
+                )
+
+        torch.testing.assert_close(saved_state["embed_tokens.weight"], embedding)
+        torch.testing.assert_close(saved_state["draft.weight"], torch.ones(1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scripts/test_domino_overfit_gate.py
+++ b/tests/test_scripts/test_domino_overfit_gate.py
@@ -1,0 +1,295 @@
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_script(name):
+    path = ROOT / "scripts" / "gates" / name
+    spec = importlib.util.spec_from_file_location(name.removesuffix(".py"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+create_data = load_script("select_overfit_sample.py")
+check_overfit = load_script("check_overfit_metrics.py")
+
+
+def fake_processing_stack(loss_tokens=40):
+    class FakeTokenizer:
+        def encode(self, text, *, add_special_tokens):
+            del add_special_tokens
+            return list(text)
+
+        def apply_chat_template(self, messages, *, add_generation_prompt, **_kwargs):
+            prompt = "PROMPT:"
+            if add_generation_prompt:
+                return prompt
+            assistant = messages[-1]
+            return (
+                prompt + assistant.get("reasoning_content", "") + assistant["content"]
+            )
+
+    def preprocess(
+        _tokenizer,
+        _conversations,
+        _template,
+        *,
+        max_length,
+    ):
+        del max_length
+        return {"loss_mask": [torch.ones(1, loss_tokens)]}
+
+    return FakeTokenizer(), object(), preprocess
+
+
+class TestCreateDominoOverfitData(unittest.TestCase):
+    def test_selects_clean_single_turn_non_reasoning_sample(self):
+        rows = [
+            {
+                "id": "multi",
+                "conversations": [
+                    {"role": "user", "content": "u"},
+                    {"role": "assistant", "content": "a" * 200},
+                    {"role": "user", "content": "u2"},
+                    {"role": "assistant", "content": "b" * 200},
+                ],
+            },
+            {
+                "id": "thinking",
+                "conversations": [
+                    {"role": "user", "content": "u"},
+                    {
+                        "role": "assistant",
+                        "content": "clean" * 40,
+                        "reasoning_content": "hidden",
+                    },
+                ],
+            },
+            {
+                "id": "selected",
+                "extra": "not copied",
+                "conversations": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "answer " * 30},
+                ],
+                "status": "success",
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source.jsonl")
+            output = os.path.join(tmp, "one.jsonl")
+            with open(source, "w", encoding="utf-8") as handle:
+                for row in rows:
+                    handle.write(json.dumps(row) + "\n")
+            index, selected, loss_tokens = create_data.create_single_sample(
+                source,
+                output,
+                model_path="unused",
+                reasoning_policy="forbidden",
+                processing_stack=fake_processing_stack(),
+            )
+            self.assertEqual(index, 2)
+            self.assertEqual(selected["id"], "selected")
+            self.assertEqual(loss_tokens, 40)
+            self.assertNotIn("extra", selected)
+            with open(output, encoding="utf-8") as handle:
+                written = [json.loads(line) for line in handle]
+            self.assertEqual(written, [selected])
+
+    def test_rejects_empty_assistant_and_existing_output(self):
+        row = {
+            "conversations": [
+                {"role": "user", "content": "question"},
+                {"role": "assistant", "content": ""},
+            ]
+        }
+        self.assertIsNone(create_data.single_turn_candidate(row))
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source.jsonl")
+            output = os.path.join(tmp, "one.jsonl")
+            Path(source).write_text("{}\n")
+            Path(output).write_text("keep\n")
+            with self.assertRaises(FileExistsError):
+                create_data.create_single_sample(
+                    source,
+                    output,
+                    model_path="unused",
+                    processing_stack=fake_processing_stack(),
+                )
+            self.assertEqual(Path(output).read_text(), "keep\n")
+
+    def test_skips_candidate_below_real_loss_token_contract(self):
+        rows = [
+            {
+                "id": "too-few-loss-tokens",
+                "conversations": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "answer " * 30},
+                ],
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source.jsonl")
+            output = os.path.join(tmp, "one.jsonl")
+            Path(source).write_text(json.dumps(rows[0]) + "\n")
+            with self.assertRaisesRegex(ValueError, "at least 32.*loss tokens"):
+                create_data.create_single_sample(
+                    source,
+                    output,
+                    model_path="unused",
+                    min_loss_tokens=32,
+                    processing_stack=fake_processing_stack(loss_tokens=31),
+                )
+            self.assertFalse(os.path.exists(output))
+
+    def test_required_reasoning_is_preserved_in_prompt_artifact(self):
+        row = {
+            "id": "reasoning-profile",
+            "conversations": [
+                {"role": "user", "content": "question"},
+                {
+                    "role": "assistant",
+                    "reasoning_content": "reasoning ",
+                    "content": "answer " * 30,
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "source.jsonl")
+            output = os.path.join(tmp, "one.jsonl")
+            artifact = os.path.join(tmp, "prompt.json")
+            Path(source).write_text(json.dumps(row) + "\n")
+            create_data.create_single_sample(
+                source,
+                output,
+                model_path="unused",
+                reasoning_policy="required",
+                prompt_output_path=artifact,
+                enable_thinking=True,
+                processing_stack=fake_processing_stack(),
+            )
+            selected = json.loads(Path(output).read_text())
+            prompt = json.loads(Path(artifact).read_text())
+            self.assertEqual(
+                selected["conversations"][-1]["reasoning_content"], "reasoning "
+            )
+            self.assertEqual(prompt["target_suffix"], "reasoning " + "answer " * 30)
+            self.assertTrue(prompt["enable_thinking"])
+            self.assertNotIn("reasoning_content", prompt["prompt_messages"][0])
+
+    def test_untruncated_gate_skips_oversized_candidate(self):
+        rows = [
+            {
+                "id": "truncated",
+                "conversations": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "a" * 200},
+                ],
+            },
+            {
+                "id": "selected",
+                "conversations": [
+                    {"role": "user", "content": "question"},
+                    {"role": "assistant", "content": "b" * 128},
+                ],
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source.jsonl"
+            output = Path(tmp) / "one.jsonl"
+            artifact = Path(tmp) / "prompt.json"
+            source.write_text("".join(json.dumps(row) + "\n" for row in rows))
+            index, selected, _ = create_data.create_single_sample(
+                str(source),
+                str(output),
+                model_path="unused",
+                max_length=150,
+                prompt_output_path=str(artifact),
+                require_untruncated=True,
+                processing_stack=fake_processing_stack(),
+            )
+            self.assertEqual(index, 1)
+            self.assertEqual(selected["id"], "selected")
+            self.assertLessEqual(
+                json.loads(artifact.read_text())["full_input_tokens"], 150
+            )
+
+
+class TestDominoOverfitGate(unittest.TestCase):
+    def test_passes_on_final_zero_loss_full_accuracy_and_checkpoint(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "train.log")
+            Path(log).write_text(
+                "[consumer] step 1 {'loss': 1.2, 'accuracy': 0.2}\n"
+                "[consumer] step 10 {'loss': 0.0, 'accuracy': 1.0}\n"
+            )
+            checkpoint = Path(tmp) / "consumer" / "run-step10"
+            checkpoint.mkdir(parents=True)
+            (checkpoint / "training_state.pt").touch()
+            result = check_overfit.check_overfit(
+                log,
+                str(Path(tmp) / "consumer"),
+                expected_step=10,
+                max_loss=1e-4,
+                min_accuracy=1.0,
+            )
+            self.assertTrue(result["passed"])
+            self.assertEqual(
+                result["checkpoint"], str(checkpoint / "training_state.pt")
+            )
+
+    def test_fails_when_any_gate_is_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = os.path.join(tmp, "train.log")
+            Path(log).write_text(
+                "[consumer] step 9 {'loss': 0.01, 'accuracy': 0.9999}\n"
+            )
+            with self.assertRaisesRegex(
+                ValueError, "final logged step.*final loss.*token accuracy.*checkpoint"
+            ):
+                check_overfit.check_overfit(
+                    log,
+                    os.path.join(tmp, "consumer"),
+                    expected_step=10,
+                    max_loss=1e-4,
+                    min_accuracy=1.0,
+                )
+
+
+class TestDominoOverfitLauncher(unittest.TestCase):
+    def test_shared_launcher_contract_and_syntax(self):
+        launcher = ROOT / "examples/disagg/run_domino_disagg_overfit_gate.sh"
+        subprocess.run(["bash", "-n", str(launcher)], check=True)
+        text = launcher.read_text()
+        for required in (
+            "${TARGET_MODEL_PATH:?set TARGET_MODEL_PATH to the target model}",
+            "${DRAFT_CONFIG_PATH:?set DRAFT_CONFIG_PATH to a Domino draft config}",
+            "${SOURCE_DATA_PATH:?set SOURCE_DATA_PATH to validated ShareGPT JSONL}",
+            "DISAGG_MAX_PROMPTS=${DISAGG_MAX_PROMPTS:-1}",
+            "DISAGG_MAX_STEPS=${DISAGG_MAX_STEPS:-400}",
+            "MIN_LOSS_TOKENS=$((2 * BLOCK_SIZE))",
+            '--reasoning-policy "$REASONING_POLICY"',
+            '--embedding-key "$EMBEDDING_KEY"',
+            '--mask-token-id "$MASK_TOKEN_ID"',
+            '--block-size "$BLOCK_SIZE"',
+            '--context-length "$MAX_LENGTH"',
+            '--prompt-output-path "$PROMPT_ARTIFACT_PATH"',
+            'if [[ -e "$WORK_DIR" ]]',
+            "scripts/gates/check_overfit_metrics.py",
+            'LATEST_CHECKPOINT="$CONSUMER_OUTPUT_DIR/$DISAGG_STORE_ID-step$DISAGG_MAX_STEPS"',
+            '[[ ! -f "$LATEST_CHECKPOINT/training_state.pt" ]]',
+        ):
+            self.assertIn(required, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds one model-parameterized correctness gate for Domino disaggregated
training and real SGLang DFLASH serving. Target-model differences are supplied
as launcher inputs; there are no per-model gate implementations or duplicated
test pipelines.

The workflow:

1. selects one structurally valid, untruncated `user`/`assistant` row using the
   real target tokenizer and SpecForge preprocessing;
2. overfits it through Mooncake, a real SGLang capture server, one producer,
   and the Domino DP trainer;
3. requires the exact final step, loss `<= 0.0001`, token accuracy `>= 1.0`,
   and a final checkpoint; and
4. exports that checkpoint and gates it through a real
   `/v1/chat/completions` request served with
   `--speculative-algorithm DFLASH`.

## One gate for every target model

Both launchers require model-specific values as inputs rather than embedding
model names in the implementation:

- `TARGET_MODEL_PATH`
- `DRAFT_CONFIG_PATH`
- `SOURCE_DATA_PATH`
- `CHAT_TEMPLATE`
- `EMBEDDING_KEY` / `LM_HEAD_KEY`
- `REASONING_POLICY` / `ENABLE_THINKING`
- context length and GPU topology

Reasoning and non-reasoning are parameter cases of the same selector, serving
client, and tests. The documentation gives Qwen3-8B and Qwen3.6-27B command
examples, but adding another target does not require another gate or test file.

## Why a draft config and checkpoint still exist

Domino is a DFLASH draft architecture with GRU logit correction, not a second
serving algorithm. `DRAFT_CONFIG_PATH` only describes the draft structure to
initialize and train (block size, mask token, captured layers, and projector);
the overfit gate does not depend on a pre-trained draft model.

Real speculative serving necessarily loads the checkpoint produced by the
overfit run, because the gate is checking whether that trained draft proposes a
target-matching block. SGLang exposes this common serving path as `DFLASH`.

## Serving assertions

The real-serving gate requires:

- `/server_info.speculative_algorithm == "DFLASH"`;
- no historical `reasoning_content` in the request;
- choice-level `choices[0].meta_info.spec_accept_length >= block_size`; and
- a generated target-prefix match of at least one block.

The request, response, server metadata, and assertions are written to
`serving_gate.json`.

## Scope

This PR has no merge dependency on the regeneration or multi-turn explosion
PRs. `SOURCE_DATA_PATH` is simply required to point to validated,
ShareGPT-compatible JSONL.

It does not add regeneration logic, multi-turn loss-mask plumbing, SGLang
server-core changes, or memory/FSDP/chunked-loss optimizations.

## Validation

- [x] generic gate tests: `15 passed`
- [x] Black check on changed Python files
- [x] Ruff/F401 check on changed Python files
- [x] shell syntax checks on both generic launchers
- [x] Qwen3.6 config JSON validation
- [x] Qwen3.6 real-tokenizer selector smoke: row 128, 925 rendered tokens,
      899 loss tokens, untruncated
- [x] `git diff --check`

### Existing real-serving evidence

The unchanged serving-client assertions previously passed with Qwen3-8B on a
real SGLang DFLASH server: `/v1/chat/completions`,
`speculative_algorithm = DFLASH`, choice-level `spec_accept_length = 16`, and
target-prefix match `16/16`.

A Qwen3.6-27B GPU overfit or real-serving end-to-end pass is not claimed here.
