### PR TITLE
refactor: define topology-free algorithm contracts

### DIFF
--- a/specforge/__init__.py
+++ b/specforge/__init__.py
@@ -1,4 +1,97 @@
-from .core import *  # noqa
-from .modeling import *  # noqa
+"""Public SpecForge package facade.
+
+Heavy model and algorithm modules are resolved lazily so lightweight contracts,
+configuration tools, and planners do not initialize PyTorch or optional model
+backends merely by importing the package.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Keep the historical package-level API visible to type checkers and IDEs
+    # without importing model implementations at runtime.
+    from .core import (  # noqa: F401
+        OnlineDFlashModel,
+        OnlineDominoModel,
+        OnlineDSparkModel,
+        OnlineEagle3Model,
+        OnlinePEagleModel,
+        QwenVLOnlineEagle3Model,
+    )
+    from .modeling import (  # noqa: F401
+        AutoDraftModelConfig,
+        AutoEagle3DraftModel,
+        CustomEagle3TargetEngine,
+        CustomEagle3TargetModel,
+        Eagle3TargetEngine,
+        HFEagle3TargetEngine,
+        HFEagle3TargetModel,
+        LlamaForCausalLMEagle3,
+        PEagleDraftModel,
+        SGLangEagle3TargetEngine,
+        SGLangEagle3TargetModel,
+        TargetEngine,
+        get_eagle3_target_model,
+        get_target_engine,
+    )
+
+_LAZY_MODULES = {
+    "core": "specforge.core",
+    "modeling": "specforge.modeling",
+}
+
+_LAZY_EXPORTS = {
+    # Algorithm wrappers historically re-exported by ``specforge.core``.
+    "OnlineDFlashModel": ("specforge.core", "OnlineDFlashModel"),
+    "OnlineDominoModel": ("specforge.core", "OnlineDominoModel"),
+    "OnlineDSparkModel": ("specforge.core", "OnlineDSparkModel"),
+    "OnlineEagle3Model": ("specforge.core", "OnlineEagle3Model"),
+    "OnlinePEagleModel": ("specforge.core", "OnlinePEagleModel"),
+    "QwenVLOnlineEagle3Model": ("specforge.core", "QwenVLOnlineEagle3Model"),
+    # Modeling facade retained for direct ``from specforge import Name`` users.
+    "AutoDraftModelConfig": ("specforge.modeling", "AutoDraftModelConfig"),
+    "AutoEagle3DraftModel": ("specforge.modeling", "AutoEagle3DraftModel"),
+    "CustomEagle3TargetEngine": (
+        "specforge.modeling",
+        "CustomEagle3TargetEngine",
+    ),
+    "CustomEagle3TargetModel": ("specforge.modeling", "CustomEagle3TargetModel"),
+    "Eagle3TargetEngine": ("specforge.modeling", "Eagle3TargetEngine"),
+    "HFEagle3TargetEngine": ("specforge.modeling", "HFEagle3TargetEngine"),
+    "HFEagle3TargetModel": ("specforge.modeling", "HFEagle3TargetModel"),
+    "LlamaForCausalLMEagle3": ("specforge.modeling", "LlamaForCausalLMEagle3"),
+    "PEagleDraftModel": ("specforge.modeling", "PEagleDraftModel"),
+    "SGLangEagle3TargetEngine": (
+        "specforge.modeling",
+        "SGLangEagle3TargetEngine",
+    ),
+    "SGLangEagle3TargetModel": ("specforge.modeling", "SGLangEagle3TargetModel"),
+    "TargetEngine": ("specforge.modeling", "TargetEngine"),
+    "get_eagle3_target_model": (
+        "specforge.modeling",
+        "get_eagle3_target_model",
+    ),
+    "get_target_engine": ("specforge.modeling", "get_target_engine"),
+}
+
+
+def __getattr__(name: str) -> object:
+    module_name = _LAZY_MODULES.get(name)
+    if module_name is not None:
+        value = import_module(module_name)
+    else:
+        export = _LAZY_EXPORTS.get(name)
+        if export is None:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        module_name, attribute = export
+        value = getattr(import_module(module_name), attribute)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals(), *_LAZY_MODULES, *_LAZY_EXPORTS})
+
 
 __all__ = ["modeling", "core"]

--- a/specforge/algorithms/__init__.py
+++ b/specforge/algorithms/__init__.py
@@ -1,0 +1,26 @@
+"""Algorithm-owned contracts for speculative draft training.
+
+The package intentionally contains no runtime, deployment, or model-loading
+policy.  Concrete algorithms register their contracts with the application
+composition root; transport and process topology are resolved elsewhere.
+"""
+
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftArchitectureContract,
+    DraftConfigResolver,
+    FeatureContract,
+    FeatureMode,
+)
+from specforge.algorithms.registry import AlgorithmRegistry
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmRegistry",
+    "AlgorithmSpec",
+    "DraftArchitectureContract",
+    "DraftConfigResolver",
+    "FeatureContract",
+    "FeatureMode",
+]

--- a/specforge/algorithms/contracts.py
+++ b/specforge/algorithms/contracts.py
@@ -1,0 +1,254 @@
+"""Topology-free contracts owned by speculative training algorithms.
+
+These value objects describe what an algorithm consumes and supports.  They do
+not describe where features come from, which process owns a model, or how a run
+is launched.  Keeping those concerns out of the algorithm contract lets the
+application layer resolve one deployment plan without creating another family
+of topology-specific builders.
+"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import FrozenSet, Iterable, Mapping, Protocol, Tuple
+
+_ALGORITHM_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _freeze_config_value(value: object) -> object:
+    """Detach and recursively freeze common config container types."""
+
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze_config_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_config_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(_freeze_config_value(item) for item in value)
+    return deepcopy(value)
+
+
+def _normalized_names(
+    values: Iterable[str],
+    *,
+    field_name: str,
+    allow_empty: bool = False,
+) -> FrozenSet[str]:
+    if isinstance(values, str):
+        raise TypeError(f"{field_name} must be an iterable of names, not a string")
+    normalized = frozenset(values)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{field_name} must not be empty")
+    invalid = [
+        repr(value)
+        for value in normalized
+        if not isinstance(value, str) or not value or value.strip() != value
+    ]
+    if invalid:
+        raise ValueError(
+            f"{field_name} must contain non-empty names without surrounding "
+            f"whitespace, got {', '.join(sorted(invalid))}"
+        )
+    return normalized
+
+
+class FeatureMode(str, Enum):
+    """How algorithm-ready target features are consumed.
+
+    The values describe data semantics, not placement.  In particular,
+    ``STREAMING`` does not imply colocated or disaggregated execution.
+    """
+
+    OFFLINE = "offline"
+    STREAMING = "streaming"
+
+
+class DraftConfigResolver(Protocol):
+    """Validate and resolve an algorithm-specific draft configuration.
+
+    The return type is deliberately opaque.  Algorithms may describe arbitrary
+    draft structures, including mixed attention stacks, without expanding this
+    shared contract every time their architecture evolves.
+    """
+
+    def __call__(self, raw_config: Mapping[str, object], /) -> object: ...
+
+
+@dataclass(frozen=True)
+class DraftArchitectureContract:
+    """Algorithm-owned resolver for one family of draft architectures."""
+
+    architecture: str
+    resolve_config: DraftConfigResolver
+
+    def __post_init__(self) -> None:
+        if not self.architecture or self.architecture.strip() != self.architecture:
+            raise ValueError(
+                "architecture must be a non-empty name without surrounding whitespace"
+            )
+        if not callable(self.resolve_config):
+            raise TypeError("resolve_config must be callable")
+
+    def resolve(self, raw_config: Mapping[str, object]) -> object:
+        """Resolve a read-only copy of an algorithm-specific config mapping."""
+
+        if not isinstance(raw_config, Mapping):
+            raise TypeError("raw_config must be a mapping")
+        read_only_config = _freeze_config_value(raw_config)
+        if not isinstance(read_only_config, Mapping):  # pragma: no cover - invariant
+            raise TypeError("raw_config did not resolve to a mapping")
+        resolved = self.resolve_config(read_only_config)
+        if resolved is None:
+            raise ValueError(
+                f"draft config resolver for {self.architecture!r} returned None"
+            )
+        return resolved
+
+
+@dataclass(frozen=True)
+class FeatureContract:
+    """Tensor-level input contract for one algorithm feature mode."""
+
+    mode: FeatureMode
+    required_tensors: FrozenSet[str]
+    optional_tensors: FrozenSet[str] = frozenset()
+    allowed_target_representations: FrozenSet[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        try:
+            mode = FeatureMode(self.mode)
+        except ValueError as exc:
+            raise ValueError(f"unsupported feature mode {self.mode!r}") from exc
+        required = _normalized_names(
+            self.required_tensors,
+            field_name="required_tensors",
+        )
+        optional = _normalized_names(
+            self.optional_tensors,
+            field_name="optional_tensors",
+            allow_empty=True,
+        )
+        representations = _normalized_names(
+            self.allowed_target_representations,
+            field_name="allowed_target_representations",
+            allow_empty=True,
+        )
+        overlap = required & optional
+        if overlap:
+            raise ValueError(
+                "required_tensors and optional_tensors must be disjoint, got "
+                f"{sorted(overlap)}"
+            )
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "required_tensors", required)
+        object.__setattr__(self, "optional_tensors", optional)
+        object.__setattr__(self, "allowed_target_representations", representations)
+
+
+@dataclass(frozen=True)
+class AlgorithmCapabilities:
+    """Algorithm constraints independent of deployment and feature transport."""
+
+    modalities: FrozenSet[str]
+    attention_backends: FrozenSet[str]
+    required_batch_size: int | None = None
+    supports_compact_teacher: bool = False
+    supports_vocab_mapping: bool = False
+
+    def __post_init__(self) -> None:
+        modalities = _normalized_names(self.modalities, field_name="modalities")
+        attention_backends = _normalized_names(
+            self.attention_backends,
+            field_name="attention_backends",
+        )
+        if self.required_batch_size is not None and (
+            isinstance(self.required_batch_size, bool)
+            or not isinstance(self.required_batch_size, int)
+            or self.required_batch_size <= 0
+        ):
+            raise ValueError("required_batch_size must be a positive integer or None")
+        for field_name in ("supports_compact_teacher", "supports_vocab_mapping"):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+        object.__setattr__(self, "modalities", modalities)
+        object.__setattr__(self, "attention_backends", attention_backends)
+
+
+@dataclass(frozen=True)
+class AlgorithmSpec:
+    """Complete topology-free contract for one registered algorithm."""
+
+    name: str
+    draft: DraftArchitectureContract
+    feature_contracts: Tuple[FeatureContract, ...]
+    capabilities: AlgorithmCapabilities
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not _ALGORITHM_NAME.fullmatch(self.name):
+            raise ValueError(
+                "algorithm name must start with a lowercase letter and contain "
+                "only lowercase letters, digits, '_' or '-'"
+            )
+        if not isinstance(self.draft, DraftArchitectureContract):
+            raise TypeError("draft must be a DraftArchitectureContract")
+        if not isinstance(self.capabilities, AlgorithmCapabilities):
+            raise TypeError("capabilities must be AlgorithmCapabilities")
+        feature_contracts = tuple(self.feature_contracts)
+        if not feature_contracts:
+            raise ValueError("feature_contracts must not be empty")
+        invalid = [
+            type(contract).__name__
+            for contract in feature_contracts
+            if not isinstance(contract, FeatureContract)
+        ]
+        if invalid:
+            raise TypeError(
+                "feature_contracts must contain FeatureContract values, got "
+                f"{invalid}"
+            )
+        modes = [contract.mode for contract in feature_contracts]
+        if len(modes) != len(set(modes)):
+            duplicates = sorted(
+                mode.value for mode in set(modes) if modes.count(mode) > 1
+            )
+            raise ValueError(
+                f"feature_contracts contains duplicate modes: {duplicates}"
+            )
+        object.__setattr__(self, "feature_contracts", feature_contracts)
+
+    @property
+    def feature_modes(self) -> FrozenSet[FeatureMode]:
+        """Supported modes derived from the contracts, never duplicated."""
+
+        return frozenset(contract.mode for contract in self.feature_contracts)
+
+    def feature_contract(self, mode: FeatureMode | str) -> FeatureContract:
+        """Return the contract for ``mode`` or raise an actionable ``KeyError``."""
+
+        try:
+            resolved_mode = FeatureMode(mode)
+        except ValueError as exc:
+            raise KeyError(f"unknown feature mode {mode!r}") from exc
+        for contract in self.feature_contracts:
+            if contract.mode is resolved_mode:
+                return contract
+        supported = sorted(item.value for item in self.feature_modes)
+        raise KeyError(
+            f"algorithm {self.name!r} does not support {resolved_mode.value!r}; "
+            f"supported modes: {supported}"
+        )
+
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmSpec",
+    "DraftArchitectureContract",
+    "DraftConfigResolver",
+    "FeatureContract",
+    "FeatureMode",
+]

--- a/specforge/algorithms/registry.py
+++ b/specforge/algorithms/registry.py
@@ -1,0 +1,71 @@
+"""Explicit, instance-owned registry for algorithm contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Tuple
+
+from specforge.algorithms.contracts import AlgorithmSpec
+
+
+@dataclass(frozen=True, init=False)
+class AlgorithmRegistry:
+    """Immutable catalog assembled explicitly by the composition root.
+
+    Importing this module never registers builtins or imports algorithm
+    implementations.  ``with_spec`` returns a new registry, so tests and
+    independent applications cannot mutate one another through module state.
+    """
+
+    _specs: Tuple[AlgorithmSpec, ...]
+
+    def __init__(self, specs: Iterable[AlgorithmSpec] = ()) -> None:
+        resolved_specs = tuple(specs)
+        invalid = [
+            type(spec).__name__
+            for spec in resolved_specs
+            if not isinstance(spec, AlgorithmSpec)
+        ]
+        if invalid:
+            raise TypeError(f"registry values must be AlgorithmSpec, got {invalid}")
+
+        names = [spec.name for spec in resolved_specs]
+        duplicates = sorted(name for name in set(names) if names.count(name) > 1)
+        if duplicates:
+            raise ValueError(f"duplicate algorithm registrations: {duplicates}")
+
+        object.__setattr__(
+            self,
+            "_specs",
+            tuple(sorted(resolved_specs, key=lambda spec: spec.name)),
+        )
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        return tuple(spec.name for spec in self._specs)
+
+    @property
+    def specs(self) -> Tuple[AlgorithmSpec, ...]:
+        return self._specs
+
+    def resolve(self, name: str) -> AlgorithmSpec:
+        for spec in self._specs:
+            if spec.name == name:
+                return spec
+        raise KeyError(
+            f"unknown algorithm {name!r}; registered algorithms: {list(self.names)}"
+        )
+
+    def with_spec(self, spec: AlgorithmSpec) -> "AlgorithmRegistry":
+        """Return a new registry containing ``spec``; duplicates fail closed."""
+
+        return AlgorithmRegistry((*self._specs, spec))
+
+    def __iter__(self) -> Iterator[AlgorithmSpec]:
+        return iter(self._specs)
+
+    def __len__(self) -> int:
+        return len(self._specs)
+
+
+__all__ = ["AlgorithmRegistry"]

--- a/tests/test_algorithms/__init__.py
+++ b/tests/test_algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for topology-free algorithm contracts."""

--- a/tests/test_algorithms/test_contracts.py
+++ b/tests/test_algorithms/test_contracts.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError
+
+from specforge.algorithms import (
+    AlgorithmCapabilities,
+    AlgorithmRegistry,
+    AlgorithmSpec,
+    DraftArchitectureContract,
+    FeatureContract,
+    FeatureMode,
+)
+
+
+def _resolve_mixed_attention(raw_config):
+    return tuple(layer["attention"] for layer in raw_config["layers"])
+
+
+def _spec(name: str = "eagle3") -> AlgorithmSpec:
+    return AlgorithmSpec(
+        name=name,
+        draft=DraftArchitectureContract(
+            architecture=f"{name}-draft",
+            resolve_config=_resolve_mixed_attention,
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.OFFLINE,
+                required_tensors={"input_ids", "hidden_states", "loss_mask"},
+                optional_tensors={"position_ids"},
+                allowed_target_representations={"hidden_state"},
+            ),
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                required_tensors={"input_ids", "hidden_states", "loss_mask"},
+                allowed_target_representations={"hidden_state", "logits"},
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            modalities={"text", "vision_language"},
+            attention_backends={"sdpa", "flex_attention"},
+            supports_compact_teacher=True,
+            supports_vocab_mapping=True,
+        ),
+    )
+
+
+class AlgorithmContractTest(unittest.TestCase):
+    def test_draft_structure_is_algorithm_owned_and_opaque(self):
+        spec = _spec()
+
+        resolved = spec.draft.resolve(
+            {
+                "layers": [
+                    {"attention": "swa"},
+                    {"attention": "swa"},
+                    {"attention": "full"},
+                ]
+            }
+        )
+
+        self.assertEqual(("swa", "swa", "full"), resolved)
+
+    def test_draft_resolver_receives_a_read_only_mapping(self):
+        def mutate(raw_config):
+            raw_config["layers"][0]["attention"] = "full"
+
+        contract = DraftArchitectureContract("draft", mutate)
+        raw_config = {"layers": [{"attention": "swa"}]}
+
+        with self.assertRaises(TypeError):
+            contract.resolve(raw_config)
+        self.assertEqual("swa", raw_config["layers"][0]["attention"])
+
+    def test_feature_contract_normalizes_names_and_derives_modes(self):
+        spec = _spec()
+
+        offline = spec.feature_contract("offline")
+
+        self.assertIsInstance(offline.required_tensors, frozenset)
+        self.assertEqual(
+            frozenset({FeatureMode.OFFLINE, FeatureMode.STREAMING}),
+            spec.feature_modes,
+        )
+
+    def test_required_and_optional_tensors_must_be_disjoint(self):
+        with self.assertRaisesRegex(ValueError, "must be disjoint"):
+            FeatureContract(
+                mode=FeatureMode.OFFLINE,
+                required_tensors={"input_ids"},
+                optional_tensors={"input_ids"},
+            )
+
+    def test_algorithm_has_at_most_one_contract_per_mode(self):
+        contract = FeatureContract(
+            mode=FeatureMode.OFFLINE,
+            required_tensors={"input_ids"},
+        )
+
+        with self.assertRaisesRegex(ValueError, "duplicate modes"):
+            AlgorithmSpec(
+                name="eagle3",
+                draft=DraftArchitectureContract("draft", lambda raw: raw),
+                feature_contracts=(contract, contract),
+                capabilities=AlgorithmCapabilities(
+                    modalities={"text"},
+                    attention_backends={"sdpa"},
+                ),
+            )
+
+    def test_algorithm_rejects_untyped_contract_parts(self):
+        with self.assertRaisesRegex(TypeError, "DraftArchitectureContract"):
+            AlgorithmSpec(
+                name="eagle3",
+                draft=object(),
+                feature_contracts=(_spec().feature_contract(FeatureMode.OFFLINE),),
+                capabilities=_spec().capabilities,
+            )
+
+    def test_required_batch_size_is_positive(self):
+        with self.assertRaisesRegex(ValueError, "positive integer"):
+            AlgorithmCapabilities(
+                modalities={"text"},
+                attention_backends={"sdpa"},
+                required_batch_size=0,
+            )
+
+    def test_contracts_are_immutable(self):
+        spec = _spec()
+
+        with self.assertRaises(FrozenInstanceError):
+            spec.name = "dflash"
+
+    def test_missing_feature_mode_reports_supported_modes(self):
+        offline_only = _spec().__class__(
+            name="offline_only",
+            draft=_spec().draft,
+            feature_contracts=(_spec().feature_contract(FeatureMode.OFFLINE),),
+            capabilities=_spec().capabilities,
+        )
+
+        with self.assertRaisesRegex(KeyError, r"supported modes: \['offline'\]"):
+            offline_only.feature_contract(FeatureMode.STREAMING)
+
+
+class AlgorithmRegistryTest(unittest.TestCase):
+    def test_registry_is_deterministic_and_explicit(self):
+        registry = AlgorithmRegistry((_spec("peagle"), _spec("eagle3")))
+
+        self.assertEqual(("eagle3", "peagle"), registry.names)
+        self.assertEqual("peagle", registry.resolve("peagle").name)
+        self.assertEqual(["eagle3", "peagle"], [spec.name for spec in registry])
+
+    def test_registry_instances_do_not_share_state(self):
+        empty = AlgorithmRegistry()
+        populated = empty.with_spec(_spec())
+
+        self.assertEqual((), empty.names)
+        self.assertEqual(("eagle3",), populated.names)
+
+    def test_duplicate_registration_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "duplicate algorithm"):
+            AlgorithmRegistry((_spec(), _spec()))
+
+    def test_unknown_algorithm_lists_registered_names(self):
+        registry = AlgorithmRegistry((_spec("eagle3"),))
+
+        with self.assertRaisesRegex(KeyError, r"registered algorithms: \['eagle3'\]"):
+            registry.resolve("missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_architecture/__init__.py
+++ b/tests/test_architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Static package-boundary tests."""

--- a/tests/test_architecture/test_package_dependencies.py
+++ b/tests/test_architecture/test_package_dependencies.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "specforge"
+
+
+@dataclass(frozen=True, order=True)
+class ImportEdge:
+    importer: str
+    imported: str
+    path: str
+    line: int
+
+
+def _module_name(path: Path) -> tuple[str, bool]:
+    relative = path.relative_to(REPO_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    is_package = parts[-1] == "__init__"
+    if is_package:
+        parts.pop()
+    return ".".join(parts), is_package
+
+
+KNOWN_INTERNAL_MODULES = frozenset(
+    _module_name(path)[0] for path in PACKAGE_ROOT.rglob("*.py")
+)
+
+
+def _relative_module(
+    importer: str,
+    *,
+    is_package: bool,
+    level: int,
+    module: str | None,
+) -> str:
+    package = importer if is_package else importer.rpartition(".")[0]
+    parts = package.split(".") if package else []
+    ascend = level - 1
+    if ascend > len(parts):
+        return ""
+    base = parts[: len(parts) - ascend]
+    if module:
+        base.extend(module.split("."))
+    return ".".join(base)
+
+
+def _literal_dynamic_import(node: ast.Call) -> str | None:
+    if not node.args or not isinstance(node.args[0], ast.Constant):
+        return None
+    module = node.args[0].value
+    if not isinstance(module, str):
+        return None
+    function = node.func
+    if isinstance(function, ast.Name) and function.id == "__import__":
+        return module
+    if isinstance(function, ast.Name) and function.id == "import_module":
+        return module
+    if (
+        isinstance(function, ast.Attribute)
+        and function.attr == "import_module"
+        and isinstance(function.value, ast.Name)
+        and function.value.id == "importlib"
+    ):
+        return module
+    return None
+
+
+def _imports(path: Path) -> Iterator[ImportEdge]:
+    importer, is_package = _module_name(path)
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+    relative_path = str(path.relative_to(REPO_ROOT))
+    for node in ast.walk(tree):
+        imported_modules: Iterable[str] = ()
+        if isinstance(node, ast.Import):
+            imported_modules = (alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                base = _relative_module(
+                    importer,
+                    is_package=is_package,
+                    level=node.level,
+                    module=node.module,
+                )
+            else:
+                base = node.module or ""
+            modules = [base] if base else []
+            if base:
+                candidates = (
+                    f"{base}.{alias.name}" for alias in node.names if alias.name != "*"
+                )
+                modules.extend(
+                    candidate
+                    for candidate in candidates
+                    if candidate in KNOWN_INTERNAL_MODULES
+                )
+            imported_modules = modules
+        elif isinstance(node, ast.Call):
+            dynamic = _literal_dynamic_import(node)
+            imported_modules = (dynamic,) if dynamic else ()
+        else:
+            continue
+
+        for imported in imported_modules:
+            if imported:
+                yield ImportEdge(
+                    importer=importer,
+                    imported=imported,
+                    path=relative_path,
+                    line=node.lineno,
+                )
+
+
+def _all_edges() -> set[ImportEdge]:
+    return {
+        edge for path in sorted(PACKAGE_ROOT.rglob("*.py")) for edge in _imports(path)
+    }
+
+
+def _literal_assignment(path: Path, name: str):
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    raise AssertionError(f"{path.relative_to(REPO_ROOT)} does not define {name}")
+
+
+def _type_checking_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+    names = set()
+    for node in tree.body:
+        if not (
+            isinstance(node, ast.If)
+            and isinstance(node.test, ast.Name)
+            and node.test.id == "TYPE_CHECKING"
+        ):
+            continue
+        for statement in node.body:
+            if isinstance(statement, ast.ImportFrom):
+                names.update(alias.asname or alias.name for alias in statement.names)
+    return names
+
+
+def _matches(module: str, prefix: str) -> bool:
+    return module == prefix or module.startswith(prefix + ".")
+
+
+FORBIDDEN_DEPENDENCIES = {
+    "specforge.algorithms": {
+        "specforge.application",
+        "specforge.config",
+        "specforge.core",
+        "specforge.eval",
+        "specforge.inference",
+        "specforge.launch",
+        "specforge.runtime",
+        "specforge.training",
+    },
+    "specforge.config": {
+        "specforge.algorithms",
+        "specforge.application",
+        "specforge.eval",
+        "specforge.inference",
+        "specforge.launch",
+        "specforge.runtime",
+        "specforge.training",
+    },
+    "specforge.runtime": {
+        "specforge.algorithms",
+        "specforge.application",
+        "specforge.config",
+        "specforge.eval",
+        "specforge.training",
+    },
+    "specforge.training": {
+        "specforge.application",
+        "specforge.config",
+        "specforge.launch",
+    },
+}
+
+
+# Existing main-branch debt.  The equality assertion makes this list
+# exhaustible: removing the import without removing its exception fails CI.
+TEMPORARY_CROSS_PLANE_EXCEPTIONS = {
+    (
+        "specforge.runtime.control_plane.controller",
+        "specforge.runtime.data_plane.sample_ref_queue",
+    ): "replace the concrete queue import with a runtime contract port",
+}
+
+
+class PackageDependencyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.edges = _all_edges()
+
+    def test_forbidden_reverse_dependencies_are_absent(self):
+        violations = []
+        for edge in self.edges:
+            for importer_prefix, forbidden_prefixes in FORBIDDEN_DEPENDENCIES.items():
+                if not _matches(edge.importer, importer_prefix):
+                    continue
+                if any(
+                    _matches(edge.imported, prefix) for prefix in forbidden_prefixes
+                ):
+                    violations.append(
+                        f"{edge.path}:{edge.line}: {edge.importer} -> {edge.imported}"
+                    )
+        self.assertEqual([], sorted(violations), "\n".join(sorted(violations)))
+
+    def test_application_is_a_top_level_dependency_boundary(self):
+        violations = [
+            f"{edge.path}:{edge.line}: {edge.importer} -> {edge.imported}"
+            for edge in self.edges
+            if _matches(edge.imported, "specforge.application")
+            and not (
+                _matches(edge.importer, "specforge.application")
+                or edge.importer == "specforge.cli"
+            )
+        ]
+        self.assertEqual([], sorted(violations), "\n".join(sorted(violations)))
+
+    def test_control_and_data_plane_cross_imports_are_explicit_debt(self):
+        observed = {
+            (edge.importer, edge.imported)
+            for edge in self.edges
+            if (
+                _matches(edge.importer, "specforge.runtime.control_plane")
+                and _matches(edge.imported, "specforge.runtime.data_plane")
+            )
+            or (
+                _matches(edge.importer, "specforge.runtime.data_plane")
+                and _matches(edge.imported, "specforge.runtime.control_plane")
+            )
+        }
+        self.assertEqual(
+            set(TEMPORARY_CROSS_PLANE_EXCEPTIONS),
+            observed,
+            "cross-plane imports changed; remove a stale exception or redesign "
+            "the new dependency behind a runtime contract",
+        )
+
+    def test_algorithm_contract_modules_are_stdlib_only(self):
+        checked = {
+            "specforge.algorithms",
+            "specforge.algorithms.contracts",
+            "specforge.algorithms.registry",
+        }
+        allowed_roots = {
+            "__future__",
+            "copy",
+            "dataclasses",
+            "enum",
+            "importlib",
+            "re",
+            "specforge",
+            "types",
+            "typing",
+        }
+        violations = []
+        for edge in self.edges:
+            if edge.importer not in checked:
+                continue
+            root = edge.imported.split(".", 1)[0]
+            allowed_specforge_import = _matches(edge.imported, "specforge.algorithms")
+            if root not in allowed_roots or (
+                root == "specforge" and not allowed_specforge_import
+            ):
+                violations.append(
+                    f"{edge.path}:{edge.line}: {edge.importer} -> {edge.imported}"
+                )
+        self.assertEqual([], sorted(violations), "\n".join(sorted(violations)))
+
+    def test_algorithm_contract_import_does_not_initialize_torch(self):
+        code = (
+            "import sys; import specforge.algorithms; "
+            "assert 'torch' not in sys.modules, sorted(sys.modules)"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+
+    def test_lazy_package_facade_preserves_existing_direct_exports(self):
+        facade = PACKAGE_ROOT / "__init__.py"
+        lazy_exports = _literal_assignment(facade, "_LAZY_EXPORTS")
+        core_exports = _literal_assignment(
+            PACKAGE_ROOT / "core" / "__init__.py", "__all__"
+        )
+        modeling_exports = _literal_assignment(
+            PACKAGE_ROOT / "modeling" / "__init__.py", "__all__"
+        )
+
+        self.assertEqual(
+            set(core_exports) | set(modeling_exports),
+            set(lazy_exports),
+        )
+        self.assertEqual(
+            set(lazy_exports),
+            _type_checking_imports(facade),
+            "runtime-lazy exports and TYPE_CHECKING exports must stay in sync",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This is PR 1 of the reviewable unified-runtime cleanup stack. It establishes
the architecture contracts and dependency guardrails before any runtime
behavior is moved or deleted.

- add immutable, topology-free algorithm contracts for draft architecture,
  feature requirements, and capabilities
- keep draft structure algorithm-owned and opaque, including mixed attention
  layouts such as `SWA + SWA + full attention`
- add an explicit, instance-owned algorithm registry with no import-time global
  registration
- add package dependency tests that detect direct, relative, dynamic, and
  nested `from package import submodule` imports
- make current control-plane/data-plane cross-import debt explicit and
  exhaustible
- lazily preserve the historical package-level model exports so lightweight
  imports do not initialize PyTorch, while retaining `TYPE_CHECKING` visibility
  for IDEs and static analyzers

## Why this is separate

PR #678 combined configuration migration, object composition, runtime topology,
algorithm movement, examples, documentation, and cleanup. This first layer is
intentionally additive and does not change launch or training behavior. It gives
later stacked PRs enforceable dependency directions instead of locking the
transitional five-builder API.

Planned follow-ups will:

1. introduce one canonical resolved run plan and one application composition root
2. collapse online execution onto the SGLang server producer/consumer pipeline
   and remove the separate colocated-online runtime path
3. inject feature contracts into runtime transport, migrate implementations from
   `core/` to `algorithms/<name>/`, and then remove legacy code/tests
4. consolidate YAML launch examples and documentation, including
   online/offline/disaggregated smoke coverage

## Validation

Local:

- `python -m unittest tests.test_algorithms.test_contracts tests.test_architecture.test_package_dependencies` — 19 passed
- pre-commit on all changed files — passed
- compileall on changed Python modules — passed

H200 devbox, exact commit `2a11578b50edd6306f67339397e83ccc48413554`:

- new algorithm-contract and architecture tests — 19 passed
- existing CLI-config, strategy-registry, and export regression tests — 20 passed
- verified `import specforge` and `import specforge.algorithms` do not load `torch`
- verified legacy `AutoDraftModelConfig`, `OnlineEagle3Model`, and VLM
  `QwenVLOnlineEagle3Model` exports still resolve

## Scope / compatibility

No training, inference, launch, YAML, benchmark, or example behavior is removed
in this PR. The full GPU strategy and disaggregated end-to-end matrix belongs to
the behavior-changing follow-up PRs.
