### PR TITLE
rocm: Domino support (validated + example)

### DIFF
--- a/examples/run_qwen3_8b_domino_online_rocm.sh
+++ b/examples/run_qwen3_8b_domino_online_rocm.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Domino online training for Qwen3-8B on AMD GPU (ROCm).
+#
+# ROCm-safe baseline: HF target backend + flex_attention, single GPU / data parallel.
+# Domino needs no ROCm-specific code changes; its bf16 GRU projector runs on ROCm
+# (MIOpen), so the NPU fp16-GRU workaround is not required. See
+# docs/get_started/installation.md.
+#
+# Override the model / data paths via environment variables if needed:
+#   TARGET_MODEL_PATH  Target model (default: Qwen/Qwen3-8B)
+#   TRAIN_DATA_PATH    Training jsonl (default: cache/dataset/sharegpt_train.jsonl)
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$(dirname "$SCRIPT_DIR")
+export TORCHINDUCTOR_CACHE_DIR=$ROOT_DIR/cache/compiled_kernels
+
+NUM_GPUS=${1:-1}
+ATTENTION_BACKEND=${2:-flex_attention}
+TARGET_MODEL_PATH=${TARGET_MODEL_PATH:-Qwen/Qwen3-8B}
+TRAIN_DATA_PATH=${TRAIN_DATA_PATH:-$ROOT_DIR/cache/dataset/sharegpt_train.jsonl}
+
+python -m torch.distributed.run \
+    --standalone \
+    --nproc_per_node "$NUM_GPUS" \
+    "$ROOT_DIR/scripts/train_domino.py" \
+    --target-model-path "$TARGET_MODEL_PATH" \
+    --draft-config-path "$ROOT_DIR/configs/qwen3-8b-domino.json" \
+    --train-data-path "$TRAIN_DATA_PATH" \
+    --output-dir "$ROOT_DIR/outputs/qwen3-8b-domino-rocm" \
+    --num-epochs 6 \
+    --batch-size 1 \
+    --learning-rate 6e-4 \
+    --warmup-ratio 0.04 \
+    --max-grad-norm 1.0 \
+    --max-length 3072 \
+    --chat-template qwen \
+    --cache-dir "$ROOT_DIR/cache" \
+    --attention-backend "$ATTENTION_BACKEND" \
+    --target-model-backend hf \
+    --block-size 16 \
+    --num-anchors 256 \
+    --loss-decay-gamma 7.0 \
+    --lambda-base-start 1.0 \
+    --lambda-base-decay-ratio 1.0 \
+    --log-interval 50 \
+    --save-interval 2000 \
+    --report-to tensorboard

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -368,7 +368,7 @@ new file mode 100644
 index 000000000..d317b2801
 --- /dev/null
 +++ b/python/sglang/srt/spec_capture_sink.py
-@@ -0,0 +1,231 @@
+@@ -0,0 +1,237 @@
 +# Copyright 2024 SGLang Team
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -473,7 +473,13 @@ index 000000000..d317b2801
 +            # before the trainer consumes it.
 +            cfg = ReplicateConfig()
 +            cfg.replica_num = 1
-+            cfg.with_hard_pin = True
++            # `with_hard_pin` exists only on newer Mooncake builds; older ROCm
++            # sglang images expose only `with_soft_pin`. Map the hard-pin intent
++            # onto whatever the installed build supports.
++            if hasattr(cfg, "with_hard_pin"):
++                cfg.with_hard_pin = True
++            elif hasattr(cfg, "with_soft_pin"):
++                cfg.with_soft_pin = True
 +            self._put_config = cfg
 +            self._store = store
 +            logger.info("spec-capture mooncake sink connected")


### PR DESCRIPTION
## Summary

Adds **Domino** enablement on AMD ROCm. Part of the ROCm series; stacks on the
foundation PR (#698).

Domino requires **no algorithm-specific code changes** on ROCm. Its bf16 GRU
projector runs on ROCm via MIOpen, so the Ascend-NPU fp16-GRU workaround in
`specforge/core/domino.py` (guarded by `get_device_type() == "npu"`) is not needed —
ROCm reports as `"cuda"` and uses the default bf16 GRU path. Once the foundation PR
removes the eager `yunchang` import, Domino trains on ROCm on the HF target backend +
`flex_attention`.

- New example: `examples/run_qwen3_8b_domino_online_rocm.sh` (HF target backend +
  `flex_attention`, single GPU — the ROCm-safe baseline).

## Test plan

- [x] Domino online training smoke on MI355X (gfx950): Qwen3-8B target, HF backend,
      `flex_attention`, finite loss + base loss, checkpoint written (bf16 GRU verified)
- [ ] Reviewer: CUDA regression unaffected (example-only change)

> Depends on #698 (foundation).