### PR TITLE
[PR678 stack 01/14] feat(config): add typed topology-aware run schema

### DIFF
--- a/benchmarks/benchmarker/humaneval.py
+++ b/benchmarks/benchmarker/humaneval.py
@@ -49,9 +49,11 @@ def check_code_passes_tests(code: str, test_code: str, entry_point: str) -> bool
         namespace = {}
         # Execute the code (function definition)
         exec(code, namespace)
-        # Execute the test code (which contains assertions)
-        # If no exception is raised, the tests pass
+        # HumanEval test payloads define check(candidate); they do not invoke it.
         exec(test_code, namespace)
+        checker = namespace.get("check")
+        if checker is not None:
+            checker(namespace[entry_point])
         return True
     except AssertionError:
         # Assertion failed - test didn't pass
@@ -83,7 +85,8 @@ class HumanEvalBenchmarker(Benchmarker):
             if self.num_samples is not None and idx >= self.num_samples:
                 break
 
-            questions.append({"question": q["prompt"]})
+            prompt = q["prompt"]
+            questions.append({"question": prompt})
 
             # Store test case and entry point for evaluation
             test_code = q.get("test", "")
@@ -95,6 +98,7 @@ class HumanEvalBenchmarker(Benchmarker):
             canonical_solution = q.get("canonical_solution", "")
             labels.append(
                 {
+                    "prompt": prompt,
                     "test": test_code,
                     "entry_point": entry_point,
                     "canonical_solution": canonical_solution,
@@ -123,13 +127,11 @@ class HumanEvalBenchmarker(Benchmarker):
         correct = 0
         valid_count = 0
 
-        for i, (pred, label) in enumerate(zip(predictions, labels)):
+        for pred, label in zip(predictions, labels):
             if label is not None and isinstance(label, dict):
                 valid_count += 1
                 if pred is not None:
                     try:
-                        # Get the prompt (function signature and docstring)
-                        prompt = self.questions[i]["question"]
                         entry_point = label.get("entry_point", "")
 
                         # The prompt contains the function signature (e.g., "def function_name(...):")
@@ -153,12 +155,14 @@ class HumanEvalBenchmarker(Benchmarker):
                                 full_code = pred_str
                             else:
                                 # Different function or no match, combine with prompt
+                                prompt = label.get("prompt", "")
                                 full_code = prompt + "\n" + pred_str
                         elif pred_str.startswith("def "):
                             # Has function definition but we can't verify entry_point, use as-is
                             full_code = pred_str
                         else:
                             # Generated code is just the body, combine with prompt
+                            prompt = label.get("prompt", "")
                             full_code = prompt + "\n" + pred_str
 
                         # Check if code passes tests
@@ -168,9 +172,8 @@ class HumanEvalBenchmarker(Benchmarker):
                             full_code, test_code, entry_point
                         ):
                             correct += 1
-                    except Exception as e:
+                    except Exception:
                         # If evaluation fails, consider it incorrect
-                        # Uncomment for debugging: print(f"Error evaluating code {i}: {e}")
                         pass
 
         return correct / valid_count if valid_count > 0 else 0.0

--- a/specforge/config/schema.py
+++ b/specforge/config/schema.py
@@ -6,13 +6,12 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-"""The typed run config behind the ``specforge`` CLI.
+"""The typed run config behind the single ``specforge train`` entry point.
 
-One validated :class:`Config` replaces the argparse-style launch knobs: it maps
-1:1 onto what the DataFlow launch builders (``specforge.launch``) and the domain
-``Trainer`` actually accept — no aspirational fields. YAML or JSON on disk;
-dotted CLI overrides (``training.learning_rate=1e-4``) re-validate through the
-same schema.
+The schema intentionally describes a *run*, not a legacy Python script.  Model
+assembly, prompt preparation, topology and the strategy-specific objective live
+behind this one validated contract.  YAML or JSON on disk and dotted CLI
+overrides both re-validate through the same schema.
 """
 
 from __future__ import annotations
@@ -20,10 +19,14 @@ from __future__ import annotations
 import json
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class ModelConfig(BaseModel):
+class StrictConfigModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ModelConfig(StrictConfigModel):
     target_model_path: str
     draft_model_config: str
     target_backend: Literal["sglang", "hf", "custom"] = "sglang"
@@ -37,65 +40,255 @@ class ModelConfig(BaseModel):
     #: aux hidden-state layer ids to capture (None = backend defaults).
     aux_hidden_state_layer_ids: Optional[List[int]] = None
     torch_dtype: Literal["bfloat16", "float16", "float32"] = "bfloat16"
+    cache_dir: Optional[str] = None
+    #: DFlash-family and P-EAGLE mask token. ``None`` resolves it from the
+    #: draft config, then the target tokenizer.
+    mask_token_id: Optional[int] = None
+    #: SGLang target-engine tuning. Ignored by hf/custom backends.
+    sglang_attention_backend: str = "flashinfer"
+    sglang_mem_fraction_static: float = Field(default=0.4, gt=0.0, le=1.0)
+    sglang_context_length: Optional[int] = Field(default=None, gt=0)
+    sglang_enable_nccl_nvls: bool = False
+    sglang_enable_symm_mem: bool = False
+    sglang_enable_torch_compile: bool = False
+    sglang_enable_dp_attention: bool = False
+    sglang_enable_dp_lm_head: bool = False
+    sglang_ep_size: int = Field(default=1, gt=0)
+    sglang_max_running_requests: Optional[int] = Field(default=None, gt=0)
+    sglang_max_total_tokens: Optional[int] = Field(default=None, gt=0)
 
 
-class DataConfig(BaseModel):
-    #: online mode — pre-tokenized prompts jsonl ({"input_ids": [...], "loss_mask": [...]}).
+class DataConfig(StrictConfigModel):
+    #: online mode — raw conversation JSON/JSONL.
+    train_data_path: str = ""
+    #: online mode — already-tokenized JSONL records.
     prompts_path: str = ""
     #: offline mode — directory of precomputed hidden-state .ckpt files.
     hidden_states_path: str = ""
-    max_length: int = 2048
+    max_length: int = Field(default=2048, gt=0)
+    chat_template: str = "llama3"
+    is_preformatted: bool = False
+    train_only_last_turn: bool = False
+    build_dataset_num_proc: int = Field(default=8, gt=0)
+    cache_dir: str = "./cache"
+    cache_key: Optional[str] = None
+    max_prompts: Optional[int] = Field(default=None, ge=0)
 
     @model_validator(mode="after")
     def _exactly_one_source(self):
-        if bool(self.prompts_path) == bool(self.hidden_states_path):
+        sources = [
+            bool(self.train_data_path),
+            bool(self.prompts_path),
+            bool(self.hidden_states_path),
+        ]
+        if sum(sources) != 1:
             raise ValueError(
-                "set exactly one of data.prompts_path (online) or "
-                "data.hidden_states_path (offline)"
+                "set exactly one of data.train_data_path (raw online data), "
+                "data.prompts_path (pre-tokenized online data), or "
+                "data.hidden_states_path (offline features)"
             )
         return self
 
 
-class TrainingConfig(BaseModel):
-    strategy: Literal["eagle3", "dflash", "domino"] = "eagle3"
-    num_epochs: int = 1
-    max_steps: Optional[int] = None
-    total_steps: Optional[int] = None
-    batch_size: int = 1
-    accumulation_steps: int = 1
-    learning_rate: float = 1e-4
-    warmup_ratio: float = 0.015
-    max_grad_norm: float = 0.5
-    ttt_length: int = 7
-    attention_backend: str = "flex_attention"
-    tp_size: int = 1
-    sp_ulysses_size: int = 1
-    sp_ring_size: int = 1
-    save_interval: int = 0
-    eval_interval: int = 0
-    log_interval: int = 50
+class TrainingConfig(StrictConfigModel):
+    strategy: Literal["eagle3", "dflash", "domino", "dspark", "peagle"] = "eagle3"
+    num_epochs: int = Field(default=1, gt=0)
+    max_steps: Optional[int] = Field(default=None, gt=0)
+    total_steps: Optional[int] = Field(default=None, gt=0)
+    batch_size: int = Field(default=1, gt=0)
+    accumulation_steps: int = Field(default=1, gt=0)
+    learning_rate: float = Field(default=1e-4, gt=0.0)
+    warmup_ratio: float = Field(default=0.015, ge=0.0, le=1.0)
+    max_grad_norm: float = Field(default=0.5, gt=0.0)
+    ttt_length: int = Field(default=7, gt=0)
+    attention_backend: Literal["eager", "sdpa", "flex_attention", "fa"] = (
+        "flex_attention"
+    )
+    #: EAGLE3 objective.
+    lk_loss_type: Optional[Literal["lambda", "alpha"]] = None
+    kl_scale: float = 1.0
+    kl_decay: float = 1.0
+    #: DFlash-family objective/model knobs.
+    num_anchors: int = Field(default=512, gt=0)
+    loss_decay_gamma: Optional[float] = None
+    loss_type: Literal[
+        "dflash",
+        "dpace",
+        "dpace-cumulative-confidence-only",
+        "dpace-continuation-value-only",
+    ] = "dflash"
+    dpace_alpha: float = 0.5
+    lambda_base_start: float = 1.0
+    lambda_base_decay_ratio: float = 0.5
+    dspark_ce_loss_alpha: float = 0.1
+    dspark_l1_loss_alpha: float = 0.9
+    dspark_confidence_head_alpha: float = 1.0
+    #: P-EAGLE COD sampling/model knobs.
+    num_depths: int = Field(default=8, gt=0)
+    down_sample_ratio: float = 0.8
+    down_sample_ratio_min: float = 0.2
+    norm_before_residual: Optional[bool] = None
+    save_interval: int = Field(default=0, ge=0)
+    log_interval: int = Field(default=50, gt=0)
     #: CheckpointManager rotation: keep the newest N checkpoints (0 = keep all).
-    max_checkpoints: int = 0
+    max_checkpoints: int = Field(default=0, ge=0)
     #: resume target: a checkpoint dir / file:// URI / run root.
     resume_from: Optional[str] = None
     #: control-plane selection for the offline builder.
     deployment_mode: Literal[
         "local_colocated", "dataflow_colocated", "disaggregated"
     ] = "local_colocated"
+    #: ``all`` is a colocated run. Disaggregated online runs launch producer
+    #: and consumer as separate ``specforge train`` processes with the same
+    #: config and different roles.
+    role: Literal["all", "producer", "consumer"] = "all"
+    server_urls: List[str] = Field(default_factory=list)
     metadata_db_path: Optional[str] = None
     seed: int = 42
 
+    @model_validator(mode="after")
+    def _validate_strategy_options(self):
+        if self.strategy == "peagle" and self.batch_size != 1:
+            raise ValueError("P-EAGLE currently requires training.batch_size=1")
+        if self.strategy == "eagle3" and self.attention_backend == "eager":
+            raise ValueError(
+                "EAGLE3 attention_backend must be sdpa, flex_attention, or fa"
+            )
+        if self.strategy == "peagle" and self.attention_backend != "flex_attention":
+            raise ValueError(
+                "P-EAGLE currently requires attention_backend=flex_attention"
+            )
+        if (
+            self.strategy in ("dflash", "domino", "dspark")
+            and self.attention_backend == "fa"
+        ):
+            raise ValueError(
+                "DFlash-family attention_backend must be eager, sdpa, or "
+                "flex_attention"
+            )
+        if not 0.0 <= self.dpace_alpha <= 1.0:
+            raise ValueError("training.dpace_alpha must be in [0, 1]")
+        if not 0.0 < self.down_sample_ratio <= 1.0:
+            raise ValueError("training.down_sample_ratio must be in (0, 1]")
+        if not 0.0 < self.down_sample_ratio_min <= self.down_sample_ratio:
+            raise ValueError(
+                "training.down_sample_ratio_min must be in "
+                "(0, training.down_sample_ratio]"
+            )
+        if self.role != "all" and self.deployment_mode != "disaggregated":
+            raise ValueError(
+                "training.role=producer/consumer requires "
+                "training.deployment_mode=disaggregated"
+            )
+        if self.deployment_mode == "disaggregated" and self.role == "all":
+            raise ValueError(
+                "training.deployment_mode=disaggregated requires "
+                "training.role=producer or consumer"
+            )
+        return self
 
-class Config(BaseModel):
+
+class Config(StrictConfigModel):
     model: ModelConfig
     data: DataConfig
     training: TrainingConfig = Field(default_factory=TrainingConfig)
     run_id: str = "specforge-run"
     output_dir: str = "./output"
 
+    @model_validator(mode="after")
+    def _validate_capability_matrix(self):
+        strategy = self.training.strategy
+        mode = self.mode
+        deployment = self.training.deployment_mode
+        layers = self.model.aux_hidden_state_layer_ids
+        if strategy in ("eagle3", "peagle"):
+            if layers is not None and (len(layers) != 3 or any(i < 0 for i in layers)):
+                raise ValueError(
+                    "EAGLE-family model.aux_hidden_state_layer_ids must contain "
+                    "exactly three non-negative layer ids"
+                )
+        elif layers is not None:
+            raise ValueError(
+                "DFlash-family capture layers come from draft_model_config; "
+                "model.aux_hidden_state_layer_ids would be ignored"
+            )
+        if mode == "offline" and strategy != "eagle3":
+            raise ValueError(
+                "offline feature training is currently supported for EAGLE3 only"
+            )
+        if (
+            strategy == "eagle3"
+            and (mode == "offline" or deployment == "disaggregated")
+            and not self.model.vocab_mapping_path
+        ):
+            raise ValueError(
+                "EAGLE3 offline and disaggregated runs require "
+                "model.vocab_mapping_path because those roles cannot derive a "
+                "shared mapping from the online prompt stream"
+            )
+        if strategy == "peagle" and deployment != "local_colocated":
+            raise ValueError("P-EAGLE currently supports colocated online runs only")
+        if strategy == "eagle3" and mode == "online" and self.training.batch_size != 1:
+            raise ValueError(
+                "EAGLE3 online capture currently requires training.batch_size=1"
+            )
+        if strategy == "dspark" and deployment != "disaggregated":
+            raise ValueError("DSpark requires disaggregated server capture")
+        if mode == "online" and deployment == "dataflow_colocated":
+            raise ValueError(
+                "online runs use local_colocated or disaggregated deployment"
+            )
+        if (
+            mode == "online"
+            and deployment == "disaggregated"
+            and self.model.target_backend != "sglang"
+        ):
+            raise ValueError(
+                "disaggregated online capture uses an SGLang server and requires "
+                "model.target_backend=sglang"
+            )
+        if (
+            mode == "online"
+            and deployment == "disaggregated"
+            and self.training.total_steps is None
+            and self.training.max_steps is None
+        ):
+            raise ValueError(
+                "disaggregated streaming runs require training.total_steps or "
+                "training.max_steps"
+            )
+        if mode == "online" and self.training.resume_from is not None:
+            raise ValueError(
+                "online resume is not yet supported by the unified entry because "
+                "streamed prompt/ref reconciliation is incomplete"
+            )
+        if self.training.role == "producer" and self.training.resume_from is not None:
+            raise ValueError("training.resume_from is valid only for a trainer role")
+        if self.model.target_backend == "custom" and strategy not in (
+            "eagle3",
+            "peagle",
+        ):
+            raise ValueError(
+                "the custom target backend currently supports EAGLE3 capture only"
+            )
+        return self
+
     @property
     def mode(self) -> str:
         return "offline" if self.data.hidden_states_path else "online"
+
+    def validate_world_size(self, world_size: int) -> None:
+        supports_data_parallel = (
+            self.mode == "online"
+            and self.training.deployment_mode == "disaggregated"
+            and self.training.role == "consumer"
+        )
+        if world_size > 1 and not supports_data_parallel:
+            raise ValueError(
+                "multi-rank training is currently supported only by an online "
+                "disaggregated consumer; colocated and offline inputs are not yet "
+                "data-parallel sharded"
+            )
 
     @classmethod
     def from_file(cls, path: str) -> "Config":

--- a/tests/test_benchmarks/__init__.py
+++ b/tests/test_benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark regression tests."""

--- a/tests/test_benchmarks/test_humaneval.py
+++ b/tests/test_benchmarks/test_humaneval.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HUMANEVAL_PATH = REPO_ROOT / "benchmarks" / "benchmarker" / "humaneval.py"
+
+
+def _load_humaneval_module(dataset):
+    """Load HumanEval with lightweight stand-ins for optional benchmark deps."""
+
+    package_name = "_dependency_light_benchmarker"
+    module_name = f"{package_name}.humaneval"
+
+    package = types.ModuleType(package_name)
+    package.__path__ = []
+
+    base = types.ModuleType(f"{package_name}.base")
+
+    class Benchmarker:
+        def __init__(self, num_samples=None, subset=None):
+            self.num_samples = num_samples
+            self.subset = subset
+
+    base.Benchmarker = Benchmarker
+
+    registry = types.ModuleType(f"{package_name}.registry")
+
+    class BenchmarkRegistry:
+        def register(self, _name):
+            return lambda cls: cls
+
+    registry.BENCHMARKS = BenchmarkRegistry()
+
+    utils = types.ModuleType(f"{package_name}.utils")
+    utils.create_simple_sgl_function = lambda **kwargs: kwargs
+
+    datasets = types.ModuleType("datasets")
+    datasets.load_dataset = lambda _name: {"test": dataset}
+
+    spec = importlib.util.spec_from_file_location(module_name, HUMANEVAL_PATH)
+    module = importlib.util.module_from_spec(spec)
+    modules = {
+        package_name: package,
+        f"{package_name}.base": base,
+        f"{package_name}.registry": registry,
+        f"{package_name}.utils": utils,
+        "datasets": datasets,
+        module_name: module,
+    }
+    with mock.patch.dict(sys.modules, modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+class HumanEvalBenchmarkerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.prompt = "def add(left, right):"
+        cls.test_code = (
+            "def check(candidate):\n"
+            "    assert candidate(2, 3) == 5\n"
+            "    assert candidate(-1, 1) == 0\n"
+        )
+        cls.module = _load_humaneval_module(
+            [
+                {
+                    "prompt": cls.prompt,
+                    "test": cls.test_code,
+                    "entry_point": "add",
+                    "canonical_solution": "    return left + right",
+                }
+            ]
+        )
+
+    def test_load_data_keeps_prompt_with_its_accuracy_label(self):
+        benchmarker = self.module.HumanEvalBenchmarker()
+
+        questions, labels = benchmarker.load_data()
+
+        self.assertEqual(questions, [{"question": self.prompt}])
+        self.assertEqual(labels[0]["prompt"], self.prompt)
+
+    def test_accuracy_uses_the_label_without_hidden_question_state(self):
+        benchmarker = self.module.HumanEvalBenchmarker()
+        _, labels = benchmarker.load_data()
+
+        correct = "def add(left, right):\n    return left + right"
+        wrong = "def add(left, right):\n    return left - right"
+
+        self.assertEqual(benchmarker.compute_accuracy([correct], labels), 1.0)
+        self.assertEqual(benchmarker.compute_accuracy([wrong], labels), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Config schema mechanics: parsing, validation, dotted overrides."""
 
+import copy
 import json
 import os
 import tempfile
@@ -14,6 +15,7 @@ MINIMAL = {
     "model": {
         "target_model_path": "some/target",
         "draft_model_config": "draft.json",
+        "vocab_mapping_path": "/mapping.pt",
     },
     "data": {"hidden_states_path": "/features"},
 }
@@ -55,11 +57,148 @@ class ConfigSchemaTest(unittest.TestCase):
             {**MINIMAL, "data": {"prompts_path": "/prompts.jsonl"}}
         )
         self.assertEqual(online.mode, "online")
+        raw = Config.model_validate(
+            {**MINIMAL, "data": {"train_data_path": "/conversations.jsonl"}}
+        )
+        self.assertEqual(raw.mode, "online")
+
+    def test_offline_eagle3_requires_explicit_vocab_mapping(self):
+        missing = copy.deepcopy(MINIMAL)
+        missing["model"].pop("vocab_mapping_path")
+        with self.assertRaisesRegex(ValidationError, "vocab_mapping_path"):
+            Config.model_validate(missing)
+        self.assertEqual(Config.model_validate(MINIMAL).mode, "offline")
 
     def test_unknown_backend_rejected(self):
         bad = {**MINIMAL, "model": {**MINIMAL["model"], "target_backend": "vllm"}}
         with self.assertRaises(ValidationError):
             Config.model_validate(bad)
+
+    def test_unknown_fields_and_unsupported_modes_fail_early(self):
+        with self.assertRaises(ValidationError):
+            Config.model_validate(
+                {
+                    **MINIMAL,
+                    "data": {"train_data_path": "/data.jsonl", "is_vlm": True},
+                }
+            )
+        with self.assertRaises(ValidationError):
+            Config.model_validate(
+                {
+                    **MINIMAL,
+                    "training": {"attention_backend": "usp"},
+                }
+            )
+        with self.assertRaises(ValidationError):
+            Config.model_validate(
+                {
+                    **MINIMAL,
+                    "training": {"tp_size": 1},
+                }
+            )
+        with self.assertRaises(ValidationError):
+            Config.model_validate(
+                {
+                    **MINIMAL,
+                    "training": {"strategy": "dflash"},
+                }
+            )
+        dspark = Config.model_validate(
+            {
+                **MINIMAL,
+                "data": {"train_data_path": "/data.jsonl"},
+                "training": {
+                    "strategy": "dspark",
+                    "deployment_mode": "disaggregated",
+                    "role": "producer",
+                    "total_steps": 10,
+                },
+            }
+        )
+        self.assertEqual(dspark.training.strategy, "dspark")
+        with self.assertRaisesRegex(ValidationError, "target_backend=sglang"):
+            Config.model_validate(
+                {
+                    **MINIMAL,
+                    "model": {**MINIMAL["model"], "target_backend": "hf"},
+                    "data": {"train_data_path": "/data.jsonl"},
+                    "training": {
+                        "strategy": "dflash",
+                        "deployment_mode": "disaggregated",
+                        "role": "producer",
+                        "total_steps": 10,
+                    },
+                }
+            )
+
+    def test_strategy_specific_capture_and_attention_are_validated(self):
+        online = {**MINIMAL, "data": {"train_data_path": "/data.jsonl"}}
+        with self.assertRaisesRegex(ValidationError, "exactly three"):
+            Config.model_validate(
+                {
+                    **online,
+                    "model": {
+                        **online["model"],
+                        "aux_hidden_state_layer_ids": [1, 2],
+                    },
+                }
+            )
+        with self.assertRaisesRegex(ValidationError, "would be ignored"):
+            Config.model_validate(
+                {
+                    **online,
+                    "model": {
+                        **online["model"],
+                        "aux_hidden_state_layer_ids": [1, 2, 3],
+                    },
+                    "training": {"strategy": "dflash"},
+                }
+            )
+        with self.assertRaisesRegex(ValidationError, "P-EAGLE"):
+            Config.model_validate(
+                {
+                    **online,
+                    "training": {
+                        "strategy": "peagle",
+                        "attention_backend": "sdpa",
+                    },
+                }
+            )
+        with self.assertRaisesRegex(ValidationError, "EAGLE3 attention_backend"):
+            Config.model_validate(
+                {**online, "training": {"attention_backend": "eager"}}
+            )
+        with self.assertRaisesRegex(ValidationError, "DFlash-family"):
+            Config.model_validate(
+                {
+                    **online,
+                    "training": {
+                        "strategy": "dflash",
+                        "attention_backend": "fa",
+                    },
+                }
+            )
+
+    def test_invalid_core_bounds_fail_during_config_validation(self):
+        cases = (
+            ("data.max_length", 0),
+            ("data.build_dataset_num_proc", 0),
+            ("training.num_epochs", 0),
+            ("training.max_steps", 0),
+            ("training.total_steps", 0),
+            ("training.batch_size", 0),
+            ("training.accumulation_steps", 0),
+            ("training.save_interval", -1),
+            ("training.log_interval", 0),
+            ("training.max_checkpoints", -1),
+        )
+        for path, value in cases:
+            with self.subTest(path=path):
+                raw = copy.deepcopy(MINIMAL)
+                section, field = path.split(".")
+                raw.setdefault(section, {})[field] = value
+                with self.assertRaises(ValidationError):
+                    Config.model_validate(raw)
 
     def test_overrides_coerce_and_revalidate(self):
         cfg = Config.model_validate(MINIMAL)


### PR DESCRIPTION
Part **P01/14** of the review stack replacing monolithic #678.

## Review this layer

**Primary decision:** are the strict schema, topology matrix, source exclusivity, and default changes the right configuration contract?

- Logical parent: [#681](https://github.com/sgl-project/SpecForge/pull/681) at `cdb81ab`
- Incremental diff: [P01 only](https://github.com/maocheng23/SpecForge/compare/agent/pr678-p00-humaneval...agent/pr678-p01-config)
- Commit: `94821f5`
- Review order: after #681

## What changes

- Adds strict Pydantic model/data/training configuration and fail-closed unknown-field handling.
- Validates source exclusivity, deployment/capability combinations, world size, and dotted overrides.
- Keeps the public CLI untouched; later layers consume this typed leaf.

## Validation

- `10 passed`
- `10 subtests passed`

## Review note

Minimal handwritten configs inherit changed defaults; shipped recipes set the affected values explicitly.

> This draft temporarily targets `main` because the logical parent ref lives in the fork. GitHub's Files tab is therefore cumulative; review the incremental link above. Mark this PR ready only after its parent lands/it is retargeted. Final tip `f9fc810` is tree-identical to corrected #678 head `3c89ddc`.