### PR TITLE
[PR678 stack 05/14] feat(algorithms): add builtin providers and model loading

### DIFF
--- a/specforge/algorithms/__init__.py
+++ b/specforge/algorithms/__init__.py
@@ -1,0 +1,22 @@
+"""Topology-free algorithm contracts and explicit registrations."""
+
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+from specforge.algorithms.registry import AlgorithmRegistration, AlgorithmRegistry
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmRegistration",
+    "AlgorithmRegistry",
+    "AlgorithmSpec",
+    "DraftRequirement",
+    "FeatureContract",
+    "FeatureMode",
+    "OfflineStorageContract",
+]

--- a/specforge/algorithms/builtin.py
+++ b/specforge/algorithms/builtin.py
@@ -1,0 +1,19 @@
+"""Explicit immutable catalog of SpecForge's built-in algorithms."""
+
+from __future__ import annotations
+
+from specforge.algorithms.dflash.providers import create_registration as dflash
+from specforge.algorithms.domino.providers import create_registration as domino
+from specforge.algorithms.dspark.providers import create_registration as dspark
+from specforge.algorithms.eagle3.providers import create_registration as eagle3
+from specforge.algorithms.peagle.providers import create_registration as peagle
+from specforge.algorithms.registry import AlgorithmRegistry
+
+
+def builtin_algorithm_registry() -> AlgorithmRegistry:
+    """Return a fresh immutable catalog without module-level mutation."""
+
+    return AlgorithmRegistry((eagle3(), peagle(), dflash(), domino(), dspark()))
+
+
+__all__ = ["builtin_algorithm_registry"]

--- a/specforge/algorithms/common/__init__.py
+++ b/specforge/algorithms/common/__init__.py
@@ -1,0 +1,29 @@
+"""Shared provider ports and small data adapters for built-in algorithms."""
+
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    OfflineDataProvider,
+    ServerCaptureLayout,
+    ServerInputAdapter,
+    ServerStreamingProvider,
+    StepProvider,
+    StepRuntimeConfig,
+    TargetDerivedDraftDefaults,
+    make_registration,
+)
+
+__all__ = [
+    "AlgorithmProviders",
+    "DraftConfigProvider",
+    "ModelProvider",
+    "OfflineDataProvider",
+    "ServerCaptureLayout",
+    "ServerInputAdapter",
+    "ServerStreamingProvider",
+    "StepProvider",
+    "StepRuntimeConfig",
+    "TargetDerivedDraftDefaults",
+    "make_registration",
+]

--- a/specforge/algorithms/common/collation.py
+++ b/specforge/algorithms/common/collation.py
@@ -1,0 +1,71 @@
+"""Small algorithm-owned batch collation helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+
+def concatenate_features(features):
+    """Concatenate equal-shaped per-sample feature dictionaries."""
+
+    if not features:
+        raise ValueError("cannot collate an empty feature batch")
+    import torch
+
+    keys = tuple(features[0])
+    expected_keys = set(keys)
+    if any(set(feature) != expected_keys for feature in features[1:]):
+        raise ValueError("all samples must expose the same feature keys")
+    return {
+        key: torch.cat([feature[key] for feature in features], dim=0) for key in keys
+    }
+
+
+def pad_and_concatenate_features(
+    features,
+    *,
+    sequence_axes: Mapping[str, int],
+    required_keys: Sequence[str],
+):
+    """Zero-pad configured tensor axes to the longest input sequence."""
+
+    if not features:
+        raise ValueError("cannot collate an empty feature batch")
+    required = tuple(required_keys)
+    missing = [
+        (index, key)
+        for index, feature in enumerate(features)
+        for key in required
+        if key not in feature
+    ]
+    if missing:
+        raise KeyError(f"feature batch is missing required keys: {missing}")
+    max_length = max(int(feature["input_ids"].shape[-1]) for feature in features)
+
+    import torch
+
+    batch = {}
+    for key in required:
+        axis = sequence_axes[key]
+        padded = []
+        for feature in features:
+            tensor = feature[key]
+            length = int(tensor.shape[axis])
+            if length > max_length:
+                raise ValueError(
+                    f"feature {key!r} sequence length {length} exceeds "
+                    f"input_ids length {max_length}"
+                )
+            if length < max_length:
+                shape = list(tensor.shape)
+                shape[axis] = max_length - length
+                tensor = torch.cat(
+                    [tensor, tensor.new_zeros(shape)],
+                    dim=axis,
+                )
+            padded.append(tensor)
+        batch[key] = torch.cat(padded, dim=0)
+    return batch
+
+
+__all__ = ["concatenate_features", "pad_and_concatenate_features"]

--- a/specforge/algorithms/common/defaults.py
+++ b/specforge/algorithms/common/defaults.py
@@ -1,0 +1,32 @@
+"""Default provider hooks shared by built-in registrations."""
+
+from __future__ import annotations
+
+
+def empty_options(_config):
+    return {}
+
+
+def empty_resume_contract(_config, _draft_model, _training_model):
+    return {}
+
+
+def no_missing_checkpoint_keys(_config, _draft_model, _training_model):
+    return frozenset()
+
+
+def one_loss_token(_config, _draft_config=None):
+    return 1
+
+
+def online_needs_input_tools(config, _draft_model):
+    return config.mode == "online"
+
+
+__all__ = [
+    "empty_options",
+    "empty_resume_contract",
+    "no_missing_checkpoint_keys",
+    "one_loss_token",
+    "online_needs_input_tools",
+]

--- a/specforge/algorithms/common/dflash_family_data.py
+++ b/specforge/algorithms/common/dflash_family_data.py
@@ -1,0 +1,121 @@
+"""Shared DFlash-family normalization and padding adapters."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from specforge.algorithms.common.collation import pad_and_concatenate_features
+
+NORMALIZER_ID = "dflash_family_offline_v1"
+
+
+def normalize_offline_sample(raw, max_len: int):
+    """Normalize raw DFlash/Domino capture tensors without target projection."""
+
+    input_ids = raw["input_ids"][:max_len].unsqueeze(0)
+    loss_mask = raw["loss_mask"][:max_len].unsqueeze(0)
+    hidden_states = raw["hidden_states"]
+    if hidden_states.dim() == 3:
+        if hidden_states.shape[0] != 1:
+            raise ValueError(
+                "offline DFlash-family hidden_states must have shape "
+                "[seq, width] or [1, seq, width], got "
+                f"{tuple(hidden_states.shape)}"
+            )
+        hidden_states = hidden_states.squeeze(0)
+    if hidden_states.dim() != 2:
+        raise ValueError(
+            "offline DFlash-family hidden_states must have shape "
+            "[seq, width] or [1, seq, width], got "
+            f"{tuple(hidden_states.shape)}"
+        )
+    hidden_states = hidden_states[:max_len].unsqueeze(0)
+    lengths = {
+        input_ids.shape[1],
+        loss_mask.shape[1],
+        hidden_states.shape[1],
+    }
+    if len(lengths) != 1:
+        raise ValueError(
+            "offline DFlash-family features have mismatched sequence lengths "
+            f"after truncation: input_ids={input_ids.shape[1]}, "
+            f"loss_mask={loss_mask.shape[1]}, "
+            f"hidden_states={hidden_states.shape[1]}"
+        )
+    return {
+        "input_ids": input_ids,
+        "loss_mask": loss_mask,
+        "hidden_states": hidden_states,
+    }
+
+
+def build_offline_reader(
+    strategy,
+    hidden_states_path,
+    *,
+    run_id,
+    ttt_length,
+    max_len,
+):
+    # Transitional runtime import; the composition root will inject this port.
+    from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+    return OfflineManifestReader(
+        hidden_states_path,
+        run_id=run_id,
+        strategy=strategy,
+        feature_keys=("input_ids", "loss_mask", "hidden_states"),
+        target_repr=None,
+        ttt_length=ttt_length,
+        max_len=max_len,
+    )
+
+
+def build_offline_normalizer(max_len, **_topology):
+    return partial(normalize_offline_sample, max_len=max_len)
+
+
+def build_collator():
+    def collate(features):
+        return pad_and_concatenate_features(
+            features,
+            sequence_axes={
+                "input_ids": 1,
+                "loss_mask": 1,
+                "hidden_states": 1,
+            },
+            required_keys=("input_ids", "loss_mask", "hidden_states"),
+        )
+
+    return collate
+
+
+def build_dspark_collator():
+    def collate(features):
+        return pad_and_concatenate_features(
+            features,
+            sequence_axes={
+                "input_ids": 1,
+                "loss_mask": 1,
+                "hidden_states": 1,
+                "target_last_hidden_states": 1,
+            },
+            required_keys=(
+                "input_ids",
+                "loss_mask",
+                "hidden_states",
+                "target_last_hidden_states",
+            ),
+        )
+
+    return collate
+
+
+__all__ = [
+    "NORMALIZER_ID",
+    "build_collator",
+    "build_dspark_collator",
+    "build_offline_normalizer",
+    "build_offline_reader",
+    "normalize_offline_sample",
+]

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -1,0 +1,1011 @@
+# coding=utf-8
+"""DFlash-family training models and shared masking helpers."""
+
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from specforge.modeling.draft.dflash import DFlashDraftModel
+
+try:
+    from torch.nn.attention.flex_attention import BlockMask, create_block_mask
+
+    FLEX_ATTENTION_AVAILABLE = True
+except ImportError:
+    FLEX_ATTENTION_AVAILABLE = False
+    BlockMask = None
+    create_block_mask = None
+
+# NPU workaround: flex_attention is not available on Ascend NPU.
+if hasattr(torch, "npu") and torch.npu.is_available():
+    FLEX_ATTENTION_AVAILABLE = False
+
+
+_VALID_LOSS_TYPES = {
+    "dflash",
+    "dpace",
+    "dpace-cumulative-confidence-only",
+    "dpace-continuation-value-only",
+}
+_DPACE_LOSS_TYPES = _VALID_LOSS_TYPES - {"dflash"}
+
+
+def compute_accept_len(
+    pred_ids_4d: torch.Tensor,
+    target_ids_4d: torch.Tensor,
+    valid_mask_4d: torch.Tensor,
+) -> torch.Tensor:
+    """Compute per-block acceptance length."""
+    correct = (pred_ids_4d == target_ids_4d) | (~valid_mask_4d)
+    accept_prefix = correct.long().cumprod(dim=2) * valid_mask_4d.long()
+    return accept_prefix.sum(dim=2).float()
+
+
+def create_dflash_sdpa_mask(anchor_positions, block_keep_mask, S, block_size, device):
+    B, N = anchor_positions.shape
+    Q_LEN = N * block_size
+    KV_LEN = S + N * block_size
+
+    q_indices = torch.arange(Q_LEN, device=device).view(1, 1, -1, 1)  # (1, 1, Q_LEN, 1)
+    kv_indices = torch.arange(KV_LEN, device=device).view(
+        1, 1, 1, -1
+    )  # (1, 1, 1, KV_LEN)
+
+    q_block_ids = q_indices // block_size
+
+    anchor_expanded = anchor_positions.view(B, 1, N, 1).repeat_interleave(
+        block_size, dim=2
+    )
+
+    mask_context = (kv_indices < S) & (kv_indices < anchor_expanded)
+
+    is_draft = kv_indices >= S
+    kv_block_ids = (kv_indices - S) // block_size
+    mask_draft = is_draft & (q_block_ids == kv_block_ids)
+
+    valid_block = block_keep_mask.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
+
+    final_mask = (mask_context | mask_draft) & valid_block
+    return final_mask
+
+
+def create_dflash_block_mask(
+    anchor_positions: torch.Tensor,
+    block_keep_mask: torch.Tensor,
+    S: int,
+    block_size: int,
+    device: torch.device,
+):
+    """Construct Flex Attention BlockMask for DFlash training.
+
+    KV: [Context (S tokens) | Block_0 | Block_1 | ... | Block_{n-1}]
+    Q:  [Block_0 | Block_1 | ... | Block_{n-1}]
+
+    Rules:
+      1. Each block sees context strictly before its anchor (kv_idx < anchor_pos).
+      2. Intra-block attention is bidirectional.
+      3. Different blocks are invisible to each other.
+      4. Invalid blocks (block_keep_mask=False) see nothing.
+    """
+
+    def dflash_mask_mod(b, h, q_idx, kv_idx):
+        q_block_id = q_idx // block_size
+        safe_q_block_id = q_block_id.clamp(max=N - 1)
+        anchor_pos = anchor_positions[b, safe_q_block_id]
+
+        is_context = kv_idx < S
+        # Strictly less than: matches inference where target_hidden[anchor_pos]
+        # is not available as context.
+        mask_context = is_context & (kv_idx < anchor_pos)
+
+        is_draft = kv_idx >= S
+        kv_block_id = (kv_idx - S) // block_size
+        mask_draft = is_draft & (q_block_id == kv_block_id)
+
+        is_valid_block = block_keep_mask[b, safe_q_block_id]
+        in_bounds = q_block_id < N
+        return (mask_context | mask_draft) & is_valid_block & in_bounds
+
+    B, N = anchor_positions.shape
+    Q_LEN = N * block_size
+    KV_LEN = S + N * block_size
+
+    return create_block_mask(
+        dflash_mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device
+    )
+
+
+class OnlineDFlashModel(nn.Module):
+    """DFlash online training wrapper with DFlash and D-PACE losses."""
+
+    def __init__(
+        self,
+        draft_model: DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        mask_token_id: int,
+        block_size: int = 16,
+        attention_backend: str = "flex_attention",
+        num_anchors: int = 512,
+        loss_decay_gamma: Optional[float] = None,
+        loss_type: str = "dflash",
+        dpace_alpha: float = 0.5,
+    ):
+        super().__init__()
+        if loss_type not in _VALID_LOSS_TYPES:
+            raise ValueError(
+                f"loss_type={loss_type!r}; must be one of {sorted(_VALID_LOSS_TYPES)}"
+            )
+        if not 0.0 <= dpace_alpha <= 1.0:
+            raise ValueError(f"dpace_alpha must be in [0, 1], got {dpace_alpha}")
+
+        self.draft_model = draft_model
+        self.lm_head = target_lm_head
+        self.embed_tokens = target_embed_tokens
+        self.block_size = block_size
+        self.mask_token_id = mask_token_id
+        self.attention_backend = attention_backend
+        self.num_anchors = num_anchors
+        self.loss_decay_gamma = loss_decay_gamma
+        self.loss_type = loss_type
+        self.dpace_alpha = dpace_alpha
+
+        self._cached_block_mask: Optional[BlockMask] = None
+        self._cached_seq_len: Optional[int] = None
+        self._cached_bsz: Optional[int] = None
+
+    def _sample_anchor_positions(
+        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Randomly sample anchor positions per sample; returns (anchors, keep_mask)."""
+        bs = self.block_size
+        bsz = loss_mask.shape[0]
+        max_anchor = max(seq_len - bs, 0)
+
+        valid = loss_mask[:, : max_anchor + 1] > 0.5
+        valid_counts = valid.sum(dim=1)
+        max_n = min(self.num_anchors, int(valid_counts.max().item()) - 1)
+
+        if max_n <= 0:
+            raise ValueError("should preprocess the data.")
+
+        indices = (
+            torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)
+        )
+        masked_indices = torch.where(
+            valid, indices, torch.tensor(seq_len + 1, device=device)
+        )
+
+        random_vals = torch.rand(bsz, max_anchor + 1, device=device)
+        random_vals = torch.where(valid, random_vals, torch.tensor(2.0, device=device))
+
+        _, sorted_idx = random_vals.sort(dim=1)
+        gathered = torch.gather(masked_indices, 1, sorted_idx)
+        anchors = gathered[:, :max_n].sort(dim=1).values
+
+        keep_mask = torch.arange(max_n, device=device).unsqueeze(
+            0
+        ) < valid_counts.unsqueeze(1).clamp(max=max_n)
+        anchors = torch.where(
+            keep_mask, anchors, torch.tensor(0, dtype=torch.long, device=device)
+        )
+
+        return anchors, keep_mask
+
+    def _create_position_ids(self, anchor_positions: torch.Tensor) -> torch.Tensor:
+        """Create absolute position IDs for parallel draft blocks."""
+        bsz, n_blocks = anchor_positions.shape
+        device = anchor_positions.device
+        offsets = torch.arange(self.block_size, device=device).view(1, 1, -1)
+        pos_ids = anchor_positions.unsqueeze(-1) + offsets
+        return pos_ids.view(bsz, -1)
+
+    def _create_noise_embed(self, input_ids, anchor_positions, block_keep_mask):
+        bsz, seq_len = input_ids.shape
+        n = anchor_positions.shape[1]
+        bs = self.block_size
+        device = input_ids.device
+
+        noise_ids = torch.full(
+            (bsz, n * bs), self.mask_token_id, dtype=torch.long, device=device
+        )
+
+        block_starts = torch.arange(n, device=device) * bs
+        block_starts = block_starts.unsqueeze(0).expand(bsz, -1)
+
+        valid_anchor_positions = anchor_positions.clamp(0, seq_len - 1)
+        anchor_tokens = torch.gather(input_ids, 1, valid_anchor_positions)
+
+        flat_batch_idx = torch.arange(bsz, device=device).unsqueeze(1).expand(bsz, n)
+        noise_ids[flat_batch_idx, block_starts] = torch.where(
+            block_keep_mask,
+            anchor_tokens,
+            torch.tensor(self.mask_token_id, dtype=torch.long, device=device),
+        )
+
+        return self.embed_tokens(noise_ids)
+
+    def _dpace_weight(
+        self,
+        prob: torch.Tensor,
+        binary_mask: torch.Tensor,
+        binary_mask_b: torch.Tensor,
+        loss_type: str,
+    ) -> torch.Tensor:
+        """Compute detached D-PACE position weights.
+
+        ``prob`` is the draft probability on the target token at each draft
+        position. Invalid positions are treated as multiplicative no-ops inside
+        prefix products and excluded from suffix sums; the caller still
+        multiplies the returned weights by ``binary_mask`` before reduction.
+        """
+        smooth = (1.0 - self.dpace_alpha) * prob + self.dpace_alpha
+        smooth = torch.where(binary_mask_b, smooth, torch.ones_like(smooth))
+        prefix = torch.cumprod(smooth, dim=-1)
+
+        if loss_type == "dpace-cumulative-confidence-only":
+            return prefix
+
+        suffix = torch.flip(
+            torch.cumsum(torch.flip(prefix * binary_mask, dims=[-1]), dim=-1),
+            dims=[-1],
+        )
+
+        if loss_type == "dpace":
+            return suffix
+        if loss_type == "dpace-continuation-value-only":
+            return suffix / prefix.clamp_min(torch.finfo(prefix.dtype).tiny)
+        raise ValueError(f"unknown D-PACE loss_type {loss_type!r}")
+
+    def _forward_draft_blocks(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        anchor_positions, block_keep_mask = self._sample_anchor_positions(
+            seq_len, loss_mask, device
+        )
+
+        noise_embedding = self._create_noise_embed(
+            input_ids, anchor_positions, block_keep_mask
+        )
+
+        context_position_ids = (
+            torch.arange(seq_len, device=device).unsqueeze(0).expand(bsz, -1)
+        )
+        draft_position_ids = self._create_position_ids(anchor_positions)
+        full_position_ids = torch.cat([context_position_ids, draft_position_ids], dim=1)
+
+        if self.attention_backend == "flex_attention":
+            dflash_attn_mask = create_dflash_block_mask(
+                anchor_positions=anchor_positions,
+                block_keep_mask=block_keep_mask,
+                S=seq_len,
+                block_size=self.block_size,
+                device=device,
+            )
+        else:
+            dflash_attn_mask = create_dflash_sdpa_mask(
+                anchor_positions=anchor_positions,
+                block_keep_mask=block_keep_mask,
+                S=seq_len,
+                block_size=self.block_size,
+                device=device,
+            )
+
+        output_hidden = self.draft_model(
+            position_ids=full_position_ids,
+            noise_embedding=noise_embedding,
+            target_hidden=hidden_states,
+            attention_mask=dflash_attn_mask,
+        )
+        return anchor_positions, block_keep_mask, output_hidden
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+        """Parallel block-wise training forward pass; returns
+        (loss, accuracy, metrics) — same shape as Domino's forward."""
+        if self.attention_backend == "flex_attention" and not FLEX_ATTENTION_AVAILABLE:
+            raise ValueError(
+                "flex_attention is not available on this device; use sdpa/eager."
+            )
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        anchor_positions, block_keep_mask, output_hidden = self._forward_draft_blocks(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            loss_mask=loss_mask,
+        )
+
+        logits = self.lm_head(output_hidden)
+
+        # --- Labels: same-position prediction (position k predicts token anchor+k) ---
+        label_offsets = torch.arange(0, self.block_size, device=device).view(1, 1, -1)
+        label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+        valid_label_mask = label_indices < seq_len
+        safe_label_indices = label_indices.clamp(max=seq_len - 1)
+
+        target_ids = torch.gather(
+            input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+
+        # --- Weight mask: block validity * bounds * exclude anchor (pos 0) * loss_mask ---
+        weight_mask = (
+            block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
+        )
+        weight_mask = weight_mask * valid_label_mask.float()
+
+        pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
+        weight_mask = weight_mask * (pos_in_block > 0).float()
+
+        original_loss_mask_gathered = torch.gather(
+            loss_mask.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+        weight_mask = weight_mask * original_loss_mask_gathered
+
+        binary_eval_mask = weight_mask.view(-1)
+
+        # --- Cross entropy ---
+        flat_logits = logits.view(-1, logits.size(-1))
+        flat_targets = target_ids.view(-1)
+
+        loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+
+        if self.loss_type == "dflash":
+            # Preserve the existing DFlash weighted-mean behavior.
+            loss_weights = weight_mask
+            if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+                k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+                decay_weights = torch.exp(
+                    -(k - 1).clamp(min=0).float() / self.loss_decay_gamma
+                )
+                loss_weights = loss_weights * decay_weights
+
+            flat_weights = loss_weights.view(-1)
+            valid_token_count = flat_weights.sum() + 1e-6
+            loss = (loss_per_token * flat_weights).sum() / valid_token_count
+        elif self.loss_type in _DPACE_LOSS_TYPES:
+            neg_log_q = loss_per_token.view_as(target_ids)
+            with torch.no_grad():
+                q = torch.exp(-neg_log_q)
+                dpace_weights = self._dpace_weight(
+                    q,
+                    weight_mask,
+                    weight_mask > 0,
+                    self.loss_type,
+                )
+            loss_weights = weight_mask * dpace_weights
+            loss = (neg_log_q * loss_weights).sum() / float(bsz)
+        else:
+            raise ValueError(f"unknown loss_type {self.loss_type!r}")
+
+        # --- Accuracy ---
+        with torch.no_grad():
+            pred_ids = torch.argmax(flat_logits, dim=-1)
+            correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+            accuracy_denom = binary_eval_mask.sum()
+            accuracy = correct.sum().float() / (accuracy_denom + 1e-6)
+
+        return loss, accuracy, {"accuracy_denom": accuracy_denom.detach()}
+
+
+class OnlineDominoModel(OnlineDFlashModel):
+    """Domino online training wrapper over DFlash block-parallel components."""
+
+    def __init__(
+        self,
+        draft_model: DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        mask_token_id: int,
+        block_size: int = 16,
+        attention_backend: str = "flex_attention",
+        num_anchors: int = 512,
+        loss_decay_gamma: Optional[float] = None,
+        shift_label: bool = False,
+    ):
+        super().__init__(
+            draft_model=draft_model,
+            target_lm_head=target_lm_head,
+            target_embed_tokens=target_embed_tokens,
+            mask_token_id=mask_token_id,
+            block_size=block_size,
+            attention_backend=attention_backend,
+            num_anchors=num_anchors,
+            loss_decay_gamma=loss_decay_gamma,
+            loss_type="dflash",
+        )
+        self.shift_label = shift_label
+
+    def _sample_anchor_positions(
+        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Randomly sample anchor positions per sample; returns (anchors, keep_mask)."""
+        bs = self.block_size
+        bsz = loss_mask.shape[0]
+        max_anchor = max(seq_len - bs, 0)
+
+        valid = loss_mask[:, : max_anchor + 1] > 0.5
+        valid_counts = valid.sum(dim=1)
+        max_n = max(1, min(self.num_anchors, int(valid_counts.max().item()) - 1))
+
+        indices = (
+            torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)
+        )
+        masked_indices = torch.where(
+            valid, indices, torch.tensor(seq_len + 1, device=device)
+        )
+
+        random_vals = torch.rand(bsz, max_anchor + 1, device=device)
+        random_vals = torch.where(valid, random_vals, torch.tensor(2.0, device=device))
+
+        _, sorted_idx = random_vals.sort(dim=1)
+        gathered = torch.gather(masked_indices, 1, sorted_idx)
+        anchors = gathered[:, :max_n].sort(dim=1).values
+
+        keep_mask = torch.arange(max_n, device=device).unsqueeze(
+            0
+        ) < valid_counts.unsqueeze(1).clamp(max=max_n)
+        anchors = torch.where(
+            keep_mask, anchors, torch.tensor(0, dtype=torch.long, device=device)
+        )
+
+        return anchors, keep_mask
+
+    def _build_domino_head_inputs(
+        self,
+        input_ids: torch.Tensor,
+        anchor_positions: torch.Tensor,
+        target_ids: torch.Tensor,
+        output_hidden: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        bsz, n, bs = target_ids.shape
+        hidden4d = output_hidden.reshape(bsz, n, bs, output_hidden.shape[-1])
+
+        prev_ids = target_ids
+        if self.shift_label:
+            prev_offsets = torch.arange(
+                0, self.block_size, device=input_ids.device
+            ).view(1, 1, -1)
+            prev_indices = (anchor_positions.unsqueeze(-1) + prev_offsets).clamp(
+                max=input_ids.size(1) - 1
+            )
+            prev_ids = torch.gather(
+                input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+                2,
+                prev_indices,
+            )
+
+        return hidden4d, prev_ids
+
+    def _apply_domino_head(
+        self,
+        base_logits4d: torch.Tensor,
+        hidden4d: torch.Tensor,
+        prev_ids: torch.Tensor,
+        target_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        head_token_ids = prev_ids if self.shift_label else target_ids
+        head_token_embeddings = self.embed_tokens(head_token_ids)
+        return self.draft_model.apply_logits_head(
+            base_logits4d,
+            hidden_states=hidden4d,
+            prev_token_embeddings=head_token_embeddings,
+        )
+
+    def _compute_extra_metrics(
+        self,
+        pred_ids: torch.Tensor,
+        flat_base_logits: torch.Tensor,
+        flat_targets: torch.Tensor,
+        binary_eval_mask: torch.Tensor,
+        actual_token_count: torch.Tensor,
+        target_ids: torch.Tensor,
+        eval_weight_mask: torch.Tensor,
+        final_loss: torch.Tensor,
+        base_loss: torch.Tensor,
+        lambda_base: float,
+    ) -> Dict[str, torch.Tensor]:
+        bsz, n, bs = target_ids.shape
+
+        base_pred_ids = torch.argmax(flat_base_logits, dim=-1)
+        base_correct = (base_pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+        base_accuracy = base_correct.sum().float() / actual_token_count
+
+        valid_mask_4d = (eval_weight_mask > 0).bool()
+        pred_accept_len = compute_accept_len(
+            pred_ids.view(bsz, n, bs), target_ids, valid_mask_4d
+        )
+        base_accept_len = compute_accept_len(
+            base_pred_ids.view(bsz, n, bs), target_ids, valid_mask_4d
+        )
+
+        valid_block_mask = valid_mask_4d.any(dim=2)
+        num_valid_blocks = valid_block_mask.sum().float() + 1e-6
+        avg_accept_len = (
+            (pred_accept_len + 1.0) * valid_block_mask.float()
+        ).sum() / num_valid_blocks
+        base_avg_accept_len = (
+            (base_accept_len + 1.0) * valid_block_mask.float()
+        ).sum() / num_valid_blocks
+
+        return {
+            "final_loss": final_loss.detach(),
+            "base_loss": base_loss.detach(),
+            "base_accuracy": base_accuracy.detach(),
+            "accept_len": avg_accept_len.detach(),
+            "base_accept_len": base_avg_accept_len.detach(),
+            "lambda_base": torch.tensor(lambda_base, device=final_loss.device),
+        }
+
+    def _compute_weighted_losses(
+        self,
+        final_logits: torch.Tensor,
+        base_logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        weight_mask: torch.Tensor,
+        lambda_base: float,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        flat_logits = final_logits.reshape(-1, final_logits.size(-1))
+        flat_base_logits = base_logits.reshape(-1, base_logits.size(-1))
+        flat_targets = target_ids.reshape(-1)
+        flat_weights = weight_mask.reshape(-1)
+
+        valid_token_count = flat_weights.sum() + 1e-6
+
+        final_loss_per_token = F.cross_entropy(
+            flat_logits, flat_targets, reduction="none"
+        )
+        final_loss = (final_loss_per_token * flat_weights).sum() / valid_token_count
+
+        base_loss_per_token = F.cross_entropy(
+            flat_base_logits, flat_targets, reduction="none"
+        )
+        base_loss = (base_loss_per_token * flat_weights).sum() / valid_token_count
+
+        loss = (1.0 - lambda_base) * final_loss + lambda_base * base_loss
+
+        return loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+        lambda_base: float = 0.0,
+    ):
+        """Parallel Domino training forward pass."""
+        if self.attention_backend == "flex_attention" and not FLEX_ATTENTION_AVAILABLE:
+            raise ValueError(
+                "flex_attention is not available on this device; use sdpa/eager."
+            )
+        bsz, seq_len = input_ids.shape
+        device = input_ids.device
+
+        anchor_positions, block_keep_mask, output_hidden = self._forward_draft_blocks(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            loss_mask=loss_mask,
+        )
+
+        label_start = 1 if self.shift_label else 0
+        label_offsets = torch.arange(
+            label_start, label_start + self.block_size, device=device
+        ).view(1, 1, -1)
+        label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+        valid_label_mask = label_indices < seq_len
+        safe_target_indices = label_indices.clamp(max=seq_len - 1)
+
+        target_ids = torch.gather(
+            input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_target_indices,
+        )
+
+        bsz, n, bs = target_ids.shape
+        base_logits = self.lm_head(output_hidden)
+        hidden4d, prev_ids = self._build_domino_head_inputs(
+            input_ids=input_ids,
+            anchor_positions=anchor_positions,
+            target_ids=target_ids,
+            output_hidden=output_hidden,
+        )
+        base_logits4d = base_logits.reshape(bsz, n, bs, -1)
+        final_logits = self._apply_domino_head(
+            base_logits4d=base_logits4d,
+            hidden4d=hidden4d,
+            prev_ids=prev_ids,
+            target_ids=target_ids,
+        ).reshape(bsz, n * bs, -1)
+
+        weight_mask = (
+            block_keep_mask.unsqueeze(-1).expand(-1, -1, self.block_size).float()
+        )
+        weight_mask = weight_mask * valid_label_mask.float()
+
+        if not self.shift_label:
+            pos_in_block = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            weight_mask = weight_mask * (pos_in_block > 0).float()
+
+        original_loss_mask_gathered = torch.gather(
+            loss_mask.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_target_indices,
+        )
+        weight_mask = weight_mask * original_loss_mask_gathered
+
+        eval_weight_mask = weight_mask.clone()
+        binary_eval_mask = weight_mask.view(-1)
+
+        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+            k = torch.arange(self.block_size, device=device).view(1, 1, -1)
+            offset = 0 if self.shift_label else 1
+            decay_weights = torch.exp(
+                -(k - offset).clamp(min=0).float() / self.loss_decay_gamma
+            )
+            weight_mask = weight_mask * decay_weights
+
+        loss, final_loss, base_loss, flat_logits, flat_base_logits, flat_targets = (
+            self._compute_weighted_losses(
+                final_logits=final_logits,
+                base_logits=base_logits,
+                target_ids=target_ids,
+                weight_mask=weight_mask,
+                lambda_base=lambda_base,
+            )
+        )
+
+        with torch.no_grad():
+            pred_ids = torch.argmax(flat_logits, dim=-1)
+            correct = (pred_ids == flat_targets) & (binary_eval_mask > 0.5)
+            accuracy_denom = binary_eval_mask.sum()
+            actual_token_count = accuracy_denom + 1e-6
+            accuracy = correct.sum().float() / actual_token_count
+
+            metrics = self._compute_extra_metrics(
+                pred_ids=pred_ids,
+                flat_base_logits=flat_base_logits,
+                flat_targets=flat_targets,
+                binary_eval_mask=binary_eval_mask,
+                actual_token_count=actual_token_count,
+                target_ids=target_ids,
+                eval_weight_mask=eval_weight_mask,
+                final_loss=final_loss,
+                base_loss=base_loss,
+                lambda_base=lambda_base,
+            )
+            metrics["accuracy_denom"] = accuracy_denom.detach()
+
+        return loss, accuracy, metrics
+
+
+class OnlineDSparkModel(OnlineDFlashModel):
+    """DSpark online training wrapper over DFlash block-parallel components."""
+
+    def __init__(
+        self,
+        draft_model: DFlashDraftModel,
+        target_lm_head: nn.Module,
+        target_embed_tokens: nn.Module,
+        mask_token_id: int,
+        block_size: int = 16,
+        attention_backend: str = "flex_attention",
+        num_anchors: int = 512,
+        loss_decay_gamma: Optional[float] = None,
+        dspark_ce_loss_alpha: float = 0.1,
+        dspark_l1_loss_alpha: float = 0.9,
+        dspark_confidence_head_alpha: float = 1.0,
+    ):
+        super().__init__(
+            draft_model=draft_model,
+            target_lm_head=target_lm_head,
+            target_embed_tokens=target_embed_tokens,
+            mask_token_id=mask_token_id,
+            block_size=block_size,
+            attention_backend=attention_backend,
+            num_anchors=num_anchors,
+            loss_decay_gamma=loss_decay_gamma,
+            loss_type="dflash",
+        )
+        if dspark_ce_loss_alpha < 0:
+            raise ValueError("dspark_ce_loss_alpha must be >= 0")
+        if dspark_l1_loss_alpha < 0:
+            raise ValueError("dspark_l1_loss_alpha must be >= 0")
+        if dspark_confidence_head_alpha < 0:
+            raise ValueError("dspark_confidence_head_alpha must be >= 0")
+
+        self.loss_type = "dspark"
+        self.dspark_ce_loss_alpha = float(dspark_ce_loss_alpha)
+        self.dspark_l1_loss_alpha = float(dspark_l1_loss_alpha)
+        self.dspark_confidence_head_alpha = float(dspark_confidence_head_alpha)
+
+    def _build_anchor_candidate_mask(
+        self,
+        seq_len: int,
+        loss_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        num_candidates = max(seq_len - 1, 0)
+        if num_candidates == 0:
+            return loss_mask[:, :0].bool()
+        anchor_valid = loss_mask[:, :num_candidates] > 0.5
+        first_target_valid = loss_mask[:, 1 : num_candidates + 1] > 0.5
+        return anchor_valid & first_target_valid
+
+    def _sample_anchor_positions(
+        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Sample fixed-width DSpark anchors; invalid slots are masked out."""
+        valid = self._build_anchor_candidate_mask(seq_len, loss_mask)
+        bsz = loss_mask.shape[0]
+        num_candidates = valid.shape[1]
+        max_n = int(self.num_anchors)
+        if num_candidates == 0:
+            anchors = torch.zeros(bsz, max_n, dtype=torch.long, device=device)
+            keep_mask = torch.zeros(bsz, max_n, dtype=torch.bool, device=device)
+            return anchors, keep_mask
+
+        valid_counts = valid.sum(dim=1)
+        indices = (
+            torch.arange(num_candidates, device=device).unsqueeze(0).expand(bsz, -1)
+        )
+        masked_indices = torch.where(
+            valid,
+            indices,
+            torch.full_like(indices, seq_len + 1),
+        )
+        random_vals = torch.rand(bsz, num_candidates, device=device)
+        random_vals = torch.where(valid, random_vals, torch.full_like(random_vals, 2.0))
+        _, sorted_idx = random_vals.sort(dim=1)
+        gathered = torch.gather(masked_indices, 1, sorted_idx)
+        if num_candidates < max_n:
+            pad = torch.full(
+                (bsz, max_n - num_candidates),
+                seq_len + 1,
+                dtype=gathered.dtype,
+                device=device,
+            )
+            gathered = torch.cat([gathered, pad], dim=1)
+        anchors = gathered[:, :max_n].sort(dim=1).values
+        keep_mask = torch.arange(max_n, device=device).unsqueeze(0) < (
+            valid_counts.unsqueeze(1).clamp(max=max_n)
+        )
+        anchors = torch.where(keep_mask, anchors, torch.zeros_like(anchors))
+        return anchors, keep_mask
+
+    def _build_dspark_labels_and_mask(
+        self,
+        input_ids: torch.Tensor,
+        loss_mask: torch.Tensor,
+        anchor_positions: torch.Tensor,
+        block_keep_mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        seq_len = input_ids.shape[1]
+        device = input_ids.device
+        label_offsets = torch.arange(1, self.block_size + 1, device=device).view(
+            1, 1, -1
+        )
+        label_indices = anchor_positions.unsqueeze(-1) + label_offsets
+        safe_label_indices = label_indices.clamp(max=seq_len - 1)
+        safe_label_indices = torch.where(
+            block_keep_mask.unsqueeze(-1),
+            safe_label_indices,
+            torch.zeros_like(safe_label_indices),
+        )
+        target_ids = torch.gather(
+            input_ids.unsqueeze(1).expand(-1, anchor_positions.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+
+        target_valid = label_indices < seq_len
+        target_loss_mask = torch.gather(
+            loss_mask.unsqueeze(1).expand(-1, label_indices.size(1), -1),
+            2,
+            safe_label_indices,
+        )
+        eval_mask = target_valid & (target_loss_mask > 0.5)
+        eval_mask = eval_mask & block_keep_mask.unsqueeze(-1)
+        eval_mask = eval_mask.to(torch.int32).cumprod(dim=-1).bool()
+        return target_ids, eval_mask, safe_label_indices
+
+    def _dspark_loss_weight_mask(
+        self,
+        eval_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        loss_weight_mask = eval_mask.to(torch.float32)
+        if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+            positions = torch.arange(self.block_size, device=eval_mask.device).view(
+                1, 1, -1
+            )
+            decay_weights = torch.exp(-positions.float() / float(self.loss_decay_gamma))
+            loss_weight_mask = loss_weight_mask * decay_weights
+        return loss_weight_mask
+
+    def _aligned_target_logits(
+        self,
+        target_last_hidden_states: Optional[torch.Tensor],
+        safe_label_indices: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        if target_last_hidden_states is None:
+            return None
+        target_pred_indices = (safe_label_indices - 1).clamp(min=0)
+        aligned_target_hidden = torch.gather(
+            target_last_hidden_states.unsqueeze(1).expand(
+                -1,
+                safe_label_indices.size(1),
+                -1,
+                -1,
+            ),
+            2,
+            target_pred_indices.unsqueeze(-1).expand(
+                -1,
+                -1,
+                -1,
+                target_last_hidden_states.size(-1),
+            ),
+        )
+        return self.lm_head(aligned_target_hidden)
+
+    def _compute_dspark_loss(
+        self,
+        *,
+        draft_logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        eval_mask: torch.Tensor,
+        confidence_pred: Optional[torch.Tensor],
+        aligned_target_logits: Optional[torch.Tensor],
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        vocab_size = draft_logits.size(-1)
+        loss_weight_mask = self._dspark_loss_weight_mask(eval_mask)
+        flat_logits = draft_logits.reshape(-1, vocab_size)
+        flat_targets = target_ids.reshape(-1)
+        flat_weights = loss_weight_mask.reshape(-1)
+
+        loss_per_token = F.cross_entropy(flat_logits, flat_targets, reduction="none")
+        ce_loss_den = flat_weights.sum()
+        ce_loss = (loss_per_token * flat_weights).sum() / (ce_loss_den + 1e-6)
+
+        l1_loss = ce_loss.new_zeros(())
+        accept_rate_3d = None
+        needs_target_distribution = (
+            self.dspark_l1_loss_alpha > 0 or confidence_pred is not None
+        )
+        if aligned_target_logits is not None and needs_target_distribution:
+            draft_probs = torch.softmax(draft_logits.float(), dim=-1)
+            target_probs = torch.softmax(aligned_target_logits.float(), dim=-1)
+            l1_dist = (draft_probs - target_probs).abs().sum(dim=-1)
+            accept_rate_3d = 1.0 - 0.5 * l1_dist
+            accept_rate_3d = accept_rate_3d.clamp_(0.0, 1.0)
+            if self.dspark_l1_loss_alpha > 0:
+                l1_loss = (l1_dist * loss_weight_mask).sum() / (ce_loss_den + 1e-6)
+        elif self.dspark_l1_loss_alpha > 0 or self.dspark_confidence_head_alpha > 0:
+            raise ValueError(
+                "DSpark L1/confidence loss requires target_last_hidden_states. "
+                "Use the disaggregated DSpark server-capture path so the "
+                "consumer receives target_last_hidden_states."
+            )
+
+        confidence_loss = ce_loss.new_zeros(())
+        confidence_abs_error = ce_loss.new_zeros(())
+        if confidence_pred is not None:
+            if accept_rate_3d is None:
+                raise ValueError(
+                    "DSpark confidence head requires aligned target logits."
+                )
+            confidence_errors = F.binary_cross_entropy_with_logits(
+                confidence_pred.float(),
+                accept_rate_3d.detach(),
+                reduction="none",
+            )
+            confidence_loss = (confidence_errors * loss_weight_mask).sum() / (
+                ce_loss_den + 1e-6
+            )
+            with torch.no_grad():
+                confidence_abs_error = (
+                    (confidence_pred.float().sigmoid() - accept_rate_3d).abs()
+                    * loss_weight_mask
+                ).sum() / (ce_loss_den + 1e-6)
+
+        loss = (
+            self.dspark_ce_loss_alpha * ce_loss
+            + self.dspark_l1_loss_alpha * l1_loss
+            + self.dspark_confidence_head_alpha * confidence_loss
+        )
+        metrics = {
+            "ce_loss": ce_loss.detach(),
+            "l1_loss": l1_loss.detach(),
+            "confidence_loss": confidence_loss.detach(),
+            "confidence_abs_error": confidence_abs_error.detach(),
+        }
+        return loss, metrics
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor,
+        target_last_hidden_states: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+        """Parallel DSpark training forward pass."""
+        if self.attention_backend == "flex_attention" and not FLEX_ATTENTION_AVAILABLE:
+            raise ValueError(
+                "flex_attention is not available on this device; use sdpa/eager."
+            )
+        bsz = input_ids.shape[0]
+        anchor_positions, block_keep_mask, output_hidden = self._forward_draft_blocks(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            loss_mask=loss_mask,
+        )
+
+        logits = self.lm_head(output_hidden)
+        num_blocks = anchor_positions.size(1)
+        output_hidden_4d = output_hidden.reshape(bsz, num_blocks, self.block_size, -1)
+        (
+            target_ids,
+            eval_mask,
+            safe_label_indices,
+        ) = self._build_dspark_labels_and_mask(
+            input_ids=input_ids,
+            loss_mask=loss_mask,
+            anchor_positions=anchor_positions,
+            block_keep_mask=block_keep_mask,
+        )
+        anchor_token_ids = torch.gather(input_ids, 1, anchor_positions)
+        prev_token_ids = torch.cat(
+            [anchor_token_ids.unsqueeze(-1), target_ids[:, :, :-1]],
+            dim=-1,
+        )
+        draft_logits = logits.reshape(bsz, num_blocks, self.block_size, -1)
+        draft_logits = self.draft_model.apply_logits_head(
+            draft_logits,
+            prev_token_ids=prev_token_ids,
+            hidden_states=output_hidden_4d,
+        )
+        confidence_pred = self.draft_model.predict_confidence(
+            output_hidden_4d,
+            prev_token_ids=prev_token_ids,
+        )
+        aligned_target_logits = self._aligned_target_logits(
+            target_last_hidden_states,
+            safe_label_indices,
+        )
+        loss, metrics = self._compute_dspark_loss(
+            draft_logits=draft_logits,
+            target_ids=target_ids,
+            eval_mask=eval_mask,
+            confidence_pred=confidence_pred,
+            aligned_target_logits=aligned_target_logits,
+        )
+        flat_logits = draft_logits.reshape(-1, draft_logits.size(-1))
+        flat_targets = target_ids.reshape(-1)
+        binary_eval_mask = eval_mask.reshape(-1)
+        with torch.no_grad():
+            pred_ids = torch.argmax(flat_logits, dim=-1)
+            correct = (pred_ids == flat_targets) & binary_eval_mask
+            accuracy_denom = binary_eval_mask.to(torch.float32).sum()
+            accuracy = correct.sum().float() / (accuracy_denom + 1e-6)
+            metrics["accuracy_denom"] = accuracy_denom.detach()
+        return loss, accuracy, metrics

--- a/specforge/algorithms/common/providers.py
+++ b/specforge/algorithms/common/providers.py
@@ -1,0 +1,660 @@
+"""Executable provider ports for built-in algorithms.
+
+The public :class:`~specforge.algorithms.contracts.AlgorithmSpec` deliberately
+contains values only.  This module is the executable half of one
+``AlgorithmRegistration``: step/model factories and data adapters selected by
+the application composition root.
+
+The provider types describe algorithm-owned behavior, never deployment
+topology.  In particular, ``ServerStreamingProvider`` means that an algorithm
+can consume features captured by an external server; it does not select a
+backend, start a server, or construct a transport.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import (
+    Any,
+    Callable,
+    FrozenSet,
+    Iterable,
+    Mapping,
+    Protocol,
+    Sequence,
+    Tuple,
+    runtime_checkable,
+)
+
+from specforge.algorithms.contracts import AlgorithmSpec, FeatureMode
+from specforge.algorithms.registry import AlgorithmRegistration
+
+Factory = Callable[..., Any]
+
+STEP_OPTIONS_CONTRACT_KEY = "specforge_step_options"
+MODEL_PROVENANCE_CONTRACT_KEY = "specforge_model_provenance"
+OMITTED_STATE_FINGERPRINT_CONTRACT_KEY = (
+    "specforge_omitted_checkpoint_state_fingerprint"
+)
+
+
+@runtime_checkable
+class ServerInputAdapter(Protocol):
+    """Modality-owned input port for external server capture.
+
+    Implementations may load a tokenizer, processor, or any other immutable
+    input tooling; turn configured source data into JSON-safe prompt payloads;
+    and map a batch of those payloads onto the SGLang ``/generate`` request.
+    The transport owns capture metadata and sampling parameters, so adapters
+    return only model-input fields.
+    """
+
+    def load_input_tools(self, config: Any) -> Any:
+        """Load tokenizer/processor tooling required by this modality."""
+
+    def prepare_prompts(
+        self,
+        config: Any,
+        input_tools: Any,
+        *,
+        draft_config: Any,
+    ) -> list[dict[str, Any]]:
+        """Build JSON-safe prompt dictionaries for the producer runtime."""
+
+    def build_request_inputs(
+        self,
+        tasks: Sequence[Any],
+    ) -> Mapping[str, Any]:
+        """Build model-input fields for one batched server request."""
+
+
+def _non_empty(value: str, *, field_name: str) -> str:
+    if not isinstance(value, str) or not value or value.strip() != value:
+        raise ValueError(
+            f"{field_name} must be a non-empty name without surrounding whitespace"
+        )
+    return value
+
+
+def _factories_are_callable(values: Iterable[tuple[str, object]]) -> None:
+    for field_name, value in values:
+        if not callable(value):
+            raise TypeError(f"{field_name} must be callable")
+
+
+def checkpoint_key_fingerprint(model: Any, keys: Iterable[str]) -> str:
+    """Hash selected state tensors with bounded host memory.
+
+    Providers may intentionally omit reconstructable frozen tensors from a
+    checkpoint. Their values still affect the model, so resume records this
+    fingerprint and rejects a reconstruction from different weights.
+    """
+
+    import torch
+
+    state = model.state_dict()
+    hasher = hashlib.sha256()
+    for key in sorted(keys):
+        if key not in state:
+            raise ValueError(
+                f"cannot fingerprint missing checkpoint-policy key {key!r}"
+            )
+        tensor = state[key]
+        if not torch.is_tensor(tensor):
+            raise TypeError(
+                f"checkpoint-policy key {key!r} is not a tensor: "
+                f"{type(tensor).__name__}"
+            )
+        hasher.update(key.encode("utf-8"))
+        hasher.update(str(tensor.dtype).encode("ascii"))
+        hasher.update(repr(tuple(tensor.shape)).encode("ascii"))
+        flat = tensor.detach().contiguous().view(-1)
+        chunk_elements = max(1, (16 * 1024 * 1024) // flat.element_size())
+        for start in range(0, flat.numel(), chunk_elements):
+            chunk = flat[start : start + chunk_elements].to(
+                device="cpu",
+                copy=True,
+            )
+            hasher.update(memoryview(chunk.view(torch.uint8).numpy()))
+    return hasher.hexdigest()
+
+
+@dataclass(frozen=True)
+class TargetDerivedDraftDefaults:
+    """Defaults used when a target config generates a draft config.
+
+    ``populate`` is the algorithm-owned seam for derived values such as
+    DFlash target-layer IDs.  Reading a config and resolving its model/config
+    class remain responsibilities of ``DraftModelRegistry``.
+    """
+
+    model_type: str
+    num_hidden_layers: int
+    draft_vocab_size: int | None = None
+    populate: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.model_type, field_name="model_type")
+        if (
+            isinstance(self.num_hidden_layers, bool)
+            or not isinstance(self.num_hidden_layers, int)
+            or self.num_hidden_layers <= 0
+        ):
+            raise ValueError("num_hidden_layers must be a positive integer")
+        if self.draft_vocab_size is not None and (
+            isinstance(self.draft_vocab_size, bool)
+            or not isinstance(self.draft_vocab_size, int)
+            or self.draft_vocab_size <= 0
+        ):
+            raise ValueError("draft_vocab_size must be a positive integer or None")
+        if self.populate is not None and not callable(self.populate):
+            raise TypeError("populate must be callable or None")
+
+
+@dataclass(frozen=True)
+class DraftConfigProvider:
+    """Algorithm policy around a registered draft architecture.
+
+    This object does not contain a model/config class and does not load a
+    config.  It supplies algorithm-specific generation and override behavior
+    to the composition root after ``DraftModelRegistry`` resolves the class.
+    """
+
+    architecture: str
+    target_defaults: TargetDerivedDraftDefaults | None = None
+    expected_auto_map_model: str | None = None
+    apply_overrides: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.architecture, field_name="architecture")
+        if self.expected_auto_map_model is not None:
+            _non_empty(
+                self.expected_auto_map_model,
+                field_name="expected_auto_map_model",
+            )
+        if self.apply_overrides is not None and not callable(self.apply_overrides):
+            raise TypeError("apply_overrides must be callable or None")
+
+
+@dataclass(frozen=True)
+class StepRuntimeConfig(Mapping[str, Any]):
+    """Resolved step options and checkpoint policy for one training run.
+
+    The mapping interface exposes only strategy constructor options, so the
+    existing runtime builders can forward this object through their
+    ``strategy_kwargs`` seam. ``Trainer`` additionally reads the immutable
+    checkpoint metadata carried alongside those options.
+    """
+
+    options: Mapping[str, Any]
+    resume_contract: Mapping[str, Any]
+    allowed_missing_checkpoint_keys: FrozenSet[str]
+
+    def __post_init__(self) -> None:
+        options = dict(self.options)
+        invalid_option_keys = sorted(
+            repr(key) for key in options if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_option_keys:
+            raise ValueError(
+                "step option keys must be non-empty strings, got "
+                f"{invalid_option_keys}"
+            )
+        resume_contract = dict(self.resume_contract)
+        invalid_contract_keys = sorted(
+            repr(key)
+            for key in resume_contract
+            if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_contract_keys:
+            raise ValueError(
+                "resume_contract keys must be non-empty strings, got "
+                f"{invalid_contract_keys}"
+            )
+        expected_options_contract = tuple(
+            (key, options[key]) for key in sorted(options)
+        )
+        recorded_options_contract = resume_contract.setdefault(
+            STEP_OPTIONS_CONTRACT_KEY,
+            expected_options_contract,
+        )
+        if recorded_options_contract != expected_options_contract:
+            raise ValueError(
+                f"{STEP_OPTIONS_CONTRACT_KEY!r} must exactly match the resolved "
+                f"step options: expected {expected_options_contract!r}, got "
+                f"{recorded_options_contract!r}"
+            )
+        allowed_missing = frozenset(self.allowed_missing_checkpoint_keys)
+        invalid_missing_keys = sorted(
+            repr(key)
+            for key in allowed_missing
+            if not isinstance(key, str) or not key.strip()
+        )
+        if invalid_missing_keys:
+            raise ValueError(
+                "allowed missing checkpoint keys must be non-empty strings, got "
+                f"{invalid_missing_keys}"
+            )
+        if (
+            allowed_missing
+            and OMITTED_STATE_FINGERPRINT_CONTRACT_KEY not in resume_contract
+        ):
+            raise ValueError(
+                "allowed missing checkpoint keys require the runtime-owned "
+                f"{OMITTED_STATE_FINGERPRINT_CONTRACT_KEY!r} resume contract"
+            )
+        object.__setattr__(self, "options", MappingProxyType(options))
+        object.__setattr__(
+            self,
+            "resume_contract",
+            MappingProxyType(resume_contract),
+        )
+        object.__setattr__(self, "allowed_missing_checkpoint_keys", allowed_missing)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.options[key]
+
+    def __iter__(self):
+        return iter(self.options)
+
+    def __len__(self) -> int:
+        return len(self.options)
+
+
+@dataclass(frozen=True)
+class StepProvider:
+    """Factories and persistence hooks for one algorithm's training step."""
+
+    build: Factory
+    options: Factory
+    resume_contract: Factory
+    allowed_missing_checkpoint_keys: Factory
+    uses_external_target_head: bool
+
+    def __post_init__(self) -> None:
+        _factories_are_callable(
+            (
+                ("build", self.build),
+                ("options", self.options),
+                ("resume_contract", self.resume_contract),
+                (
+                    "allowed_missing_checkpoint_keys",
+                    self.allowed_missing_checkpoint_keys,
+                ),
+            )
+        )
+        if not isinstance(self.uses_external_target_head, bool):
+            raise TypeError("uses_external_target_head must be a bool")
+
+    def bind_runtime(
+        self,
+        config: Any,
+        draft_model: Any,
+        training_model: Any,
+        *,
+        model_provenance: Mapping[str, Any] | None = None,
+    ) -> StepRuntimeConfig:
+        """Resolve algorithm checkpoint semantics against the live model."""
+
+        options = self.options(config)
+        if not isinstance(options, Mapping):
+            raise TypeError(
+                "step options must return a mapping, got " f"{type(options).__name__}"
+            )
+        provider_contract = self.resume_contract(config, draft_model, training_model)
+        if not isinstance(provider_contract, Mapping):
+            raise TypeError(
+                "step resume_contract must return a mapping, got "
+                f"{type(provider_contract).__name__}"
+            )
+        resume_contract = dict(provider_contract)
+        reserved = {
+            STEP_OPTIONS_CONTRACT_KEY,
+            MODEL_PROVENANCE_CONTRACT_KEY,
+            OMITTED_STATE_FINGERPRINT_CONTRACT_KEY,
+        } & resume_contract.keys()
+        if reserved:
+            raise ValueError(
+                "provider resume_contract uses runtime-owned fields: "
+                f"{sorted(reserved)}"
+            )
+        resume_contract[STEP_OPTIONS_CONTRACT_KEY] = tuple(
+            (key, options[key]) for key in sorted(options)
+        )
+        if model_provenance is not None:
+            resume_contract[MODEL_PROVENANCE_CONTRACT_KEY] = tuple(
+                (key, model_provenance[key]) for key in sorted(model_provenance)
+            )
+        allowed_missing = frozenset(
+            self.allowed_missing_checkpoint_keys(
+                config,
+                draft_model,
+                training_model,
+            )
+        )
+        if allowed_missing:
+            resume_contract[OMITTED_STATE_FINGERPRINT_CONTRACT_KEY] = (
+                checkpoint_key_fingerprint(draft_model, allowed_missing)
+            )
+        return StepRuntimeConfig(
+            options=options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=allowed_missing,
+        )
+
+
+@dataclass(frozen=True)
+class ModelProvider:
+    """Algorithm-owned model assembly hooks.
+
+    Keeping concrete model imports inside hook functions lets the immutable
+    registry resolve without importing Torch or Transformers.
+    """
+
+    draft_config: DraftConfigProvider
+    build_draft: Factory
+    build_training_model: Factory
+    resolve_capture_layers: Factory
+    minimum_loss_tokens: Factory
+    needs_input_tools: Factory
+    default_dataloader_num_workers: int
+    allow_missing_warm_start_embedding: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.draft_config, DraftConfigProvider):
+            raise TypeError("draft_config must be a DraftConfigProvider")
+        _factories_are_callable(
+            (
+                ("build_draft", self.build_draft),
+                ("build_training_model", self.build_training_model),
+                ("resolve_capture_layers", self.resolve_capture_layers),
+                ("minimum_loss_tokens", self.minimum_loss_tokens),
+                ("needs_input_tools", self.needs_input_tools),
+            )
+        )
+        if (
+            isinstance(self.default_dataloader_num_workers, bool)
+            or not isinstance(self.default_dataloader_num_workers, int)
+            or self.default_dataloader_num_workers < 0
+        ):
+            raise ValueError(
+                "default_dataloader_num_workers must be a non-negative integer"
+            )
+        if not isinstance(self.allow_missing_warm_start_embedding, bool):
+            raise TypeError("allow_missing_warm_start_embedding must be a bool")
+
+
+@dataclass(frozen=True)
+class OfflineDataProvider:
+    """Reader, normalizer, and collator for one offline modality."""
+
+    modality: str
+    normalizer_id: str
+    build_reader: Factory
+    build_normalizer: Factory
+    build_collator: Factory
+
+    def __post_init__(self) -> None:
+        _non_empty(self.modality, field_name="modality")
+        _non_empty(self.normalizer_id, field_name="normalizer_id")
+        _factories_are_callable(
+            (
+                ("build_reader", self.build_reader),
+                ("build_normalizer", self.build_normalizer),
+                ("build_collator", self.build_collator),
+            )
+        )
+
+
+@dataclass(frozen=True)
+class ServerCaptureLayout:
+    """Maps generic server artifacts onto algorithm-ready feature names."""
+
+    aux_feature: str | None
+    last_hidden_feature: str | None
+    passthrough: Tuple[Tuple[str, str, Tuple[int, ...]], ...]
+    attention_mask_feature: str | None = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "aux_feature",
+            "last_hidden_feature",
+            "attention_mask_feature",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                _non_empty(value, field_name=field_name)
+        passthrough = tuple(self.passthrough)
+        for feature_name, payload_key, trailing_shape in passthrough:
+            _non_empty(feature_name, field_name="passthrough feature name")
+            _non_empty(payload_key, field_name="passthrough payload key")
+            if any(
+                isinstance(size, bool) or not isinstance(size, int) or size < 0
+                for size in trailing_shape
+            ):
+                raise ValueError(
+                    "passthrough trailing shapes must contain non-negative integers"
+                )
+        object.__setattr__(self, "passthrough", passthrough)
+
+
+@dataclass(frozen=True)
+class ServerStreamingProvider:
+    """Algorithm adapter for externally captured streaming features.
+
+    ``build_input_adapter`` is deliberately modality-neutral. Text providers
+    can leave it unset; the current runtime does not support VLM registration
+    or media requests.
+    """
+
+    modality: str
+    capture_method: str
+    target_representation: str | None
+    layout: ServerCaptureLayout
+    build_collator: Factory
+    build_input_adapter: Factory | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty(self.modality, field_name="modality")
+        _non_empty(self.capture_method, field_name="capture_method")
+        if self.target_representation is not None:
+            _non_empty(
+                self.target_representation,
+                field_name="target_representation",
+            )
+        if not isinstance(self.layout, ServerCaptureLayout):
+            raise TypeError("layout must be a ServerCaptureLayout")
+        if not callable(self.build_collator):
+            raise TypeError("build_collator must be callable")
+        if self.build_input_adapter is not None and not callable(
+            self.build_input_adapter
+        ):
+            raise TypeError("build_input_adapter must be callable or None")
+
+    def create_input_adapter(self, config: Any) -> ServerInputAdapter | None:
+        """Construct and validate the optional modality-owned input adapter."""
+
+        if self.build_input_adapter is None:
+            return None
+        adapter = self.build_input_adapter(config)
+        required = (
+            "load_input_tools",
+            "prepare_prompts",
+            "build_request_inputs",
+        )
+        missing = [
+            name for name in required if not callable(getattr(adapter, name, None))
+        ]
+        if missing:
+            raise TypeError(
+                "build_input_adapter must return a ServerInputAdapter; "
+                f"missing callable methods: {missing}"
+            )
+        return adapter
+
+
+@dataclass(frozen=True)
+class AlgorithmProviders:
+    """Executable providers paired with one pure ``AlgorithmSpec``."""
+
+    algorithm_name: str
+    step: StepProvider
+    model: ModelProvider
+    offline: Tuple[OfflineDataProvider, ...] = ()
+    server_streaming: Tuple[ServerStreamingProvider, ...] = ()
+    vocab_mapping_modes: FrozenSet[FeatureMode] = frozenset()
+
+    def __post_init__(self) -> None:
+        _non_empty(self.algorithm_name, field_name="algorithm_name")
+        if not isinstance(self.step, StepProvider):
+            raise TypeError("step must be a StepProvider")
+        if not isinstance(self.model, ModelProvider):
+            raise TypeError("model must be a ModelProvider")
+        offline = tuple(self.offline)
+        streaming = tuple(self.server_streaming)
+        self._validate_unique_modalities(offline, field_name="offline")
+        self._validate_unique_modalities(
+            streaming,
+            field_name="server_streaming",
+        )
+        modes = frozenset(FeatureMode(mode) for mode in self.vocab_mapping_modes)
+        object.__setattr__(self, "offline", offline)
+        object.__setattr__(self, "server_streaming", streaming)
+        object.__setattr__(self, "vocab_mapping_modes", modes)
+
+    @staticmethod
+    def _validate_unique_modalities(providers, *, field_name: str) -> None:
+        modalities = [provider.modality for provider in providers]
+        duplicates = sorted(
+            modality for modality in set(modalities) if modalities.count(modality) > 1
+        )
+        if duplicates:
+            raise ValueError(f"duplicate {field_name} modalities: {duplicates}")
+
+    def offline_for(self, modality: str) -> OfflineDataProvider:
+        return self._provider_for(self.offline, modality, kind="offline")
+
+    def server_streaming_for(self, modality: str) -> ServerStreamingProvider:
+        return self._provider_for(
+            self.server_streaming,
+            modality,
+            kind="server streaming",
+        )
+
+    def _provider_for(self, providers, modality: str, *, kind: str):
+        for provider in providers:
+            if provider.modality == modality:
+                return provider
+        available = sorted(provider.modality for provider in providers)
+        raise KeyError(
+            f"algorithm {self.algorithm_name!r} has no {kind} provider for "
+            f"modality {modality!r}; available: {available}"
+        )
+
+
+def make_registration(
+    spec: AlgorithmSpec,
+    providers: AlgorithmProviders,
+) -> AlgorithmRegistration:
+    """Validate contract/provider parity and return one registration."""
+
+    if providers.algorithm_name != spec.name:
+        raise ValueError(
+            f"provider algorithm {providers.algorithm_name!r} does not match "
+            f"spec {spec.name!r}"
+        )
+    if providers.model.draft_config.architecture not in (
+        spec.draft.compatible_architectures
+    ):
+        raise ValueError(
+            "model provider architecture is not compatible with the algorithm "
+            f"contract: {providers.model.draft_config.architecture!r}"
+        )
+
+    expected = {contract.key for contract in spec.feature_contracts}
+    provided = {
+        *((FeatureMode.OFFLINE, provider.modality) for provider in providers.offline),
+        *(
+            (FeatureMode.STREAMING, provider.modality)
+            for provider in providers.server_streaming
+        ),
+    }
+    if provided != expected:
+        raise ValueError(
+            "feature contract/provider keys differ: "
+            f"contracts={sorted((mode.value, modality) for mode, modality in expected)}, "
+            f"providers={sorted((mode.value, modality) for mode, modality in provided)}"
+        )
+    has_vocab_mapping_provider = bool(providers.vocab_mapping_modes)
+    if has_vocab_mapping_provider != spec.capabilities.supports_vocab_mapping:
+        raise ValueError(
+            "vocab-mapping capability/provider mismatch: "
+            f"contract={spec.capabilities.supports_vocab_mapping}, "
+            f"provider_modes={sorted(mode.value for mode in providers.vocab_mapping_modes)}"
+        )
+    unavailable_mapping_modes = providers.vocab_mapping_modes - spec.feature_modes
+    if unavailable_mapping_modes:
+        raise ValueError(
+            "vocab-mapping provider modes lack feature contracts: "
+            f"{sorted(mode.value for mode in unavailable_mapping_modes)}"
+        )
+
+    for provider in providers.offline:
+        contract = spec.feature_contract(FeatureMode.OFFLINE, provider.modality)
+        if contract.storage is None:  # pragma: no cover - contract invariant
+            raise ValueError("offline contract is missing storage")
+        if provider.normalizer_id != contract.storage.normalizer:
+            raise ValueError(
+                f"offline normalizer mismatch for {provider.modality!r}: "
+                f"{provider.normalizer_id!r} != {contract.storage.normalizer!r}"
+            )
+    for provider in providers.server_streaming:
+        contract = spec.feature_contract(FeatureMode.STREAMING, provider.modality)
+        if provider.target_representation != contract.default_target_representation:
+            raise ValueError(
+                f"streaming target representation mismatch for "
+                f"{provider.modality!r}: {provider.target_representation!r} != "
+                f"{contract.default_target_representation!r}"
+            )
+        layout = provider.layout
+        emitted = {
+            *(
+                feature
+                for feature in (
+                    layout.aux_feature,
+                    layout.last_hidden_feature,
+                    layout.attention_mask_feature,
+                )
+                if feature is not None
+            ),
+            *(feature for feature, _payload, _shape in layout.passthrough),
+        }
+        missing = contract.required_tensors - emitted
+        if missing:
+            raise ValueError(
+                f"server capture layout for {provider.modality!r} does not emit "
+                f"required tensors: {sorted(missing)}"
+            )
+
+    return AlgorithmRegistration(spec=spec, providers=providers)
+
+
+__all__ = [
+    "AlgorithmProviders",
+    "DraftConfigProvider",
+    "MODEL_PROVENANCE_CONTRACT_KEY",
+    "ModelProvider",
+    "OMITTED_STATE_FINGERPRINT_CONTRACT_KEY",
+    "OfflineDataProvider",
+    "STEP_OPTIONS_CONTRACT_KEY",
+    "ServerCaptureLayout",
+    "ServerInputAdapter",
+    "ServerStreamingProvider",
+    "StepProvider",
+    "StepRuntimeConfig",
+    "TargetDerivedDraftDefaults",
+    "checkpoint_key_fingerprint",
+    "make_registration",
+]

--- a/specforge/algorithms/contracts.py
+++ b/specforge/algorithms/contracts.py
@@ -1,0 +1,364 @@
+"""Pure contracts describing what a speculative training algorithm consumes.
+
+This module intentionally contains no factories, model classes, or runtime
+objects.  Algorithm implementations live behind provider ports; deployment and
+transport are resolved by the application layer.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum
+from typing import FrozenSet, Iterable, Tuple
+
+_ALGORITHM_NAME = re.compile(r"^[a-z][a-z0-9_-]*$")
+
+
+def _normalized_names(
+    values: Iterable[str],
+    *,
+    field_name: str,
+    allow_empty: bool = False,
+) -> FrozenSet[str]:
+    if isinstance(values, str):
+        raise TypeError(f"{field_name} must be an iterable of names, not a string")
+    normalized = frozenset(values)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{field_name} must not be empty")
+    invalid = [
+        repr(value)
+        for value in normalized
+        if not isinstance(value, str) or not value or value.strip() != value
+    ]
+    if invalid:
+        raise ValueError(
+            f"{field_name} must contain non-empty names without surrounding "
+            f"whitespace, got {', '.join(sorted(invalid))}"
+        )
+    return normalized
+
+
+def _assert_pure_value(value: object, *, path: str) -> None:
+    """Reject executable or opaque state recursively from public contracts."""
+
+    if isinstance(value, type) or callable(value):
+        raise TypeError(f"{path} must be a pure value, got executable {value!r}")
+    if value is None or isinstance(value, (str, int, float, bool, Enum)):
+        return
+    if isinstance(value, (tuple, list, set, frozenset)):
+        for index, item in enumerate(value):
+            _assert_pure_value(item, path=f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _assert_pure_value(key, path=f"{path}.key")
+            _assert_pure_value(item, path=f"{path}[{key!r}]")
+        return
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_pure_value(
+                getattr(value, field.name),
+                path=f"{path}.{field.name}",
+            )
+        return
+    raise TypeError(
+        f"{path} must contain only serializable contract values, got "
+        f"{type(value).__name__}"
+    )
+
+
+class FeatureMode(str, Enum):
+    """How algorithm-ready target features are consumed."""
+
+    OFFLINE = "offline"
+    STREAMING = "streaming"
+
+
+@dataclass(frozen=True)
+class DraftRequirement:
+    """Pure compatibility requirements for a draft architecture.
+
+    Draft configuration loading, target-derived generation, validation, and
+    model construction belong to the draft-model registry and algorithm-owned
+    providers.  Only stable identifiers and declarative override names belong
+    here.
+    """
+
+    compatible_architectures: FrozenSet[str]
+    default_architecture: str
+    supported_overrides: FrozenSet[str] = frozenset()
+    fixed_override_values: Tuple[Tuple[str, int], ...] = ()
+
+    def __post_init__(self) -> None:
+        architectures = _normalized_names(
+            self.compatible_architectures,
+            field_name="compatible_architectures",
+        )
+        overrides = _normalized_names(
+            self.supported_overrides,
+            field_name="supported_overrides",
+            allow_empty=True,
+        )
+        if self.default_architecture not in architectures:
+            raise ValueError(
+                "default_architecture must be present in " "compatible_architectures"
+            )
+        fixed_values = tuple(self.fixed_override_values)
+        fixed_names = [name for name, _value in fixed_values]
+        duplicates = sorted(
+            name for name in set(fixed_names) if fixed_names.count(name) > 1
+        )
+        if duplicates:
+            raise ValueError(f"duplicate fixed override values: {duplicates}")
+        unsupported = sorted(set(fixed_names) - overrides)
+        if unsupported:
+            raise ValueError(
+                "fixed_override_values must name supported overrides, got "
+                f"{unsupported}"
+            )
+        if any(
+            not isinstance(name, str)
+            or isinstance(value, bool)
+            or not isinstance(value, int)
+            for name, value in fixed_values
+        ):
+            raise TypeError("fixed_override_values must contain (name, integer) pairs")
+        object.__setattr__(self, "compatible_architectures", architectures)
+        object.__setattr__(self, "supported_overrides", overrides)
+        object.__setattr__(self, "fixed_override_values", fixed_values)
+
+
+@dataclass(frozen=True)
+class OfflineStorageContract:
+    """Raw offline record shape before an algorithm normalizer is applied."""
+
+    format: str
+    required_tensors: FrozenSet[str]
+    normalizer: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        for field_name in ("format", "normalizer"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value or value.strip() != value:
+                raise ValueError(
+                    f"{field_name} must be a non-empty name without surrounding "
+                    "whitespace"
+                )
+        if self.schema_version != 1:
+            raise ValueError("only offline storage schema_version=1 is supported")
+        object.__setattr__(
+            self,
+            "required_tensors",
+            _normalized_names(
+                self.required_tensors,
+                field_name="required_tensors",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class FeatureContract:
+    """Algorithm-ready tensors for one ``(mode, modality)`` pair."""
+
+    mode: FeatureMode
+    modality: str
+    required_tensors: FrozenSet[str]
+    optional_tensors: FrozenSet[str] = frozenset()
+    allowed_target_representations: FrozenSet[str] = frozenset()
+    default_target_representation: str | None = None
+    schema_version: int = 1
+    storage: OfflineStorageContract | None = None
+
+    def __post_init__(self) -> None:
+        try:
+            mode = FeatureMode(self.mode)
+        except ValueError as exc:
+            raise ValueError(f"unsupported feature mode {self.mode!r}") from exc
+        if (
+            not isinstance(self.modality, str)
+            or not self.modality
+            or self.modality.strip() != self.modality
+        ):
+            raise ValueError(
+                "modality must be a non-empty name without surrounding whitespace"
+            )
+        if self.schema_version != 1:
+            raise ValueError("only feature schema_version=1 is supported")
+        required = _normalized_names(
+            self.required_tensors,
+            field_name="required_tensors",
+        )
+        optional = _normalized_names(
+            self.optional_tensors,
+            field_name="optional_tensors",
+            allow_empty=True,
+        )
+        representations = _normalized_names(
+            self.allowed_target_representations,
+            field_name="allowed_target_representations",
+            allow_empty=True,
+        )
+        overlap = required & optional
+        if overlap:
+            raise ValueError(
+                "required_tensors and optional_tensors must be disjoint, got "
+                f"{sorted(overlap)}"
+            )
+        if representations:
+            if self.default_target_representation not in representations:
+                raise ValueError(
+                    "default_target_representation must be present in "
+                    "allowed_target_representations"
+                )
+        elif self.default_target_representation is not None:
+            raise ValueError(
+                "default_target_representation requires at least one allowed "
+                "target representation"
+            )
+        if mode is FeatureMode.OFFLINE and self.storage is None:
+            raise ValueError("offline feature contracts require a storage contract")
+        if mode is FeatureMode.STREAMING and self.storage is not None:
+            raise ValueError("streaming feature contracts cannot define storage")
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "required_tensors", required)
+        object.__setattr__(self, "optional_tensors", optional)
+        object.__setattr__(self, "allowed_target_representations", representations)
+
+    @property
+    def key(self) -> tuple[FeatureMode, str]:
+        return self.mode, self.modality
+
+
+@dataclass(frozen=True)
+class AlgorithmCapabilities:
+    """Static algorithm constraints independent of deployment topology."""
+
+    attention_backends: FrozenSet[str]
+    required_batch_size: int | None = None
+    supports_compact_teacher: bool = False
+    supports_vocab_mapping: bool = False
+    allows_aux_layer_override: bool = False
+
+    def __post_init__(self) -> None:
+        attention_backends = _normalized_names(
+            self.attention_backends,
+            field_name="attention_backends",
+        )
+        if self.required_batch_size is not None and (
+            isinstance(self.required_batch_size, bool)
+            or not isinstance(self.required_batch_size, int)
+            or self.required_batch_size <= 0
+        ):
+            raise ValueError("required_batch_size must be a positive integer or None")
+        for field_name in (
+            "supports_compact_teacher",
+            "supports_vocab_mapping",
+            "allows_aux_layer_override",
+        ):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"{field_name} must be a bool")
+        object.__setattr__(self, "attention_backends", attention_backends)
+
+
+@dataclass(frozen=True)
+class AlgorithmSpec:
+    """Complete topology-free, executable-free contract for one algorithm."""
+
+    name: str
+    draft: DraftRequirement
+    feature_contracts: Tuple[FeatureContract, ...]
+    capabilities: AlgorithmCapabilities
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not _ALGORITHM_NAME.fullmatch(self.name):
+            raise ValueError(
+                "algorithm name must start with a lowercase letter and contain "
+                "only lowercase letters, digits, '_' or '-'"
+            )
+        if not isinstance(self.draft, DraftRequirement):
+            raise TypeError("draft must be a DraftRequirement")
+        if not isinstance(self.capabilities, AlgorithmCapabilities):
+            raise TypeError("capabilities must be AlgorithmCapabilities")
+        contracts = tuple(self.feature_contracts)
+        if not contracts:
+            raise ValueError("feature_contracts must not be empty")
+        invalid = [
+            type(contract).__name__
+            for contract in contracts
+            if not isinstance(contract, FeatureContract)
+        ]
+        if invalid:
+            raise TypeError(
+                "feature_contracts must contain FeatureContract values, got "
+                f"{invalid}"
+            )
+        keys = [contract.key for contract in contracts]
+        duplicates = sorted(
+            (mode.value, modality)
+            for mode, modality in set(keys)
+            if keys.count((mode, modality)) > 1
+        )
+        if duplicates:
+            raise ValueError(
+                "feature_contracts contains duplicate (mode, modality) keys: "
+                f"{duplicates}"
+            )
+        object.__setattr__(self, "feature_contracts", contracts)
+        _assert_pure_value(self, path="AlgorithmSpec")
+
+    @property
+    def modalities(self) -> FrozenSet[str]:
+        return frozenset(contract.modality for contract in self.feature_contracts)
+
+    @property
+    def feature_modes(self) -> FrozenSet[FeatureMode]:
+        return frozenset(contract.mode for contract in self.feature_contracts)
+
+    @property
+    def supports_online(self) -> bool:
+        """Whether any streaming feature contract is declared."""
+
+        return FeatureMode.STREAMING in self.feature_modes
+
+    def supports(self, mode: FeatureMode | str, modality: str) -> bool:
+        try:
+            resolved_mode = FeatureMode(mode)
+        except ValueError:
+            return False
+        return any(
+            contract.key == (resolved_mode, modality)
+            for contract in self.feature_contracts
+        )
+
+    def feature_contract(
+        self,
+        mode: FeatureMode | str,
+        modality: str,
+    ) -> FeatureContract:
+        try:
+            resolved_mode = FeatureMode(mode)
+        except ValueError as exc:
+            raise KeyError(f"unknown feature mode {mode!r}") from exc
+        for contract in self.feature_contracts:
+            if contract.key == (resolved_mode, modality):
+                return contract
+        supported = sorted(
+            (contract.mode.value, contract.modality)
+            for contract in self.feature_contracts
+        )
+        raise KeyError(
+            f"algorithm {self.name!r} does not support "
+            f"({resolved_mode.value!r}, {modality!r}); supported: {supported}"
+        )
+
+
+__all__ = [
+    "AlgorithmCapabilities",
+    "AlgorithmSpec",
+    "DraftRequirement",
+    "FeatureContract",
+    "FeatureMode",
+    "OfflineStorageContract",
+]

--- a/specforge/algorithms/dflash/__init__.py
+++ b/specforge/algorithms/dflash/__init__.py
@@ -1,0 +1,5 @@
+"""DFlash algorithm registration."""
+
+from specforge.algorithms.dflash.providers import create_registration
+
+__all__ = ["create_registration"]

--- a/specforge/algorithms/dflash/providers.py
+++ b/specforge/algorithms/dflash/providers.py
@@ -1,0 +1,207 @@
+"""Built-in DFlash registration and executable providers."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from specforge.algorithms.common.defaults import (
+    empty_options,
+    no_missing_checkpoint_keys,
+)
+from specforge.algorithms.common.dflash_family_data import (
+    NORMALIZER_ID,
+    build_collator,
+    build_offline_normalizer,
+    build_offline_reader,
+)
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    OfflineDataProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepProvider,
+    TargetDerivedDraftDefaults,
+    make_registration,
+)
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+
+ALGORITHM_NAME = "dflash"
+DRAFT_ARCHITECTURE = "DFlashDraftModel"
+
+
+def build_step(wrapped_model, *, target_head=None, **_options):
+    del target_head
+    from specforge.training.strategies.base import DFlashTrainStrategy
+
+    return DFlashTrainStrategy(wrapped_model)
+
+
+def resume_contract(_config, draft_model, training_model):
+    """Persist resolved DFlash architecture, sampling, and loss semantics."""
+
+    return {
+        "dflash_draft_num_hidden_layers": int(draft_model.config.num_hidden_layers),
+        "dflash_target_layer_ids": tuple(
+            int(layer_id) for layer_id in draft_model.target_layer_ids
+        ),
+        "dflash_block_size": int(training_model.block_size),
+        "dflash_mask_token_id": int(training_model.mask_token_id),
+        "dflash_attention_backend": str(training_model.attention_backend),
+        "dflash_num_anchors": int(training_model.num_anchors),
+        "dflash_loss_decay_gamma": training_model.loss_decay_gamma,
+        "dflash_loss_type": str(training_model.loss_type),
+        "dflash_dpace_alpha": float(training_model.dpace_alpha),
+    }
+
+
+def build_draft(config, draft_config):
+    from specforge.algorithms.model_providers import build_registered_draft
+
+    return build_registered_draft(config, draft_config)
+
+
+def build_training_model(config, draft_model, draft_config, target_config, tokenizer):
+    from specforge.algorithms.model_providers import build_dflash_model
+
+    return build_dflash_model(
+        config,
+        draft_model,
+        draft_config,
+        target_config,
+        tokenizer,
+    )
+
+
+def resolve_capture_layers(config, draft_config, target_config):
+    from specforge.algorithms.model_providers import resolve_dflash_capture_layers
+
+    return resolve_dflash_capture_layers(config, draft_config, target_config)
+
+
+def populate_target_defaults(payload, target_config, config):
+    from specforge.algorithms.model_providers import populate_dflash_generated_config
+
+    return populate_dflash_generated_config(payload, target_config, config)
+
+
+def apply_draft_overrides(config, draft_config):
+    from specforge.algorithms.model_providers import apply_dflash_overrides
+
+    return apply_dflash_overrides(config, draft_config)
+
+
+def minimum_loss_tokens(config, draft_config):
+    from specforge.algorithms.model_providers import dflash_min_loss_tokens
+
+    return dflash_min_loss_tokens(config, draft_config)
+
+
+def needs_input_tools(config, draft_model):
+    from specforge.algorithms.model_providers import dflash_needs_input_tools
+
+    return dflash_needs_input_tools(config, draft_model)
+
+
+def algorithm_spec() -> AlgorithmSpec:
+    ready = {"input_ids", "loss_mask", "hidden_states"}
+    return AlgorithmSpec(
+        name=ALGORITHM_NAME,
+        draft=DraftRequirement(
+            compatible_architectures={DRAFT_ARCHITECTURE},
+            default_architecture=DRAFT_ARCHITECTURE,
+            supported_overrides={"num_hidden_layers", "block_size"},
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.OFFLINE,
+                modality="text",
+                required_tensors=ready,
+                storage=OfflineStorageContract(
+                    format="specforge_hidden_states_v1",
+                    required_tensors=ready,
+                    normalizer=NORMALIZER_ID,
+                ),
+            ),
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                modality="text",
+                required_tensors=ready,
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"eager", "sdpa", "flex_attention"},
+        ),
+    )
+
+
+def algorithm_providers() -> AlgorithmProviders:
+    collator = build_collator
+    return AlgorithmProviders(
+        algorithm_name=ALGORITHM_NAME,
+        step=StepProvider(
+            build=build_step,
+            options=empty_options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=no_missing_checkpoint_keys,
+            uses_external_target_head=False,
+        ),
+        model=ModelProvider(
+            draft_config=DraftConfigProvider(
+                architecture=DRAFT_ARCHITECTURE,
+                expected_auto_map_model="dflash.DFlashDraftModel",
+                target_defaults=TargetDerivedDraftDefaults(
+                    model_type="qwen3",
+                    num_hidden_layers=1,
+                    populate=populate_target_defaults,
+                ),
+                apply_overrides=apply_draft_overrides,
+            ),
+            build_draft=build_draft,
+            build_training_model=build_training_model,
+            resolve_capture_layers=resolve_capture_layers,
+            minimum_loss_tokens=minimum_loss_tokens,
+            needs_input_tools=needs_input_tools,
+            default_dataloader_num_workers=8,
+        ),
+        offline=(
+            OfflineDataProvider(
+                modality="text",
+                normalizer_id=NORMALIZER_ID,
+                build_reader=partial(build_offline_reader, ALGORITHM_NAME),
+                build_normalizer=build_offline_normalizer,
+                build_collator=collator,
+            ),
+        ),
+        server_streaming=(
+            ServerStreamingProvider(
+                modality="text",
+                capture_method="dflash",
+                target_representation=None,
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_states",
+                    last_hidden_feature=None,
+                    passthrough=(
+                        ("input_ids", "input_ids", ()),
+                        ("loss_mask", "loss_mask", ()),
+                    ),
+                ),
+                build_collator=collator,
+            ),
+        ),
+    )
+
+
+def create_registration():
+    return make_registration(algorithm_spec(), algorithm_providers())
+
+
+__all__ = ["algorithm_providers", "algorithm_spec", "create_registration"]

--- a/specforge/algorithms/domino/__init__.py
+++ b/specforge/algorithms/domino/__init__.py
@@ -1,0 +1,5 @@
+"""Domino algorithm registration."""
+
+from specforge.algorithms.domino.providers import create_registration
+
+__all__ = ["create_registration"]

--- a/specforge/algorithms/domino/providers.py
+++ b/specforge/algorithms/domino/providers.py
@@ -1,0 +1,204 @@
+"""Built-in Domino registration and executable providers."""
+
+from __future__ import annotations
+
+from functools import partial
+
+from specforge.algorithms.common.defaults import no_missing_checkpoint_keys
+from specforge.algorithms.common.dflash_family_data import (
+    NORMALIZER_ID,
+    build_collator,
+    build_offline_normalizer,
+    build_offline_reader,
+)
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    OfflineDataProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepProvider,
+    make_registration,
+)
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+
+ALGORITHM_NAME = "domino"
+DRAFT_ARCHITECTURE = "DominoDraftModel"
+
+
+def build_step(
+    wrapped_model,
+    *,
+    target_head=None,
+    lambda_start=1.0,
+    decay_ratio=0.5,
+):
+    del target_head
+    from specforge.training.strategies.base import DominoTrainStrategy
+
+    return DominoTrainStrategy(
+        wrapped_model,
+        lambda_start=lambda_start,
+        decay_ratio=decay_ratio,
+    )
+
+
+def step_options(config):
+    from specforge.algorithms.model_providers import domino_strategy_kwargs
+
+    return domino_strategy_kwargs(config)
+
+
+def resume_contract(config, draft_model, training_model):
+    """Persist resolved Domino model, sampling, and objective semantics."""
+
+    return {
+        "domino_draft_num_hidden_layers": int(draft_model.config.num_hidden_layers),
+        "domino_target_layer_ids": tuple(
+            int(layer_id) for layer_id in draft_model.target_layer_ids
+        ),
+        "domino_block_size": int(training_model.block_size),
+        "domino_mask_token_id": int(training_model.mask_token_id),
+        "domino_attention_backend": str(training_model.attention_backend),
+        "domino_num_anchors": int(training_model.num_anchors),
+        "domino_loss_decay_gamma": training_model.loss_decay_gamma,
+        "domino_shift_label": bool(training_model.shift_label),
+        "domino_pure_draft_prefix_len": int(draft_model.pure_draft_prefix_len),
+        "domino_lambda_base_start": float(config.training.lambda_base_start),
+        "domino_lambda_base_decay_ratio": float(
+            config.training.lambda_base_decay_ratio
+        ),
+    }
+
+
+def build_draft(config, draft_config):
+    from specforge.algorithms.model_providers import build_registered_draft
+
+    return build_registered_draft(config, draft_config)
+
+
+def build_training_model(config, draft_model, draft_config, target_config, tokenizer):
+    from specforge.algorithms.model_providers import build_domino_model
+
+    return build_domino_model(
+        config,
+        draft_model,
+        draft_config,
+        target_config,
+        tokenizer,
+    )
+
+
+def resolve_capture_layers(config, draft_config, target_config):
+    from specforge.algorithms.model_providers import resolve_dflash_capture_layers
+
+    return resolve_dflash_capture_layers(config, draft_config, target_config)
+
+
+def minimum_loss_tokens(config, draft_config):
+    from specforge.algorithms.model_providers import dflash_min_loss_tokens
+
+    return dflash_min_loss_tokens(config, draft_config)
+
+
+def needs_input_tools(config, draft_model):
+    from specforge.algorithms.model_providers import dflash_needs_input_tools
+
+    return dflash_needs_input_tools(config, draft_model)
+
+
+def algorithm_spec() -> AlgorithmSpec:
+    ready = {"input_ids", "loss_mask", "hidden_states"}
+    return AlgorithmSpec(
+        name=ALGORITHM_NAME,
+        draft=DraftRequirement(
+            compatible_architectures={DRAFT_ARCHITECTURE},
+            default_architecture=DRAFT_ARCHITECTURE,
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.OFFLINE,
+                modality="text",
+                required_tensors=ready,
+                storage=OfflineStorageContract(
+                    format="specforge_hidden_states_v1",
+                    required_tensors=ready,
+                    normalizer=NORMALIZER_ID,
+                ),
+            ),
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                modality="text",
+                required_tensors=ready,
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"eager", "sdpa", "flex_attention"},
+        ),
+    )
+
+
+def algorithm_providers() -> AlgorithmProviders:
+    collator = build_collator
+    return AlgorithmProviders(
+        algorithm_name=ALGORITHM_NAME,
+        step=StepProvider(
+            build=build_step,
+            options=step_options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=no_missing_checkpoint_keys,
+            uses_external_target_head=False,
+        ),
+        model=ModelProvider(
+            draft_config=DraftConfigProvider(
+                architecture=DRAFT_ARCHITECTURE,
+                expected_auto_map_model="domino.DominoDraftModel",
+            ),
+            build_draft=build_draft,
+            build_training_model=build_training_model,
+            resolve_capture_layers=resolve_capture_layers,
+            minimum_loss_tokens=minimum_loss_tokens,
+            needs_input_tools=needs_input_tools,
+            default_dataloader_num_workers=8,
+        ),
+        offline=(
+            OfflineDataProvider(
+                modality="text",
+                normalizer_id=NORMALIZER_ID,
+                build_reader=partial(build_offline_reader, ALGORITHM_NAME),
+                build_normalizer=build_offline_normalizer,
+                build_collator=collator,
+            ),
+        ),
+        server_streaming=(
+            ServerStreamingProvider(
+                modality="text",
+                capture_method="dflash",
+                target_representation=None,
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_states",
+                    last_hidden_feature=None,
+                    passthrough=(
+                        ("input_ids", "input_ids", ()),
+                        ("loss_mask", "loss_mask", ()),
+                    ),
+                ),
+                build_collator=collator,
+            ),
+        ),
+    )
+
+
+def create_registration():
+    return make_registration(algorithm_spec(), algorithm_providers())
+
+
+__all__ = ["algorithm_providers", "algorithm_spec", "create_registration"]

--- a/specforge/algorithms/dspark/__init__.py
+++ b/specforge/algorithms/dspark/__init__.py
@@ -1,0 +1,5 @@
+"""DSpark algorithm registration."""
+
+from specforge.algorithms.dspark.providers import create_registration
+
+__all__ = ["create_registration"]

--- a/specforge/algorithms/dspark/providers.py
+++ b/specforge/algorithms/dspark/providers.py
@@ -1,0 +1,167 @@
+"""Built-in DSpark registration and executable providers."""
+
+from __future__ import annotations
+
+from specforge.algorithms.common.defaults import (
+    empty_options,
+    no_missing_checkpoint_keys,
+)
+from specforge.algorithms.common.dflash_family_data import build_dspark_collator
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepProvider,
+    make_registration,
+)
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+)
+
+ALGORITHM_NAME = "dspark"
+DRAFT_ARCHITECTURE = "DSparkDraftModel"
+
+
+def build_step(wrapped_model, *, target_head=None, **_options):
+    del target_head
+    from specforge.training.strategies.base import DSparkTrainStrategy
+
+    return DSparkTrainStrategy(wrapped_model)
+
+
+def resume_contract(_config, draft_model, training_model):
+    """Persist resolved DSpark model, sampling, and objective semantics."""
+
+    return {
+        "dspark_draft_num_hidden_layers": int(draft_model.config.num_hidden_layers),
+        "dspark_target_layer_ids": tuple(
+            int(layer_id) for layer_id in draft_model.target_layer_ids
+        ),
+        "dspark_block_size": int(training_model.block_size),
+        "dspark_mask_token_id": int(training_model.mask_token_id),
+        "dspark_attention_backend": str(training_model.attention_backend),
+        "dspark_num_anchors": int(training_model.num_anchors),
+        "dspark_loss_decay_gamma": training_model.loss_decay_gamma,
+        "dspark_ce_loss_alpha": float(training_model.dspark_ce_loss_alpha),
+        "dspark_l1_loss_alpha": float(training_model.dspark_l1_loss_alpha),
+        "dspark_confidence_head_alpha": float(
+            training_model.dspark_confidence_head_alpha
+        ),
+    }
+
+
+def build_draft(config, draft_config):
+    from specforge.algorithms.model_providers import build_registered_draft
+
+    return build_registered_draft(config, draft_config)
+
+
+def build_training_model(config, draft_model, draft_config, target_config, tokenizer):
+    from specforge.algorithms.model_providers import build_dspark_model
+
+    return build_dspark_model(
+        config,
+        draft_model,
+        draft_config,
+        target_config,
+        tokenizer,
+    )
+
+
+def resolve_capture_layers(config, draft_config, target_config):
+    from specforge.algorithms.model_providers import resolve_dflash_capture_layers
+
+    return resolve_dflash_capture_layers(config, draft_config, target_config)
+
+
+def minimum_loss_tokens(config, draft_config):
+    from specforge.algorithms.model_providers import dflash_min_loss_tokens
+
+    return dflash_min_loss_tokens(config, draft_config)
+
+
+def needs_input_tools(config, draft_model):
+    from specforge.algorithms.model_providers import dflash_needs_input_tools
+
+    return dflash_needs_input_tools(config, draft_model)
+
+
+def algorithm_spec() -> AlgorithmSpec:
+    return AlgorithmSpec(
+        name=ALGORITHM_NAME,
+        draft=DraftRequirement(
+            compatible_architectures={DRAFT_ARCHITECTURE},
+            default_architecture=DRAFT_ARCHITECTURE,
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                modality="text",
+                required_tensors={
+                    "input_ids",
+                    "loss_mask",
+                    "hidden_states",
+                    "target_last_hidden_states",
+                },
+                allowed_target_representations={"hidden_state"},
+                default_target_representation="hidden_state",
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"eager", "sdpa", "flex_attention"},
+        ),
+    )
+
+
+def algorithm_providers() -> AlgorithmProviders:
+    return AlgorithmProviders(
+        algorithm_name=ALGORITHM_NAME,
+        step=StepProvider(
+            build=build_step,
+            options=empty_options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=no_missing_checkpoint_keys,
+            uses_external_target_head=False,
+        ),
+        model=ModelProvider(
+            draft_config=DraftConfigProvider(
+                architecture=DRAFT_ARCHITECTURE,
+                expected_auto_map_model="dspark.DSparkDraftModel",
+            ),
+            build_draft=build_draft,
+            build_training_model=build_training_model,
+            resolve_capture_layers=resolve_capture_layers,
+            minimum_loss_tokens=minimum_loss_tokens,
+            needs_input_tools=needs_input_tools,
+            default_dataloader_num_workers=8,
+        ),
+        server_streaming=(
+            ServerStreamingProvider(
+                modality="text",
+                capture_method="dflash",
+                target_representation="hidden_state",
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_states",
+                    last_hidden_feature="target_last_hidden_states",
+                    passthrough=(
+                        ("input_ids", "input_ids", ()),
+                        ("loss_mask", "loss_mask", ()),
+                    ),
+                ),
+                build_collator=build_dspark_collator,
+            ),
+        ),
+    )
+
+
+def create_registration():
+    return make_registration(algorithm_spec(), algorithm_providers())
+
+
+__all__ = ["algorithm_providers", "algorithm_spec", "create_registration"]

--- a/specforge/algorithms/eagle3/__init__.py
+++ b/specforge/algorithms/eagle3/__init__.py
@@ -1,0 +1,5 @@
+"""EAGLE3 algorithm registration."""
+
+from specforge.algorithms.eagle3.providers import create_registration
+
+__all__ = ["create_registration"]

--- a/specforge/algorithms/eagle3/data.py
+++ b/specforge/algorithms/eagle3/data.py
@@ -1,0 +1,103 @@
+"""EAGLE3-owned offline normalization and collation factories."""
+
+from __future__ import annotations
+
+from functools import partial
+
+NORMALIZER_ID = "eagle3_offline_v1"
+
+
+def normalize_offline_sample(raw, max_len: int):
+    """Map the stored target states to the EAGLE3 training tensor names."""
+
+    import torch
+
+    hidden_state = raw["aux_hidden_state"].squeeze(0)[:max_len].unsqueeze(0)
+    target = raw["hidden_state"].squeeze(0)[:max_len].unsqueeze(0)
+    input_ids = raw["input_ids"][:max_len].unsqueeze(0)
+    loss_mask = raw["loss_mask"][:max_len].clone().unsqueeze(0)
+    if loss_mask.numel() > 0:
+        loss_mask[0, -1] = 0
+    return {
+        "attention_mask": torch.ones_like(loss_mask, dtype=torch.long),
+        "loss_mask": loss_mask,
+        "target": target,
+        "hidden_state": hidden_state,
+        "input_ids": input_ids,
+    }
+
+
+def build_offline_reader(
+    hidden_states_path,
+    *,
+    run_id,
+    ttt_length,
+    max_len,
+):
+    # Keep the heavy reader import lazy so resolving the algorithm registry is
+    # side-effect free.
+    from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+    return OfflineManifestReader(
+        hidden_states_path,
+        run_id=run_id,
+        strategy="eagle3",
+        ttt_length=ttt_length,
+        max_len=max_len,
+        target_repr="hidden_state",
+    )
+
+
+def build_offline_normalizer(
+    max_len,
+    *,
+    ttt_length=1,
+    use_usp_preprocess=False,
+):
+    if not use_usp_preprocess:
+        return partial(normalize_offline_sample, max_len=max_len)
+
+    # USP sharding remains in the retained implementation until its process
+    # groups become explicit provider inputs.
+    import torch.distributed as dist
+
+    from specforge.data.preprocessing import OfflineEagle3Dataset
+    from specforge.distributed import get_draft_sp_group, get_sp_ring_group
+
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("USP preprocessing requires initialized process groups")
+    sp_group = get_draft_sp_group()
+    ring_group = get_sp_ring_group()
+    return partial(
+        OfflineEagle3Dataset.process_data_usp,
+        max_len=max_len,
+        ttt_length=ttt_length,
+        sp_rank=dist.get_rank(sp_group),
+        sp_size=dist.get_world_size(sp_group),
+        ring_rank=dist.get_rank(ring_group),
+        sp_ring_size=dist.get_world_size(ring_group),
+    )
+
+
+def build_offline_collator():
+    # This retained collator owns USP-aware padding.  It can move here once the
+    # distributed helper contracts are independent of specforge.data.
+    from specforge.data.utils import DataCollatorWithPadding
+
+    return DataCollatorWithPadding()
+
+
+def build_server_collator():
+    from specforge.algorithms.common.collation import concatenate_features
+
+    return concatenate_features
+
+
+__all__ = [
+    "NORMALIZER_ID",
+    "build_offline_collator",
+    "build_offline_normalizer",
+    "build_offline_reader",
+    "build_server_collator",
+    "normalize_offline_sample",
+]

--- a/specforge/algorithms/eagle3/model.py
+++ b/specforge/algorithms/eagle3/model.py
@@ -1,0 +1,513 @@
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in HuggingFace Transformers.
+# Portions of this code are adapted from:
+#   - https://github.com/EleutherAI/gpt-neox (Apache License 2.0)
+#   - https://github.com/huggingface/transformers (Apache License 2.0)
+#   - https://github.com/SafeAILab/EAGLE (Apache License 2.0)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EAGLE3 training model implementation."""
+
+from typing import Callable, List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.cache_utils import DynamicCache
+
+from specforge.core.compact_teacher import (
+    DEFAULT_VOCAB_CHUNK_SIZE,
+    compute_target_p_padded_from_hidden,
+)
+from specforge.core.eagle3_adapters import BackendAdapter, SdpaLikeAdapter, UspAdapter
+from specforge.core.lk_loss import compute_acceptance_rate, compute_lk_loss
+from specforge.core.loss import LogSoftmaxLoss
+from specforge.modeling.draft import Eagle3DraftModel
+from specforge.utils import padding
+
+
+class Eagle3Model(nn.Module):
+    pass
+
+
+def _compute_loss_and_acceptance_rate(
+    *,
+    logits: torch.Tensor,
+    target_p: torch.Tensor,
+    target_p_on_draft: torch.Tensor,
+    position_mask: torch.Tensor,
+    lk_loss_type: Optional[str],
+    kl_scale: float,
+    kl_decay: float,
+    reduce_metrics_fn: Optional[
+        Callable[..., Tuple[torch.Tensor, torch.Tensor]]
+    ] = None,
+    reduce_loss_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute step loss and acceptance rate for KL/LK objectives.
+
+    Args:
+        logits: Draft model logits for current step.
+        target_p: Renormalized target distribution over draft-vocab tokens (for KL).
+        target_p_on_draft: Original target probabilities restricted to draft-vocab tokens (for acceptance terms).
+        position_mask: Mask indicating valid tokens for loss/metric aggregation.
+        lk_loss_type: LK objective mode (`None`, `"alpha"`, or `"lambda"`).
+        kl_scale: Scale factor for lambda LK mixing weight.
+        kl_decay: Decay factor for lambda LK mixing weight.
+        reduce_metrics_fn: Optional distributed reducer for metric numer/denom.
+        reduce_loss_fn: Optional distributed reducer for KL loss.
+    """
+    kl_loss = LogSoftmaxLoss.apply(logits, target_p, position_mask)
+    if reduce_loss_fn is not None:
+        kl_loss = reduce_loss_fn(kl_loss)
+
+    with torch.set_grad_enabled(lk_loss_type is not None):
+        acceptance_rate, log_acceptance_rate = compute_acceptance_rate(
+            logits=logits,
+            target_probs=target_p_on_draft,
+            position_mask=position_mask,
+            reduce_fn=reduce_metrics_fn,
+        )
+
+    if lk_loss_type is None:
+        loss = kl_loss
+    else:
+        loss = compute_lk_loss(
+            kl_loss=kl_loss,
+            acceptance_rate=acceptance_rate,
+            log_acceptance_rate=log_acceptance_rate,
+            lk_loss_type=lk_loss_type,
+            kl_scale=kl_scale,
+            kl_decay=kl_decay,
+        )
+    return acceptance_rate.detach(), loss
+
+
+class OnlineEagle3Model(Eagle3Model):
+    """
+    In sgl-spec, we implement offline/online training.
+    Online training means we have the target hidden_states available during training.
+    Eagle3 using test time training technique (TTT) to train the draft model.
+    1. We first extract the hidden states from the target model.
+    2. Then concatenate the hidden states from 3 aux layers (layer 1, layer num_layers//2, layer num_layers-4).
+    3. We project the concatenated hidden states to the target hidden size. from (batch, seq_len, 3*hidden_size) to (batch, seq_len, hidden_size)
+    4. We concat the projected hidden states and embedding output as the input for the draft model.
+    5. finally, we run TTT to train the draft model. input size is (batch, seq_len, hidden_size * 2)
+    """
+
+    def __init__(
+        self,
+        draft_model: Eagle3DraftModel,
+        length: int = 7,
+        attention_backend="sdpa",
+        lk_loss_type: Optional[str] = None,
+        kl_scale: float = 1.0,
+        kl_decay: float = 1.0,
+    ):
+        """
+        Args:
+            draft_model: the draft model to be trained.
+            length: TTT length, it means how many turns to unroll during TTT.
+            lk_loss_type: LK loss objective type. One of {"lambda", "alpha"}.
+            kl_scale: Initial KL weight scale for lambda LK loss.
+            kl_decay: Decay factor for adaptive KL weight in lambda LK loss.
+        """
+        super().__init__()
+        self.draft_model = draft_model
+        self.length = length
+        self.attention_backend = attention_backend
+        self.lk_loss_type = lk_loss_type
+        self.kl_scale = kl_scale
+        self.kl_decay = kl_decay
+
+    def _make_adapter(self) -> BackendAdapter:
+        if self.attention_backend == "usp":
+            return UspAdapter(self)
+        return SdpaLikeAdapter(self)
+
+    def _acc_and_loss(
+        self,
+        *,
+        logits: torch.Tensor,
+        target_p: torch.Tensor,
+        target_p_on_draft: torch.Tensor,
+        target_token_ids: torch.Tensor,
+        position_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+        adapter: BackendAdapter,
+    ) -> Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        with torch.no_grad():
+            pred_draft_token_ids = logits.argmax(-1)
+            pred_target_token_ids = (
+                pred_draft_token_ids + self.draft_model.d2t[pred_draft_token_ids]
+            )
+            local_correct = (
+                (pred_target_token_ids == target_token_ids) * loss_mask.squeeze(-1)
+            ).sum()
+            local_denom = loss_mask.sum().clamp_min(1e-6)
+            local_correct, local_denom = adapter.reduce_metrics(
+                local_correct=local_correct, local_denom=local_denom
+            )
+            acc = local_correct / local_denom
+
+        acceptance_rate, loss = _compute_loss_and_acceptance_rate(
+            logits=logits,
+            target_p=target_p,
+            target_p_on_draft=target_p_on_draft,
+            position_mask=position_mask,
+            lk_loss_type=self.lk_loss_type,
+            kl_scale=self.kl_scale,
+            kl_decay=self.kl_decay,
+            reduce_metrics_fn=adapter.reduce_metrics,
+            reduce_loss_fn=adapter.reduce_loss,
+        )
+        loss_denom = torch.tensor(
+            logits.shape[0] * logits.shape[1],
+            device=logits.device,
+            dtype=torch.float32,
+        )
+        return (
+            acc,
+            acceptance_rate,
+            loss,
+            local_correct,
+            local_denom,
+            loss.detach(),
+            loss_denom,
+        )
+
+    def _prepare_position_ids(
+        self,
+        position_ids: Optional[torch.Tensor],
+        *,
+        seq_length: int,
+        past_key_values_length: int,
+        device: torch.device,
+    ) -> Optional[torch.Tensor]:
+        if position_ids is None:
+            if self.attention_backend == "usp":
+                return None
+            return (
+                torch.arange(
+                    past_key_values_length,
+                    seq_length + past_key_values_length,
+                    dtype=torch.long,
+                    device=device,
+                )
+                .unsqueeze(0)
+                .view(-1, seq_length)
+            )
+
+        position_ids = position_ids.long()
+        if position_ids.ndim not in (2, 3):
+            raise ValueError(
+                "position_ids must have shape [batch, seq_length] or "
+                "[axes, batch, seq_length], got "
+                f"{tuple(position_ids.shape)}"
+            )
+        if position_ids.shape[-1] != seq_length:
+            raise ValueError(
+                "position_ids final dimension must equal seq_length="
+                f"{seq_length}, got {tuple(position_ids.shape)}"
+            )
+        if position_ids.ndim == 3:
+            return position_ids
+        return position_ids.reshape(-1, seq_length)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        target: torch.Tensor,
+        loss_mask: torch.Tensor,
+        hidden_states: torch.Tensor,
+        past_key_values: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        position_ids: Optional[torch.Tensor] = None,
+        target_hidden_for_compact: Optional[torch.Tensor] = None,
+        target_head_weight: Optional[torch.Tensor] = None,
+        compact_teacher_chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
+    ) -> Tuple[
+        List[torch.Tensor],
+        List[torch.Tensor],
+        List[torch.Tensor],
+        List[torch.Tensor],
+        List[torch.Tensor],
+        List[torch.Tensor],
+        List[torch.Tensor],
+    ]:
+        """
+        Online eagle model trainer, modified from: https://github.com/SafeAILab/EAGLE/blob/main/eagle/traineagle3/cnets.py#L711
+
+        Args:
+            input_ids: (batch, seq_len)
+            attention_mask: (batch, seq_len)
+            loss_mask: (batch, seq_len)
+            past_key_values: We dont use this past_key_values in eagle3, but keep it for compatibility. We control kvcache by cache_hidden.
+            position_ids: ``[batch, seq_len]`` or ``[axes, batch, seq_len]``.
+            target_hidden_for_compact, target_head_weight, compact_teacher_chunk_size:
+                when the first two are given, the padded teacher is built from hidden
+                states in draft-vocab space and ``target`` is ignored.
+        """
+        # Step 1: handle vocab size
+        if target_hidden_for_compact is not None:
+            (
+                target_p_padded,
+                target_p_on_draft_padded,
+                target_token_ids_padded,
+                position_mask,
+            ) = compute_target_p_padded_from_hidden(
+                hidden=target_hidden_for_compact,
+                lm_head_weight=target_head_weight,
+                t2d=self.draft_model.t2d,
+                loss_mask=loss_mask,
+                length=self.length,
+                chunk_size=compact_teacher_chunk_size,
+            )
+            del target_hidden_for_compact
+        else:
+            (
+                target_p_padded,
+                target_p_on_draft_padded,
+                target_token_ids_padded,
+                position_mask,
+            ) = _compute_target_p_padded(
+                target=target,
+                t2d=self.draft_model.t2d,
+                loss_mask=loss_mask,
+                length=self.length,
+            )
+            del target
+        torch.cuda.empty_cache()
+
+        # basic info
+        batch_size, seq_length, _ = hidden_states.shape
+        seq_length_with_past = seq_length
+        past_key_values_length = 0
+
+        # Step 2: project the concatenated hidden states to the target hidden size
+        hidden_states = self.draft_model.project_hidden_states(hidden_states)
+
+        # Step 3: process the KV cache and position IDs
+        if past_key_values is not None:
+            past_key_values_length = past_key_values[0][0].shape[2]
+            seq_length_with_past = seq_length_with_past + past_key_values_length
+        position_ids = self._prepare_position_ids(
+            position_ids=position_ids,
+            seq_length=seq_length,
+            past_key_values_length=past_key_values_length,
+            device=hidden_states.device,
+        )
+
+        # Step 4: handle attention mask
+        if attention_mask is None:
+            attention_mask = torch.ones(
+                (batch_size, seq_length_with_past),
+                dtype=torch.bool,
+                device=hidden_states.device,
+            )
+        if self.attention_backend == "sdpa":
+            attention_mask = self.draft_model.prepare_decoder_attention_mask(
+                attention_mask=attention_mask,
+                hidden_states=hidden_states,
+                batch_size=batch_size,
+                seq_length=seq_length,
+                past_key_values_length=past_key_values_length,
+            )
+
+        # Step 5: run TTT
+        plosses = []
+        acceptance_rates = []
+        acces = []
+        metric_corrects = []
+        metric_denoms = []
+        metric_losses = []
+        metric_loss_denoms = []
+        adapter = self._make_adapter()
+        # for sequence paralle, position mask and input ids will split by sequence dim, need to keep origin for ttt shift
+        global_input_ids = input_ids
+        if self.attention_backend in ["sdpa", "fa", "usp"]:
+            cache_hidden = [[], []]
+            past_key_values = None
+        elif self.attention_backend == "flex_attention":
+            cache_hidden = None
+            past_key_values = DynamicCache()
+        else:
+            raise ValueError(f"Unknown attention backend: {self.attention_backend}")
+
+        for idx in range(self.length):
+            state = adapter.step_view(
+                idx=idx,
+                ttt_length=self.length,
+                global_input_ids=global_input_ids,
+                attention_mask=attention_mask,
+                loss_mask=loss_mask,
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                target_p_padded=target_p_padded,
+                target_p_on_draft_padded=target_p_on_draft_padded,
+                target_token_ids_padded=target_token_ids_padded,
+                position_mask=position_mask,
+                seq_length=seq_length,
+            )
+            is_last = idx == self.length - 1
+
+            # Step 5.1: embed the input ids
+            inputs_embeds = self.draft_model.embed_input_ids(state.input_ids)
+            inputs_embeds = inputs_embeds.to(hidden_states.dtype)
+
+            # Step 5.2: run the draft model backbone
+            hidden_states_out = self.draft_model.backbone(
+                input_embeds=inputs_embeds,
+                hidden_states=state.hidden_states,
+                cache_hidden=cache_hidden,
+                attention_mask=state.attention_mask,
+                position_ids=state.position_ids,
+                past_key_values=past_key_values,
+                use_cache=True,
+            )
+
+            # update hidden states for next step
+            hidden_states = hidden_states_out
+
+            # Step 5.4: get logits
+            logits = self.draft_model.compute_logits(hidden_states)
+
+            # Step 5.5 + 5.6: metric and loss
+            (
+                acc,
+                acceptance_rate,
+                loss,
+                correct,
+                denom,
+                metric_loss,
+                loss_denom,
+            ) = self._acc_and_loss(
+                logits=logits,
+                target_p=state.target_p,
+                target_p_on_draft=state.target_p_on_draft,
+                target_token_ids=state.target_token_ids,
+                position_mask=state.position_mask,
+                loss_mask=state.loss_mask,
+                adapter=adapter,
+            )
+            acces.append(acc)
+            acceptance_rates.append(acceptance_rate)
+            plosses.append(loss)
+            metric_corrects.append(correct)
+            metric_denoms.append(denom)
+            metric_losses.append(metric_loss)
+            metric_loss_denoms.append(loss_denom)
+
+            if not is_last:
+                # Step 5.7: we need to update the loss mask
+                global_input_ids = padding(global_input_ids, left=False)
+                position_mask = padding(position_mask, left=False)
+                loss_mask = padding(loss_mask, left=False)
+                # Flex attention mask shirnking is handled inside attention module
+        return (
+            plosses,
+            acceptance_rates,
+            acces,
+            metric_corrects,
+            metric_denoms,
+            metric_losses,
+            metric_loss_denoms,
+        )
+
+
+def _compute_target_p_padded(target, t2d, loss_mask, length):
+    with torch.no_grad():
+        (
+            target_p,
+            target_p_on_draft,
+            target_token_ids,
+            position_mask,
+        ) = _compute_target_p(
+            target=target,
+            t2d=t2d,
+            loss_mask=loss_mask,
+        )
+
+        assert len(target_p.shape) == 3
+        target_p_padded = F.pad(
+            target_p,
+            pad=(0, 0, 0, length),
+            mode="constant",
+            # For bitwise equality with previous code
+            value=1 / target_p.shape[-1],
+        )
+        target_p_on_draft_padded = F.pad(
+            target_p_on_draft,
+            pad=(0, 0, 0, length),
+            mode="constant",
+            value=0.0,
+        )
+        target_token_ids_padded = F.pad(
+            target_token_ids,
+            pad=(0, length),
+            mode="constant",
+            value=0,
+        )
+
+        return (
+            target_p_padded,
+            target_p_on_draft_padded,
+            target_token_ids_padded,
+            position_mask,
+        )
+
+
+@torch.compile(dynamic=None)
+def _compute_target_p(target, t2d, loss_mask):
+    target_head = target.float()
+    target_token_ids = target_head.argmax(-1)
+    target_mask = t2d[target_token_ids]
+    target_mask = target_mask[..., None].int()
+    position_mask = target_mask * loss_mask
+    draft_target_head = target_head[..., t2d]
+    target_p = nn.Softmax(dim=2)(draft_target_head)
+    target_logsumexp = torch.logsumexp(target_head, dim=-1, keepdim=True)
+    target_p_on_draft = torch.exp(draft_target_head - target_logsumexp)
+    target_p = target_p.detach()
+    target_p_on_draft = target_p_on_draft.detach()
+    target_token_ids = target_token_ids.detach()
+    return target_p, target_p_on_draft, target_token_ids, position_mask
+
+
+@torch.compile(dynamic=None)
+def _compute_metric_acc(logits, target_token_ids, loss_mask, d2t):
+    correct, denom = _compute_metric_counts(logits, target_token_ids, loss_mask, d2t)
+    return correct / denom
+
+
+@torch.compile(dynamic=None)
+def _compute_metric_counts(logits, target_token_ids, loss_mask, d2t):
+    pred_draft_token_ids = logits.argmax(-1)
+    pred_target_token_ids = pred_draft_token_ids + d2t[pred_draft_token_ids]
+    correct = (
+        (pred_target_token_ids == target_token_ids) * loss_mask.squeeze(-1)
+    ).sum()
+    denom = loss_mask.sum().clamp_min(1e-6)
+    return correct, denom

--- a/specforge/algorithms/eagle3/providers.py
+++ b/specforge/algorithms/eagle3/providers.py
@@ -1,0 +1,229 @@
+"""Built-in EAGLE3 registration and executable providers."""
+
+from __future__ import annotations
+
+from specforge.algorithms.common.defaults import (
+    no_missing_checkpoint_keys,
+    one_loss_token,
+    online_needs_input_tools,
+)
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    OfflineDataProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepProvider,
+    TargetDerivedDraftDefaults,
+    make_registration,
+)
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+from specforge.algorithms.eagle3.data import (
+    NORMALIZER_ID,
+    build_offline_collator,
+    build_offline_normalizer,
+    build_offline_reader,
+    build_server_collator,
+)
+
+ALGORITHM_NAME = "eagle3"
+DRAFT_ARCHITECTURE = "LlamaForCausalLMEagle3"
+
+
+# Keep executable imports lazy so resolving the immutable registry remains
+# dependency-light. Concrete step execution stays in training.strategies;
+# EAGLE3 model and data implementations are owned by this package.
+def build_step(wrapped_model, *, target_head=None, **options):
+    from specforge.training.strategies.base import Eagle3TrainStrategy
+
+    return Eagle3TrainStrategy(
+        wrapped_model,
+        target_head=target_head,
+        **options,
+    )
+
+
+def step_options(config):
+    from specforge.algorithms.model_providers import eagle3_strategy_kwargs
+
+    return eagle3_strategy_kwargs(config)
+
+
+def resume_contract(config, draft_model, training_model):
+    """Persist every resolved EAGLE3 model/objective setting used by a step."""
+
+    return {
+        "eagle3_draft_num_hidden_layers": int(draft_model.config.num_hidden_layers),
+        "eagle3_ttt_length": int(training_model.length),
+        "eagle3_attention_backend": str(training_model.attention_backend),
+        "eagle3_lk_loss_type": training_model.lk_loss_type,
+        "eagle3_kl_scale": float(training_model.kl_scale),
+        "eagle3_kl_decay": float(training_model.kl_decay),
+        "eagle3_compact_teacher": bool(config.training.compact_teacher),
+        "eagle3_compact_teacher_chunk_size": (
+            config.training.compact_teacher_chunk_size
+        ),
+    }
+
+
+def allowed_missing_checkpoint_keys(_config, draft_model, _training_model):
+    """Allow only the frozen target-copied embedding omitted by EAGLE3 saves."""
+
+    embedding_parameters = [
+        parameter
+        for name, parameter in draft_model.named_parameters()
+        if "embed" in name.lower()
+    ]
+    if not embedding_parameters or any(
+        parameter.requires_grad for parameter in embedding_parameters
+    ):
+        return no_missing_checkpoint_keys(_config, draft_model, _training_model)
+    return frozenset(key for key in draft_model.state_dict() if "embed" in key.lower())
+
+
+def build_draft(config, draft_config):
+    from specforge.algorithms.model_providers import build_eagle3_draft
+
+    return build_eagle3_draft(config, draft_config)
+
+
+def build_training_model(config, draft_model, draft_config, target_config, tokenizer):
+    from specforge.algorithms.model_providers import build_eagle3_model
+
+    return build_eagle3_model(
+        config,
+        draft_model,
+        draft_config,
+        target_config,
+        tokenizer,
+    )
+
+
+def resolve_capture_layers(config, draft_config, target_config):
+    from specforge.algorithms.model_providers import resolve_eagle_capture_layers
+
+    return resolve_eagle_capture_layers(config, draft_config, target_config)
+
+
+def algorithm_spec() -> AlgorithmSpec:
+    required = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+    return AlgorithmSpec(
+        name=ALGORITHM_NAME,
+        draft=DraftRequirement(
+            compatible_architectures={DRAFT_ARCHITECTURE},
+            default_architecture=DRAFT_ARCHITECTURE,
+            supported_overrides={"attention_layout", "num_hidden_layers"},
+            fixed_override_values=(("num_hidden_layers", 1),),
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.OFFLINE,
+                modality="text",
+                required_tensors=required,
+                optional_tensors={"position_ids"},
+                allowed_target_representations={"hidden_state"},
+                default_target_representation="hidden_state",
+                storage=OfflineStorageContract(
+                    format="specforge_hidden_states_v1",
+                    required_tensors={
+                        "input_ids",
+                        "loss_mask",
+                        "hidden_state",
+                        "aux_hidden_state",
+                    },
+                    normalizer=NORMALIZER_ID,
+                ),
+            ),
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                modality="text",
+                required_tensors=required,
+                allowed_target_representations={"hidden_state"},
+                default_target_representation="hidden_state",
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"sdpa", "flex_attention", "fa", "usp"},
+            supports_compact_teacher=True,
+            supports_vocab_mapping=True,
+            allows_aux_layer_override=True,
+        ),
+    )
+
+
+def algorithm_providers() -> AlgorithmProviders:
+    return AlgorithmProviders(
+        algorithm_name=ALGORITHM_NAME,
+        step=StepProvider(
+            build=build_step,
+            options=step_options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=allowed_missing_checkpoint_keys,
+            uses_external_target_head=True,
+        ),
+        model=ModelProvider(
+            draft_config=DraftConfigProvider(
+                architecture=DRAFT_ARCHITECTURE,
+                target_defaults=TargetDerivedDraftDefaults(
+                    model_type="llama",
+                    num_hidden_layers=1,
+                    draft_vocab_size=32000,
+                ),
+            ),
+            build_draft=build_draft,
+            build_training_model=build_training_model,
+            resolve_capture_layers=resolve_capture_layers,
+            minimum_loss_tokens=one_loss_token,
+            needs_input_tools=online_needs_input_tools,
+            default_dataloader_num_workers=4,
+            allow_missing_warm_start_embedding=True,
+        ),
+        offline=(
+            OfflineDataProvider(
+                modality="text",
+                normalizer_id=NORMALIZER_ID,
+                build_reader=build_offline_reader,
+                build_normalizer=build_offline_normalizer,
+                build_collator=build_offline_collator,
+            ),
+        ),
+        server_streaming=(
+            ServerStreamingProvider(
+                modality="text",
+                capture_method="eagle3",
+                target_representation="hidden_state",
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_state",
+                    last_hidden_feature="target",
+                    passthrough=(
+                        ("input_ids", "input_ids", ()),
+                        ("loss_mask", "loss_mask", ()),
+                    ),
+                    attention_mask_feature="attention_mask",
+                ),
+                build_collator=build_server_collator,
+            ),
+        ),
+        vocab_mapping_modes=frozenset({FeatureMode.OFFLINE, FeatureMode.STREAMING}),
+    )
+
+
+def create_registration():
+    return make_registration(algorithm_spec(), algorithm_providers())
+
+
+__all__ = ["algorithm_providers", "algorithm_spec", "create_registration"]

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -1,0 +1,471 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Algorithm-owned model and configuration providers.
+
+The public assembler owns topology and lifecycle.  This module owns the facts
+that vary by draft method: how to create its config and model, which target
+features it captures, and which dataset policies it needs.  All heavy imports
+remain inside callables so resolving the algorithm registry stays import-light.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+
+    from specforge.config import Config
+
+
+@dataclass
+class AlgorithmModelParts:
+    """Algorithm-specific pieces returned to the application assembler."""
+
+    model: Any
+    target_head: Any = None
+    capture_layers: Optional[List[int]] = None
+
+
+def dflash_needs_input_tools(cfg: Config, draft_model: Any) -> bool:
+    method_config = getattr(draft_model.config, "dflash_config", None) or {}
+    needs_mask_fallback = (
+        cfg.model.mask_token_id is None and method_config.get("mask_token_id") is None
+    )
+    return cfg.mode == "online" or needs_mask_fallback
+
+
+def _torch_dtype(cfg: Config):
+    import torch
+
+    return getattr(torch, cfg.model.torch_dtype)
+
+
+def _device():
+    from specforge.utils import get_local_device
+
+    return get_local_device()
+
+
+def _warm_start(
+    cfg: Config,
+    draft_model: Any,
+    draft_config: Any,
+    *,
+    allow_missing_embedding: bool = False,
+) -> None:
+    if not cfg.model.draft_checkpoint_path:
+        return
+    from specforge.training.model_loading import warm_start_draft_model
+
+    warm_start_draft_model(
+        draft_model,
+        cfg.model.draft_checkpoint_path,
+        draft_config=draft_config,
+        strategy=cfg.training.strategy,
+        allow_missing_embedding=allow_missing_embedding,
+        cache_dir=cfg.model.cache_dir,
+        trust_remote_code=cfg.model.trust_remote_code,
+    )
+
+
+def _load_vocab_mapping(cfg: Config, draft_model: Any) -> None:
+    if cfg.model.vocab_mapping_path:
+        draft_model.load_vocab_mapping(cfg.model.vocab_mapping_path)
+
+
+def build_eagle3_draft(cfg: Config, draft_config: PretrainedConfig):
+    from specforge.modeling.auto import AutoDraftModel
+
+    draft_model = AutoDraftModel.from_config(
+        draft_config,
+        attention_backend=cfg.training.attention_backend,
+        torch_dtype=_torch_dtype(cfg),
+    )
+    _warm_start(
+        cfg,
+        draft_model,
+        draft_config,
+        allow_missing_embedding=True,
+    )
+    _load_vocab_mapping(cfg, draft_model)
+    if cfg.model.load_target_embedding:
+        draft_model.load_embedding(
+            cfg.model.target_model_path,
+            embedding_key=cfg.model.embedding_key,
+        )
+    draft_model.freeze_embedding()
+    return draft_model.to(device=_device(), dtype=_torch_dtype(cfg))
+
+
+def build_peagle_draft(cfg: Config, draft_config: PretrainedConfig):
+    from specforge.modeling.draft.peagle import PEagleDraftModel
+
+    draft_model = PEagleDraftModel(
+        draft_config,
+        norm_before_residual=cfg.training.norm_before_residual,
+    )
+    if cfg.model.load_target_embedding:
+        draft_model.load_embedding(
+            cfg.model.target_model_path,
+            embedding_key=cfg.model.embedding_key,
+        )
+    _warm_start(
+        cfg,
+        draft_model,
+        draft_config,
+        allow_missing_embedding=True,
+    )
+    _load_vocab_mapping(cfg, draft_model)
+    return draft_model.to(device=_device(), dtype=_torch_dtype(cfg))
+
+
+def peagle_resume_contract(
+    _cfg: Config, draft_model: Any, model: Any
+) -> Dict[str, Any]:
+    """Persist the resolved P-EAGLE model and objective semantics."""
+
+    return {
+        "peagle_num_draft_layers": len(draft_model.layers),
+        "peagle_norm_before_residual": bool(draft_model.norm_before_residual),
+        "peagle_num_depths": int(model.num_depths),
+        "peagle_down_sample_ratio": float(model.down_sample_ratio),
+        "peagle_down_sample_ratio_min": float(model.down_sample_ratio_min),
+        "peagle_mask_token_id": int(model.mask_token_id),
+    }
+
+
+def build_registered_draft(cfg: Config, draft_config: PretrainedConfig):
+    from specforge.modeling.auto import AutoDraftModel
+
+    draft_config._attn_implementation = cfg.training.attention_backend
+    draft_model = AutoDraftModel.from_config(
+        draft_config,
+        torch_dtype=_torch_dtype(cfg),
+    )
+    _warm_start(cfg, draft_model, draft_config)
+    return draft_model.to(device=_device(), dtype=_torch_dtype(cfg))
+
+
+def resolve_eagle_capture_layers(
+    cfg: Config, draft_config: Any, target_config: Any
+) -> List[int]:
+    """Resolve EAGLE capture layers from run override, draft config, or target."""
+
+    layers = cfg.model.aux_hidden_state_layer_ids
+    if layers is None:
+        eagle_config = (
+            draft_config.get("eagle_config", {})
+            if isinstance(draft_config, dict)
+            else getattr(draft_config, "eagle_config", {})
+        ) or {}
+        layers = eagle_config.get("eagle_aux_hidden_state_layer_ids")
+    if layers is None:
+        target_config = getattr(target_config, "text_config", target_config)
+        num_layers = int(target_config.num_hidden_layers)
+        layers = [1, num_layers // 2 - 1, num_layers - 4]
+    layers = list(layers)
+    if len(layers) != 3 or any(not isinstance(i, int) or i < 0 for i in layers):
+        raise ValueError(
+            "resolved EAGLE capture layers must contain exactly three "
+            f"non-negative integers, got {layers!r}"
+        )
+    return layers
+
+
+def resolve_dflash_capture_layers(
+    _cfg: Config, draft_config: Any, _target_config: Any
+) -> List[int]:
+    method_config = (
+        draft_config.get("dflash_config", {})
+        if isinstance(draft_config, dict)
+        else getattr(draft_config, "dflash_config", {})
+    ) or {}
+    layers = list(method_config.get("target_layer_ids", []))
+    if not layers:
+        raise ValueError("draft config does not define target capture layer ids")
+    return layers
+
+
+def _resolve_mask_token_id(cfg: Config, draft_model: Any, tokenizer: Any) -> int:
+    from specforge.training.model_utils import resolve_mask_token_id
+
+    return resolve_mask_token_id(
+        explicit=cfg.model.mask_token_id,
+        tokenizer=tokenizer,
+        draft_model=draft_model,
+        embedding_vocab_size=int(draft_model.config.vocab_size),
+    )
+
+
+def build_eagle3_model(
+    cfg: Config,
+    draft_model: Any,
+    draft_config: Any,
+    target_config: Any,
+    _tokenizer: Any,
+) -> AlgorithmModelParts:
+    from specforge.algorithms.eagle3.model import OnlineEagle3Model
+
+    model = OnlineEagle3Model(
+        draft_model=draft_model,
+        length=cfg.training.ttt_length,
+        attention_backend=cfg.training.attention_backend,
+        lk_loss_type=cfg.training.lk_loss_type,
+        kl_scale=cfg.training.kl_scale,
+        kl_decay=cfg.training.kl_decay,
+    ).to(device=_device(), dtype=_torch_dtype(cfg))
+    needs_target_head = cfg.mode == "offline" or (
+        cfg.deployment.mode == "disaggregated" and cfg.training.role == "consumer"
+    )
+    target_head = None
+    if needs_target_head:
+        from specforge.modeling.target.target_head import TargetHead
+
+        target_head = TargetHead.from_pretrained(
+            cfg.model.target_model_path,
+            lm_head_key=cfg.model.lm_head_key,
+            cache_dir=cfg.model.cache_dir,
+            trust_remote_code=cfg.model.trust_remote_code,
+        )
+    return AlgorithmModelParts(
+        model=model,
+        target_head=target_head,
+    )
+
+
+def build_peagle_model(
+    cfg: Config,
+    draft_model: Any,
+    _draft_config: Any,
+    _target_config: Any,
+    tokenizer: Any,
+) -> AlgorithmModelParts:
+    from specforge.algorithms.peagle.model import OnlinePEagleModel
+
+    mask_token_id = _resolve_mask_token_id(cfg, draft_model, tokenizer)
+    model = OnlinePEagleModel(
+        draft_model=draft_model,
+        mask_token_id=mask_token_id,
+        num_depths=cfg.training.num_depths,
+        down_sample_ratio=cfg.training.down_sample_ratio,
+        down_sample_ratio_min=cfg.training.down_sample_ratio_min,
+    ).to(device=_device(), dtype=_torch_dtype(cfg))
+    # Server capture transports the final target hidden state instead of full
+    # vocabulary logits.  The consumer resolves that representation through the
+    # same frozen target head used by offline EAGLE3; no target model is loaded
+    # in the trainer process.
+    target_head = None
+    if (
+        cfg.mode == "online"
+        and cfg.deployment.mode == "disaggregated"
+        and cfg.training.role == "consumer"
+    ):
+        from specforge.modeling.target.target_head import TargetHead
+
+        target_head = TargetHead.from_pretrained(
+            cfg.model.target_model_path,
+            lm_head_key=cfg.model.lm_head_key,
+            cache_dir=cfg.model.cache_dir,
+            trust_remote_code=cfg.model.trust_remote_code,
+        )
+    return AlgorithmModelParts(model=model, target_head=target_head)
+
+
+def _build_dflash_family_model(
+    cfg: Config,
+    draft_model: Any,
+    tokenizer: Any,
+    model_factory: Callable[[Dict[str, Any]], Any],
+) -> AlgorithmModelParts:
+    from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
+
+    mask_token_id = _resolve_mask_token_id(cfg, draft_model, tokenizer)
+    draft_model.mask_token_id = mask_token_id
+    method_config = getattr(draft_model.config, "dflash_config", None)
+    if method_config is None:
+        draft_model.config.dflash_config = {}
+        method_config = draft_model.config.dflash_config
+    method_config["mask_token_id"] = mask_token_id
+    method_config["target_layer_ids"] = list(draft_model.target_layer_ids)
+
+    target_parts = TargetEmbeddingsAndHead.from_pretrained(
+        cfg.model.target_model_path,
+        embed_key=cfg.model.embedding_key,
+        lm_head_key=cfg.model.lm_head_key,
+        cache_dir=cfg.model.cache_dir,
+        device=_device().type,
+        dtype=_torch_dtype(cfg),
+        trust_remote_code=cfg.model.trust_remote_code,
+    )
+    common = {
+        "draft_model": draft_model,
+        "target_lm_head": target_parts.lm_head,
+        "target_embed_tokens": target_parts.embed_tokens,
+        "mask_token_id": mask_token_id,
+        "block_size": int(draft_model.block_size),
+        "attention_backend": cfg.training.attention_backend,
+        "num_anchors": cfg.training.num_anchors,
+        "loss_decay_gamma": cfg.training.loss_decay_gamma,
+    }
+    model = model_factory(common).to(device=_device(), dtype=_torch_dtype(cfg))
+    return AlgorithmModelParts(
+        model=model,
+        capture_layers=list(draft_model.target_layer_ids),
+    )
+
+
+def build_dflash_model(
+    cfg: Config,
+    draft_model: Any,
+    _draft_config: Any,
+    _target_config: Any,
+    tokenizer: Any,
+) -> AlgorithmModelParts:
+    from specforge.algorithms.common.dflash_family_model import OnlineDFlashModel
+
+    return _build_dflash_family_model(
+        cfg,
+        draft_model,
+        tokenizer,
+        lambda common: OnlineDFlashModel(
+            **common,
+            loss_type=cfg.training.loss_type,
+            dpace_alpha=cfg.training.dpace_alpha,
+        ),
+    )
+
+
+def build_domino_model(
+    cfg: Config,
+    draft_model: Any,
+    _draft_config: Any,
+    _target_config: Any,
+    tokenizer: Any,
+) -> AlgorithmModelParts:
+    from specforge.algorithms.common.dflash_family_model import OnlineDominoModel
+
+    return _build_dflash_family_model(
+        cfg,
+        draft_model,
+        tokenizer,
+        lambda common: OnlineDominoModel(
+            **common,
+            shift_label=bool(getattr(draft_model, "shift_label", False)),
+        ),
+    )
+
+
+def build_dspark_model(
+    cfg: Config,
+    draft_model: Any,
+    _draft_config: Any,
+    _target_config: Any,
+    tokenizer: Any,
+) -> AlgorithmModelParts:
+    from specforge.algorithms.common.dflash_family_model import OnlineDSparkModel
+
+    return _build_dflash_family_model(
+        cfg,
+        draft_model,
+        tokenizer,
+        lambda common: OnlineDSparkModel(
+            **common,
+            dspark_ce_loss_alpha=cfg.training.dspark_ce_loss_alpha,
+            dspark_l1_loss_alpha=cfg.training.dspark_l1_loss_alpha,
+            dspark_confidence_head_alpha=(cfg.training.dspark_confidence_head_alpha),
+        ),
+    )
+
+
+def eagle3_strategy_kwargs(cfg: Config) -> Dict[str, Any]:
+    return {
+        "compact_teacher": cfg.training.compact_teacher,
+        "compact_teacher_chunk_size": cfg.training.compact_teacher_chunk_size,
+    }
+
+
+def domino_strategy_kwargs(cfg: Config) -> Dict[str, Any]:
+    return {
+        "lambda_start": cfg.training.lambda_base_start,
+        "decay_ratio": cfg.training.lambda_base_decay_ratio,
+    }
+
+
+def dflash_min_loss_tokens(_cfg: Config, draft_config: Any) -> int:
+    block_size = getattr(draft_config, "block_size", None)
+    if (
+        not isinstance(block_size, int)
+        or isinstance(block_size, bool)
+        or block_size < 1
+    ):
+        raise ValueError(
+            "DFlash-family draft config must define a positive integer block_size"
+        )
+    return 2 * block_size
+
+
+def populate_dflash_generated_config(
+    payload: Dict[str, Any], target_config: Any, _cfg: Config
+) -> None:
+    from specforge.modeling.draft.dflash import build_target_layer_ids
+
+    target_layers = getattr(target_config, "num_hidden_layers", None)
+    if not isinstance(target_layers, int) or target_layers < 1:
+        raise ValueError(
+            "DFlash auto-generation requires target num_hidden_layers, got "
+            f"{target_layers!r}"
+        )
+    payload["num_target_layers"] = target_layers
+    payload["block_size"] = 16
+    payload["dflash_config"] = {
+        "target_layer_ids": build_target_layer_ids(target_layers, 1)
+    }
+
+
+def apply_dflash_overrides(cfg: Config, draft_config: Any) -> None:
+    if cfg.model.draft_num_hidden_layers is None:
+        return
+    from specforge.modeling.draft.dflash import build_target_layer_ids
+
+    target_layers = int(draft_config.num_target_layers)
+    method_config = dict(getattr(draft_config, "dflash_config", None) or {})
+    method_config["target_layer_ids"] = build_target_layer_ids(
+        target_layers, cfg.model.draft_num_hidden_layers
+    )
+    draft_config.dflash_config = method_config
+
+
+__all__ = [
+    "AlgorithmModelParts",
+    "apply_dflash_overrides",
+    "build_dflash_model",
+    "build_domino_model",
+    "build_dspark_model",
+    "build_eagle3_draft",
+    "build_eagle3_model",
+    "build_peagle_draft",
+    "peagle_resume_contract",
+    "build_peagle_model",
+    "build_registered_draft",
+    "dflash_min_loss_tokens",
+    "dflash_needs_input_tools",
+    "domino_strategy_kwargs",
+    "eagle3_strategy_kwargs",
+    "populate_dflash_generated_config",
+    "resolve_dflash_capture_layers",
+    "resolve_eagle_capture_layers",
+]

--- a/specforge/algorithms/peagle/__init__.py
+++ b/specforge/algorithms/peagle/__init__.py
@@ -1,0 +1,5 @@
+"""P-EAGLE algorithm registration."""
+
+from specforge.algorithms.peagle.providers import create_registration
+
+__all__ = ["create_registration"]

--- a/specforge/algorithms/peagle/model.py
+++ b/specforge/algorithms/peagle/model.py
@@ -1,0 +1,347 @@
+"""P-EAGLE training model and COD sampling helpers."""
+
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from torch.nn.attention.flex_attention import create_block_mask
+
+from specforge.core.loss import LogSoftmaxLoss
+from specforge.modeling.draft.peagle import PEagleDraftModel
+
+
+def generate_cod_sample_indices(
+    seq_length: int,
+    loss_mask: torch.Tensor,
+    num_depths: int = 8,
+    down_sample_ratio: float = 0.8,
+    down_sample_ratio_min: float = 0.2,
+    filter_position_zero: bool = True,
+    lengths: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    if loss_mask.dim() == 2:
+        if loss_mask.shape[0] != 1:
+            raise ValueError("COD sampling currently requires batch size 1")
+        loss_mask = loss_mask[0]
+    elif loss_mask.dim() != 1:
+        raise ValueError("loss_mask must have shape [seq] or [1, seq]")
+    if loss_mask.numel() != seq_length:
+        raise ValueError(
+            f"loss_mask has {loss_mask.numel()} positions, expected {seq_length}"
+        )
+
+    device = loss_mask.device
+    if lengths is None:
+        lengths = torch.tensor([seq_length], dtype=torch.long, device=device)
+    else:
+        lengths = lengths.to(device=device, dtype=torch.long).flatten()
+    if lengths.numel() == 0 or torch.any(lengths <= 0):
+        raise ValueError("lengths must contain positive document lengths")
+    packed_length = int(lengths.sum().item())
+    if packed_length > seq_length:
+        raise ValueError(
+            f"packed document lengths sum to {packed_length}, above {seq_length}"
+        )
+    document_ids = torch.repeat_interleave(
+        torch.arange(lengths.numel(), device=device, dtype=torch.long),
+        lengths,
+    )
+    if packed_length < seq_length:
+        document_ids = torch.cat(
+            [
+                document_ids,
+                torch.full(
+                    (seq_length - packed_length,),
+                    -1,
+                    device=device,
+                    dtype=torch.long,
+                ),
+            ]
+        )
+
+    all_valid_indices = torch.where(loss_mask == 1)[0]
+
+    sample_indices = [torch.arange(seq_length, device=device)]
+    n_per_depth = [seq_length]
+    prev_indices = all_valid_indices
+
+    for d in range(1, num_depths):
+        candidate_targets = prev_indices[prev_indices >= d]
+        candidate_anchors = candidate_targets - d
+        same_document = (document_ids[candidate_targets] >= 0) & (
+            document_ids[candidate_targets] == document_ids[candidate_anchors]
+        )
+        eligible_indices = candidate_targets[same_document]
+        valid_length = max(0, all_valid_indices.shape[0] - d)
+        ratio = max(down_sample_ratio**d, down_sample_ratio_min)
+        sample_size = min(int(valid_length * ratio), eligible_indices.shape[0])
+
+        if sample_size <= 0:
+            break
+
+        if eligible_indices.shape[0] > sample_size:
+            random_selection = torch.randperm(eligible_indices.shape[0], device=device)[
+                :sample_size
+            ]
+            sampled_idx = eligible_indices[random_selection]
+            sampled_idx = torch.sort(sampled_idx)[0]
+        else:
+            sampled_idx = eligible_indices
+
+        next_candidates = (sampled_idx + 1) % seq_length
+        if filter_position_zero:
+            next_candidates = next_candidates[next_candidates != 0]
+        mask = torch.isin(next_candidates, all_valid_indices)
+        prev_indices = next_candidates[mask]
+
+        sample_indices.append(sampled_idx - d)
+        n_per_depth.append(sampled_idx.shape[0])
+
+    anchor_pos = torch.cat(sample_indices)
+    depth = torch.cat(
+        [
+            torch.full((n,), i, device=device, dtype=torch.long)
+            for i, n in enumerate(n_per_depth)
+        ]
+    )
+    return anchor_pos, depth
+
+
+def create_peagle_mask_mod(anchor_pos, depth, lengths, total_seq_len):
+    lengths = lengths.to(device=anchor_pos.device, dtype=torch.long).flatten()
+    document_ids = torch.repeat_interleave(
+        torch.arange(lengths.shape[0], device=lengths.device, dtype=torch.long),
+        lengths,
+    )
+    document_ids = torch.cat(
+        [
+            document_ids,
+            -1
+            * torch.ones(
+                total_seq_len - document_ids.shape[0],
+                device=lengths.device,
+                dtype=torch.long,
+            ),
+        ]
+    ).contiguous()
+
+    def peagle_mask_mod(_b, _h, q_idx, kv_idx):
+        q_anchor_pos = anchor_pos[q_idx]
+        kv_anchor_pos = anchor_pos[kv_idx]
+        q_depth = depth[q_idx]
+        kv_depth = depth[kv_idx]
+
+        same_document = document_ids[q_anchor_pos] == document_ids[kv_anchor_pos]
+        is_not_padding = document_ids[q_anchor_pos] != -1
+        same_rollout = q_anchor_pos == kv_anchor_pos
+        kv_depth0 = kv_depth == 0
+        in_depth_order = q_depth >= kv_depth
+        is_anchor_causal = q_anchor_pos >= kv_anchor_pos
+
+        return (
+            is_not_padding
+            & same_document
+            & ((kv_depth0 & is_anchor_causal) | (same_rollout & in_depth_order))
+        )
+
+    return peagle_mask_mod
+
+
+def compute_peagle_metrics(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    loss_mask: torch.Tensor,
+    anchor_pos: torch.Tensor,
+    depth: torch.Tensor,
+    num_depths: int,
+    t2d: torch.Tensor,
+) -> Tuple[torch.Tensor, Dict[str, Any]]:
+    device = logits.device
+    orig_positions = anchor_pos + depth
+
+    # Ensure loss_mask is 2D [batch, seq_len]
+    if loss_mask.dim() == 3:
+        loss_mask = loss_mask.squeeze(-1)
+
+    sampled_loss_mask = loss_mask[:, orig_positions].float()  # [batch, total_sampled]
+
+    # Map targets to draft vocabulary and skip positions whose target top-1
+    # token is outside the draft vocabulary.
+    target_logits = targets[:, orig_positions, :]
+    if t2d is not None and t2d.dtype == torch.bool:
+        target_top1 = targets.argmax(dim=-1)[:, orig_positions]
+        target_in_draft_vocab = t2d[target_top1].to(sampled_loss_mask.dtype)
+        sampled_loss_mask = sampled_loss_mask * target_in_draft_vocab
+        target_logits = target_logits[:, :, t2d]
+
+    target_p = torch.nn.functional.softmax(target_logits.float(), dim=-1)
+    position_mask = sampled_loss_mask.unsqueeze(-1)  # [batch, total_sampled, 1]
+    total_positions = position_mask.shape[0] * position_mask.shape[1]
+    denominator = sampled_loss_mask.sum().clamp_min(1e-6)
+    loss = LogSoftmaxLoss.apply(logits, target_p, position_mask) * (
+        total_positions / denominator
+    )
+
+    with torch.no_grad():
+        pred_ids = torch.argmax(logits, dim=-1)  # [batch, total_sampled]
+        target_ids = torch.argmax(target_p, dim=-1)  # [batch, total_sampled]
+
+        metrics: Dict[str, Any] = {
+            "loss_sum": loss.detach(),
+            "loss_total": torch.tensor(1.0, device=device),
+        }
+
+        correct_total = torch.tensor(0.0, device=device)
+        count_total = torch.tensor(0.0, device=device)
+        for d in range(num_depths):
+            depth_mask = (depth == d).unsqueeze(0) & (sampled_loss_mask > 0.5)
+            d_correct = ((pred_ids == target_ids) & depth_mask).sum().float()
+            d_total = depth_mask.sum().float()
+            metrics[f"position_{d}_acc_sum"] = d_correct
+            metrics[f"position_{d}_acc_total"] = d_total
+            correct_total += d_correct
+            count_total += d_total
+
+        metrics["full_acc_sum"] = correct_total
+        metrics["full_acc_total"] = count_total
+
+    return loss, metrics
+
+
+class OnlinePEagleModel(nn.Module):
+
+    def __init__(
+        self,
+        draft_model: PEagleDraftModel,
+        mask_token_id: int,
+        num_depths: int = 8,
+        down_sample_ratio: float = 0.7,
+        down_sample_ratio_min: float = 0.2,
+    ):
+        super().__init__()
+        self.draft_model = draft_model
+        self.mask_token_id = mask_token_id
+        self.num_depths = num_depths
+        self.down_sample_ratio = down_sample_ratio
+        self.down_sample_ratio_min = down_sample_ratio_min
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        target: torch.Tensor,
+        loss_mask: torch.Tensor,
+        hidden_states: torch.Tensor,
+        lengths: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Dict[str, Any]]:
+        """P-EAGLE training forward pass.
+
+        Args:
+            input_ids: [batch, seq_len] - input token IDs
+            attention_mask: [batch, seq_len] - padding mask
+            target: [batch, seq_len, vocab_size] - target logits from target model
+            loss_mask: [batch, seq_len] - which positions contribute to loss
+            hidden_states: [batch, seq_len, 3*hidden_size] - concatenated aux hidden states
+            lengths: [num_samples] - sequence lengths for multi-sample packing
+        """
+        device = hidden_states.device
+        if input_ids.dim() != 2 or input_ids.shape[0] != 1:
+            raise ValueError("P-EAGLE currently requires per-rank batch size 1")
+        seq_length = input_ids.shape[1]
+
+        # Ensure loss_mask is 2D [batch, seq_len]
+        if loss_mask.dim() == 3:
+            loss_mask = loss_mask.squeeze(-1)
+
+        if lengths is None:
+            lengths = torch.tensor([seq_length], dtype=torch.long, device=device)
+        else:
+            lengths = lengths.to(device=device, dtype=torch.long).flatten()
+
+        # Step 1: COD sampling
+        anchor_pos, depth = generate_cod_sample_indices(
+            seq_length=seq_length,
+            loss_mask=loss_mask,
+            lengths=lengths,
+            num_depths=self.num_depths,
+            down_sample_ratio=self.down_sample_ratio,
+            down_sample_ratio_min=self.down_sample_ratio_min,
+        )
+        total_sampled = anchor_pos.shape[0]
+        orig_positions = anchor_pos + depth
+        is_depth_0 = depth == 0
+
+        # Step 2: Build sampled input_ids
+        sampled_ids = torch.where(
+            is_depth_0,
+            input_ids[0, orig_positions],
+            torch.tensor(self.mask_token_id, dtype=input_ids.dtype, device=device),
+        ).unsqueeze(0)
+
+        inputs_embeds = self.draft_model.embed_input_ids(sampled_ids).to(
+            hidden_states.dtype
+        )
+
+        # Step 3: Build sampled hidden states
+        mask_hidden = self.draft_model.mask_hidden.to(
+            device=device, dtype=hidden_states.dtype
+        )
+        sampled_hidden = torch.where(
+            is_depth_0.unsqueeze(-1),
+            hidden_states[0, orig_positions],
+            mask_hidden.squeeze(0).expand(orig_positions.shape[0], -1),
+        ).unsqueeze(0)
+
+        # Step 4: Project and concatenate
+        sampled_hidden = self.draft_model.project_hidden_states(sampled_hidden)
+        layer_input = torch.cat([inputs_embeds, sampled_hidden], dim=-1)
+
+        # Step 5: Position IDs and rotary embeddings
+        position_ids = orig_positions.unsqueeze(0)
+
+        # Step 6: Create flex attention mask
+        mask_mod = create_peagle_mask_mod(
+            anchor_pos=anchor_pos,
+            depth=depth,
+            lengths=lengths,
+            total_seq_len=seq_length,
+        )
+        block_mask = create_block_mask(
+            mask_mod,
+            B=None,
+            H=None,
+            Q_LEN=total_sampled,
+            KV_LEN=total_sampled,
+            device=device,
+        )
+
+        # Step 7: Run through draft model layers
+        cos, sin = self.draft_model.rotary_emb(
+            layer_input, seq_len=position_ids.max().item() + 1
+        )
+        cos = cos.squeeze(0).squeeze(0)
+        sin = sin.squeeze(0).squeeze(0)
+        cos = cos[position_ids]
+        sin = sin[position_ids]
+        position_embeddings = (cos, sin)
+
+        h = layer_input
+        for layer in self.draft_model.layers:
+            h = layer(h, block_mask, position_embeddings)
+
+        # Step 8: Compute logits
+        logits = self.draft_model.compute_logits(h)
+
+        # Step 9: Compute loss and metrics (target is already logits from target model)
+        loss, metrics = compute_peagle_metrics(
+            logits=logits,
+            targets=target,
+            loss_mask=loss_mask,
+            anchor_pos=anchor_pos,
+            depth=depth,
+            num_depths=self.num_depths,
+            t2d=self.draft_model.t2d,
+        )
+
+        return loss, metrics

--- a/specforge/algorithms/peagle/providers.py
+++ b/specforge/algorithms/peagle/providers.py
@@ -1,0 +1,159 @@
+"""Built-in P-EAGLE registration and server-streaming providers."""
+
+from __future__ import annotations
+
+from specforge.algorithms.common.defaults import (
+    empty_options,
+    no_missing_checkpoint_keys,
+    one_loss_token,
+    online_needs_input_tools,
+)
+from specforge.algorithms.common.providers import (
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ModelProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepProvider,
+    TargetDerivedDraftDefaults,
+    make_registration,
+)
+from specforge.algorithms.contracts import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+)
+from specforge.algorithms.eagle3.data import build_server_collator
+
+ALGORITHM_NAME = "peagle"
+DRAFT_ARCHITECTURE = "PEagleDraftModel"
+
+
+def build_step(wrapped_model, *, target_head=None, **_options):
+    from specforge.training.strategies.base import PEagleTrainStrategy
+
+    return PEagleTrainStrategy(wrapped_model, target_head=target_head)
+
+
+def resume_contract(config, draft_model, training_model):
+    from specforge.algorithms.model_providers import peagle_resume_contract
+
+    contract = peagle_resume_contract(config, draft_model, training_model)
+    contract["peagle_attention_backend"] = config.training.attention_backend
+    return contract
+
+
+def build_draft(config, draft_config):
+    from specforge.algorithms.model_providers import build_peagle_draft
+
+    return build_peagle_draft(config, draft_config)
+
+
+def build_training_model(config, draft_model, draft_config, target_config, tokenizer):
+    from specforge.algorithms.model_providers import build_peagle_model
+
+    return build_peagle_model(
+        config,
+        draft_model,
+        draft_config,
+        target_config,
+        tokenizer,
+    )
+
+
+def resolve_capture_layers(config, draft_config, target_config):
+    from specforge.algorithms.model_providers import resolve_eagle_capture_layers
+
+    return resolve_eagle_capture_layers(config, draft_config, target_config)
+
+
+def algorithm_spec() -> AlgorithmSpec:
+    return AlgorithmSpec(
+        name=ALGORITHM_NAME,
+        draft=DraftRequirement(
+            compatible_architectures={DRAFT_ARCHITECTURE},
+            default_architecture=DRAFT_ARCHITECTURE,
+            supported_overrides={"attention_layout", "num_hidden_layers"},
+        ),
+        feature_contracts=(
+            FeatureContract(
+                mode=FeatureMode.STREAMING,
+                modality="text",
+                required_tensors={
+                    "input_ids",
+                    "attention_mask",
+                    "loss_mask",
+                    "hidden_state",
+                    "target",
+                },
+                optional_tensors={"lengths"},
+                allowed_target_representations={"hidden_state"},
+                default_target_representation="hidden_state",
+            ),
+        ),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"flex_attention"},
+            required_batch_size=1,
+            supports_vocab_mapping=True,
+            allows_aux_layer_override=True,
+        ),
+    )
+
+
+def algorithm_providers() -> AlgorithmProviders:
+    return AlgorithmProviders(
+        algorithm_name=ALGORITHM_NAME,
+        step=StepProvider(
+            build=build_step,
+            options=empty_options,
+            resume_contract=resume_contract,
+            allowed_missing_checkpoint_keys=no_missing_checkpoint_keys,
+            # Server capture stores the target's last hidden state.  The
+            # consumer therefore injects a frozen target head before cutover.
+            uses_external_target_head=True,
+        ),
+        model=ModelProvider(
+            draft_config=DraftConfigProvider(
+                architecture=DRAFT_ARCHITECTURE,
+                target_defaults=TargetDerivedDraftDefaults(
+                    model_type="llama",
+                    num_hidden_layers=4,
+                    draft_vocab_size=32000,
+                ),
+            ),
+            build_draft=build_draft,
+            build_training_model=build_training_model,
+            resolve_capture_layers=resolve_capture_layers,
+            minimum_loss_tokens=one_loss_token,
+            needs_input_tools=online_needs_input_tools,
+            default_dataloader_num_workers=4,
+            allow_missing_warm_start_embedding=True,
+        ),
+        server_streaming=(
+            ServerStreamingProvider(
+                modality="text",
+                capture_method="eagle3",
+                target_representation="hidden_state",
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_state",
+                    last_hidden_feature="target",
+                    passthrough=(
+                        ("input_ids", "input_ids", ()),
+                        ("loss_mask", "loss_mask", ()),
+                    ),
+                    attention_mask_feature="attention_mask",
+                ),
+                build_collator=build_server_collator,
+            ),
+        ),
+        vocab_mapping_modes=frozenset({FeatureMode.STREAMING}),
+    )
+
+
+def create_registration():
+    return make_registration(algorithm_spec(), algorithm_providers())
+
+
+__all__ = ["algorithm_providers", "algorithm_spec", "create_registration"]

--- a/specforge/algorithms/registry.py
+++ b/specforge/algorithms/registry.py
@@ -1,0 +1,99 @@
+"""Explicit, immutable registrations for algorithm contracts and providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Tuple
+
+from specforge.algorithms.contracts import AlgorithmSpec
+
+
+@dataclass(frozen=True)
+class AlgorithmRegistration:
+    """One lookup result containing pure metadata and executable providers.
+
+    Keeping the two halves in one registration avoids parallel spec/provider
+    registries.  Planning reads ``spec``; the composition root alone reads
+    ``providers``.
+    """
+
+    spec: AlgorithmSpec
+    providers: object
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.spec, AlgorithmSpec):
+            raise TypeError("spec must be an AlgorithmSpec")
+        if self.providers is None:
+            raise TypeError("providers must not be None")
+        provider_name = getattr(self.providers, "algorithm_name", self.spec.name)
+        if provider_name != self.spec.name:
+            raise ValueError(
+                "provider algorithm_name must match spec.name: "
+                f"{provider_name!r} != {self.spec.name!r}"
+            )
+
+    @property
+    def name(self) -> str:
+        return self.spec.name
+
+
+@dataclass(frozen=True, init=False)
+class AlgorithmRegistry:
+    """Immutable catalog assembled explicitly by the composition root."""
+
+    _registrations: Tuple[AlgorithmRegistration, ...]
+
+    def __init__(
+        self,
+        registrations: Iterable[AlgorithmRegistration] = (),
+    ) -> None:
+        resolved = tuple(registrations)
+        invalid = [
+            type(registration).__name__
+            for registration in resolved
+            if not isinstance(registration, AlgorithmRegistration)
+        ]
+        if invalid:
+            raise TypeError(
+                "registry values must be AlgorithmRegistration, got " f"{invalid}"
+            )
+        names = [registration.name for registration in resolved]
+        duplicates = sorted(name for name in set(names) if names.count(name) > 1)
+        if duplicates:
+            raise ValueError(f"duplicate algorithm registrations: {duplicates}")
+        object.__setattr__(
+            self,
+            "_registrations",
+            tuple(sorted(resolved, key=lambda registration: registration.name)),
+        )
+
+    @property
+    def names(self) -> Tuple[str, ...]:
+        return tuple(registration.name for registration in self._registrations)
+
+    @property
+    def registrations(self) -> Tuple[AlgorithmRegistration, ...]:
+        return self._registrations
+
+    def resolve(self, name: str) -> AlgorithmRegistration:
+        for registration in self._registrations:
+            if registration.name == name:
+                return registration
+        raise KeyError(
+            f"unknown algorithm {name!r}; registered algorithms: {list(self.names)}"
+        )
+
+    def with_registration(
+        self,
+        registration: AlgorithmRegistration,
+    ) -> "AlgorithmRegistry":
+        return AlgorithmRegistry((*self._registrations, registration))
+
+    def __iter__(self) -> Iterator[AlgorithmRegistration]:
+        return iter(self._registrations)
+
+    def __len__(self) -> int:
+        return len(self._registrations)
+
+
+__all__ = ["AlgorithmRegistration", "AlgorithmRegistry"]

--- a/specforge/core/compact_teacher.py
+++ b/specforge/core/compact_teacher.py
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (the "License").
 """Compact (draft-vocabulary) teacher distribution for EAGLE-3 training.
 
-Reproduces the teacher quantities of ``specforge.core.eagle3._compute_target_p`` from
-the target's last hidden states and ``lm_head`` weight without materializing the full
-``[B, S, vocab_size]`` fp32 logits: the draft-vocab logits come from a ``t2d``-sliced
-head, and the full-vocab ``logsumexp``/``argmax`` from a streaming reduction over
-vocabulary chunks.
+Reproduces the teacher quantities of
+``specforge.algorithms.eagle3.model._compute_target_p`` from the target's last hidden
+states and ``lm_head`` weight without materializing the full ``[B, S, vocab_size]``
+fp32 logits: the draft-vocab logits come from a ``t2d``-sliced head, and the
+full-vocab ``logsumexp``/``argmax`` from a streaming reduction over vocabulary
+chunks.
 
 Scope: offline training only. The teacher uses the full (unsharded, rank-replicated)
 target ``lm_head`` weight, so the computation is a pure function of
@@ -233,7 +234,6 @@ def validate_vocab_mapping_consistency(t2d: torch.Tensor, d2t: torch.Tensor) -> 
 def validate_compact_teacher_enabled(
     *,
     is_online: bool,
-    is_vlm: bool,
     draft_vocab_size: int,
     vocab_size: int,
     t2d: torch.Tensor,
@@ -249,10 +249,6 @@ def validate_compact_teacher_enabled(
         raise ValueError(
             "compact teacher supports offline training only; disable --compact-teacher "
             "or train offline."
-        )
-    if is_vlm:
-        raise ValueError(
-            "compact teacher does not support VLM training yet; disable --compact-teacher."
         )
     if target_head_weight is None:
         raise ValueError(

--- a/specforge/core/loss.py
+++ b/specforge/core/loss.py
@@ -226,19 +226,3 @@ class LogSoftmaxLoss(torch.autograd.Function):
         )
         logits = logits.view(B, T, V)
         return logits, None, None
-
-
-if __name__ == "__main__":
-    device = "cuda"
-    B, T, V = 1, 1024, 16000
-    logits = torch.randn(B, T, V, device=device, requires_grad=True)
-    logits2 = logits.clone().detach().requires_grad_(True)
-    target = torch.randn(B, T, V, device=device)
-    position_mask = torch.randint(0, 2, (B, T, 1), dtype=torch.bool, device=device)
-    position_mask = torch.ones((B, T, 1), dtype=torch.bool, device=device)
-    output1 = LogSoftmaxLoss.apply(logits, target, position_mask)
-    output2 = _compute_loss(logits2, target, position_mask)
-    torch.testing.assert_close(output1, output2, rtol=1e-4, atol=1e-4)
-    output1.backward()
-    output2.backward()
-    torch.testing.assert_close(logits.grad, logits2.grad, rtol=1e-4, atol=1e-4)

--- a/specforge/modeling/auto.py
+++ b/specforge/modeling/auto.py
@@ -110,6 +110,12 @@ class AutoEagle3DraftModel(AutoModelForCausalLMBase):
         return model
 
 
+# Stack-only compatibility alias: new algorithm providers use the topology-free
+# name while the still-public legacy CLI imports AutoEagle3DraftModel.  P12
+# replaces this file with the exact server-only target blob.
+AutoDraftModel = AutoEagle3DraftModel
+
+
 class AutoDistributedTargetModel(AutoModelForCausalLMBase):
     # the model mapping is currently hardcoded, we should support lazy model mapping via registry
     _model_mapping = {

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -188,7 +188,7 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
 
 def build_target_layer_ids(num_target_layers: int, num_draft_layers: int):
     if num_draft_layers == 1:
-        return [(num_target_layers // 2)]
+        return [num_target_layers // 2]
     start = 1
     end = num_target_layers - 3
     span = end - start
@@ -209,6 +209,45 @@ def extract_context_feature(
         selected_states.append(hidden_states[layer_id + offset])
     target_hidden = torch.cat(selected_states, dim=-1)
     return target_hidden
+
+
+def normalize_draft_head_checkpoint_keys(
+    module,
+    state_dict,
+    prefix,
+    local_metadata,
+    strict,
+    missing_keys,
+    unexpected_keys,
+    error_msgs,
+):
+    """Map checkpoint-only nested head names onto the direct module layout.
+
+    Early Domino/DSpark checkpoints saved their auxiliary heads beneath a
+    ``logit_head`` container. The live architecture no longer owns that wrapper,
+    but those tensors remain valid and must not be dropped during warm start or
+    full resume.
+    """
+
+    del module, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    checkpoint_prefixes = (
+        ("logit_head.prefix_gru.", "prefix_gru."),
+        ("logit_head.embed_proj.", "embed_proj."),
+        ("logit_head.markov_head.", "markov_head."),
+        ("logit_head.confidence_head.", "confidence_head."),
+    )
+    for key in list(state_dict):
+        if not key.startswith(prefix):
+            continue
+        local_key = key[len(prefix) :]
+        for checkpoint_prefix, model_prefix in checkpoint_prefixes:
+            if not local_key.startswith(checkpoint_prefix):
+                continue
+            normalized_key = prefix + model_prefix + local_key[len(checkpoint_prefix) :]
+            if normalized_key not in state_dict:
+                state_dict[normalized_key] = state_dict[key]
+            state_dict.pop(key)
+            break
 
 
 @register_draft
@@ -244,38 +283,8 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         self.pure_draft_prefix_len = dflash_config.get("pure_draft_prefix_len", 0)
         self.shift_label = dflash_config.get("shift_label", False)
         self._init_draft_head(config, dflash_config)
-        self.register_load_state_dict_pre_hook(self._remap_legacy_draft_head_keys)
+        self.register_load_state_dict_pre_hook(normalize_draft_head_checkpoint_keys)
         self.post_init()
-
-    @staticmethod
-    def _remap_legacy_draft_head_keys(
-        module,
-        state_dict,
-        prefix,
-        local_metadata,
-        strict,
-        missing_keys,
-        unexpected_keys,
-        error_msgs,
-    ):
-        del module, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
-        legacy_prefixes = (
-            ("logit_head.prefix_gru.", "prefix_gru."),
-            ("logit_head.embed_proj.", "embed_proj."),
-            ("logit_head.markov_head.", "markov_head."),
-            ("logit_head.confidence_head.", "confidence_head."),
-        )
-        for key in list(state_dict.keys()):
-            if not key.startswith(prefix):
-                continue
-            local_key = key[len(prefix) :]
-            for old_prefix, new_prefix in legacy_prefixes:
-                if local_key.startswith(old_prefix):
-                    new_key = prefix + new_prefix + local_key[len(old_prefix) :]
-                    if new_key not in state_dict:
-                        state_dict[new_key] = state_dict[key]
-                    state_dict.pop(key)
-                    break
 
     def _init_draft_head(self, config, dflash_config: dict) -> None:
         del config, dflash_config

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -10,7 +10,6 @@ from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache
 from transformers.models.llama.configuration_llama import LlamaConfig
-from yunchang.comm import SeqAllToAll4D
 
 from specforge.modeling.draft.flex_attention import (
     compile_friendly_create_block_mask,
@@ -1370,6 +1369,7 @@ class LlamaUSPFlashAttention(LlamaAttention):
         output_attentions: bool = False,
         use_cache: bool = False,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+        from yunchang.comm import SeqAllToAll4D
 
         bsz, q_len, _ = hidden_states.size()
         local_q_len = q_len

--- a/specforge/modeling/target/target_head.py
+++ b/specforge/modeling/target/target_head.py
@@ -13,16 +13,20 @@ from specforge.utils import get_local_device, padding
 
 
 class TargetHead(nn.Module):
-    def __init__(self, model_path, trust_remote_code: bool = False):
+    def __init__(
+        self,
+        model_path,
+        trust_remote_code: bool = False,
+        cache_dir: Optional[str] = None,
+    ):
         super().__init__()
         self.config = AutoConfig.from_pretrained(
-            model_path, trust_remote_code=trust_remote_code
+            model_path,
+            trust_remote_code=trust_remote_code,
+            cache_dir=cache_dir,
         )
-        # Fall back to ``text_config`` when present so that VLM models load correctly.
-        self.text_config = getattr(self.config, "text_config", self.config)
-
-        self.hidden_size = self.text_config.hidden_size
-        self.vocab_size = self.text_config.vocab_size
+        self.hidden_size = self.config.hidden_size
+        self.vocab_size = self.config.vocab_size
 
         self.fc = nn.Linear(self.hidden_size, self.vocab_size, bias=False)
 
@@ -34,7 +38,11 @@ class TargetHead(nn.Module):
         cache_dir: Optional[str] = None,
         trust_remote_code: bool = False,
     ) -> "TargetHead":
-        target_head = cls(model_path, trust_remote_code=trust_remote_code)
+        target_head = cls(
+            model_path,
+            trust_remote_code=trust_remote_code,
+            cache_dir=cache_dir,
+        )
         target_head.load_weights(
             model_path=model_path,
             lm_head_key=lm_head_key,
@@ -56,7 +64,7 @@ class TargetHead(nn.Module):
         if os.path.exists(model_path):
             self.model_path = model_path
         else:
-            self.model_path = snapshot_download(repo_id=model_path)
+            self.model_path = snapshot_download(repo_id=model_path, cache_dir=cache_dir)
 
         # model_path is a local directory
         # check if there is file ending with index.json

--- a/specforge/modeling/target/target_utils.py
+++ b/specforge/modeling/target/target_utils.py
@@ -88,30 +88,27 @@ class TargetEmbeddingsAndHead(nn.Module):
 
     def _load_weights(
         self, model_path: str, embed_key: str, lm_head_key: str, tie_weights: bool
-    ):
+    ) -> set[str]:
         index_files = glob.glob(os.path.join(model_path, "*.index.json"))
         weight_map = {}
         files_to_load = {}
+        required_keys = [embed_key]
+        if not tie_weights:
+            required_keys.append(lm_head_key)
 
         if index_files:
             with open(index_files[0], "r") as f:
                 index = json.load(f)
             weight_map = index.get("weight_map", {})
 
-            if embed_key in weight_map:
-                files_to_load[embed_key] = weight_map[embed_key]
-            else:
+            missing_from_index = sorted(set(required_keys) - weight_map.keys())
+            if missing_from_index:
                 raise ValueError(
-                    f"Embedding key '{embed_key}' not found in weight map."
+                    "Required target weight keys are missing from the checkpoint "
+                    f"index: {missing_from_index}"
                 )
-
-            if not tie_weights:
-                if lm_head_key in weight_map:
-                    files_to_load[lm_head_key] = weight_map[lm_head_key]
-                else:
-                    print(
-                        f"Warning: {lm_head_key} not found. Ensure model doesn't use tied weights manually."
-                    )
+            for key in required_keys:
+                files_to_load[key] = weight_map[key]
         else:
             safetensors = glob.glob(os.path.join(model_path, "*.safetensors"))
             bins = glob.glob(os.path.join(model_path, "*.bin"))
@@ -120,9 +117,8 @@ class TargetEmbeddingsAndHead(nn.Module):
             if not target_file:
                 raise FileNotFoundError("No checkpoint found.")
 
-            files_to_load[embed_key] = os.path.basename(target_file)
-            if not tie_weights:
-                files_to_load[lm_head_key] = os.path.basename(target_file)
+            filename = os.path.basename(target_file)
+            files_to_load.update({key: filename for key in required_keys})
 
         loaded_keys = set()
 
@@ -134,8 +130,16 @@ class TargetEmbeddingsAndHead(nn.Module):
             file_to_keys_map[full_path].append(key)
 
         for file_path, keys in file_to_keys_map.items():
-            self._load_file_content(file_path, keys, embed_key, lm_head_key)
-            loaded_keys.update(keys)
+            loaded_keys.update(
+                self._load_file_content(file_path, keys, embed_key, lm_head_key)
+            )
+
+        missing_keys = sorted(set(required_keys) - loaded_keys)
+        if missing_keys:
+            raise RuntimeError(
+                "Required target weight tensors were not loaded from the "
+                f"checkpoint: {missing_keys}"
+            )
 
         if tie_weights:
             print(
@@ -143,12 +147,7 @@ class TargetEmbeddingsAndHead(nn.Module):
             )
             self.lm_head.weight = self.embed_tokens.weight
 
-        if embed_key not in loaded_keys:
-            raise RuntimeError("Failed to load embeddings.")
-        if not tie_weights and lm_head_key not in loaded_keys:
-            print(
-                "Warning: LM Head weights were not found (and tie_weights is False). Head is random."
-            )
+        return loaded_keys
 
     def _load_file_content(
         self,
@@ -156,7 +155,7 @@ class TargetEmbeddingsAndHead(nn.Module):
         keys_to_extract: list,
         target_embed_key: str,
         target_head_key: str,
-    ):
+    ) -> set[str]:
         """Helper to load specific keys from a file"""
         print(f"Loading {keys_to_extract} from {os.path.basename(file_path)}...")
 
@@ -178,15 +177,27 @@ class TargetEmbeddingsAndHead(nn.Module):
             del full_state
             gc.collect()
 
+        loaded_keys = set()
         for k, tensor in state_dict_part.items():
             if k == target_embed_key:
-                self.embed_tokens.weight.data.copy_(tensor)
+                if tensor.shape != self.embed_tokens.weight.shape:
+                    raise RuntimeError(
+                        f"Shape mismatch for {k}. Expected "
+                        f"{self.embed_tokens.weight.shape}, got {tensor.shape}"
+                    )
+                with torch.no_grad():
+                    self.embed_tokens.weight.copy_(tensor)
                 print(" -> Loaded Embeddings")
             elif k == target_head_key:
-                if tensor.shape == self.lm_head.weight.data.shape:
-                    self.lm_head.weight.data.copy_(tensor)
-                    print(" -> Loaded LM Head")
-                else:
+                if tensor.shape != self.lm_head.weight.shape:
                     raise RuntimeError(
                         f"Shape mismatch for {k}. Expected {self.lm_head.weight.shape}, got {tensor.shape}"
                     )
+                with torch.no_grad():
+                    self.lm_head.weight.copy_(tensor)
+                print(" -> Loaded LM Head")
+            else:
+                continue
+            loaded_keys.add(k)
+
+        return loaded_keys

--- a/specforge/runtime/contracts.py
+++ b/specforge/runtime/contracts.py
@@ -34,7 +34,7 @@ SCHEMA_VERSION = 1
 
 RunMode = Literal["online", "offline"]
 DeploymentMode = Literal["local_colocated", "dataflow_colocated", "disaggregated"]
-DraftStrategyName = Literal["eagle3", "dflash", "domino", "dspark"]
+DraftStrategyName = Literal["eagle3", "dflash", "domino", "dspark", "peagle"]
 # Tagged union for the EAGLE3 target feature. The *strategy* owns the
 # projection so the trainer core stays branch-free:
 #   - pruned_logits: rollout applied the t2d vocab map; stored (seq, draft_vocab)

--- a/specforge/runtime/control_plane/DESIGN.md
+++ b/specforge/runtime/control_plane/DESIGN.md
@@ -1,79 +1,127 @@
-# Control Plane Design (PR 4/7 — `runtime/control_plane`)
+# Control plane design
 
-This is the design note for the **control plane**, scoped to this plane.
-The cross-plane picture (whole-system map, endpoint reference, autonomy) lives in
-`ARCHITECTURE.md`, added in the integration PR (7/7); the shared records every
-plane exchanges are in [`../contracts.py`](../contracts.py).
+The control plane moves metadata only. Its public record-accepting endpoints run
+`assert_no_tensors`; feature tensors stay behind the data-plane `FeatureStore`.
+The whole-system topology is documented in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md).
 
-## Responsibility
+## Responsibilities
 
-Metadata-only scheduling, lifecycle, leasing, and recovery durability. Owns prompt and sample lifecycle, prompt/train leases, worker/trainer registration, dedup of committed samples, and the durable ack transaction. NEVER touches tensors (every record-accepting entrypoint runs assert_no_tensors) — all large tensors travel through the data plane. Online commit_samples and offline enqueue_offline_refs converge onto the same SampleRefQueue so the trainer path has no online/offline branch. Recovery-critical state sits behind a MetadataStore seam so a durable backend (SQLite/Redis/DB) is a swap, not a rewrite. (Note: weight publishing / weight-version registry is explicitly NOT yet implemented — flagged in source NOTE comments in both controller.py and metadata_store.py.)
+`DataFlowController` provides the shared metadata primitives:
 
-## Internal mechanics
+- prompt ingest, leasing, retry, and terminal failure;
+- `SampleRef` commit deduplication;
+- optional sample-ref lease/ack/fail primitives used by tests and internal
+  staging, but disabled on the canonical online producer;
+- trainer registration and optimizer-boundary ack transactions;
+- status for active prompt, queue, and durable-ack state.
+
+The launch topology decides which subset is active. The controller has no run
+loop and never calls a rollout worker or trainer.
+
+## Topology-specific ownership
+
+| Topology | Controller/ledger ownership | Reference delivery |
+| --- | --- | --- |
+| Colocated offline | No ledger or staging queue | Fixed, re-iterable ref list |
+| Disaggregated offline | No training ledger; producer publishes a static manifest | Fixed, re-iterable manifest refs |
+| Disaggregated online producer | Prompt lifecycle only; `NoOpMetadataStore`; local sample enqueue is disabled | Publishes refs directly to the shared `StreamingRefChannel` |
+| Disaggregated online consumer | Rank 0 owns the only fresh retaining ledger; every rank owns a `DPAckController` view | `RefDistributor -> per-rank InboxChannel -> StreamingRefQueue` |
+
+The online-disaggregated producer therefore has no training ledger and no local
+training queue. Deduplication and durable training state belong exclusively to
+the consumer attempt.
+
+## Online-disaggregated consumer
 
 ```mermaid
 flowchart TD
-  classDef control fill:#e8f0fe,stroke:#3b6fd6,color:#0b2e6b;
-
-  subgraph CTRL[DataFlowController passive]
-    PEND[_prompt_pending deque]
-    LEASED[_prompt_leased map]
-    FAILEDP[_prompt_failed map]
-  end
-  ING[ingest_prompts] --> PEND
-  LPT[lease_prompt_tasks popleft] --> LEASED
-  FPT[fail_prompt_tasks requeue or fail] --> PEND
-
-  COMMIT[commit_samples per ref] -->|commit_sample dedup| MS[MetadataStore]
-  COMMIT -->|put fresh| Q[SampleRefQueue]
-  ENQ[enqueue_offline_refs] -->|commit_sample dedup| MS
-  ENQ -->|put fresh| Q
-
-  LTR[lease_train_refs] -->|get| Q
-  ATR[ack_train_refs] -->|record_train_ack first| MS
-  ATR -->|get_committed then ack| Q
-  FR[fail_refs] -->|get_committed then fail| Q
-
-  TL[TrainLease get ack fail] --> LTR
-  TL --> ATR
-  TL --> FR
-
-  class PEND,LEASED,FAILEDP,ING,LPT,FPT,COMMIT,ENQ,LTR,ATR,FR,TL,MS,Q control;
+  SRC[shared StreamingRefChannel] --> RD[RefDistributor on rank 0]
+  RD -->|commit and dedup| DB[(fresh SQLite ledger)]
+  RD --> I0[rank 0 InboxChannel]
+  RD --> IN[rank N InboxChannel]
+  I0 --> Q0[rank 0 StreamingRefQueue]
+  IN --> QN[rank N StreamingRefQueue]
+  Q0 --> T0[rank 0 trainer]
+  QN --> TN[rank N trainer]
+  T0 --> ACK[DPAckController collective]
+  TN --> ACK
+  ACK -->|rank 0 writes once| DB
 ```
 
-The `DataFlowController` is a passive metadata-only coordinator: it has no run loop, and every record-accepting entrypoint runs `assert_no_tensors`. It holds prompt lifecycle state — `_prompts`, a `_prompt_pending` deque, `_prompt_leased`, and `_prompt_failed` — under a single `_lock` that guards only the prompt/worker/trainer mutations and the `status()` snapshot; the sample-commit and train paths instead rely on the store's and queue's own internal locking. Durable/recovery state lives behind the `MetadataStore` seam: `commit_sample` dedups by `sample_id` (False = duplicate, dropped) and `record_train_ack` commits {acked sample_ids, global_step, optimizer_durable} as one atomic transaction. Online `commit_samples` and offline `enqueue_offline_refs` converge by enqueuing only fresh refs onto the same `SampleRefQueue`, so the trainer path has no online/offline branch. `ack_train_refs` deliberately orders `record_train_ack` BEFORE `sample_queue.ack` so a restart reconciles release state from the single committed marker. `TrainLease` is a stateless adapter that forwards `get`/`ack`/`fail` through the controller, so a cross-node trainer never holds a raw in-process queue and the durable ack is always recorded. Weight publishing / a weight-version registry is explicitly not yet implemented (flagged in source NOTEs).
+Rank 0 is the single bookkeeping authority:
 
-## Deployment modes
+1. It rejects a non-retaining or non-fresh ledger.
+2. It is the only process that reads the producer channel.
+3. It commits and deduplicates refs, then dispatches only complete global
+   optimizer windows into one inbox per rank.
+4. It gathers each rank's optimizer-boundary sample ids through
+   `DPAckController` and records one durable ack transaction.
 
-The same code path serves every `DeploymentMode`; `build_control_plane_for_mode(mode, run_id)` builds the controller and durable-ack policy. `local_colocated` uses `NoOpMetadataStore` and `durable_ack=False`. `dataflow_colocated` / `disaggregated` keep the durable store (SQLite when a path is given, else the controller's in-memory default) and optimizer-boundary ack.
+Non-authority ranks participate in the gather but never write the durable
+ledger. After rank 0 broadcasts commit success, every rank removes only its
+local feature ids and collectively reports cleanup failures before inbox ack.
+One-rank runs use this exact path as well; there is no direct-channel consumer
+branch.
 
-The no-op axis is the *store + durable-ack transaction*. Prompt leasing and in-process `SampleRefQueue` bookkeeping stay shared across modes, and backpressure remains opt-in. Because `NoOpMetadataStore` retains nothing, `status()` committed/acked/backlog counts read 0 and `TrainLease`/`fail_refs` cannot reconstruct refs; cross-process trainers need a retaining store.
+Inbox queue acknowledgements happen after each materialized micro-batch and are
+forwarded by the distributor to the source channel's consumed counter. Durable
+ack is separate: it happens once at the optimizer boundary and includes all
+`dp_size * batch_size * accumulation_steps` sample ids. This separation keeps
+producer backpressure responsive without weakening optimizer-step durability.
 
-## Endpoints
+## Handshake and termination
 
-### What this plane calls into
+Consumer rank 0 publishes
 
-| From | Endpoint | Plane |
-|---|---|---|
-| `DataFlowController` | `MetadataStore.commit_sample` | control |
-| `DataFlowController` | `MetadataStore.record_train_ack` | control |
-| `DataFlowController` | `MetadataStore.get_committed` | control |
-| `DataFlowController` | `SampleRefQueue.put` | control |
-| `DataFlowController` | `SampleRefQueue.get` | control |
-| `DataFlowController` | `SampleRefQueue.ack` | control |
-| `DataFlowController` | `SampleRefQueue.fail` | control |
-| `TrainLease` | `DataFlowController.lease_train_refs` | control |
-| `TrainLease` | `DataFlowController.ack_train_refs` | control |
-| `TrainLease` | `DataFlowController.fail_refs` | control |
+```text
+quantum = dp_size * batch_size * accumulation_steps
+```
 
-### Who calls into this plane
+before the distributor starts. The producer waits for that value and requires
+its in-flight high watermark to be at least `quantum`. The canonical CLI uses
+`DISAGG_IN_FLIGHT_HIGH_WATERMARK=256` when the variable is unset.
 
-| Caller | Endpoint | Plane |
-|---|---|---|
-| `RolloutWorker` | `DataFlowController.register_rollout_worker` | control |
-| `RolloutWorker` | `DataFlowController.lease_prompt_tasks` | control |
-| `RolloutWorker` | `DataFlowController.commit_samples` | control |
-| `RolloutWorker` | `DataFlowController.fail_prompt_tasks` | control |
-| `OfflineManifestReader` | `DataFlowController.enqueue_offline_refs` | control |
-| `FeatureDataLoader` | `TrainLease.get` | control |
-| `TrainerController` | `DataFlowController.ack_train_refs` | control |
+The distributor closes rank inboxes only after the producer source is closed,
+all source refs are drained, and no partial quantum remains. A partial quantum
+at EOF is a terminal attempt failure: the staged refs are failed non-retryably,
+their feature objects are aborted best-effort, and every rank receives a
+failure sentinel rather than a clean close.
+
+Producer and consumer failures use distinct sentinels, so neither side can
+interpret a peer crash as successful EOF. Early consumer completion also
+signals the producer to stop and clean published Mooncake objects.
+
+## Freshness and recovery contract
+
+The canonical online launcher requires a new SQLite path for every fresh
+consumer, including `dp_size=1`, and rejects an existing database, WAL, or SHM
+file. The runtime also rejects a ledger with committed rows. Inbox files are
+ephemeral and recreated by rank 0 for a fresh attempt.
+
+Online disaggregated recovery is consumer-only. With the original SQLite
+ledger, channel/inboxes, Mooncake objects, and matching checkpoint still
+available, rank 0 verifies the durable step, skips acknowledged refs, and
+requeues the unacknowledged tail. A producer never resumes, and a consumed
+stream is never iterated as a second trainer epoch. A new producer attempt must
+use fresh channel, store-id, run-id, and output artifacts.
+
+The durable acknowledgement step must equal the restored checkpoint step.
+Acknowledgements can advance after the most recent periodic checkpoint, so a
+crash in that interval is intentionally non-resumable: recovery fails closed
+rather than replaying consumed refs against older optimizer state.
+
+Offline refs remain fixed and re-iterable, so offline checkpoint resume and
+multiple epochs keep their existing semantics.
+
+## Metadata stores
+
+- `NoOpMetadataStore` is used where no durable sample ledger is required, most
+  importantly offline paths and the online-disaggregated producer.
+- `InMemoryMetadataStore` supports local bookkeeping and non-authority DP
+  controller instances.
+- `SQLiteMetadataStore` is the canonical online-disaggregated consumer ledger.
+  Rank 0 is its sole writer.
+
+Weight publishing and a weight-version registry are not implemented in this
+control plane.

--- a/specforge/runtime/control_plane/flow_control.py
+++ b/specforge/runtime/control_plane/flow_control.py
@@ -1,0 +1,135 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Hysteretic producer flow control for the canonical streaming runtime."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class FlowControlLimits:
+    """Reference/byte watermarks and the per-worker capture lease cap."""
+
+    high_watermark_refs: int = 256
+    low_watermark_refs: Optional[int] = None
+    high_watermark_bytes: Optional[int] = None
+    low_watermark_bytes: Optional[int] = None
+    max_prompt_lease_per_worker: int = 8
+
+    def __post_init__(self) -> None:
+        low_refs = (
+            self.high_watermark_refs
+            if self.low_watermark_refs is None
+            else self.low_watermark_refs
+        )
+        low_bytes = (
+            self.high_watermark_bytes
+            if self.low_watermark_bytes is None
+            else self.low_watermark_bytes
+        )
+        if self.high_watermark_refs < 1:
+            raise ValueError("high_watermark_refs must be >= 1")
+        if low_refs < 0 or low_refs > self.high_watermark_refs:
+            raise ValueError(
+                "low_watermark_refs must be between 0 and high_watermark_refs"
+            )
+        if self.high_watermark_bytes is None and self.low_watermark_bytes is not None:
+            raise ValueError("low_watermark_bytes requires high_watermark_bytes")
+        if self.high_watermark_bytes is not None:
+            if self.high_watermark_bytes < 1:
+                raise ValueError("high_watermark_bytes must be >= 1")
+            if low_bytes is None or not 0 <= low_bytes <= self.high_watermark_bytes:
+                raise ValueError(
+                    "low_watermark_bytes must be between 0 and " "high_watermark_bytes"
+                )
+        if self.max_prompt_lease_per_worker < 1:
+            raise ValueError("max_prompt_lease_per_worker must be >= 1")
+
+    @property
+    def resolved_low_watermark_refs(self) -> int:
+        return (
+            self.high_watermark_refs
+            if self.low_watermark_refs is None
+            else self.low_watermark_refs
+        )
+
+    @property
+    def resolved_low_watermark_bytes(self) -> Optional[int]:
+        if self.high_watermark_bytes is None:
+            return None
+        return (
+            self.high_watermark_bytes
+            if self.low_watermark_bytes is None
+            else self.low_watermark_bytes
+        )
+
+
+class ProducerFlowControl:
+    """Thread-safe pause/resume policy shared by all rollout workers."""
+
+    def __init__(self, limits: FlowControlLimits) -> None:
+        self.limits = limits
+        self._paused = False
+        self._lock = threading.Lock()
+        self._stats = {
+            "pause_transitions": 0,
+            "resume_transitions": 0,
+            "wait_checks": 0,
+        }
+
+    def prompt_lease(self, requested: int) -> int:
+        """Cap a worker's capture request at the configured in-flight lease."""
+        return max(0, min(int(requested), self.limits.max_prompt_lease_per_worker))
+
+    def should_pause(self, *, in_flight_refs: int, resident_bytes: int = 0) -> bool:
+        """Apply ref/byte hysteresis and return the current latched state."""
+        refs = max(0, int(in_flight_refs))
+        resident = max(0, int(resident_bytes))
+        high_bytes = self.limits.high_watermark_bytes
+        low_bytes = self.limits.resolved_low_watermark_bytes
+        over_high = refs >= self.limits.high_watermark_refs or (
+            high_bytes is not None and resident >= high_bytes
+        )
+        under_low = refs <= self.limits.resolved_low_watermark_refs and (
+            low_bytes is None or resident <= low_bytes
+        )
+        with self._lock:
+            if not self._paused and over_high:
+                self._paused = True
+                self._stats["pause_transitions"] += 1
+            elif self._paused and under_low:
+                self._paused = False
+                self._stats["resume_transitions"] += 1
+            if self._paused:
+                self._stats["wait_checks"] += 1
+            return self._paused
+
+    def snapshot(
+        self, *, in_flight_refs: int, resident_bytes: int = 0
+    ) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "paused": self._paused,
+                **self._stats,
+                "in_flight_refs": int(in_flight_refs),
+                "resident_bytes": int(resident_bytes),
+                "high_watermark_refs": self.limits.high_watermark_refs,
+                "low_watermark_refs": self.limits.resolved_low_watermark_refs,
+                "high_watermark_bytes": self.limits.high_watermark_bytes,
+                "low_watermark_bytes": self.limits.resolved_low_watermark_bytes,
+                "max_prompt_lease_per_worker": (
+                    self.limits.max_prompt_lease_per_worker
+                ),
+            }
+
+
+__all__ = ["FlowControlLimits", "ProducerFlowControl"]

--- a/specforge/training/model_loading.py
+++ b/specforge/training/model_loading.py
@@ -1,0 +1,462 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Draft configuration and weights-only initialization for unified training.
+
+This module deliberately keeps model initialization separate from training
+resume.  A warm start can read draft weights from a Hugging Face checkpoint or
+from SpecForge's shared ``training_state.pt`` payload, but it has no access to
+an optimizer, scheduler, controller counters, or RNG state.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+
+if TYPE_CHECKING:
+    from transformers import PretrainedConfig
+
+    from specforge.config import Config
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_FILE = "config.json"
+_STATE_FILE = "training_state.pt"
+
+# These are the architecture fields the legacy EAGLE generator copied from the
+# target, plus RoPE/attention fields needed by newer Qwen-family targets.  A
+# whitelist avoids feeding a target-specific nested config into the registered
+# Llama/Qwen3 draft classes.
+_TARGET_ARCHITECTURE_FIELDS = (
+    "vocab_size",
+    "hidden_size",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "intermediate_size",
+    "max_position_embeddings",
+    "rms_norm_eps",
+    "hidden_act",
+    "initializer_range",
+    "attention_bias",
+    "attention_dropout",
+    "head_dim",
+    "rope_theta",
+    "rope_scaling",
+    "bos_token_id",
+    "eos_token_id",
+    "pad_token_id",
+    "sliding_window",
+    "use_sliding_window",
+    "max_window_layers",
+)
+
+
+@dataclass(frozen=True)
+class WarmStartReport:
+    """Observable result of loading draft weights without training state."""
+
+    source: str
+    checkpoint_format: Literal["specforge", "pretrained"]
+    loaded_keys: int
+    missing_keys: Tuple[str, ...]
+    loaded_embedding: bool
+
+
+def _assembly_spec(strategy: str):
+    from specforge.training.strategies.registry import resolve_strategy
+
+    return resolve_strategy(strategy).assembly
+
+
+def _without_file_uri(source: str) -> str:
+    return source[len("file://") :] if source.startswith("file://") else source
+
+
+def _looks_like_local_path(source: str) -> bool:
+    return (
+        source.startswith((".", "/", "~", "file://"))
+        or source.endswith(".json")
+        or os.path.exists(os.path.expanduser(_without_file_uri(source)))
+    )
+
+
+def _draft_config_from_dict(payload: Dict[str, Any]) -> "PretrainedConfig":
+    # Importing the draft package registers every built-in architecture before
+    # consulting the registry. Model modules keep accelerator-only dependencies
+    # behind execution boundaries, so this remains safe in a CPU producer.
+    import specforge.modeling.draft  # noqa: F401
+    from specforge.modeling.draft.registry import DRAFT_REGISTRY, available_drafts
+
+    payload = dict(payload)
+    architectures = payload.get("architectures") or []
+    if not isinstance(architectures, (list, tuple)) or len(architectures) != 1:
+        raise ValueError(
+            "draft config must name exactly one architecture; " f"got {architectures!r}"
+        )
+    architecture = architectures[0]
+    if architecture not in DRAFT_REGISTRY:
+        raise ValueError(
+            f"draft architecture {architecture!r} is not registered; "
+            f"available: {available_drafts()}"
+        )
+
+    payload["architectures"] = [architecture]
+    payload["tie_word_embeddings"] = False
+    payload.setdefault("use_cache", True)
+    if payload.get("draft_vocab_size") is None:
+        payload["draft_vocab_size"] = payload.get("vocab_size")
+    return DRAFT_REGISTRY[architecture].config_class.from_dict(payload)
+
+
+def load_draft_config_source(
+    source: str,
+    *,
+    cache_dir: Optional[str] = None,
+    trust_remote_code: bool = False,
+) -> "PretrainedConfig":
+    """Load a registered draft config from JSON, a directory, or an HF repo."""
+
+    if not source:
+        raise ValueError("draft config source must be non-empty")
+    local_source = os.path.abspath(os.path.expanduser(_without_file_uri(str(source))))
+    if os.path.isfile(local_source):
+        config_path = local_source
+    elif os.path.isdir(local_source):
+        config_path = os.path.join(local_source, _CONFIG_FILE)
+        if not os.path.isfile(config_path):
+            raise FileNotFoundError(
+                f"draft model directory has no {_CONFIG_FILE}: {local_source}"
+            )
+    else:
+        if _looks_like_local_path(str(source)):
+            raise FileNotFoundError(f"draft model config does not exist: {source}")
+        from transformers import AutoConfig
+
+        loaded = AutoConfig.from_pretrained(
+            source,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
+        )
+        return _draft_config_from_dict(loaded.to_dict())
+
+    try:
+        with open(config_path, encoding="utf-8") as stream:
+            payload = json.load(stream)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid draft config JSON {config_path}: {exc}") from exc
+    return _draft_config_from_dict(payload)
+
+
+def _checkpoint_config_source(checkpoint_source: Optional[str]) -> Optional[str]:
+    """Return a config-bearing warm-start source, if it can be identified."""
+
+    if not checkpoint_source:
+        return None
+    raw_source = str(checkpoint_source)
+    local_source = os.path.abspath(os.path.expanduser(_without_file_uri(raw_source)))
+    if os.path.isfile(local_source):
+        if os.path.basename(local_source) == _CONFIG_FILE:
+            return local_source
+        sibling = os.path.join(os.path.dirname(local_source), _CONFIG_FILE)
+        return sibling if os.path.isfile(sibling) else None
+    if os.path.isdir(local_source):
+        direct = os.path.join(local_source, _CONFIG_FILE)
+        if os.path.isfile(direct):
+            return direct
+        # A run root may point at a future checkpoint layout that also persists
+        # config.json.  Do not resolve or read training state just to find it.
+        candidates = []
+        for pointer in glob.glob(os.path.join(local_source, "*-latest")):
+            candidate = os.path.join(os.path.realpath(pointer), _CONFIG_FILE)
+            if os.path.isfile(candidate):
+                candidates.append(candidate)
+        if len(set(candidates)) == 1:
+            return candidates[0]
+        return None
+    if _looks_like_local_path(raw_source):
+        return None
+    # A non-local warm-start source is an HF repository. Its config is the best
+    # architecture contract unless the run supplies an explicit config source.
+    return raw_source
+
+
+def _target_text_config(config: "PretrainedConfig") -> "PretrainedConfig":
+    return getattr(config, "text_config", config)
+
+
+def _serializable_config_value(value: Any) -> Any:
+    try:
+        import torch
+
+        if isinstance(value, torch.dtype):
+            return str(value).replace("torch.", "")
+    except ImportError:
+        pass
+    return value
+
+
+def _generate_draft_config(cfg: "Config") -> "PretrainedConfig":
+    strategy = cfg.training.strategy
+    policy = _assembly_spec(strategy).draft_config
+    if not policy.supports_auto_generation:
+        raise ValueError(
+            f"training.strategy={strategy!r} requires model.draft_model_config "
+            "or a pretrained model.draft_checkpoint_path containing config.json"
+        )
+
+    from transformers import AutoConfig
+
+    target_config = AutoConfig.from_pretrained(
+        cfg.model.target_model_path,
+        cache_dir=cfg.model.cache_dir,
+        trust_remote_code=cfg.model.trust_remote_code,
+    )
+    target_config = _target_text_config(target_config)
+    payload: Dict[str, Any] = {}
+    for field in _TARGET_ARCHITECTURE_FIELDS:
+        value = getattr(target_config, field, None)
+        if value is not None:
+            payload[field] = _serializable_config_value(value)
+
+    required = [name for name in ("vocab_size", "hidden_size") if name not in payload]
+    if required:
+        raise ValueError(
+            f"target config {cfg.model.target_model_path!r} cannot generate a "
+            f"draft config; missing {required}"
+        )
+    payload["architectures"] = [policy.architecture]
+    payload["model_type"] = policy.auto_model_type
+    payload["num_hidden_layers"] = policy.auto_num_hidden_layers
+    payload["tie_word_embeddings"] = False
+    payload["use_cache"] = True
+    if payload.get("pad_token_id") is None:
+        payload["pad_token_id"] = 0
+    if policy.auto_draft_vocab_size is not None:
+        payload["draft_vocab_size"] = policy.auto_draft_vocab_size
+    if policy.populate_generated is not None:
+        policy.populate_generated(payload, target_config, cfg)
+    return _draft_config_from_dict(payload)
+
+
+def _apply_draft_overrides(cfg: "Config", draft_config: "PretrainedConfig") -> None:
+    num_layers = cfg.model.draft_num_hidden_layers
+    if num_layers is not None:
+        draft_config.num_hidden_layers = num_layers
+    if cfg.model.draft_block_size is not None:
+        draft_config.block_size = cfg.model.draft_block_size
+    apply_overrides = _assembly_spec(cfg.training.strategy).draft_config.apply_overrides
+    if apply_overrides is not None:
+        apply_overrides(cfg, draft_config)
+
+
+def resolve_draft_config(cfg: "Config") -> "PretrainedConfig":
+    """Resolve and validate the draft architecture for one typed run config."""
+
+    source = cfg.model.draft_model_config
+    if not source:
+        source = _checkpoint_config_source(cfg.model.draft_checkpoint_path)
+    if source:
+        draft_config = load_draft_config_source(
+            source,
+            cache_dir=cfg.model.cache_dir,
+            trust_remote_code=cfg.model.trust_remote_code,
+        )
+    else:
+        draft_config = _generate_draft_config(cfg)
+
+    expected = _assembly_spec(cfg.training.strategy).draft_config.architecture
+    architectures = list(getattr(draft_config, "architectures", None) or [])
+    if architectures != [expected]:
+        raise ValueError(
+            f"training.strategy={cfg.training.strategy!r} requires draft "
+            f"architecture {expected}, got {architectures!r}"
+        )
+    _apply_draft_overrides(cfg, draft_config)
+    return draft_config
+
+
+def draft_config_dict(cfg: "Config") -> Dict[str, Any]:
+    """JSON-compatible resolved draft config for capture-only producer roles."""
+
+    return resolve_draft_config(cfg).to_dict()
+
+
+def _has_pretrained_weights(path: str) -> bool:
+    names = (
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "pytorch_model.bin",
+        "pytorch_model.bin.index.json",
+    )
+    return any(os.path.isfile(os.path.join(path, name)) for name in names)
+
+
+def _runtime_state_file(source: str) -> Optional[str]:
+    """Resolve SpecForge checkpoint storage without loading resume state."""
+
+    path = os.path.abspath(os.path.expanduser(_without_file_uri(str(source))))
+    if os.path.isfile(path):
+        return path if os.path.basename(path) == _STATE_FILE else None
+    if not os.path.isdir(path):
+        return None
+
+    direct = os.path.join(path, _STATE_FILE)
+    if os.path.isfile(direct) and not _has_pretrained_weights(path):
+        return direct
+    has_run_pointers = bool(
+        glob.glob(os.path.join(path, "*-latest"))
+        or glob.glob(os.path.join(path, "*-step*"))
+    )
+    if not has_run_pointers:
+        return None
+
+    from specforge.training.checkpoint import CheckpointManager
+
+    checkpoint_dir = CheckpointManager.resolve_resume_dir(path)
+    return os.path.join(checkpoint_dir, _STATE_FILE)
+
+
+def _load_specforge_draft_state(
+    state_path: str, *, expected_strategy: str
+) -> Dict[str, Any]:
+    import torch
+
+    try:
+        # The restricted unpickler accepts tensors and primitive metadata while
+        # refusing arbitrary checkpoint objects. Only draft_state_dict is used.
+        state = torch.load(state_path, map_location="cpu", weights_only=True)
+    except Exception as exc:
+        raise ValueError(
+            f"cannot read weights-only SpecForge checkpoint {state_path}: {exc}"
+        ) from exc
+    if not isinstance(state, dict) or not isinstance(
+        state.get("draft_state_dict"), dict
+    ):
+        raise ValueError(
+            f"SpecForge warm-start checkpoint has no draft_state_dict: {state_path}"
+        )
+    saved_strategy = state.get("strategy")
+    if saved_strategy is not None and saved_strategy != expected_strategy:
+        raise ValueError(
+            f"warm-start checkpoint {state_path} was written by strategy "
+            f"{saved_strategy!r}; this run trains {expected_strategy!r}"
+        )
+    return state["draft_state_dict"]
+
+
+def _load_pretrained_draft_state(
+    source: str,
+    *,
+    draft_config: "PretrainedConfig",
+    cache_dir: Optional[str],
+    trust_remote_code: bool,
+) -> Dict[str, Any]:
+    from specforge.modeling.auto import AutoDraftModel
+
+    loaded, loading_info = AutoDraftModel.from_pretrained(
+        source,
+        config=draft_config,
+        cache_dir=cache_dir,
+        trust_remote_code=trust_remote_code,
+        output_loading_info=True,
+    )
+    missing_from_source = set(loading_info.get("missing_keys") or [])
+    state = {
+        key: value.detach().cpu()
+        for key, value in loaded.state_dict().items()
+        if key not in missing_from_source
+    }
+    del loaded
+    return state
+
+
+def warm_start_draft_model(
+    model: Any,
+    source: str,
+    *,
+    draft_config: "PretrainedConfig",
+    strategy: str,
+    cache_dir: Optional[str] = None,
+    trust_remote_code: bool = False,
+) -> WarmStartReport:
+    """Load only draft weights, never optimizer/counters/RNG training state."""
+
+    runtime_state = _runtime_state_file(source)
+    if runtime_state is not None:
+        checkpoint_format: Literal["specforge", "pretrained"] = "specforge"
+        state = _load_specforge_draft_state(runtime_state, expected_strategy=strategy)
+    else:
+        checkpoint_format = "pretrained"
+        state = _load_pretrained_draft_state(
+            source,
+            draft_config=draft_config,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
+        )
+
+    if not state:
+        raise ValueError(f"warm-start checkpoint {source!r} contains no draft weights")
+    try:
+        result = model.load_state_dict(state, strict=False)
+    except RuntimeError as exc:
+        raise ValueError(
+            f"warm-start checkpoint {source!r} has incompatible draft tensor "
+            f"shapes: {exc}"
+        ) from exc
+    loaded_keys = len(state) - len(result.unexpected_keys)
+    if result.unexpected_keys or loaded_keys == 0:
+        raise ValueError(
+            f"warm-start checkpoint {source!r} does not match this draft model: "
+            f"loaded={loaded_keys}/{len(state)}, "
+            f"unexpected={sorted(result.unexpected_keys)}"
+        )
+    allowed_missing = set()
+    if _assembly_spec(strategy).allow_missing_warm_start_embedding:
+        allowed_missing = {key for key in result.missing_keys if "embed" in key.lower()}
+    required_missing = sorted(set(result.missing_keys) - allowed_missing)
+    if required_missing:
+        raise ValueError(
+            f"warm-start checkpoint {source!r} is missing draft weights required "
+            f"by this architecture: {required_missing}"
+        )
+
+    report = WarmStartReport(
+        source=str(source),
+        checkpoint_format=checkpoint_format,
+        loaded_keys=loaded_keys,
+        missing_keys=tuple(sorted(result.missing_keys)),
+        loaded_embedding=any("embed" in key.lower() for key in state),
+    )
+    logger.info(
+        "Warm-started %d draft tensors from %s (%s); missing=%s",
+        report.loaded_keys,
+        report.source,
+        report.checkpoint_format,
+        list(report.missing_keys),
+    )
+    return report
+
+
+__all__ = [
+    "WarmStartReport",
+    "draft_config_dict",
+    "load_draft_config_source",
+    "resolve_draft_config",
+    "warm_start_draft_model",
+]

--- a/specforge/training/model_utils.py
+++ b/specforge/training/model_utils.py
@@ -1,0 +1,63 @@
+"""Small model-assembly utilities shared by training strategies."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def resolve_mask_token_id(
+    *,
+    explicit: Optional[int],
+    tokenizer: Any,
+    embedding_vocab_size: int,
+    draft_model: Any = None,
+) -> int:
+    """Resolve a MASK id without resizing the draft embedding table.
+
+    Priority is explicit config, draft metadata, tokenizer MASK id, an unused
+    tokenizer slot in the existing embedding table, then a standard fallback
+    token. Every candidate is range checked before it can reach a model lookup.
+    """
+
+    method_config = (
+        getattr(getattr(draft_model, "config", None), "dflash_config", None) or {}
+    )
+    candidates = [
+        ("explicit mask token", explicit),
+        ("draft config mask token", method_config.get("mask_token_id")),
+        ("tokenizer mask token", getattr(tokenizer, "mask_token_id", None)),
+    ]
+    try:
+        tokenizer_size = len(tokenizer)
+    except TypeError:
+        tokenizer_size = embedding_vocab_size
+    if tokenizer_size < embedding_vocab_size:
+        candidates.append(("unused embedding slot", tokenizer_size))
+    candidates.extend(
+        (name, getattr(tokenizer, attribute, None))
+        for name, attribute in (
+            ("tokenizer pad token", "pad_token_id"),
+            ("tokenizer eos token", "eos_token_id"),
+            ("tokenizer unknown token", "unk_token_id"),
+        )
+    )
+
+    for source, candidate in candidates:
+        if candidate is None:
+            continue
+        candidate = int(candidate)
+        if not 0 <= candidate < embedding_vocab_size:
+            if source.startswith("explicit"):
+                raise ValueError(
+                    f"mask token id {candidate} is outside draft embedding "
+                    f"vocabulary [0, {embedding_vocab_size})"
+                )
+            continue
+        return candidate
+    raise ValueError(
+        "unable to resolve a mask token id within the draft embedding "
+        f"vocabulary [0, {embedding_vocab_size})"
+    )
+
+
+__all__ = ["resolve_mask_token_id"]

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -8,10 +8,10 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 """DraftTrainStrategy: per-draft-model required features + forward/loss + projection.
 
-A strategy is the only place that knows how a draft model (EAGLE3 / DFlash /
-Domino) turns a normalized ``TrainBatch`` into a loss; ``TrainerCore`` stays
-branch-free and the strategy owns the target projection. Imports model code,
-so it is imported by training entry points, not at package load.
+A strategy is the only place that knows how a draft model (EAGLE3 / P-EAGLE /
+DFlash / Domino) turns a normalized ``TrainBatch`` into a loss; ``TrainerCore``
+stays branch-free and the strategy owns the target projection. Imports model
+code, so it is imported by training entry points, not at package load.
 """
 
 from __future__ import annotations
@@ -53,8 +53,7 @@ def linear_lambda_base(
 ) -> float:
     """Domino base-loss weight: linear decay from ``lambda_start`` to 0 over the
     first ``total_steps * decay_ratio`` steps, then 0, clamped to ``[0, 1]``.
-    Single source for the runtime strategy and ``scripts/train_domino.py``;
-    requires a real ``total_steps`` (> 0)."""
+    Requires a real ``total_steps`` (> 0)."""
     decay_steps = max(1, int(total_steps * decay_ratio))
     progress = min(global_step / decay_steps, 1.0)
     return max(0.0, min(1.0, lambda_start * (1.0 - progress)))
@@ -86,6 +85,35 @@ class DraftTrainStrategy(abc.ABC):
         return state_dict
 
 
+def _prepare_eagle_target(
+    *,
+    target_head: Optional[nn.Module],
+    target_repr: Optional[str],
+    input_ids: torch.Tensor,
+    target: torch.Tensor,
+    loss_mask: torch.Tensor,
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Normalize EAGLE-family teacher features for a training forward.
+
+    Online capture already shifts logits and input IDs. Offline capture stores
+    the target model's final hidden state, so the frozen target head owns the
+    equivalent shift and projection to full-vocabulary logits.
+    """
+    if target_repr == "hidden_state":
+        if target_head is None:
+            raise ValueError(
+                "target_repr='hidden_state' requires a target_head to re-run "
+                "the lm_head projection"
+            )
+        input_ids, target, loss_mask = target_head.preprocess(
+            input_ids, target, loss_mask
+        )
+        target = target_head(target.to(device))
+        return input_ids.to(device), target, loss_mask.to(device)
+    return input_ids.to(device), target.to(device), loss_mask.to(device)
+
+
 class Eagle3TrainStrategy(DraftTrainStrategy):
     """EAGLE3 TTT strategy wrapping the existing ``OnlineEagle3Model``.
 
@@ -110,10 +138,72 @@ class Eagle3TrainStrategy(DraftTrainStrategy):
         *,
         target_head: Optional[nn.Module] = None,
         ploss_decay: float = 0.8,
+        compact_teacher: bool = False,
+        compact_teacher_chunk_size: Optional[int] = None,
     ) -> None:
         self.eagle3_model = eagle3_model
         self.target_head = target_head
         self.ploss_decay = ploss_decay
+        self.compact_teacher = compact_teacher
+        self.compact_teacher_chunk_size = compact_teacher_chunk_size
+        if compact_teacher:
+            self._validate_compact_teacher()
+
+    def _validate_compact_teacher(self) -> None:
+        """Validate the offline compact-teacher contract before the first step.
+
+        The strategy is constructed after the vocab mapping has been loaded and
+        after FSDP wrapping.  FSDP exposes the wrapped module as ``module``;
+        walking that one boundary keeps validation independent of the backend
+        while the actual forward still goes through the wrapped model.
+        """
+        if self.target_head is None:
+            raise ValueError(
+                "compact teacher requires the offline target_head; it is not "
+                "available for online capture"
+            )
+
+        model = self.eagle3_model
+        if not hasattr(model, "draft_model") and hasattr(model, "module"):
+            model = model.module
+        draft_model = getattr(model, "draft_model", None)
+        if draft_model is None:
+            raise ValueError(
+                "compact teacher requires an EAGLE3 model with a draft_model"
+            )
+
+        from specforge.core.compact_teacher import (
+            validate_compact_teacher_enabled,
+            validate_vocab_mapping_consistency,
+        )
+
+        target_head_weight = getattr(
+            getattr(self.target_head, "fc", None), "weight", None
+        )
+        vocab_size = (
+            int(target_head_weight.shape[0])
+            if target_head_weight is not None and target_head_weight.dim() >= 1
+            else int(
+                getattr(getattr(self.target_head, "config", None), "vocab_size", 0)
+            )
+        )
+        draft_vocab_size = int(
+            getattr(
+                getattr(draft_model, "config", None),
+                "draft_vocab_size",
+                int(draft_model.t2d.sum().item()),
+            )
+        )
+        validate_compact_teacher_enabled(
+            is_online=False,
+            is_vlm=False,
+            draft_vocab_size=draft_vocab_size,
+            vocab_size=vocab_size,
+            t2d=draft_model.t2d,
+            target_head_weight=target_head_weight,
+            chunk_size=self.compact_teacher_chunk_size,
+        )
+        validate_vocab_mapping_consistency(draft_model.t2d, draft_model.d2t)
 
     def trainable_module(self) -> nn.Module:
         return self.eagle3_model
@@ -129,22 +219,14 @@ class Eagle3TrainStrategy(DraftTrainStrategy):
         loss_mask: torch.Tensor,
         device: torch.device,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        if target_repr == "hidden_state":
-            if self.target_head is None:
-                raise ValueError(
-                    "target_repr='hidden_state' requires a target_head to re-run "
-                    "the lm_head projection"
-                )
-            # mirrors offline run_forward: shift input_ids/target, add mask dim,
-            # then project the target last hidden state to full-vocab logits.
-            input_ids, target, loss_mask = self.target_head.preprocess(
-                input_ids, target, loss_mask
-            )
-            target = self.target_head(target.to(device))
-            return input_ids.to(device), target, loss_mask.to(device)
-        # logits / pruned_logits: rollout already produced (and shifted) the
-        # distribution.
-        return input_ids.to(device), target.to(device), loss_mask.to(device)
+        return _prepare_eagle_target(
+            target_head=self.target_head,
+            target_repr=target_repr,
+            input_ids=input_ids,
+            target=target,
+            loss_mask=loss_mask,
+            device=device,
+        )
 
     def forward_loss(
         self, batch: TrainBatch, ctx: Optional[StepContext] = None
@@ -154,9 +236,34 @@ class Eagle3TrainStrategy(DraftTrainStrategy):
         device = self._device()
         target_repr = batch.metadata.get("target_repr")
 
-        input_ids, target, loss_mask = self._prepare_target(
-            target_repr, t["input_ids"], t["target"], t["loss_mask"], device
-        )
+        compact_kwargs: Dict[str, Any] = {}
+        if self.compact_teacher:
+            if target_repr != "hidden_state":
+                raise ValueError(
+                    "compact teacher is offline-only and requires "
+                    "target_repr='hidden_state'"
+                )
+            # Preserve TargetHead.preprocess's shift exactly, but do not call
+            # TargetHead.forward: OnlineEagle3Model streams the frozen head in
+            # vocabulary chunks from these kwargs instead.
+            input_ids, target_hidden, loss_mask = self.target_head.preprocess(
+                t["input_ids"], t["target"], t["loss_mask"]
+            )
+            input_ids = input_ids.to(device)
+            target_hidden = target_hidden.to(device)
+            loss_mask = loss_mask.to(device)
+            from specforge.core.compact_teacher import build_offline_teacher_inputs
+
+            target, compact_kwargs = build_offline_teacher_inputs(
+                compact=True,
+                target_model=self.target_head,
+                target_hidden=target_hidden,
+                chunk_size_arg=self.compact_teacher_chunk_size,
+            )
+        else:
+            input_ids, target, loss_mask = self._prepare_target(
+                target_repr, t["input_ids"], t["target"], t["loss_mask"], device
+            )
         position_ids = t.get("position_ids")
         (
             plosses,
@@ -173,6 +280,7 @@ class Eagle3TrainStrategy(DraftTrainStrategy):
             target=target,
             hidden_states=t["hidden_state"].to(device),
             position_ids=position_ids.to(device) if position_ids is not None else None,
+            **compact_kwargs,
         )
         weights = [self.ploss_decay**i for i in range(len(plosses))]
         loss = sum(weights[i] * plosses[i] for i in range(len(plosses)))
@@ -202,6 +310,99 @@ class Eagle3TrainStrategy(DraftTrainStrategy):
             k.replace("draft_model.", ""): v
             for k, v in state_dict.items()
             if "draft_model." in k and not (embed_frozen and "embed" in k.lower())
+        }
+
+
+class PEagleTrainStrategy(DraftTrainStrategy):
+    """P-EAGLE COD strategy wrapping ``OnlinePEagleModel``.
+
+    P-EAGLE consumes the same target capture as EAGLE3. The runtime schema uses
+    the singular ``hidden_state`` name, while ``OnlinePEagleModel.forward`` uses
+    ``hidden_states``; this strategy is the explicit boundary between them.
+    """
+
+    name = "peagle"
+    required_features = {
+        "input_ids",
+        "attention_mask",
+        "loss_mask",
+        "hidden_state",
+        "target",
+    }
+
+    def __init__(
+        self,
+        peagle_model: nn.Module,
+        *,
+        target_head: Optional[nn.Module] = None,
+    ) -> None:
+        self.peagle_model = peagle_model
+        self.target_head = target_head
+
+    def trainable_module(self) -> nn.Module:
+        return self.peagle_model
+
+    def _device(self) -> torch.device:
+        return next(self.peagle_model.parameters()).device
+
+    def forward_loss(
+        self, batch: TrainBatch, ctx: Optional[StepContext] = None
+    ) -> StepOutput:
+        self.validate_batch(batch)
+        tensors = batch.tensors
+        device = self._device()
+        input_ids, target, loss_mask = _prepare_eagle_target(
+            target_head=self.target_head,
+            target_repr=batch.metadata.get("target_repr"),
+            input_ids=tensors["input_ids"],
+            target=tensors["target"],
+            loss_mask=tensors["loss_mask"],
+            device=device,
+        )
+
+        lengths = tensors.get("lengths")
+        if lengths is None:
+            # P-EAGLE is currently batch-size 1. Deriving the document length
+            # from the padding mask prevents COD samples from treating padded
+            # positions as part of the document in the offline path.
+            lengths = tensors["attention_mask"].sum(dim=-1)
+
+        loss, model_metrics = self.peagle_model(
+            input_ids=input_ids,
+            attention_mask=tensors["attention_mask"].to(device),
+            loss_mask=loss_mask,
+            target=target,
+            hidden_states=tensors["hidden_state"].to(device),
+            lengths=lengths.to(device),
+        )
+        if not isinstance(loss, torch.Tensor) or loss.numel() != 1:
+            raise ValueError(
+                "peagle model must return a scalar loss tensor; "
+                f"got {type(loss).__name__} with shape="
+                f"{getattr(loss, 'shape', None)}"
+            )
+
+        metrics = {
+            name: value.detach() if isinstance(value, torch.Tensor) else value
+            for name, value in model_metrics.items()
+        }
+        correct = metrics.get("full_acc_sum")
+        denominator = metrics.get("full_acc_total")
+        if correct is not None and denominator is not None:
+            correct = torch.as_tensor(correct, device=device)
+            denominator = torch.as_tensor(denominator, device=device)
+            metrics["accuracy"] = correct / denominator.clamp_min(1)
+
+        return StepOutput(loss=loss.reshape(()), metrics=metrics)
+
+    def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        # Unlike the stock EAGLE3 path, P-EAGLE trains its token embeddings and
+        # mask_hidden parameter. Persist the complete draft model so both survive
+        # checkpoint/resume and export.
+        return {
+            key.replace("draft_model.", ""): value
+            for key, value in state_dict.items()
+            if "draft_model." in key
         }
 
 
@@ -237,14 +438,10 @@ class DFlashTrainStrategy(DraftTrainStrategy):
             hidden_states=t["hidden_states"].to(device),
             loss_mask=t["loss_mask"].to(device),
         )
-        return StepOutput(
-            loss=loss,
-            metrics={
-                "accuracy": accuracy.detach(),
-                # the accuracy's own denominator, so eval can weight it exactly
-                "accuracy_denom": model_metrics["accuracy_denom"],
-            },
-        )
+        metrics = {"accuracy": accuracy.detach()}
+        if "accuracy_denom" in model_metrics:
+            metrics["accuracy_denom"] = model_metrics["accuracy_denom"]
+        return StepOutput(loss=loss, metrics=metrics)
 
     def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
         # Everything trainable lives under draft_model.; the target
@@ -290,9 +487,9 @@ class DSparkTrainStrategy(DraftTrainStrategy):
         )
         metrics = {
             "accuracy": accuracy.detach(),
-            "accuracy_denom": model_metrics["accuracy_denom"],
         }
         for name in (
+            "accuracy_denom",
             "ce_loss",
             "l1_loss",
             "confidence_loss",
@@ -359,15 +556,13 @@ class DominoTrainStrategy(DraftTrainStrategy):
             loss_mask=t["loss_mask"].to(device),
             lambda_base=lambda_base,
         )
-        return StepOutput(
-            loss=loss,
-            metrics={
-                "accuracy": accuracy.detach(),
-                # the accuracy's own denominator, so eval can weight it exactly
-                "accuracy_denom": model_metrics["accuracy_denom"],
-                "lambda_base": torch.tensor(float(lambda_base)),
-            },
-        )
+        metrics = {
+            "accuracy": accuracy.detach(),
+            "lambda_base": torch.tensor(float(lambda_base)),
+        }
+        if "accuracy_denom" in model_metrics:
+            metrics["accuracy_denom"] = model_metrics["accuracy_denom"]
+        return StepOutput(loss=loss, metrics=metrics)
 
     def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
         # Everything trainable lives under draft_model.; the target
@@ -382,6 +577,7 @@ class DominoTrainStrategy(DraftTrainStrategy):
 __all__ = [
     "DraftTrainStrategy",
     "Eagle3TrainStrategy",
+    "PEagleTrainStrategy",
     "DFlashTrainStrategy",
     "DSparkTrainStrategy",
     "DominoTrainStrategy",

--- a/tests/test_algorithms/__init__.py
+++ b/tests/test_algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Algorithm contract tests."""

--- a/tests/test_algorithms/test_builtin_parity.py
+++ b/tests/test_algorithms/test_builtin_parity.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from specforge.algorithms.builtin import builtin_algorithm_registry
+
+
+class BuiltinProviderParityTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.registry = builtin_algorithm_registry()
+
+    def test_builtin_contract_matrix_preserves_pr678_capabilities(self):
+        expected = {
+            "dflash": (
+                "DFlashDraftModel",
+                {"input_ids", "loss_mask", "hidden_states"},
+                {"eager", "sdpa", "flex_attention"},
+                None,
+            ),
+            "domino": (
+                "DominoDraftModel",
+                {"input_ids", "loss_mask", "hidden_states"},
+                {"eager", "sdpa", "flex_attention"},
+                None,
+            ),
+            "dspark": (
+                "DSparkDraftModel",
+                {
+                    "input_ids",
+                    "loss_mask",
+                    "hidden_states",
+                    "target_last_hidden_states",
+                },
+                {"eager", "sdpa", "flex_attention"},
+                None,
+            ),
+            "eagle3": (
+                "LlamaForCausalLMEagle3",
+                {
+                    "input_ids",
+                    "attention_mask",
+                    "loss_mask",
+                    "hidden_state",
+                    "target",
+                },
+                {"sdpa", "flex_attention", "fa", "usp"},
+                None,
+            ),
+            "peagle": (
+                "PEagleDraftModel",
+                {
+                    "input_ids",
+                    "attention_mask",
+                    "loss_mask",
+                    "hidden_state",
+                    "target",
+                },
+                {"flex_attention"},
+                1,
+            ),
+        }
+        for name, (architecture, features, backends, batch_size) in expected.items():
+            with self.subTest(algorithm=name):
+                registration = self.registry.resolve(name)
+                self.assertEqual(
+                    architecture,
+                    registration.providers.model.draft_config.architecture,
+                )
+                streaming = registration.spec.feature_contract("streaming", "text")
+                self.assertEqual(features, streaming.required_tensors)
+                self.assertEqual(
+                    backends,
+                    registration.spec.capabilities.attention_backends,
+                )
+                self.assertEqual(
+                    batch_size,
+                    registration.spec.capabilities.required_batch_size,
+                )
+
+    def test_existing_server_capture_layouts_are_preserved(self):
+        expected = {
+            "dflash": (
+                "hidden_states",
+                None,
+                (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
+                None,
+            ),
+            "domino": (
+                "hidden_states",
+                None,
+                (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
+                None,
+            ),
+            "dspark": (
+                "hidden_states",
+                "target_last_hidden_states",
+                (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
+                None,
+            ),
+            "eagle3": (
+                "hidden_state",
+                "target",
+                (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
+                "attention_mask",
+            ),
+            "peagle": (
+                "hidden_state",
+                "target",
+                (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
+                "attention_mask",
+            ),
+        }
+        for name, layout_values in expected.items():
+            with self.subTest(algorithm=name):
+                layout = (
+                    self.registry.resolve(name)
+                    .providers.server_streaming_for("text")
+                    .layout
+                )
+                self.assertEqual(
+                    layout_values,
+                    (
+                        layout.aux_feature,
+                        layout.last_hidden_feature,
+                        layout.passthrough,
+                        layout.attention_mask_feature,
+                    ),
+                )
+
+    def test_peagle_reuses_the_eagle_server_contract_explicitly(self):
+        peagle = self.registry.resolve("peagle").providers
+        eagle3 = self.registry.resolve("eagle3").providers
+        peagle_stream = peagle.server_streaming_for("text")
+        eagle_stream = eagle3.server_streaming_for("text")
+
+        self.assertEqual("eagle3", peagle_stream.capture_method)
+        self.assertEqual(eagle_stream.layout, peagle_stream.layout)
+        self.assertEqual("hidden_state", peagle_stream.target_representation)
+        self.assertTrue(peagle.step.uses_external_target_head)
+
+    def test_step_factories_preserve_concrete_strategy_types(self):
+        expected = {
+            "eagle3": "Eagle3TrainStrategy",
+            "peagle": "PEagleTrainStrategy",
+            "dflash": "DFlashTrainStrategy",
+            "domino": "DominoTrainStrategy",
+            "dspark": "DSparkTrainStrategy",
+        }
+        model = object()
+        for name, class_name in expected.items():
+            with self.subTest(algorithm=name):
+                provider = self.registry.resolve(name).providers.step
+                instance = provider.build(model, target_head=None)
+                self.assertEqual(class_name, type(instance).__name__)
+
+    def test_dflash_family_collator_matches_existing_padding_contract(self):
+        short = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "loss_mask": torch.tensor([[1, 1, 1]]),
+            "hidden_states": torch.ones(1, 3, 4),
+        }
+        long = {
+            "input_ids": torch.tensor([[4, 5, 6, 7, 8]]),
+            "loss_mask": torch.tensor([[1, 1, 1, 1, 1]]),
+            "hidden_states": torch.ones(1, 5, 4),
+        }
+        for name in ("dflash", "domino"):
+            with self.subTest(algorithm=name):
+                collate = (
+                    self.registry.resolve(name)
+                    .providers.server_streaming_for("text")
+                    .build_collator()
+                )
+                batch = collate([short, long])
+                self.assertEqual((2, 5), tuple(batch["input_ids"].shape))
+                self.assertEqual((2, 5, 4), tuple(batch["hidden_states"].shape))
+                self.assertEqual([1, 1, 1, 0, 0], batch["loss_mask"][0].tolist())
+
+    def test_dspark_collator_preserves_target_last_hidden_states(self):
+        short = {
+            "input_ids": torch.tensor([[1, 2]]),
+            "loss_mask": torch.ones(1, 2, dtype=torch.long),
+            "hidden_states": torch.ones(1, 2, 4),
+            "target_last_hidden_states": torch.ones(1, 2, 3),
+        }
+        long = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "loss_mask": torch.ones(1, 3, dtype=torch.long),
+            "hidden_states": torch.ones(1, 3, 4),
+            "target_last_hidden_states": torch.ones(1, 3, 3),
+        }
+        collate = (
+            self.registry.resolve("dspark")
+            .providers.server_streaming_for("text")
+            .build_collator()
+        )
+        batch = collate([short, long])
+        self.assertEqual((2, 3, 3), tuple(batch["target_last_hidden_states"].shape))
+        self.assertTrue(torch.all(batch["target_last_hidden_states"][0, 2:] == 0))
+
+    def test_small_normalizers_match_retained_implementations(self):
+        from specforge.data.preprocessing import (
+            process_offline_dflash_sample,
+            process_offline_eagle3_sample,
+        )
+
+        eagle_raw = {
+            "input_ids": torch.tensor([1, 2, 3, 4]),
+            "loss_mask": torch.ones(4, dtype=torch.long),
+            "hidden_state": torch.arange(24).reshape(1, 4, 6),
+            "aux_hidden_state": torch.arange(48).reshape(1, 4, 12),
+        }
+        dflash_raw = {
+            "input_ids": torch.tensor([1, 2, 3, 4]),
+            "loss_mask": torch.ones(4, dtype=torch.long),
+            "hidden_states": torch.arange(24).reshape(1, 4, 6),
+        }
+        cases = (
+            ("eagle3", eagle_raw, process_offline_eagle3_sample),
+            ("dflash", dflash_raw, process_offline_dflash_sample),
+            ("domino", dflash_raw, process_offline_dflash_sample),
+        )
+        for name, raw, retained in cases:
+            with self.subTest(algorithm=name):
+                provider = self.registry.resolve(name).providers.offline_for("text")
+                actual = provider.build_normalizer(3)(raw)
+                expected = retained(raw, 3)
+                self.assertEqual(set(expected), set(actual))
+                for key in expected:
+                    self.assertTrue(torch.equal(expected[key], actual[key]), key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_algorithms/test_builtin_providers.py
+++ b/tests/test_algorithms/test_builtin_providers.py
@@ -1,0 +1,418 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from dataclasses import fields
+from pathlib import Path
+from types import SimpleNamespace
+
+from specforge.algorithms.builtin import builtin_algorithm_registry
+from specforge.algorithms.common.providers import (
+    MODEL_PROVENANCE_CONTRACT_KEY,
+    OMITTED_STATE_FINGERPRINT_CONTRACT_KEY,
+    STEP_OPTIONS_CONTRACT_KEY,
+    AlgorithmProviders,
+    DraftConfigProvider,
+    ServerCaptureLayout,
+    ServerStreamingProvider,
+    StepRuntimeConfig,
+)
+from specforge.algorithms.contracts import AlgorithmSpec, FeatureMode
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BUILTINS = ("dflash", "domino", "dspark", "eagle3", "peagle")
+
+
+class BuiltinProviderContractTest(unittest.TestCase):
+    def setUp(self):
+        self.registry = builtin_algorithm_registry()
+
+    def test_five_builtins_are_explicit_and_instance_owned(self):
+        self.assertEqual(BUILTINS, self.registry.names)
+        self.assertIsNot(builtin_algorithm_registry(), self.registry)
+
+    def test_every_registration_pairs_contract_and_providers(self):
+        for registration in self.registry:
+            with self.subTest(algorithm=registration.name):
+                self.assertIsInstance(registration.spec, AlgorithmSpec)
+                self.assertIsInstance(registration.providers, AlgorithmProviders)
+                self.assertEqual(
+                    registration.name,
+                    registration.providers.algorithm_name,
+                )
+                contract_keys = {c.key for c in registration.spec.feature_contracts}
+                provider_keys = {
+                    *(
+                        (FeatureMode.OFFLINE, p.modality)
+                        for p in registration.providers.offline
+                    ),
+                    *(
+                        (FeatureMode.STREAMING, p.modality)
+                        for p in registration.providers.server_streaming
+                    ),
+                }
+                self.assertEqual(contract_keys, provider_keys)
+
+    def test_algorithm_metadata_has_no_factories_or_topology_flags(self):
+        field_names = {field.name for field in fields(AlgorithmSpec)}
+        self.assertEqual(
+            {"name", "draft", "feature_contracts", "capabilities"},
+            field_names,
+        )
+        forbidden = {
+            "supports_online",
+            "supported_deployments",
+            "supported_target_backends",
+            "deployment_mode",
+            "target_backend",
+        }
+        for registration in self.registry:
+            with self.subTest(algorithm=registration.name):
+                self.assertTrue(forbidden.isdisjoint(vars(registration.spec)))
+                self.assertEqual(
+                    registration.spec.supports_online,
+                    bool(registration.providers.server_streaming),
+                )
+
+    def test_builtin_online_providers_are_server_streaming_only(self):
+        for registration in self.registry:
+            with self.subTest(algorithm=registration.name):
+                providers = registration.providers
+                self.assertGreaterEqual(len(providers.server_streaming), 1)
+                self.assertFalse(hasattr(providers, "colocated"))
+                self.assertFalse(hasattr(providers, "target_backend"))
+                self.assertFalse(hasattr(providers, "deployment"))
+
+    def test_draft_resolution_stays_outside_algorithm_spec(self):
+        provider_fields = {field.name for field in fields(DraftConfigProvider)}
+        self.assertEqual(
+            {
+                "architecture",
+                "target_defaults",
+                "expected_auto_map_model",
+                "apply_overrides",
+            },
+            provider_fields,
+        )
+        forbidden = {
+            "config_class",
+            "model_class",
+            "load_config",
+            "resolve_config",
+            "resolve_model",
+        }
+        self.assertTrue(forbidden.isdisjoint(provider_fields))
+        for registration in self.registry:
+            with self.subTest(algorithm=registration.name):
+                self.assertFalse(hasattr(registration.spec, "draft_config_resolver"))
+
+    def test_target_derived_defaults_and_overrides_are_provider_owned(self):
+        expected = {
+            "eagle3": ("llama", 1, 32000, False),
+            "peagle": ("llama", 4, 32000, False),
+            "dflash": ("qwen3", 1, None, True),
+        }
+        for name, (model_type, layers, vocab_size, has_override) in expected.items():
+            with self.subTest(algorithm=name):
+                policy = self.registry.resolve(name).providers.model.draft_config
+                defaults = policy.target_defaults
+                self.assertIsNotNone(defaults)
+                self.assertEqual(model_type, defaults.model_type)
+                self.assertEqual(layers, defaults.num_hidden_layers)
+                self.assertEqual(vocab_size, defaults.draft_vocab_size)
+                self.assertEqual(has_override, policy.apply_overrides is not None)
+
+        for name in ("domino", "dspark"):
+            with self.subTest(algorithm=name):
+                policy = self.registry.resolve(name).providers.model.draft_config
+                self.assertIsNone(policy.target_defaults)
+                self.assertIsNone(policy.apply_overrides)
+
+    def test_vlm_is_not_registered_as_a_builtin(self):
+        for registration in self.registry:
+            modalities = {
+                contract.modality for contract in registration.spec.feature_contracts
+            }
+            self.assertEqual({"text"}, modalities, registration.name)
+
+    def test_builtin_resume_contracts_cover_resolved_objective_semantics(self):
+        training = SimpleNamespace(
+            attention_backend="flex_attention",
+            compact_teacher=True,
+            compact_teacher_chunk_size=1024,
+            lambda_base_start=0.75,
+            lambda_base_decay_ratio=0.25,
+        )
+        config = SimpleNamespace(training=training)
+        draft = SimpleNamespace(
+            config=SimpleNamespace(num_hidden_layers=2),
+            layers=[object(), object()],
+            norm_before_residual=True,
+            target_layer_ids=[3, 7],
+            pure_draft_prefix_len=2,
+        )
+        dflash_family = SimpleNamespace(
+            block_size=16,
+            mask_token_id=0,
+            attention_backend="flex_attention",
+            num_anchors=64,
+            loss_decay_gamma=2.0,
+            loss_type="dpace",
+            dpace_alpha=0.4,
+            shift_label=True,
+            dspark_ce_loss_alpha=0.1,
+            dspark_l1_loss_alpha=0.8,
+            dspark_confidence_head_alpha=0.2,
+        )
+        models = {
+            "eagle3": SimpleNamespace(
+                length=7,
+                attention_backend="flex_attention",
+                lk_loss_type="lambda",
+                kl_scale=0.9,
+                kl_decay=0.8,
+            ),
+            "peagle": SimpleNamespace(
+                num_depths=5,
+                down_sample_ratio=0.7,
+                down_sample_ratio_min=0.3,
+                mask_token_id=31,
+            ),
+            "dflash": dflash_family,
+            "domino": dflash_family,
+            "dspark": dflash_family,
+        }
+        expected_keys = {
+            "eagle3": {
+                "eagle3_ttt_length",
+                "eagle3_lk_loss_type",
+                "eagle3_kl_scale",
+                "eagle3_kl_decay",
+                "eagle3_compact_teacher",
+            },
+            "peagle": {
+                "peagle_num_draft_layers",
+                "peagle_num_depths",
+                "peagle_down_sample_ratio",
+                "peagle_mask_token_id",
+            },
+            "dflash": {
+                "dflash_block_size",
+                "dflash_num_anchors",
+                "dflash_loss_type",
+                "dflash_dpace_alpha",
+            },
+            "domino": {
+                "domino_block_size",
+                "domino_shift_label",
+                "domino_pure_draft_prefix_len",
+                "domino_lambda_base_start",
+                "domino_lambda_base_decay_ratio",
+            },
+            "dspark": {
+                "dspark_block_size",
+                "dspark_ce_loss_alpha",
+                "dspark_l1_loss_alpha",
+                "dspark_confidence_head_alpha",
+            },
+        }
+
+        for name in BUILTINS:
+            with self.subTest(algorithm=name):
+                step = self.registry.resolve(name).providers.step
+                contract = step.resume_contract(config, draft, models[name])
+                self.assertTrue(expected_keys[name] <= contract.keys())
+                self.assertTrue(all(key.startswith(f"{name}_") for key in contract))
+
+    def test_step_runtime_config_binds_options_contract_and_missing_key_policy(self):
+        step = self.registry.resolve("eagle3").providers.step
+        draft = SimpleNamespace(
+            config=SimpleNamespace(num_hidden_layers=1),
+            named_parameters=lambda: (),
+            state_dict=lambda: {},
+        )
+        config = SimpleNamespace(
+            training=SimpleNamespace(
+                attention_backend="flex_attention",
+                compact_teacher=False,
+                compact_teacher_chunk_size=None,
+            )
+        )
+        model = SimpleNamespace(
+            length=7,
+            attention_backend="flex_attention",
+            lk_loss_type=None,
+            kl_scale=1.0,
+            kl_decay=1.0,
+        )
+
+        model_provenance = {"target_model": ("reference", "model-id")}
+        runtime = step.bind_runtime(
+            config,
+            draft,
+            model,
+            model_provenance=model_provenance,
+        )
+
+        self.assertIsInstance(runtime, StepRuntimeConfig)
+        self.assertEqual(dict(runtime), step.options(config))
+        self.assertEqual(
+            {
+                key: value
+                for key, value in runtime.resume_contract.items()
+                if key not in {STEP_OPTIONS_CONTRACT_KEY, MODEL_PROVENANCE_CONTRACT_KEY}
+            },
+            step.resume_contract(config, draft, model),
+        )
+        self.assertEqual(
+            runtime.resume_contract[STEP_OPTIONS_CONTRACT_KEY],
+            (
+                ("compact_teacher", False),
+                ("compact_teacher_chunk_size", None),
+            ),
+        )
+        self.assertEqual(
+            runtime.resume_contract[MODEL_PROVENANCE_CONTRACT_KEY],
+            (("target_model", ("reference", "model-id")),),
+        )
+        self.assertEqual(runtime.allowed_missing_checkpoint_keys, frozenset())
+
+    def test_missing_checkpoint_policy_requires_a_runtime_fingerprint(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            OMITTED_STATE_FINGERPRINT_CONTRACT_KEY,
+        ):
+            StepRuntimeConfig(
+                options={},
+                resume_contract={},
+                allowed_missing_checkpoint_keys={"embed_tokens.weight"},
+            )
+
+    def test_step_options_are_canonical_resume_metadata(self):
+        runtime = StepRuntimeConfig(
+            options={"objective_scale": 0.5},
+            resume_contract={},
+            allowed_missing_checkpoint_keys=frozenset(),
+        )
+        self.assertEqual(
+            runtime.resume_contract[STEP_OPTIONS_CONTRACT_KEY],
+            (("objective_scale", 0.5),),
+        )
+
+        with self.assertRaisesRegex(ValueError, STEP_OPTIONS_CONTRACT_KEY):
+            StepRuntimeConfig(
+                options={"objective_scale": 0.5},
+                resume_contract={
+                    STEP_OPTIONS_CONTRACT_KEY: (("objective_scale", 1.0),),
+                },
+                allowed_missing_checkpoint_keys=frozenset(),
+            )
+
+    def test_streaming_provider_constructs_a_generic_input_adapter(self):
+        config = object()
+        calls = []
+
+        class GenericInputAdapter:
+            def load_input_tools(self, received_config):
+                return ("tools", received_config)
+
+            def prepare_prompts(
+                self,
+                received_config,
+                input_tools,
+                *,
+                draft_config,
+            ):
+                return [
+                    {
+                        "config": received_config,
+                        "input_tools": input_tools,
+                        "draft_config": draft_config,
+                    }
+                ]
+
+            def build_request_inputs(self, tasks):
+                return {"generic_model_inputs": list(tasks)}
+
+        adapter = GenericInputAdapter()
+
+        def build_input_adapter(received_config):
+            calls.append(received_config)
+            return adapter
+
+        provider = ServerStreamingProvider(
+            modality="vision_language",
+            capture_method="eagle3",
+            target_representation="hidden_state",
+            layout=ServerCaptureLayout(
+                aux_feature="hidden_state",
+                last_hidden_feature="target",
+                passthrough=(("position_ids", "position_ids", (3,)),),
+            ),
+            build_collator=lambda: None,
+            build_input_adapter=build_input_adapter,
+        )
+
+        self.assertEqual("vision_language", provider.modality)
+        self.assertIs(adapter, provider.create_input_adapter(config))
+        self.assertEqual([config], calls)
+        self.assertEqual(
+            {"generic_model_inputs": ["task"]},
+            adapter.build_request_inputs(["task"]),
+        )
+
+    def test_streaming_provider_rejects_incomplete_input_adapters(self):
+        required_methods = (
+            "load_input_tools",
+            "prepare_prompts",
+            "build_request_inputs",
+        )
+        for invalid_method in required_methods:
+            methods = {
+                name: (lambda *args, **kwargs: None) for name in required_methods
+            }
+            methods[invalid_method] = object()
+            incomplete = SimpleNamespace(**methods)
+            provider = ServerStreamingProvider(
+                modality="plugin_modality",
+                capture_method="eagle3",
+                target_representation="hidden_state",
+                layout=ServerCaptureLayout(
+                    aux_feature="hidden_state",
+                    last_hidden_feature="target",
+                    passthrough=(),
+                ),
+                build_collator=lambda: None,
+                build_input_adapter=lambda _config: incomplete,
+            )
+
+            with (
+                self.subTest(method=invalid_method),
+                self.assertRaisesRegex(
+                    TypeError,
+                    f"missing callable methods: \\['{invalid_method}'\\]",
+                ),
+            ):
+                provider.create_input_adapter(object())
+
+    def test_building_catalog_does_not_import_training_or_torch(self):
+        code = (
+            "import sys; "
+            "from specforge.algorithms.builtin import builtin_algorithm_registry; "
+            "r=builtin_algorithm_registry(); assert len(r)==5; "
+            "assert 'torch' not in sys.modules; "
+            "assert 'specforge.training.strategies.registry' not in sys.modules"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr or result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_algorithms/test_contracts.py
+++ b/tests/test_algorithms/test_contracts.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import FrozenInstanceError, fields, is_dataclass
+from enum import Enum
+
+from specforge.algorithms import (
+    AlgorithmCapabilities,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+    OfflineStorageContract,
+)
+
+
+def _offline(modality: str = "text") -> FeatureContract:
+    return FeatureContract(
+        mode=FeatureMode.OFFLINE,
+        modality=modality,
+        required_tensors={"input_ids", "hidden_states", "loss_mask"},
+        allowed_target_representations={"hidden_state"},
+        default_target_representation="hidden_state",
+        storage=OfflineStorageContract(
+            format="manifest_v1",
+            required_tensors={"input_ids", "hidden_states", "loss_mask"},
+            normalizer="eagle3_offline_v1",
+        ),
+    )
+
+
+def _streaming(modality: str = "text") -> FeatureContract:
+    required = {"input_ids", "hidden_state", "target", "loss_mask"}
+    if modality == "vision_language":
+        required.add("position_ids")
+    return FeatureContract(
+        mode=FeatureMode.STREAMING,
+        modality=modality,
+        required_tensors=required,
+        allowed_target_representations={"hidden_state"},
+        default_target_representation="hidden_state",
+    )
+
+
+def _spec(*contracts: FeatureContract) -> AlgorithmSpec:
+    return AlgorithmSpec(
+        name="eagle3",
+        draft=DraftRequirement(
+            compatible_architectures={"LlamaForCausalLMEagle3"},
+            default_architecture="LlamaForCausalLMEagle3",
+            supported_overrides={"attention_layout", "num_hidden_layers"},
+        ),
+        feature_contracts=contracts or (_offline(), _streaming()),
+        capabilities=AlgorithmCapabilities(
+            attention_backends={"sdpa", "flex_attention"},
+            supports_compact_teacher=True,
+            supports_vocab_mapping=True,
+        ),
+    )
+
+
+def _assert_contract_is_pure(value: object) -> None:
+    if isinstance(value, type) or callable(value):
+        raise AssertionError(f"executable value leaked into contract: {value!r}")
+    if value is None or isinstance(value, (str, int, float, bool, Enum)):
+        return
+    if isinstance(value, (tuple, list, set, frozenset)):
+        for item in value:
+            _assert_contract_is_pure(item)
+        return
+    if is_dataclass(value) and not isinstance(value, type):
+        for field in fields(value):
+            _assert_contract_is_pure(getattr(value, field.name))
+        return
+    raise AssertionError(f"opaque value leaked into contract: {type(value).__name__}")
+
+
+class AlgorithmContractTest(unittest.TestCase):
+    def test_spec_is_recursively_pure(self):
+        _assert_contract_is_pure(_spec())
+
+    def test_same_mode_can_define_multiple_modalities(self):
+        spec = _spec(_streaming("text"), _streaming("vision_language"))
+
+        self.assertTrue(spec.supports("streaming", "text"))
+        self.assertIn(
+            "position_ids",
+            spec.feature_contract("streaming", "vision_language").required_tensors,
+        )
+
+    def test_online_capability_is_derived_from_streaming_contract(self):
+        self.assertFalse(_spec(_offline()).supports_online)
+        self.assertTrue(_spec(_streaming()).supports_online)
+
+    def test_duplicate_mode_and_modality_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            _spec(_streaming(), _streaming())
+
+    def test_offline_requires_storage_contract(self):
+        with self.assertRaisesRegex(ValueError, "require a storage contract"):
+            FeatureContract(
+                mode="offline",
+                modality="text",
+                required_tensors={"input_ids"},
+            )
+
+    def test_streaming_rejects_offline_storage_contract(self):
+        with self.assertRaisesRegex(ValueError, "cannot define storage"):
+            FeatureContract(
+                mode="streaming",
+                modality="text",
+                required_tensors={"input_ids"},
+                storage=OfflineStorageContract(
+                    format="manifest_v1",
+                    required_tensors={"input_ids"},
+                    normalizer="text_v1",
+                ),
+            )
+
+    def test_contracts_are_immutable(self):
+        spec = _spec()
+
+        with self.assertRaises(FrozenInstanceError):
+            spec.name = "dflash"
+
+    def test_draft_requirement_accepts_flexible_layout_override(self):
+        requirement = _spec().draft
+
+        self.assertIn("attention_layout", requirement.supported_overrides)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_algorithms/test_eagle3_position_ids.py
+++ b/tests/test_algorithms/test_eagle3_position_ids.py
@@ -1,0 +1,86 @@
+"""Generic position-ID contracts for the EAGLE3 training model."""
+
+import importlib.util
+import inspect
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import torch
+
+_loss_module = types.ModuleType("specforge.core.loss")
+_loss_module.LogSoftmaxLoss = object
+_model_spec = importlib.util.spec_from_file_location(
+    "test_eagle3_position_model",
+    Path(__file__).resolve().parents[2]
+    / "specforge"
+    / "algorithms"
+    / "eagle3"
+    / "model.py",
+)
+assert _model_spec is not None and _model_spec.loader is not None
+_model_module = importlib.util.module_from_spec(_model_spec)
+_missing = object()
+_previous_loss_module = sys.modules.get("specforge.core.loss", _missing)
+sys.modules["specforge.core.loss"] = _loss_module
+try:
+    _model_spec.loader.exec_module(_model_module)
+finally:
+    if _previous_loss_module is _missing:
+        sys.modules.pop("specforge.core.loss", None)
+    else:
+        sys.modules["specforge.core.loss"] = _previous_loss_module
+OnlineEagle3Model = _model_module.OnlineEagle3Model
+
+
+class Eagle3PositionIdsTest(unittest.TestCase):
+    def setUp(self):
+        self.model = OnlineEagle3Model(draft_model=object(), attention_backend="sdpa")
+
+    def _prepare(self, position_ids, *, seq_length=4):
+        return self.model._prepare_position_ids(
+            position_ids,
+            seq_length=seq_length,
+            past_key_values_length=0,
+            device=torch.device("cpu"),
+        )
+
+    def test_accepts_supplied_2d_position_ids(self):
+        position_ids = torch.arange(8, dtype=torch.int32).reshape(2, 4)
+
+        prepared = self._prepare(position_ids)
+
+        self.assertEqual(prepared.shape, (2, 4))
+        self.assertEqual(prepared.dtype, torch.long)
+        self.assertTrue(torch.equal(prepared, position_ids.long()))
+
+    def test_accepts_generic_3d_position_ids(self):
+        position_ids = torch.arange(16).reshape(2, 2, 4)
+
+        prepared = self._prepare(position_ids)
+
+        self.assertEqual(prepared.shape, (2, 2, 4))
+        self.assertTrue(torch.equal(prepared, position_ids))
+
+    def test_rejects_position_ids_with_an_invalid_shape(self):
+        for position_ids in (torch.arange(4), torch.zeros(2, 3, dtype=torch.long)):
+            with self.subTest(shape=tuple(position_ids.shape)):
+                with self.assertRaisesRegex(ValueError, "position_ids"):
+                    self._prepare(position_ids)
+
+    def test_forward_surface_has_no_builtin_vlm_arguments(self):
+        parameters = inspect.signature(OnlineEagle3Model.forward).parameters
+
+        self.assertNotIn("is_vlm", parameters)
+        self.assertNotIn("image_grid_thw", parameters)
+        self.assertFalse(
+            any(
+                parameter.kind is inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters.values()
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_algorithms/test_registry.py
+++ b/tests/test_algorithms/test_registry.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+from specforge.algorithms import (
+    AlgorithmCapabilities,
+    AlgorithmRegistration,
+    AlgorithmRegistry,
+    AlgorithmSpec,
+    DraftRequirement,
+    FeatureContract,
+    FeatureMode,
+)
+
+
+@dataclass(frozen=True)
+class _Providers:
+    algorithm_name: str
+
+
+def _registration(name: str) -> AlgorithmRegistration:
+    return AlgorithmRegistration(
+        spec=AlgorithmSpec(
+            name=name,
+            draft=DraftRequirement(
+                compatible_architectures={f"{name}-draft"},
+                default_architecture=f"{name}-draft",
+            ),
+            feature_contracts=(
+                FeatureContract(
+                    mode=FeatureMode.STREAMING,
+                    modality="text",
+                    required_tensors={"input_ids"},
+                ),
+            ),
+            capabilities=AlgorithmCapabilities(attention_backends={"sdpa"}),
+        ),
+        providers=_Providers(name),
+    )
+
+
+class AlgorithmRegistryTest(unittest.TestCase):
+    def test_registry_is_deterministic_and_instance_owned(self):
+        empty = AlgorithmRegistry()
+        registry = AlgorithmRegistry((_registration("peagle"), _registration("eagle3")))
+
+        self.assertEqual((), empty.names)
+        self.assertEqual(("eagle3", "peagle"), registry.names)
+        self.assertEqual("peagle", registry.resolve("peagle").name)
+
+    def test_with_registration_returns_new_registry(self):
+        empty = AlgorithmRegistry()
+        populated = empty.with_registration(_registration("eagle3"))
+
+        self.assertEqual((), empty.names)
+        self.assertEqual(("eagle3",), populated.names)
+
+    def test_duplicate_registration_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "duplicate algorithm"):
+            AlgorithmRegistry((_registration("eagle3"), _registration("eagle3")))
+
+    def test_provider_name_must_match_spec(self):
+        registration = _registration("eagle3")
+
+        with self.assertRaisesRegex(ValueError, "must match"):
+            AlgorithmRegistration(
+                spec=registration.spec,
+                providers=_Providers("dflash"),
+            )
+
+    def test_unknown_algorithm_lists_registered_names(self):
+        registry = AlgorithmRegistry((_registration("eagle3"),))
+
+        with self.assertRaisesRegex(
+            KeyError,
+            r"registered algorithms: \['eagle3'\]",
+        ):
+            registry.resolve("missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling/test_auto_model.py
+++ b/tests/test_modeling/test_auto_model.py
@@ -1,13 +1,14 @@
 import unittest
 
-from specforge.modeling.auto import AutoEagle3DraftModel, LlamaForCausalLMEagle3
+from specforge.modeling.auto import AutoDraftModel
+from specforge.modeling.draft.llama3_eagle import LlamaForCausalLMEagle3
 
 
 class TestAutoModelForCausalLM(unittest.TestCase):
 
     def test_automodel(self):
         """init"""
-        model = AutoEagle3DraftModel.from_pretrained(
+        model = AutoDraftModel.from_pretrained(
             "jamesliu1/sglang-EAGLE3-Llama-3.1-Instruct-8B"
         )
         self.assertIsInstance(model, LlamaForCausalLMEagle3)

--- a/tests/test_modeling/test_draft_registry.py
+++ b/tests/test_modeling/test_draft_registry.py
@@ -1,9 +1,8 @@
 # coding=utf-8
 """E gate: draft-architecture registry drives the auto loaders.
 
-Adding a draft architecture = a class + @register_draft; both auto loaders
-(config-from-file and model-from-config) resolve it from the registry with the
-legacy hardcoded mappings kept only as fallback.
+Adding a draft architecture means adding a class with ``@register_draft``; both
+auto loaders resolve it from that registry.
 """
 
 import json
@@ -13,7 +12,7 @@ import unittest
 
 from transformers import LlamaConfig, Qwen3Config
 
-from specforge.modeling.auto import AutoDraftModelConfig, AutoEagle3DraftModel
+from specforge.modeling.auto import AutoDraftModel, AutoDraftModelConfig
 from specforge.modeling.draft import (
     DRAFT_REGISTRY,
     DFlashDraftModel,
@@ -67,11 +66,6 @@ TINY_DSPARK = {
     },
 }
 
-TINY_LEGACY_DSPARK = {
-    **TINY_DSPARK,
-    "architectures": ["DFlashDraftModel"],
-}
-
 TINY_DOMINO = {
     **TINY_DFLASH,
     "architectures": ["DominoDraftModel"],
@@ -83,11 +77,6 @@ TINY_DOMINO = {
         "pure_draft_prefix_len": 0,
         "shift_label": False,
     },
-}
-
-TINY_LEGACY_DOMINO = {
-    **TINY_DOMINO,
-    "architectures": ["DFlashDraftModel"],
 }
 
 
@@ -158,38 +147,18 @@ class AutoLoaderRegistryTest(unittest.TestCase):
         path = _write(TINY_DSPARK)
         self.addCleanup(os.unlink, path)
         config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
+        model = AutoDraftModel.from_config(config)
         self.assertIsInstance(model, DSparkDraftModel)
         self.assertIsInstance(model, DFlashDraftModel)
         self.assertEqual(model.projector_type, "dspark")
         self.assertIsNotNone(model.markov_head)
         self.assertIsNotNone(model.confidence_head)
 
-    def test_from_config_maps_legacy_dspark_projector_to_explicit_draft(self):
-        path = _write(TINY_LEGACY_DSPARK)
-        self.addCleanup(os.unlink, path)
-        config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
-        self.assertIsInstance(model, DSparkDraftModel)
-        self.assertIsInstance(model, DFlashDraftModel)
-        self.assertEqual(model.projector_type, "dspark")
-        self.assertIsNotNone(model.markov_head)
-
-    def test_from_config_maps_legacy_domino_projector_to_explicit_draft(self):
-        path = _write(TINY_LEGACY_DOMINO)
-        self.addCleanup(os.unlink, path)
-        config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
-        self.assertIsInstance(model, DominoDraftModel)
-        self.assertIsInstance(model, DFlashDraftModel)
-        self.assertEqual(model.projector_type, "domino")
-        self.assertIsNotNone(model.prefix_gru)
-
     def test_from_config_builds_domino_as_explicit_draft(self):
         path = _write(TINY_DOMINO)
         self.addCleanup(os.unlink, path)
         config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
+        model = AutoDraftModel.from_config(config)
         self.assertIsInstance(model, DominoDraftModel)
         self.assertIsInstance(model, DFlashDraftModel)
         self.assertEqual(model.projector_type, "domino")
@@ -200,7 +169,7 @@ class AutoLoaderRegistryTest(unittest.TestCase):
         path = _write(TINY_DOMINO)
         self.addCleanup(os.unlink, path)
         config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
+        model = AutoDraftModel.from_config(config)
         keys = set(model.state_dict())
         self.assertTrue(any(key.startswith("prefix_gru.") for key in keys))
         self.assertTrue(any(key.startswith("embed_proj.") for key in keys))
@@ -210,7 +179,7 @@ class AutoLoaderRegistryTest(unittest.TestCase):
         path = _write(TINY_DSPARK)
         self.addCleanup(os.unlink, path)
         config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
+        model = AutoDraftModel.from_config(config)
         keys = set(model.state_dict())
         self.assertTrue(any(key.startswith("markov_head.") for key in keys))
         self.assertTrue(any(key.startswith("confidence_head.") for key in keys))
@@ -227,7 +196,7 @@ class AutoLoaderRegistryTest(unittest.TestCase):
         path = _write(TINY_EAGLE3)
         self.addCleanup(os.unlink, path)
         config = AutoDraftModelConfig.from_file(path)
-        model = AutoEagle3DraftModel.from_config(config)
+        model = AutoDraftModel.from_config(config)
         self.assertIsInstance(model, LlamaForCausalLMEagle3)
 
 

--- a/tests/test_runtime/test_flow_control.py
+++ b/tests/test_runtime/test_flow_control.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Canonical producer flow-control policy (CPU-only)."""
+
+import unittest
+
+from specforge.runtime.control_plane.flow_control import (
+    FlowControlLimits,
+    ProducerFlowControl,
+)
+
+
+class FlowControlTest(unittest.TestCase):
+    def test_reference_and_byte_hysteresis_share_one_pause_latch(self):
+        policy = ProducerFlowControl(
+            FlowControlLimits(
+                high_watermark_refs=10,
+                low_watermark_refs=4,
+                high_watermark_bytes=100,
+                low_watermark_bytes=40,
+            )
+        )
+        self.assertFalse(policy.should_pause(in_flight_refs=9, resident_bytes=99))
+        self.assertTrue(policy.should_pause(in_flight_refs=10, resident_bytes=20))
+        self.assertTrue(policy.should_pause(in_flight_refs=5, resident_bytes=20))
+        self.assertFalse(policy.should_pause(in_flight_refs=4, resident_bytes=40))
+        self.assertTrue(policy.should_pause(in_flight_refs=1, resident_bytes=100))
+        self.assertTrue(policy.should_pause(in_flight_refs=1, resident_bytes=50))
+        self.assertFalse(policy.should_pause(in_flight_refs=1, resident_bytes=40))
+
+        snapshot = policy.snapshot(in_flight_refs=1, resident_bytes=40)
+        self.assertEqual(snapshot["pause_transitions"], 2)
+        self.assertEqual(snapshot["resume_transitions"], 2)
+        self.assertGreater(snapshot["wait_checks"], 0)
+
+    def test_prompt_lease_is_capped_per_worker(self):
+        policy = ProducerFlowControl(FlowControlLimits(max_prompt_lease_per_worker=3))
+        self.assertEqual(policy.prompt_lease(8), 3)
+        self.assertEqual(policy.prompt_lease(2), 2)
+
+    def test_invalid_watermarks_are_rejected(self):
+        with self.assertRaises(ValueError):
+            FlowControlLimits(high_watermark_refs=4, low_watermark_refs=5)
+        with self.assertRaises(ValueError):
+            FlowControlLimits(low_watermark_bytes=10)
+        with self.assertRaises(ValueError):
+            FlowControlLimits(
+                high_watermark_bytes=10,
+                low_watermark_bytes=11,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Part **P05/14** of the review stack replacing monolithic #678.

## Review this layer

**Primary decision:** do the EAGLE3, DFlash, Domino, DSpark, and P-EAGLE providers preserve legacy behavior while establishing clean ownership?

- Logical parent: [#685](https://github.com/sgl-project/SpecForge/pull/685) at `dec4e10`
- Incremental diff: [P05 only](https://github.com/maocheng23/SpecForge/compare/agent/pr678-p04-algorithm-contracts...agent/pr678-p05-algorithm-providers)
- Commit: `9714702`
- Review order: after #685

## What changes

- Adds executable builtin providers, shared data/model implementations, draft loading, warm start, and resume metadata.
- Keeps existing core paths authoritative during this additive phase.
- Uses one documented stack-only `AutoDraftModel` compatibility alias; later cutover removes it and the final tree contains none.

## Validation

- `50 passed`
- `55 subtests passed`

- GitHub Actions lint: passed after the lint-clean restack.

## Review note

Review provider/legacy parity, resume fingerprints, lazy import isolation, and strategy-specific capture layers.

> This draft temporarily targets `main` because the logical parent ref lives in the fork. GitHub's Files tab is therefore cumulative; review the incremental link above. Mark this PR ready only after its parent lands/it is retargeted. Final tip `4d9b08a` is tree-identical to corrected #678 head `3c89ddc`.