### PR TITLE
[PR678 stack 04/14] feat(algorithms): add contracts and provider interfaces

### DIFF
--- a/specforge/algorithms/__init__.py
+++ b/specforge/algorithms/__init__.py
@@ -1,0 +1,22 @@
+"""Topology-free algorithm contracts and explicit registrations."""
+
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+from specforge.algorithms.registry import AlgorithmRegistration, AlgorithmRegistry
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmRegistration",
+    "AlgorithmRegistry",
+    "AlgorithmSpec",
+    "DraftRequirement",
+    "FeatureContract",
+    "FeatureMode",
+    "OfflineStorageContract",
+]

--- a/specforge/algorithms/common/__init__.py
+++ b/specforge/algorithms/common/__init__.py
@@ -1,0 +1,29 @@
+"""Shared provider ports and small data adapters for built-in algorithms."""
+
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    OfflineDataProvider,
+    ServerCaptureLayout,
+    ServerInputAdapter,
+    ServerStreamingProvider,
+    StepProvider,
+    StepRuntimeConfig,
+    TargetDerivedDraftDefaults,
+    make_registration,
+)
+
+__all__ = [
+    "AlgorithmProviders",
+    "DraftConfigProvider",
+    "ModelProvider",
+    "OfflineDataProvider",
+    "ServerCaptureLayout",
+    "ServerInputAdapter",
+    "ServerStreamingProvider",
+    "StepProvider",
+    "StepRuntimeConfig",
+    "TargetDerivedDraftDefaults",
+    "make_registration",
+]

--- a/specforge/algorithms/common/collation.py
+++ b/specforge/algorithms/common/collation.py
@@ -1,0 +1,71 @@
+"""Small algorithm-owned batch collation helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+
+def concatenate_features(features):
+    """Concatenate equal-shaped per-sample feature dictionaries."""
+
+    if not features:
+        raise ValueError("cannot collate an empty feature batch")
+    import torch
+
+    keys = tuple(features[0])
+    expected_keys = set(keys)
+    if any(set(feature) != expected_keys for feature in features[1:]):
+        raise ValueError("all samples must expose the same feature keys")
+    return {
+        key: torch.cat([feature[key] for feature in features], dim=0) for key in keys
+    }
+
+
+def pad_and_concatenate_features(
+    features,
+    *,
+    sequence_axes: Mapping[str, int],
+    required_keys: Sequence[str],
+):
+    """Zero-pad configured tensor axes to the longest input sequence."""
+
+    if not features:
+        raise ValueError("cannot collate an empty feature batch")
+    required = tuple(required_keys)
+    missing = [
+        (index, key)
+        for index, feature in enumerate(features)
+        for key in required
+        if key not in feature
+    ]
+    if missing:
+        raise KeyError(f"feature batch is missing required keys: {missing}")
+    max_length = max(int(feature["input_ids"].shape[-1]) for feature in features)
+
+    import torch
+
+    batch = {}
+    for key in required:
+        axis = sequence_axes[key]
+        padded = []
+        for feature in features:
+            tensor = feature[key]
+            length = int(tensor.shape[axis])
+            if length > max_length:
+                raise ValueError(
+                    f"feature {key!r} sequence length {length} exceeds "
+                    f"input_ids length {max_length}"
+                )
+            if length < max_length:
+                shape = list(tensor.shape)
+                shape[axis] = max_length - length
+                tensor = torch.cat(
+                    [tensor, tensor.new_zeros(shape)],
+                    dim=axis,
+                )
+            padded.append(tensor)
+        batch[key] = torch.cat(padded, dim=0)
+    return batch
+
+
+__all__ = ["concatenate_features", "pad_and_concatenate_features"]

--- a/specforge/algorithms/common/defaults.py
+++ b/specforge/algorithms/common/defaults.py
@@ -1,0 +1,32 @@
+"""Default provider hooks shared by built-in registrations."""
+
+from __future__ import annotations
+
+
+def empty_options(_config):
+    return {}
+
+
+def empty_resume_contract(_config, _draft_model, _training_model):
+    return {}
+
+
+def no_missing_checkpoint_keys(_config, _draft_model, _training_model):
+    return frozenset()
+
+
+def one_loss_token(_config, _draft_config=None):
+    return 1
+
+
+def online_needs_input_tools(config, _draft_model):
+    return config.mode == "online"
+
+
+__all__ = [
+    "empty_options",
+    "empty_resume_contract",
+    "no_missing_checkpoint_keys",
+    "one_loss_token",
+    "online_needs_input_tools",
+]

--- a/specforge/algorithms/common/providers.py
+++ b/specforge/algorithms/common/providers.py
@@ -1,0 +1,660 @@
+"""Executable provider ports for built-in algorithms.
+
+The public :class:`~specforge.algorithms.contracts.AlgorithmSpec` deliberately
+contains values only.  This module is the executable half of one
+``AlgorithmRegistration``: step/model factories and data adapters selected by
+the application composition root.
+
+The provider types describe algorithm-owned behavior, never deployment
+topology.  In particular, ``ServerStreamingProvider`` means that an algorithm
+can consume features captured by an external server; it does not select a
+backend, start a server, or construct a transport.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import (
+    Any,
+    Callable,
+    FrozenSet,
+    Iterable,
+    Mapping,
+    Protocol,
+    Sequence,
+    Tuple,
+    runtime_checkable,
+)
+
+from specforge.algorithms.contracts import AlgorithmSpec, FeatureMode
+from specforge.algorithms.registry import AlgorithmRegistration
+
+Factory = Callable[..., Any]
+
+STEP_OPTIONS_CONTRACT_KEY = "specforge_step_options"
+MODEL_PROVENANCE_CONTRACT_KEY = "specforge_model_provenance"
+OMITTED_STATE_FINGERPRINT_CONTRACT_KEY = (
+    "specforge_omitted_checkpoint_state_fingerprint"
+)
+
+
+@runtime_checkable
+class ServerInputAdapter(Protocol):
+    """Modality-owned input port for external server capture.
+
+    Implementations may load a tokenizer, processor, or any other immutable
+    input tooling; turn configured source data into JSON-safe prompt payloads;
+    and map a batch of those payloads onto the SGLang ``/generate`` request.
+    The transport owns capture metadata and sampling parameters, so adapters
+    return only model-input fields.
+    """
+
+    def load_input_tools(self, config: Any) -> Any:
+        """Load tokenizer/processor tooling required by this modality."""
+
+    def prepare_prompts(
+        self,
+        config: Any,
+        input_tools: Any,
+        *,
+        draft_config: Any,
+    ) -> list[dict[str, Any]]:
+        """Build JSON-safe prompt dictionaries for the producer runtime."""
+
+    def build_request_inputs(
+        self,
+        tasks: Sequence[Any],
+    ) -> Mapping[str, Any]:
+        """Build model-input fields for one batched server request."""
+
+
+def _non_empty(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(
+            f"{field_name} must be a non-empty name without surrounding whitespace"
+        )
+    return value
+
+
+def _factories_are_callable(values: Iterable[tuple[str, object]]) -> None:
+    for field_name, value in values:
+        if not callable(value):
+            raise TypeError(f"{field_name} must be callable")
+
+
+def checkpoint_key_fingerprint(model: Any, keys: Iterable[str]) -> str:
+    """Hash selected state tensors with bounded host memory.
+
+    Providers may intentionally omit reconstructable frozen tensors from a
+    checkpoint. Their values still affect the model, so resume records this
+    fingerprint and rejects a reconstruction from different weights.
+    """
+
+    import torch
+
+    state = model.state_dict()
+    hasher = hashlib.sha256()
+    for key in sorted(keys):
+        if key not in state:
+            raise ValueError(
+                f"cannot fingerprint missing checkpoint-policy key {key!r}"
+            )
+        tensor = state[key]
+        if not torch.is_tensor(tensor):
+            raise TypeError(
+                f"checkpoint-policy key {key!r} is not a tensor: "
+                f"{type(tensor).__name__}"
+            )
+        hasher.update(key.encode("utf-8"))
+        hasher.update(str(tensor.dtype).encode("ascii"))
+        hasher.update(repr(tuple(tensor.shape)).encode("ascii"))
+        flat = tensor.detach().contiguous().view(-1)
+        chunk_elements = max(1, (16 * 1024 * 1024) // flat.element_size())
+        for start in range(0, flat.numel(), chunk_elements):
+            chunk = flat[start : start + chunk_elements].to(
+                device="cpu",
+                copy=True,
+            )
+            hasher.update(memoryview(chunk.view(torch.uint8).numpy()))
+    return hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class TargetDerivedDraftDefaults:
+    """Defaults used when a target config generates a draft config.
+
+    ``populate`` is the algorithm-owned seam for derived values such as
+    DFlash target-layer IDs.  Reading a config and resolving its model/config
+    class remain responsibilities of ``DraftModelRegistry``.
+    """
+
+    model_type: str
+    num_hidden_layers: int
+    draft_vocab_size: int | None = None
+    populate: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.model_type, field_name="model_type")
+        if (
+            isinstance(self.num_hidden_layers, bool)
+            or not isinstance(self.num_hidden_layers, int)
+            or self.num_hidden_layers <= 0
+        ):
+            raise ValueError("num_hidden_layers must be a positive integer")
+        if self.draft_vocab_size is not None and (
+            isinstance(self.draft_vocab_size, bool)
+            or not isinstance(self.draft_vocab_size, int)
+            or self.draft_vocab_size <= 0
+        ):
+            raise ValueError("draft_vocab_size must be a positive integer or None")
+        if self.populate is not None and not callable(self.populate):
+            raise TypeError("populate must be callable or None")
+
+
+@dataclass(frozen=True)
+class DraftConfigProvider:
+    """Algorithm policy around a registered draft architecture.
+
+    This object does not contain a model/config class and does not load a
+    config.  It supplies algorithm-specific generation and override behavior
+    to the composition root after ``DraftModelRegistry`` resolves the class.
+    """
+
+    architecture: str
+    target_defaults: TargetDerivedDraftDefaults | None = None
+    expected_auto_map_model: str | None = None
+    apply_overrides: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.architecture, field_name="architecture")
+        if self.expected_auto_map_model is not None:
+            _non_empty(
+                self.expected_auto_map_model,
+                field_name="expected_auto_map_model",
+            )
+        if self.apply_overrides is not None and not callable(self.apply_overrides):
+            raise TypeError("apply_overrides must be callable or None")
+
+
+@dataclass(frozen=True)
+class StepRuntimeConfig(Mapping[str, Any]):
+    """Resolved step options and checkpoint policy for one training run.
+
+    The mapping interface exposes only strategy constructor options, so the
+    existing runtime builders can forward this object through their
+    ``strategy_kwargs`` seam. ``Trainer`` additionally reads the immutable
+    checkpoint metadata carried alongside those options.
+    """
+
+    options: Mapping[str, Any]
+    resume_contract: Mapping[str, Any]
+    allowed_missing_checkpoint_keys: FrozenSet[str]
+
+    def __post_init__(self) -> None:
+        options = dict(self.options)
+        invalid_option_keys = sorted(
+            repr(key) for key in options if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_option_keys:
+            raise ValueError(
+                "step option keys must be non-empty strings, got "
+                f"{invalid_option_keys}"
+            )
+        resume_contract = dict(self.resume_contract)
+        invalid_contract_keys = sorted(
+            repr(key)
+            for key in resume_contract
+            if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_contract_keys:
+            raise ValueError(
+                "resume_contract keys must be non-empty strings, got "
+                f"{invalid_contract_keys}"
+            )
+        expected_options_contract = tuple(
+            (key, options[key]) for key in sorted(options)
+        )
+        recorded_options_contract = resume_contract.setdefault(
+            STEP_OPTIONS_CONTRACT_KEY,
+            expected_options_contract,
+        )
+        if recorded_options_contract != expected_options_contract:
+            raise ValueError(
+                f"{STEP_OPTIONS_CONTRACT_KEY!r} must exactly match the resolved "
+                f"step options: expected {expected_options_contract!r}, got "
+                f"{recorded_options_contract!r}"
+            )
+        allowed_missing = frozenset(self.allowed_missing_checkpoint_keys)
+        invalid_missing_keys = sorted(
+            repr(key)
+            for key in allowed_missing
+            if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_missing_keys:
+            raise ValueError(
+                "allowed missing checkpoint keys must be non-empty strings, got "
+                f"{invalid_missing_keys}"
+            )
+        if (
+            allowed_missing
+            and OMITTED_STATE_FINGERPRINT_CONTRACT_KEY not in resume_contract
+        ):
+            raise ValueError(
+                "allowed missing checkpoint keys require the runtime-owned "
+                f"{OMITTED_STATE_FINGERPRINT_CONTRACT_KEY!r} resume contract"
+            )
+        object.__setattr__(self, "options", MappingProxyType(options))
+        object.__setattr__(
+            self,
+            "resume_contract",
+            MappingProxyType(resume_contract),
+        )
+        object.__setattr__(self, "allowed_missing_checkpoint_keys", allowed_missing)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.options[key]
+
+    def __iter__(self):
+        return iter(self.options)
+
+    def __len__(self) -> int:
+        return len(self.options)
+
+
+@dataclass(frozen=True)
+class StepProvider:
+    """Factories and persistence hooks for one algorithm's training step."""
+
+    build: Factory
+    options: Factory
+    resume_contract: Factory
+    allowed_missing_checkpoint_keys: Factory
+    uses_external_target_head: bool
+
+    def __post_init__(self) -> None:
+        _factories_are_callable(
+            (
+                ("build", self.build),
+                ("options", self.options),
+                ("resume_contract", self.resume_contract),
+                (
+                    "allowed_missing_checkpoint_keys",
+                    self.allowed_missing_checkpoint_keys,
+                ),
+            )
+        )
+        if not isinstance(self.uses_external_target_head, bool):
+            raise TypeError("uses_external_target_head must be a bool")
+
+    def bind_runtime(
+        self,
+        config: Any,
+        draft_model: Any,
+        training_model: Any,
+        *,
+        model_provenance: Mapping[str, Any] | None = None,
+    ) -> StepRuntimeConfig:
+        """Resolve algorithm checkpoint semantics against the live model."""
+
+        options = self.options(config)
+        if not isinstance(options, Mapping):
+            raise TypeError(
+                "step options must return a mapping, got " f"{type(options).__name__}"
+            )
+        provider_contract = self.resume_contract(config, draft_model, training_model)
+        if not isinstance(provider_contract, Mapping):
+            raise TypeError(
+                "step resume_contract must return a mapping, got "
+                f"{type(provider_contract).__name__}"
+            )
+        resume_contract = dict(provider_contract)
+        reserved = {
+            STEP_OPTIONS_CONTRACT_KEY,
+            MODEL_PROVENANCE_CONTRACT_KEY,
+            OMITTED_STATE_FINGERPRINT_CONTRACT_KEY,
+        } & resume_contract.keys()
+        if reserved:
+            raise ValueError(
+                "provider resume_contract uses runtime-owned fields: "
+                f"{sorted(reserved)}"
+            )
+        resume_contract[STEP_OPTIONS_CONTRACT_KEY] = tuple(
+            (key, options[key]) for key in sorted(options)
+        )
+        if model_provenance is not None:
+            resume_contract[MODEL_PROVENANCE_CONTRACT_KEY] = tuple(
+                (key, model_provenance[key]) for key in sorted(model_provenance)
+            )
+        allowed_missing = frozenset(
+            self.allowed_missing_checkpoint_keys(
+                config,
+                draft_model,
+                training_model,
+            )
+        )
+        if allowed_missing:
+            resume_contract[OMITTED_STATE_FINGERPRINT_CONTRACT_KEY] = (
+                checkpoint_key_fingerprint(draft_model, allowed_missing)
+            )
+        return StepRuntimeConfig(
+            options=options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=allowed_missing,
+        )
+
+
+@dataclass(frozen=True)
+class ModelProvider:
+    """Algorithm-owned model assembly hooks.
+
+    Keeping concrete model imports inside hook functions lets the immutable
+    registry resolve without importing Torch or Transformers.
+    """
+
+    draft_config: DraftConfigProvider
+    build_draft: Factory
+    build_training_model: Factory
+    resolve_capture_layers: Factory
+    minimum_loss_tokens: Factory
+    needs_input_tools: Factory
+    default_dataloader_num_workers: int
+    allow_missing_warm_start_embedding: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.draft_config, DraftConfigProvider):
+            raise TypeError("draft_config must be a DraftConfigProvider")
+        _factories_are_callable(
+            (
+                ("build_draft", self.build_draft),
+                ("build_training_model", self.build_training_model),
+                ("resolve_capture_layers", self.resolve_capture_layers),
+                ("minimum_loss_tokens", self.minimum_loss_tokens),
+                ("needs_input_tools", self.needs_input_tools),
+            )
+        )
+        if (
+            isinstance(self.default_dataloader_num_workers, bool)
+            or not isinstance(self.default_dataloader_num_workers, int)
+            or self.default_dataloader_num_workers < 0
+        ):
+            raise ValueError(
+                "default_dataloader_num_workers must be a non-negative integer"
+            )
+        if not isinstance(self.allow_missing_warm_start_embedding, bool):
+            raise TypeError("allow_missing_warm_start_embedding must be a bool")
+
+
+@dataclass(frozen=True)
+class OfflineDataProvider:
+    """Reader, normalizer, and collator for one offline modality."""
+
+    modality: str
+    normalizer_id: str
+    build_reader: Factory
+    build_normalizer: Factory
+    build_collator: Factory
+
+    def __post_init__(self) -> None:
+        _non_empty(self.modality, field_name="modality")
+        _non_empty(self.normalizer_id, field_name="normalizer_id")
+        _factories_are_callable(
+            (
+                ("build_reader", self.build_reader),
+                ("build_normalizer", self.build_normalizer),
+                ("build_collator", self.build_collator),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ServerCaptureLayout:
+    """Maps generic server artifacts onto algorithm-ready feature names."""
+
+    aux_feature: str | None
+    last_hidden_feature: str | None
+    passthrough: Tuple[Tuple[str, str, Tuple[int, ...]], ...]
+    attention_mask_feature: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "aux_feature",
+            "last_hidden_feature",
+            "attention_mask_feature",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                _non_empty(value, field_name=field_name)
+        passthrough = tuple(self.passthrough)
+        for feature_name, payload_key, trailing_shape in passthrough:
+            _non_empty(feature_name, field_name="passthrough feature name")
+            _non_empty(payload_key, field_name="passthrough payload key")
+            if any(
+                isinstance(size, bool) or not isinstance(size, int) or size < 0
+                for size in trailing_shape
+            ):
+                raise ValueError(
+                    "passthrough trailing shapes must contain non-negative integers"
+                )
+        object.__setattr__(self, "passthrough", passthrough)
+
+
+@dataclass(frozen=True)
+class ServerStreamingProvider:
+    """Algorithm adapter for externally captured streaming features.
+
+    ``build_input_adapter`` is deliberately modality-neutral. Text providers
+    can leave it unset; the current runtime does not support VLM registration
+    or media requests.
+    """
+
+    modality: str
+    capture_method: str
+    target_representation: str | None
+    layout: ServerCaptureLayout
+    build_collator: Factory
+    build_input_adapter: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.modality, field_name="modality")
+        _non_empty(self.capture_method, field_name="capture_method")
+        if self.target_representation is not None:
+            _non_empty(
+                self.target_representation,
+                field_name="target_representation",
+            )
+        if not isinstance(self.layout, ServerCaptureLayout):
+            raise TypeError("layout must be a ServerCaptureLayout")
+        if not callable(self.build_collator):
+            raise TypeError("build_collator must be callable")
+        if self.build_input_adapter is not None and not callable(
+            self.build_input_adapter
+        ):
+            raise TypeError("build_input_adapter must be callable or None")
+
+    def create_input_adapter(self, config: Any) -> ServerInputAdapter | None:
+        """Construct and validate the optional modality-owned input adapter."""
+
+        if self.build_input_adapter is None:
+            return None
+        adapter = self.build_input_adapter(config)
+        required = (
+            "load_input_tools",
+            "prepare_prompts",
+            "build_request_inputs",
+        )
+        missing = [
+            name for name in required if not callable(getattr(adapter, name, None))
+        ]
+        if missing:
+            raise TypeError(
+                "build_input_adapter must return a ServerInputAdapter; "
+                f"missing callable methods: {missing}"
+            )
+        return adapter
+
+
+@dataclass(frozen=True)
+class AlgorithmProviders:
+    """Executable providers paired with one pure ``AlgorithmSpec``."""
+
+    algorithm_name: str
+    step: StepProvider
+    model: ModelProvider
+    offline: Tuple[OfflineDataProvider, ...] = ()
+    server_streaming: Tuple[ServerStreamingProvider, ...] = ()
+    vocab_mapping_modes: FrozenSet[FeatureMode] = frozenset()
+
+    def __post_init__(self) -> None:
+        _non_empty(self.algorithm_name, field_name="algorithm_name")
+        if not isinstance(self.step, StepProvider):
+            raise TypeError("step must be a StepProvider")
+        if not isinstance(self.model, ModelProvider):
+            raise TypeError("model must be a ModelProvider")
+        offline = tuple(self.offline)
+        streaming = tuple(self.server_streaming)
+        self._validate_unique_modalities(offline, field_name="offline")
+        self._validate_unique_modalities(
+            streaming,
+            field_name="server_streaming",
+        )
+        modes = frozenset(FeatureMode(mode) for mode in self.vocab_mapping_modes)
+        object.__setattr__(self, "offline", offline)
+        object.__setattr__(self, "server_streaming", streaming)
+        object.__setattr__(self, "vocab_mapping_modes", modes)
+
+    @staticmethod
+    def _validate_unique_modalities(providers, *, field_name: str) -> None:
+        modalities = [provider.modality for provider in providers]
+        duplicates = sorted(
+            modality for modality in set(modalities) if modalities.count(modality) > 1
+        )
+        if duplicates:
+            raise ValueError(f"duplicate {field_name} modalities: {duplicates}")
+
+    def offline_for(self, modality: str) -> OfflineDataProvider:
+        return self._provider_for(self.offline, modality, kind="offline")
+
+    def server_streaming_for(self, modality: str) -> ServerStreamingProvider:
+        return self._provider_for(
+            self.server_streaming,
+            modality,
+            kind="server streaming",
+        )
+
+    def _provider_for(self, providers, modality: str, *, kind: str):
+        for provider in providers:
+            if provider.modality == modality:
+                return provider
+        available = sorted(provider.modality for provider in providers)
+        raise KeyError(
+            f"algorithm {self.algorithm_name!r} has no {kind} provider for "
+            f"modality {modality!r}; available: {available}"
+        )
+
+
+def make_registration(
+    spec: AlgorithmSpec,
+    providers: AlgorithmProviders,
+) -> AlgorithmRegistration:
+    """Validate contract/provider parity and return one registration."""
+
+    if providers.algorithm_name != spec.name:
+        raise ValueError(
+            f"provider algorithm {providers.algorithm_name!r} does not match "
+            f"spec {spec.name!r}"
+        )
+    if providers.model.draft_config.architecture not in (
+        spec.draft.compatible_architectures
+    ):
+        raise ValueError(
+            "model provider architecture is not compatible with the algorithm "
+            f"contract: {providers.model.draft_config.architecture!r}"
+        )
+
+    expected = {contract.key for contract in spec.feature_contracts}
+    provided = {
+        *((FeatureMode.OFFLINE, provider.modality) for provider in providers.offline),
+        *(
+            (FeatureMode.STREAMING, provider.modality)
+            for provider in providers.server_streaming
+        ),
+    }
+    if provided != expected:
+        raise ValueError(
+            "feature contract/provider keys differ: "
+            f"contracts={sorted((mode.value, modality) for mode, modality in expected)}, "
+            f"providers={sorted((mode.value, modality) for mode, modality in provided)}"
+        )
+    has_vocab_mapping_provider = bool(providers.vocab_mapping_modes)
+    if has_vocab_mapping_provider != spec.capabilities.supports_vocab_mapping:
+        raise ValueError(
+            "vocab-mapping capability/provider mismatch: "
+            f"contract={spec.capabilities.supports_vocab_mapping}, "
+            f"provider_modes={sorted(mode.value for mode in providers.vocab_mapping_modes)}"
+        )
+    unavailable_mapping_modes = providers.vocab_mapping_modes - spec.feature_modes
+    if unavailable_mapping_modes:
+        raise ValueError(
+            "vocab-mapping provider modes lack feature contracts: "
+            f"{sorted(mode.value for mode in unavailable_mapping_modes)}"
+        )
+
+    for provider in providers.offline:
+        contract = spec.feature_contract(FeatureMode.OFFLINE, provider.modality)
+        if contract.storage is None:  # pragma: no cover - contract invariant
+            raise ValueError("offline contract is missing storage")
+        if provider.normalizer_id != contract.storage.normalizer:
+            raise ValueError(
+                f"offline normalizer mismatch for {provider.modality!r}: "
+                f"{provider.normalizer_id!r} != {contract.storage.normalizer!r}"
+            )
+    for provider in providers.server_streaming:
+        contract = spec.feature_contract(FeatureMode.STREAMING, provider.modality)
+        if provider.target_representation != contract.default_target_representation:
+            raise ValueError(
+                f"streaming target representation mismatch for "
+                f"{provider.modality!r}: {provider.target_representation!r} != "
+                f"{contract.default_target_representation!r}"
+            )
+        layout = provider.layout
+        emitted = {
+            *(
+                feature
+                for feature in (
+                    layout.aux_feature,
+                    layout.last_hidden_feature,
+                    layout.attention_mask_feature,
+                )
+                if feature is not None
+            ),
+            *(feature for feature, _payload, _shape in layout.passthrough),
+        }
+        missing = contract.required_tensors - emitted
+        if missing:
+            raise ValueError(
+                f"server capture layout for {provider.modality!r} does not emit "
+                f"required tensors: {sorted(missing)}"
+            )
+
+    return AlgorithmRegistration(spec=spec, providers=providers)
+
+
+__all__ = [
+    "AlgorithmProviders",
+    "DraftConfigProvider",
+    "MODEL_PROVENANCE_CONTRACT_KEY",
+    "ModelProvider",
+    "OMITTED_STATE_FINGERPRINT_CONTRACT_KEY",
+    "OfflineDataProvider",
+    "STEP_OPTIONS_CONTRACT_KEY",
+    "ServerCaptureLayout",
+    "ServerInputAdapter",
+    "ServerStreamingProvider",
+    "StepProvider",
+    "StepRuntimeConfig",
+    "TargetDerivedDraftDefaults",
+    "checkpoint_key_fingerprint",
+    "make_registration",
+]

--- a/specforge/algorithms/contracts.py
+++ b/specforge/algorithms/contracts.py
@@ -1,0 +1,364 @@
+"""Pure contracts describing what a speculative training algorithm consumes.
+
+This module intentionally contains no factories, model classes, or runtime
+objects.  Algorithm implementations live behind provider ports; deployment and
+transport are resolved by the application layer.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+from typing import FrozenSet, Iterable, Tuple
+
+_ALGORITHM_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _normalized_names(
+    values: Iterable[str],
+    *,
+    field_name: str,
+    allow_empty: bool = False,
+) -> FrozenSet[str]:
+    if isinstance(values, str):
+        raise TypeError(f"{field_name} must be an iterable of names, not a string")
+    normalized = frozenset(values)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{field_name} must not be empty")
+    invalid = [
+        repr(value)
+        for value in normalized
+        if not isinstance(value, str) or not value or value.strip() != value
+    ]
+    if invalid:
+        raise ValueError(
+            f"{field_name} must contain non-empty names without surrounding "
+            f"whitespace, got {', '.join(sorted(invalid))}"
+        )
+    return normalized
+
+
+def _assert_pure_value(value: object, *, path: str) -> None:
+    """Reject executable or opaque state recursively from public contracts."""
+
+    if isinstance(value, type) or callable(value):
+        raise TypeError(f"{path} must be a pure value, got executable {value!r}")
+    if value is None or isinstance(value, (str, int, float, bool, Enum)):
+        return
+    if isinstance(value, (tuple, list, set, frozenset)):
+        for index, item in enumerate(value):
+            _assert_pure_value(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _assert_pure_value(key, path=f"{path}.key")
+            _assert_pure_value(item, path=f"{path}[{key!r}]")
+        return
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_pure_value(
+                getattr(value, field.name),
+                path=f"{path}.{field.name}",
+            )
+        return
+    raise TypeError(
+        f"{path} must contain only serializable contract values, got "
+        f"{type(value).__name__}"
+    )
+
+
+class FeatureMode(str, Enum):
+    """How algorithm-ready target features are consumed."""
+
+    OFFLINE = "offline"
+    STREAMING = "streaming"
+
+
+@dataclass(frozen=True)
+class DraftRequirement:
+    """Pure compatibility requirements for a draft architecture.
+
+    Draft configuration loading, target-derived generation, validation, and
+    model construction belong to the draft-model registry and algorithm-owned
+    providers.  Only stable identifiers and declarative override names belong
+    here.
+    """
+
+    compatible_architectures: FrozenSet[str]
+    default_architecture: str
+    supported_overrides: FrozenSet[str] = frozenset()
+    fixed_override_values: Tuple[Tuple[str, int], ...] = ()
+
+    def __post_init__(self) -> None:
+        architectures = _normalized_names(
+            self.compatible_architectures,
+            field_name="compatible_architectures",
+        )
+        overrides = _normalized_names(
+            self.supported_overrides,
+            field_name="supported_overrides",
+            allow_empty=True,
+        )
+        if self.default_architecture not in architectures:
+            raise ValueError(
+                "default_architecture must be present in " "compatible_architectures"
+            )
+        fixed_values = tuple(self.fixed_override_values)
+        fixed_names = [name for name, _value in fixed_values]
+        duplicates = sorted(
+            name for name in set(fixed_names) if fixed_names.count(name) > 1
+        )
+        if duplicates:
+            raise ValueError(f"duplicate fixed override values: {duplicates}")
+        unsupported = sorted(set(fixed_names) - overrides)
+        if unsupported:
+            raise ValueError(
+                "fixed_override_values must name supported overrides, got "
+                f"{unsupported}"
+            )
+        if any(
+            not isinstance(name, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int)
+            for name, value in fixed_values
+        ):
+            raise TypeError("fixed_override_values must contain (name, integer) pairs")
+        object.__setattr__(self, "compatible_architectures", architectures)
+        object.__setattr__(self, "supported_overrides", overrides)
+        object.__setattr__(self, "fixed_override_values", fixed_values)
+
+
+@dataclass(frozen=True)
+class OfflineStorageContract:
+    """Raw offline record shape before an algorithm normalizer is applied."""
+
+    format: str
+    required_tensors: FrozenSet[str]
+    normalizer: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        for field_name in ("format", "normalizer"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value or value.strip() != value:
+                raise ValueError(
+                    f"{field_name} must be a non-empty name without surrounding "
+                    "whitespace"
+                )
+        if self.schema_version != 1:
+            raise ValueError("only offline storage schema_version=1 is supported")
+        object.__setattr__(
+            self,
+            "required_tensors",
+            _normalized_names(
+                self.required_tensors,
+                field_name="required_tensors",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class FeatureContract:
+    """Algorithm-ready tensors for one ``(mode, modality)`` pair."""
+
+    mode: FeatureMode
+    modality: str
+    required_tensors: FrozenSet[str]
+    optional_tensors: FrozenSet[str] = frozenset()
+    allowed_target_representations: FrozenSet[str] = frozenset()
+    default_target_representation: str | None = None
+    schema_version: int = 1
+    storage: OfflineStorageContract | None = None
+
+    def __post_init__(self) -> None:
+        try:
+            mode = FeatureMode(self.mode)
+        except ValueError as exc:
+            raise ValueError(f"unsupported feature mode {self.mode!r}") from exc
+        if (
+            not isinstance(self.modality, str)
+            or not self.modality
+            or self.modality.strip() != self.modality
+        ):
+            raise ValueError(
+                "modality must be a non-empty name without surrounding whitespace"
+            )
+        if self.schema_version != 1:
+            raise ValueError("only feature schema_version=1 is supported")
+        required = _normalized_names(
+            self.required_tensors,
+            field_name="required_tensors",
+        )
+        optional = _normalized_names(
+            self.optional_tensors,
+            field_name="optional_tensors",
+            allow_empty=True,
+        )
+        representations = _normalized_names(
+            self.allowed_target_representations,
+            field_name="allowed_target_representations",
+            allow_empty=True,
+        )
+        overlap = required & optional
+        if overlap:
+            raise ValueError(
+                "required_tensors and optional_tensors must be disjoint, got "
+                f"{sorted(overlap)}"
+            )
+        if representations:
+            if self.default_target_representation not in representations:
+                raise ValueError(
+                    "default_target_representation must be present in "
+                    "allowed_target_representations"
+                )
+        elif self.default_target_representation is not None:
+            raise ValueError(
+                "default_target_representation requires at least one allowed "
+                "target representation"
+            )
+        if mode is FeatureMode.OFFLINE and self.storage is None:
+            raise ValueError("offline feature contracts require a storage contract")
+        if mode is FeatureMode.STREAMING and self.storage is not None:
+            raise ValueError("streaming feature contracts cannot define storage")
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "required_tensors", required)
+        object.__setattr__(self, "optional_tensors", optional)
+        object.__setattr__(self, "allowed_target_representations", representations)
+
+    @property
+    def key(self) -> tuple[FeatureMode, str]:
+        return self.mode, self.modality
+
+
+@dataclass(frozen=True)
+class AlgorithmCapabilities:
+    """Static algorithm constraints independent of deployment topology."""
+
+    attention_backends: FrozenSet[str]
+    required_batch_size: int | None = None
+    supports_compact_teacher: bool = False
+    supports_vocab_mapping: bool = False
+    allows_aux_layer_override: bool = False
+
+    def __post_init__(self) -> None:
+        attention_backends = _normalized_names(
+            self.attention_backends,
+            field_name="attention_backends",
+        )
+        if self.required_batch_size is not None and (
+            isinstance(self.required_batch_size, bool)
+            or not isinstance(self.required_batch_size, int)
+            or self.required_batch_size <= 0
+        ):
+            raise ValueError("required_batch_size must be a positive integer or None")
+        for field_name in (
+            "supports_compact_teacher",
+            "supports_vocab_mapping",
+            "allows_aux_layer_override",
+        ):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+        object.__setattr__(self, "attention_backends", attention_backends)
+
+
+@dataclass(frozen=True)
+class AlgorithmSpec:
+    """Complete topology-free, executable-free contract for one algorithm."""
+
+    name: str
+    draft: DraftRequirement
+    feature_contracts: Tuple[FeatureContract, ...]
+    capabilities: AlgorithmCapabilities
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not _ALGORITHM_NAME.fullmatch(self.name):
+            raise ValueError(
+                "algorithm name must start with a lowercase letter and contain "
+                "only lowercase letters, digits, '_' or '-'"
+            )
+        if not isinstance(self.draft, DraftRequirement):
+            raise TypeError("draft must be a DraftRequirement")
+        if not isinstance(self.capabilities, AlgorithmCapabilities):
+            raise TypeError("capabilities must be AlgorithmCapabilities")
+        contracts = tuple(self.feature_contracts)
+        if not contracts:
+            raise ValueError("feature_contracts must not be empty")
+        invalid = [
+            type(contract).__name__
+            for contract in contracts
+            if not isinstance(contract, FeatureContract)
+        ]
+        if invalid:
+            raise TypeError(
+                "feature_contracts must contain FeatureContract values, got "
+                f"{invalid}"
+            )
+        keys = [contract.key for contract in contracts]
+        duplicates = sorted(
+            (mode.value, modality)
+            for mode, modality in set(keys)
+            if keys.count((mode, modality)) > 1
+        )
+        if duplicates:
+            raise ValueError(
+                "feature_contracts contains duplicate (mode, modality) keys: "
+                f"{duplicates}"
+            )
+        object.__setattr__(self, "feature_contracts", contracts)
+        _assert_pure_value(self, path="AlgorithmSpec")
+
+    @property
+    def modalities(self) -> FrozenSet[str]:
+        return frozenset(contract.modality for contract in self.feature_contracts)
+
+    @property
+    def feature_modes(self) -> FrozenSet[FeatureMode]:
+        return frozenset(contract.mode for contract in self.feature_contracts)
+
+    @property
+    def supports_online(self) -> bool:
+        """Whether any streaming feature contract is declared."""
+
+        return FeatureMode.STREAMING in self.feature_modes
+
+    def supports(self, mode: FeatureMode | str, modality: str) -> bool:
+        try:
+            resolved_mode = FeatureMode(mode)
+        except ValueError:
+            return False
+        return any(
+            contract.key == (resolved_mode, modality)
+            for contract in self.feature_contracts
+        )
+
+    def feature_contract(
+        self,
+        mode: FeatureMode | str,
+        modality: str,
+    ) -> FeatureContract:
+        try:
+            resolved_mode = FeatureMode(mode)
+        except ValueError as exc:
+            raise KeyError(f"unknown feature mode {mode!r}") from exc
+        for contract in self.feature_contracts:
+            if contract.key == (resolved_mode, modality):
+                return contract
+        supported = sorted(
+            (contract.mode.value, contract.modality)
+            for contract in self.feature_contracts
+        )
+        raise KeyError(
+            f"algorithm {self.name!r} does not support "
+            f"({resolved_mode.value!r}, {modality!r}); supported: {supported}"
+        )
+
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmSpec",
+    "DraftRequirement",
+    "FeatureContract",
+    "FeatureMode",
+    "OfflineStorageContract",
+]

--- a/specforge/algorithms/registry.py
+++ b/specforge/algorithms/registry.py
@@ -1,0 +1,99 @@
+"""Explicit, immutable registrations for algorithm contracts and providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Tuple
+
+from specforge.algorithms.contracts import AlgorithmSpec
+
+
+@dataclass(frozen=True)
+class AlgorithmRegistration:
+    """One lookup result containing pure metadata and executable providers.
+
+    Keeping the two halves in one registration avoids parallel spec/provider
+    registries.  Planning reads ``spec``; the composition root alone reads
+    ``providers``.
+    """
+
+    spec: AlgorithmSpec
+    providers: object
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.spec, AlgorithmSpec):
+            raise TypeError("spec must be an AlgorithmSpec")
+        if self.providers is None:
+            raise TypeError("providers must not be None")
+        provider_name = getattr(self.providers, "algorithm_name", self.spec.name)
+        if provider_name != self.spec.name:
+            raise ValueError(
+                "provider algorithm_name must match spec.name: "
+                f"{provider_name!r} != {self.spec.name!r}"
+            )
+
+    @property
+    def name(self) -> str:
+        return self.spec.name
+
+
+@dataclass(frozen=True, init=False)
+class AlgorithmRegistry:
+    """Immutable catalog assembled explicitly by the composition root."""
+
+    _registrations: Tuple[AlgorithmRegistration, ...]
+
+    def __init__(
+        self,
+        registrations: Iterable[AlgorithmRegistration] = (),
+    ) -> None:
+        resolved = tuple(registrations)
+        invalid = [
+            type(registration).__name__
+            for registration in resolved
+            if not isinstance(registration, AlgorithmRegistration)
+        ]
+        if invalid:
+            raise TypeError(
+                "registry values must be AlgorithmRegistration, got " f"{invalid}"
+            )
+        names = [registration.name for registration in resolved]
+        duplicates = sorted(name for name in set(names) if names.count(name) > 1)
+        if duplicates:
+            raise ValueError(f"duplicate algorithm registrations: {duplicates}")
+        object.__setattr__(
+            self,
+            "_registrations",
+            tuple(sorted(resolved, key=lambda registration: registration.name)),
+        )
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        return tuple(registration.name for registration in self._registrations)
+
+    @property
+    def registrations(self) -> Tuple[AlgorithmRegistration, ...]:
+        return self._registrations
+
+    def resolve(self, name: str) -> AlgorithmRegistration:
+        for registration in self._registrations:
+            if registration.name == name:
+                return registration
+        raise KeyError(
+            f"unknown algorithm {name!r}; registered algorithms: {list(self.names)}"
+        )
+
+    def with_registration(
+        self,
+        registration: AlgorithmRegistration,
+    ) -> "AlgorithmRegistry":
+        return AlgorithmRegistry((*self._registrations, registration))
+
+    def __iter__(self) -> Iterator[AlgorithmRegistration]:
+        return iter(self._registrations)
+
+    def __len__(self) -> int:
+        return len(self._registrations)
+
+
+__all__ = ["AlgorithmRegistration", "AlgorithmRegistry"]

--- a/tests/test_algorithms/__init__.py
+++ b/tests/test_algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Algorithm contract tests."""

--- a/tests/test_algorithms/test_contracts.py
+++ b/tests/test_algorithms/test_contracts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError, fields, is_dataclass
+from enum import Enum
+
+from specforge.algorithms import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+
+
+def _offline(modality: str = "text") -> FeatureContract:
+    return FeatureContract(
+        mode=FeatureMode.OFFLINE,
+        modality=modality,
+        required_tensors={"input_ids", "hidden_states", "loss_mask"},
+        allowed_target_representations={"hidden_state"},
+        default_target_representation="hidden_state",
+        storage=OfflineStorageContract(
+            format="manifest_v1",
+            required_tensors={"input_ids", "hidden_states", "loss_mask"},
+            normalizer="eagle3_offline_v1",
+        ),
+    )
+
+
+def _streaming(modality: str = "text") -> FeatureContract:
+    required = {"input_ids", "hidden_state", "target", "loss_mask"}
+    if modality == "vision_language":
+        required.add("position_ids")
+    return FeatureContract(
+        mode=FeatureMode.STREAMING,
+        modality=modality,
+        required_tensors=required,
+        allowed_target_representations={"hidden_state"},
+        default_target_representation="hidden_state",
+    )
+
+
+def _spec(*contracts: FeatureContract) -> AlgorithmSpec:
+    return AlgorithmSpec(
+        name="eagle3",
+        draft=DraftRequirement(
+            compatible_architectures={"LlamaForCausalLMEagle3"},
+            default_architecture="LlamaForCausalLMEagle3",
+            supported_overrides={"attention_layout", "num_hidden_layers"},
+        ),
+        feature_contracts=contracts or (_offline(), _streaming()),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"sdpa", "flex_attention"},
+            supports_compact_teacher=True,
+            supports_vocab_mapping=True,
+        ),
+    )
+
+
+def _assert_contract_is_pure(value: object) -> None:
+    if isinstance(value, type) or callable(value):
+        raise AssertionError(f"executable value leaked into contract: {value!r}")
+    if value is None or isinstance(value, (str, int, float, bool, Enum)):
+        return
+    if isinstance(value, (tuple, list, set, frozenset)):
+        for item in value:
+            _assert_contract_is_pure(item)
+        return
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_contract_is_pure(getattr(value, field.name))
+        return
+    raise AssertionError(f"opaque value leaked into contract: {type(value).__name__}")
+
+
+class AlgorithmContractTest(unittest.TestCase):
+    def test_spec_is_recursively_pure(self):
+        _assert_contract_is_pure(_spec())
+
+    def test_same_mode_can_define_multiple_modalities(self):
+        spec = _spec(_streaming("text"), _streaming("vision_language"))
+
+        self.assertTrue(spec.supports("streaming", "text"))
+        self.assertIn(
+            "position_ids",
+            spec.feature_contract("streaming", "vision_language").required_tensors,
+        )
+
+    def test_online_capability_is_derived_from_streaming_contract(self):
+        self.assertFalse(_spec(_offline()).supports_online)
+        self.assertTrue(_spec(_streaming()).supports_online)
+
+    def test_duplicate_mode_and_modality_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            _spec(_streaming(), _streaming())
+
+    def test_offline_requires_storage_contract(self):
+        with self.assertRaisesRegex(ValueError, "require a storage contract"):
+            FeatureContract(
+                mode="offline",
+                modality="text",
+                required_tensors={"input_ids"},
+            )
+
+    def test_streaming_rejects_offline_storage_contract(self):
+        with self.assertRaisesRegex(ValueError, "cannot define storage"):
+            FeatureContract(
+                mode="streaming",
+                modality="text",
+                required_tensors={"input_ids"},
+                storage=OfflineStorageContract(
+                    format="manifest_v1",
+                    required_tensors={"input_ids"},
+                    normalizer="text_v1",
+                ),
+            )
+
+    def test_contracts_are_immutable(self):
+        spec = _spec()
+
+        with self.assertRaises(FrozenInstanceError):
+            spec.name = "dflash"
+
+    def test_draft_requirement_accepts_flexible_layout_override(self):
+        requirement = _spec().draft
+
+        self.assertIn("attention_layout", requirement.supported_overrides)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_algorithms/test_registry.py
+++ b/tests/test_algorithms/test_registry.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+from specforge.algorithms import (
+    AlgorithmCapabilities,
+    AlgorithmRegistration,
+    AlgorithmRegistry,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+)
+
+
+@dataclass(frozen=True)
+class _Providers:
+    algorithm_name: str
+
+
+def _registration(name: str) -> AlgorithmRegistration:
+    return AlgorithmRegistration(
+        spec=AlgorithmSpec(
+            name=name,
+            draft=DraftRequirement(
+                compatible_architectures={f"{name}-draft"},
+                default_architecture=f"{name}-draft",
+            ),
+            feature_contracts=(
+                FeatureContract(
+                    mode=FeatureMode.STREAMING,
+                    modality="text",
+                    required_tensors={"input_ids"},
+                ),
+            ),
+            capabilities=AlgorithmCapabilities(attention_backends={"sdpa"}),
+        ),
+        providers=_Providers(name),
+    )
+
+
+class AlgorithmRegistryTest(unittest.TestCase):
+    def test_registry_is_deterministic_and_instance_owned(self):
+        empty = AlgorithmRegistry()
+        registry = AlgorithmRegistry((_registration("peagle"), _registration("eagle3")))
+
+        self.assertEqual((), empty.names)
+        self.assertEqual(("eagle3", "peagle"), registry.names)
+        self.assertEqual("peagle", registry.resolve("peagle").name)
+
+    def test_with_registration_returns_new_registry(self):
+        empty = AlgorithmRegistry()
+        populated = empty.with_registration(_registration("eagle3"))
+
+        self.assertEqual((), empty.names)
+        self.assertEqual(("eagle3",), populated.names)
+
+    def test_duplicate_registration_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "duplicate algorithm"):
+            AlgorithmRegistry((_registration("eagle3"), _registration("eagle3")))
+
+    def test_provider_name_must_match_spec(self):
+        registration = _registration("eagle3")
+
+        with self.assertRaisesRegex(ValueError, "must match"):
+            AlgorithmRegistration(
+                spec=registration.spec,
+                providers=_Providers("dflash"),
+            )
+
+    def test_unknown_algorithm_lists_registered_names(self):
+        registry = AlgorithmRegistry((_registration("eagle3"),))
+
+        with self.assertRaisesRegex(
+            KeyError,
+            r"registered algorithms: \['eagle3'\]",
+        ):
+            registry.resolve("missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part **P04/14** of the review stack replacing monolithic #678.

## Review this layer

**Primary decision:** are the immutable contracts and registry/provider interfaces stable enough to own every builtin algorithm?

- Logical parent: [#684](https://github.com/sgl-project/SpecForge/pull/684) at `5bc85b8`
- Incremental diff: [P04 only](https://github.com/maocheng23/SpecForge/compare/agent/pr678-p03-flow-control...agent/pr678-p04-algorithm-contracts)
- Commit: `dec4e10`
- Review order: after #684

## What changes

- Introduces algorithm, capture, and storage contracts plus common collation/default types.
- Adds a deterministic instance-owned registry and provider interfaces.
- Concrete builtin activation is deliberately deferred to P05.

## Validation

- `13 passed`

- GitHub Actions lint: passed after the lint-clean restack.

## Review note

Review contract purity, modality uniqueness, duplicate registration failure, and provider/spec identity.

> This draft temporarily targets `main` because the logical parent ref lives in the fork. GitHub's Files tab is therefore cumulative; review the incremental link above. Mark this PR ready only after its parent lands/it is retargeted. Final tip `4d9b08a` is tree-identical to corrected #678 head `3c89ddc`.