### PR TITLE
[PR678 stack 03/14] feat(runtime): add flow-control policy primitives

### DIFF
--- a/specforge/runtime/contracts.py
+++ b/specforge/runtime/contracts.py
@@ -34,7 +34,7 @@ SCHEMA_VERSION = 1
 
 RunMode = Literal["online", "offline"]
 DeploymentMode = Literal["local_colocated", "dataflow_colocated", "disaggregated"]
-DraftStrategyName = Literal["eagle3", "dflash", "domino", "dspark"]
+DraftStrategyName = Literal["eagle3", "dflash", "domino", "dspark", "peagle"]
 # Tagged union for the EAGLE3 target feature. The *strategy* owns the
 # projection so the trainer core stays branch-free:
 #   - pruned_logits: rollout applied the t2d vocab map; stored (seq, draft_vocab)

--- a/specforge/runtime/control_plane/DESIGN.md
+++ b/specforge/runtime/control_plane/DESIGN.md
@@ -1,79 +1,127 @@
-# Control Plane Design (PR 4/7 — `runtime/control_plane`)
+# Control plane design
 
-This is the design note for the **control plane**, scoped to this plane.
-The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
-`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
-plane exchanges are in [`../contracts.py`](../contracts.py).
+The control plane moves metadata only. Its public record-accepting endpoints run
+`assert_no_tensors`; feature tensors stay behind the data-plane `FeatureStore`.
+The whole-system topology is documented in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md).
 
-## Responsibility
+## Responsibilities
 
-Metadata-only scheduling, lifecycle, leasing, and recovery durability. Owns prompt and sample lifecycle, prompt/train leases, worker/trainer registration, dedup of committed samples, and the durable ack transaction. NEVER touches tensors (every record-accepting entrypoint runs assert_no_tensors) — all large tensors travel through the data plane. Online commit_samples and offline enqueue_offline_refs converge onto the same SampleRefQueue so the trainer path has no online/offline branch. Recovery-critical state sits behind a MetadataStore seam so a durable backend (SQLite/Redis/DB) is a swap, not a rewrite. (Note: weight publishing / weight-version registry is explicitly NOT yet implemented — flagged in source NOTE comments in both controller.py and metadata_store.py.)
+`DataFlowController` provides the shared metadata primitives:
 
-## Internal mechanics
+- prompt ingest, leasing, retry, and terminal failure;
+- `SampleRef` commit deduplication;
+- optional sample-ref lease/ack/fail primitives used by tests and internal
+  staging, but disabled on the canonical online producer;
+- trainer registration and optimizer-boundary ack transactions;
+- status for active prompt, queue, and durable-ack state.
+
+The launch topology decides which subset is active. The controller has no run
+loop and never calls a rollout worker or trainer.
+
+## Topology-specific ownership
+
+| Topology | Controller/ledger ownership | Reference delivery |
+| --- | --- | --- |
+| Colocated offline | No ledger or staging queue | Fixed, re-iterable ref list |
+| Disaggregated offline | No training ledger; producer publishes a static manifest | Fixed, re-iterable manifest refs |
+| Disaggregated online producer | Prompt lifecycle only; `NoOpMetadataStore`; local sample enqueue is disabled | Publishes refs directly to the shared `StreamingRefChannel` |
+| Disaggregated online consumer | Rank 0 owns the only fresh retaining ledger; every rank owns a `DPAckController` view | `RefDistributor -> per-rank InboxChannel -> StreamingRefQueue` |
+
+The online-disaggregated producer therefore has no training ledger and no local
+training queue. Deduplication and durable training state belong exclusively to
+the consumer attempt.
+
+## Online-disaggregated consumer
 
 ```mermaid
 flowchart TD
-  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
-
-  subgraph CTRL[DataFlowController passive]
-    PEND[_prompt_pending deque]
-    LEASED[_prompt_leased map]
-    FAILEDP[_prompt_failed map]
-  end
-  ING[ingest_prompts] --> PEND
-  LPT[lease_prompt_tasks popleft] --> LEASED
-  FPT[fail_prompt_tasks requeue or fail] --> PEND
-
-  COMMIT[commit_samples per ref] -->|commit_sample dedup| MS[MetadataStore]
-  COMMIT -->|put fresh| Q[SampleRefQueue]
-  ENQ[enqueue_offline_refs] -->|commit_sample dedup| MS
-  ENQ -->|put fresh| Q
-
-  LTR[lease_train_refs] -->|get| Q
-  ATR[ack_train_refs] -->|record_train_ack first| MS
-  ATR -->|get_committed then ack| Q
-  FR[fail_refs] -->|get_committed then fail| Q
-
-  TL[TrainLease get ack fail] --> LTR
-  TL --> ATR
-  TL --> FR
-
-  class PEND,LEASED,FAILEDP,ING,LPT,FPT,COMMIT,ENQ,LTR,ATR,FR,TL,MS,Q control;
+  SRC[shared StreamingRefChannel] --> RD[RefDistributor on rank 0]
+  RD -->|commit and dedup| DB[(fresh SQLite ledger)]
+  RD --> I0[rank 0 InboxChannel]
+  RD --> IN[rank N InboxChannel]
+  I0 --> Q0[rank 0 StreamingRefQueue]
+  IN --> QN[rank N StreamingRefQueue]
+  Q0 --> T0[rank 0 trainer]
+  QN --> TN[rank N trainer]
+  T0 --> ACK[DPAckController collective]
+  TN --> ACK
+  ACK -->|rank 0 writes once| DB
 ```
 
-The `DataFlowController` is a passive metadata-only coordinator: it has no run loop, and every record-accepting entrypoint runs `assert_no_tensors`. It holds prompt lifecycle state — `_prompts`, a `_prompt_pending` deque, `_prompt_leased`, and `_prompt_failed` — under a single `_lock` that guards only the prompt/worker/trainer mutations and the `status()` snapshot; the sample-commit and train paths instead rely on the store's and queue's own internal locking. Durable/recovery state lives behind the `MetadataStore` seam: `commit_sample` dedups by `sample_id` (False = duplicate, dropped) and `record_train_ack` commits {acked sample_ids, global_step, optimizer_durable} as one atomic transaction. Online `commit_samples` and offline `enqueue_offline_refs` converge by enqueuing only fresh refs onto the same `SampleRefQueue`, so the trainer path has no online/offline branch. `ack_train_refs` deliberately orders `record_train_ack` BEFORE `sample_queue.ack` so a restart reconciles release state from the single committed marker. `TrainLease` is a stateless adapter that forwards `get`/`ack`/`fail` through the controller, so a cross-node trainer never holds a raw in-process queue and the durable ack is always recorded. Weight publishing / a weight-version registry is explicitly not yet implemented (flagged in source NOTEs).
+Rank 0 is the single bookkeeping authority:
 
-## Deployment modes
+1. It rejects a non-retaining or non-fresh ledger.
+2. It is the only process that reads the producer channel.
+3. It commits and deduplicates refs, then dispatches only complete global
+   optimizer windows into one inbox per rank.
+4. It gathers each rank's optimizer-boundary sample ids through
+   `DPAckController` and records one durable ack transaction.
 
-The same code path serves every `DeploymentMode`; `build_control_plane_for_mode(mode, run_id)` builds the controller and durable-ack policy. `local_colocated` uses `NoOpMetadataStore` and `durable_ack=False`. `dataflow_colocated` / `disaggregated` keep the durable store (SQLite when a path is given, else the controller's in-memory default) and optimizer-boundary ack.
+Non-authority ranks participate in the gather but never write the durable
+ledger. After rank 0 broadcasts commit success, every rank removes only its
+local feature ids and collectively reports cleanup failures before inbox ack.
+One-rank runs use this exact path as well; there is no direct-channel consumer
+branch.
 
-The no-op axis is the *store + durable-ack transaction*. Prompt leasing and in-process `SampleRefQueue` bookkeeping stay shared across modes, and backpressure remains opt-in. Because `NoOpMetadataStore` retains nothing, `status()` committed/acked/backlog counts read 0 and `TrainLease`/`fail_refs` cannot reconstruct refs; cross-process trainers need a retaining store.
+Inbox queue acknowledgements happen after each materialized micro-batch and are
+forwarded by the distributor to the source channel's consumed counter. Durable
+ack is separate: it happens once at the optimizer boundary and includes all
+`dp_size * batch_size * accumulation_steps` sample ids. This separation keeps
+producer backpressure responsive without weakening optimizer-step durability.
 
-## Endpoints
+## Handshake and termination
 
-### What this plane calls into
+Consumer rank 0 publishes
 
-| From | Endpoint | Plane |
-|---|---|---|
-| `DataFlowController` | `MetadataStore.commit_sample` | control |
-| `DataFlowController` | `MetadataStore.record_train_ack` | control |
-| `DataFlowController` | `MetadataStore.get_committed` | control |
-| `DataFlowController` | `SampleRefQueue.put` | control |
-| `DataFlowController` | `SampleRefQueue.get` | control |
-| `DataFlowController` | `SampleRefQueue.ack` | control |
-| `DataFlowController` | `SampleRefQueue.fail` | control |
-| `TrainLease` | `DataFlowController.lease_train_refs` | control |
-| `TrainLease` | `DataFlowController.ack_train_refs` | control |
-| `TrainLease` | `DataFlowController.fail_refs` | control |
+```text
+quantum = dp_size * batch_size * accumulation_steps
+```
 
-### Who calls into this plane
+before the distributor starts. The producer waits for that value and requires
+its in-flight high watermark to be at least `quantum`. The canonical CLI uses
+`DISAGG_IN_FLIGHT_HIGH_WATERMARK=256` when the variable is unset.
 
-| Caller | Endpoint | Plane |
-|---|---|---|
-| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
-| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
-| `RolloutWorker` | `DataFlowController.commit_samples` | control |
-| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |
-| `OfflineManifestReader` | `DataFlowController.enqueue_offline_refs` | control |
-| `FeatureDataLoader` | `TrainLease.get` | control |
-| `TrainerController` | `DataFlowController.ack_train_refs` | control |
+The distributor closes rank inboxes only after the producer source is closed,
+all source refs are drained, and no partial quantum remains. A partial quantum
+at EOF is a terminal attempt failure: the staged refs are failed non-retryably,
+their feature objects are aborted best-effort, and every rank receives a
+failure sentinel rather than a clean close.
+
+Producer and consumer failures use distinct sentinels, so neither side can
+interpret a peer crash as successful EOF. Early consumer completion also
+signals the producer to stop and clean published Mooncake objects.
+
+## Freshness and recovery contract
+
+The canonical online launcher requires a new SQLite path for every fresh
+consumer, including `dp_size=1`, and rejects an existing database, WAL, or SHM
+file. The runtime also rejects a ledger with committed rows. Inbox files are
+ephemeral and recreated by rank 0 for a fresh attempt.
+
+Online disaggregated recovery is consumer-only. With the original SQLite
+ledger, channel/inboxes, Mooncake objects, and matching checkpoint still
+available, rank 0 verifies the durable step, skips acknowledged refs, and
+requeues the unacknowledged tail. A producer never resumes, and a consumed
+stream is never iterated as a second trainer epoch. A new producer attempt must
+use fresh channel, store-id, run-id, and output artifacts.
+
+The durable acknowledgement step must equal the restored checkpoint step.
+Acknowledgements can advance after the most recent periodic checkpoint, so a
+crash in that interval is intentionally non-resumable: recovery fails closed
+rather than replaying consumed refs against older optimizer state.
+
+Offline refs remain fixed and re-iterable, so offline checkpoint resume and
+multiple epochs keep their existing semantics.
+
+## Metadata stores
+
+- `NoOpMetadataStore` is used where no durable sample ledger is required, most
+  importantly offline paths and the online-disaggregated producer.
+- `InMemoryMetadataStore` supports local bookkeeping and non-authority DP
+  controller instances.
+- `SQLiteMetadataStore` is the canonical online-disaggregated consumer ledger.
+  Rank 0 is its sole writer.
+
+Weight publishing and a weight-version registry are not implemented in this
+control plane.

--- a/specforge/runtime/control_plane/flow_control.py
+++ b/specforge/runtime/control_plane/flow_control.py
@@ -1,0 +1,135 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Hysteretic producer flow control for the canonical streaming runtime."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class FlowControlLimits:
+    """Reference/byte watermarks and the per-worker capture lease cap."""
+
+    high_watermark_refs: int = 256
+    low_watermark_refs: Optional[int] = None
+    high_watermark_bytes: Optional[int] = None
+    low_watermark_bytes: Optional[int] = None
+    max_prompt_lease_per_worker: int = 8
+
+    def __post_init__(self) -> None:
+        low_refs = (
+            self.high_watermark_refs
+            if self.low_watermark_refs is None
+            else self.low_watermark_refs
+        )
+        low_bytes = (
+            self.high_watermark_bytes
+            if self.low_watermark_bytes is None
+            else self.low_watermark_bytes
+        )
+        if self.high_watermark_refs < 1:
+            raise ValueError("high_watermark_refs must be >= 1")
+        if low_refs < 0 or low_refs > self.high_watermark_refs:
+            raise ValueError(
+                "low_watermark_refs must be between 0 and high_watermark_refs"
+            )
+        if self.high_watermark_bytes is None and self.low_watermark_bytes is not None:
+            raise ValueError("low_watermark_bytes requires high_watermark_bytes")
+        if self.high_watermark_bytes is not None:
+            if self.high_watermark_bytes < 1:
+                raise ValueError("high_watermark_bytes must be >= 1")
+            if low_bytes is None or not 0 <= low_bytes <= self.high_watermark_bytes:
+                raise ValueError(
+                    "low_watermark_bytes must be between 0 and " "high_watermark_bytes"
+                )
+        if self.max_prompt_lease_per_worker < 1:
+            raise ValueError("max_prompt_lease_per_worker must be >= 1")
+
+    @property
+    def resolved_low_watermark_refs(self) -> int:
+        return (
+            self.high_watermark_refs
+            if self.low_watermark_refs is None
+            else self.low_watermark_refs
+        )
+
+    @property
+    def resolved_low_watermark_bytes(self) -> Optional[int]:
+        if self.high_watermark_bytes is None:
+            return None
+        return (
+            self.high_watermark_bytes
+            if self.low_watermark_bytes is None
+            else self.low_watermark_bytes
+        )
+
+
+class ProducerFlowControl:
+    """Thread-safe pause/resume policy shared by all rollout workers."""
+
+    def __init__(self, limits: FlowControlLimits) -> None:
+        self.limits = limits
+        self._paused = False
+        self._lock = threading.Lock()
+        self._stats = {
+            "pause_transitions": 0,
+            "resume_transitions": 0,
+            "wait_checks": 0,
+        }
+
+    def prompt_lease(self, requested: int) -> int:
+        """Cap a worker's capture request at the configured in-flight lease."""
+        return max(0, min(int(requested), self.limits.max_prompt_lease_per_worker))
+
+    def should_pause(self, *, in_flight_refs: int, resident_bytes: int = 0) -> bool:
+        """Apply ref/byte hysteresis and return the current latched state."""
+        refs = max(0, int(in_flight_refs))
+        resident = max(0, int(resident_bytes))
+        high_bytes = self.limits.high_watermark_bytes
+        low_bytes = self.limits.resolved_low_watermark_bytes
+        over_high = refs >= self.limits.high_watermark_refs or (
+            high_bytes is not None and resident >= high_bytes
+        )
+        under_low = refs <= self.limits.resolved_low_watermark_refs and (
+            low_bytes is None or resident <= low_bytes
+        )
+        with self._lock:
+            if not self._paused and over_high:
+                self._paused = True
+                self._stats["pause_transitions"] += 1
+            elif self._paused and under_low:
+                self._paused = False
+                self._stats["resume_transitions"] += 1
+            if self._paused:
+                self._stats["wait_checks"] += 1
+            return self._paused
+
+    def snapshot(
+        self, *, in_flight_refs: int, resident_bytes: int = 0
+    ) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "paused": self._paused,
+                **self._stats,
+                "in_flight_refs": int(in_flight_refs),
+                "resident_bytes": int(resident_bytes),
+                "high_watermark_refs": self.limits.high_watermark_refs,
+                "low_watermark_refs": self.limits.resolved_low_watermark_refs,
+                "high_watermark_bytes": self.limits.high_watermark_bytes,
+                "low_watermark_bytes": self.limits.resolved_low_watermark_bytes,
+                "max_prompt_lease_per_worker": (
+                    self.limits.max_prompt_lease_per_worker
+                ),
+            }
+
+
+__all__ = ["FlowControlLimits", "ProducerFlowControl"]

--- a/tests/test_runtime/test_flow_control.py
+++ b/tests/test_runtime/test_flow_control.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Canonical producer flow-control policy (CPU-only)."""
+
+import unittest
+
+from specforge.runtime.control_plane.flow_control import (
+    FlowControlLimits,
+    ProducerFlowControl,
+)
+
+
+class FlowControlTest(unittest.TestCase):
+    def test_reference_and_byte_hysteresis_share_one_pause_latch(self):
+        policy = ProducerFlowControl(
+            FlowControlLimits(
+                high_watermark_refs=10,
+                low_watermark_refs=4,
+                high_watermark_bytes=100,
+                low_watermark_bytes=40,
+            )
+        )
+        self.assertFalse(policy.should_pause(in_flight_refs=9, resident_bytes=99))
+        self.assertTrue(policy.should_pause(in_flight_refs=10, resident_bytes=20))
+        self.assertTrue(policy.should_pause(in_flight_refs=5, resident_bytes=20))
+        self.assertFalse(policy.should_pause(in_flight_refs=4, resident_bytes=40))
+        self.assertTrue(policy.should_pause(in_flight_refs=1, resident_bytes=100))
+        self.assertTrue(policy.should_pause(in_flight_refs=1, resident_bytes=50))
+        self.assertFalse(policy.should_pause(in_flight_refs=1, resident_bytes=40))
+
+        snapshot = policy.snapshot(in_flight_refs=1, resident_bytes=40)
+        self.assertEqual(snapshot["pause_transitions"], 2)
+        self.assertEqual(snapshot["resume_transitions"], 2)
+        self.assertGreater(snapshot["wait_checks"], 0)
+
+    def test_prompt_lease_is_capped_per_worker(self):
+        policy = ProducerFlowControl(FlowControlLimits(max_prompt_lease_per_worker=3))
+        self.assertEqual(policy.prompt_lease(8), 3)
+        self.assertEqual(policy.prompt_lease(2), 2)
+
+    def test_invalid_watermarks_are_rejected(self):
+        with self.assertRaises(ValueError):
+            FlowControlLimits(high_watermark_refs=4, low_watermark_refs=5)
+        with self.assertRaises(ValueError):
+            FlowControlLimits(low_watermark_bytes=10)
+        with self.assertRaises(ValueError):
+            FlowControlLimits(
+                high_watermark_bytes=10,
+                low_watermark_bytes=11,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Part **P03/14** of the review stack replacing monolithic #678.

## Review this layer

**Primary decision:** are the ref/byte watermarks, hysteresis boundaries, and per-worker prompt leases deadlock-safe?

- Logical parent: [#683](https://github.com/sgl-project/SpecForge/pull/683) at `2cfc4d1`
- Incremental diff: [P03 only](https://github.com/maocheng23/SpecForge/compare/agent/pr678-p02-data-plane...agent/pr678-p03-flow-control)
- Commit: `5bc85b8`
- Review order: after #683

## What changes

- Adds immutable ref/byte watermark limits.
- Adds a thread-safe hysteretic producer-pause latch and per-worker prompt leases.
- This layer is additive; controller/backpressure cutover is deliberately later.

## Validation

- `3 passed`

- GitHub Actions lint: passed after the lint-clean restack.

## Review note

Pause is `>= high`; resume is `<= low`. Review combined ref/byte latch behavior.

> #683 is merged and this branch is based directly on the resulting `main`; GitHub's Files tab is P03-only. Final tip `4d9b08a` is tree-identical to corrected #678 head `3c89ddc`.