### PR TITLE
rocm: EAGLE3 support (lazy yunchang + graceful fa/usp errors + example)

### DIFF
--- a/examples/run_qwen3_8b_eagle3_online_rocm.sh
+++ b/examples/run_qwen3_8b_eagle3_online_rocm.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# EAGLE3 online training for Qwen3-8B on AMD GPU (ROCm).
+#
+# ROCm-safe baseline: HF target backend + flex_attention, single GPU / data parallel.
+# The `fa` / `usp` attention backends and yunchang sequence parallel are not available
+# on ROCm (they require a CUDA flash-attn build); see docs/get_started/installation.md.
+#
+# Override the model / data paths via environment variables if needed:
+#   TARGET_MODEL_PATH  Target model (default: Qwen/Qwen3-8B)
+#   TRAIN_DATA_PATH    Training jsonl (default: cache/dataset/sharegpt_train.jsonl)
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+
+NUM_GPUS=${1:-1}
+ATTENTION_BACKEND=${2:-flex_attention}
+TARGET_MODEL_PATH=${TARGET_MODEL_PATH:-Qwen/Qwen3-8B}
+TRAIN_DATA_PATH=${TRAIN_DATA_PATH:-$ROOT_DIR/cache/dataset/sharegpt_train.jsonl}
+
+python -m torch.distributed.run \
+    --standalone \
+    --nproc_per_node "$NUM_GPUS" \
+    "$ROOT_DIR/scripts/train_eagle3.py" \
+    --target-model-path "$TARGET_MODEL_PATH" \
+    --draft-model-config "$ROOT_DIR/configs/qwen3-8b-eagle3.json" \
+    --train-data-path "$TRAIN_DATA_PATH" \
+    --output-dir "$ROOT_DIR/outputs/qwen3-8b-eagle3-rocm" \
+    --num-epochs 10 \
+    --batch-size 1 \
+    --learning-rate 1e-4 \
+    --max-length 4096 \
+    --chat-template qwen \
+    --cache-dir "$ROOT_DIR/cache" \
+    --embedding-key model.embed_tokens.weight \
+    --tp-size 1 \
+    --attention-backend "$ATTENTION_BACKEND" \
+    --target-model-backend hf \
+    --report-to tensorboard

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -368,7 +368,7 @@ new file mode 100644
 index 000000000..d317b2801
 --- /dev/null
 +++ b/python/sglang/srt/spec_capture_sink.py
-@@ -0,0 +1,231 @@
+@@ -0,0 +1,237 @@
 +# Copyright 2024 SGLang Team
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -473,7 +473,13 @@ index 000000000..d317b2801
 +            # before the trainer consumes it.
 +            cfg = ReplicateConfig()
 +            cfg.replica_num = 1
-+            cfg.with_hard_pin = True
++            # `with_hard_pin` exists only on newer Mooncake builds; older ROCm
++            # sglang images expose only `with_soft_pin`. Map the hard-pin intent
++            # onto whatever the installed build supports.
++            if hasattr(cfg, "with_hard_pin"):
++                cfg.with_hard_pin = True
++            elif hasattr(cfg, "with_soft_pin"):
++                cfg.with_soft_pin = True
 +            self._put_config = cfg
 +            self._store = store
 +            logger.info("spec-capture mooncake sink connected")

--- a/specforge/modeling/draft/llama3_eagle.py
+++ b/specforge/modeling/draft/llama3_eagle.py
@@ -10,7 +10,6 @@ from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache
 from transformers.models.llama.configuration_llama import LlamaConfig
-from yunchang.comm import SeqAllToAll4D
 
 from specforge.modeling.draft.flex_attention import (
     compile_friendly_create_block_mask,
@@ -1346,6 +1345,18 @@ class LlamaUSPFlashAttention(LlamaAttention):
         assert (
             dist.is_initialized()
         ), f"LlamaUSPAttention requires torch.distributed; call init_distributed first."
+        # yunchang depends on CUDA flash-attn; import it lazily so this only fails when
+        # the `usp` attention backend is actually selected, not on every draft-model
+        # import (e.g. on ROCm, where yunchang is unavailable).
+        try:
+            from yunchang.comm import SeqAllToAll4D
+        except ImportError as e:
+            raise ImportError(
+                "The `usp` attention backend requires `yunchang` (which depends on CUDA "
+                "flash-attn) and is not available on this platform. Use `sdpa` or "
+                "`flex_attention` instead, e.g. on ROCm."
+            ) from e
+        self._SeqAllToAll4D = SeqAllToAll4D
         if isinstance(self.rotary_emb, LlamaMutiRotaryEmbedding):
             raise NotImplementedError(
                 f"LlamaMutiRotaryEmbedding is currently not supported for LlamaUSPFlashAttention."
@@ -1379,7 +1390,7 @@ class LlamaUSPFlashAttention(LlamaAttention):
         # =============================================================
         query_states = self.q_proj(hidden_states)
         query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim)
-        query_states = SeqAllToAll4D.apply(
+        query_states = self._SeqAllToAll4D.apply(
             self.ulysses_pg,
             query_states,
             self.scatter_idx,
@@ -1391,7 +1402,7 @@ class LlamaUSPFlashAttention(LlamaAttention):
         key_states = key_states.view(
             bsz, q_len, self.num_key_value_heads, self.head_dim
         )
-        key_states = SeqAllToAll4D.apply(
+        key_states = self._SeqAllToAll4D.apply(
             self.ulysses_pg,
             key_states,
             self.scatter_idx,
@@ -1403,7 +1414,7 @@ class LlamaUSPFlashAttention(LlamaAttention):
         value_states = value_states.view(
             bsz, q_len, self.num_key_value_heads, self.head_dim
         )
-        value_states = SeqAllToAll4D.apply(
+        value_states = self._SeqAllToAll4D.apply(
             self.ulysses_pg,
             value_states,
             self.scatter_idx,
@@ -1463,7 +1474,7 @@ class LlamaUSPFlashAttention(LlamaAttention):
         # =============================================================
         # 4. Ulysses Gather & Output Projection
         # =============================================================
-        attn_output = SeqAllToAll4D.apply(
+        attn_output = self._SeqAllToAll4D.apply(
             self.ulysses_pg,
             attn_output,
             self.gather_idx,  # Scatter idx: 1 (Seq)
@@ -1553,6 +1564,12 @@ class LlamaDecoderLayer(nn.Module):
             print_with_rank("Using flex attention on draft model training!")
             self.self_attn = LlamaFlexAttention(config=config)
         elif attention_backend == "fa":
+            if _std_flash_attn_import_error is not None:
+                raise ImportError(
+                    "The `fa` attention backend requires `flash_attn`, which is not "
+                    "installed (or failed to import). Install a flash-attn build for "
+                    "your platform, or use `sdpa` / `flex_attention` (e.g. on ROCm)."
+                ) from _std_flash_attn_import_error
             self.self_attn = LlamaFlashAttention(config=config)
         elif attention_backend == "usp":
             self.self_attn = LlamaUSPFlashAttention(config=config)


### PR DESCRIPTION
## Summary

Adds **EAGLE3** support on AMD ROCm. Part of the ROCm enablement series; stacks on
the foundation PR (#698).

- `specforge/modeling/draft/llama3_eagle.py` imported `yunchang.comm.SeqAllToAll4D`
  at module top. `yunchang` depends on a CUDA flash-attn build, so this crashed
  `import specforge` on ROCm even for the default `sdpa` / `flex_attention` path
  (this module is imported unconditionally by the package). It is now imported
  **lazily** inside `LlamaUSPFlashAttention.__init__`, so it's only needed when the
  `usp` backend is actually selected.
- The `fa` and `usp` attention backends now raise a **clear, actionable error** when
  their CUDA deps are missing, instead of crashing at import time or deep in the
  forward pass.
- New ROCm EAGLE3 example (`examples/run_qwen3_8b_eagle3_online_rocm.sh`): HF target
  backend + `flex_attention`, single GPU — the ROCm-safe baseline.

Out of scope (documented, graceful errors): `fa` / `usp` flash-attn and yunchang
Ulysses/Ring sequence parallel — these need a CUDA flash-attn build.

## Test plan

- [x] `python -m py_compile specforge/modeling/draft/llama3_eagle.py`
- [x] EAGLE3 online training smoke on MI355X (gfx950): Qwen3-8B target, HF backend,
      `flex_attention`, finite loss + checkpoint written
- [ ] Reviewer: CUDA regression — `usp` backend still constructs and trains with yunchang

> Depends on #698 (foundation). Full `import specforge` on ROCm needs both.