### PR TITLE
DFlash/Domino: Add support for the FlexAttention FLASH backend

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 
 from specforge.core.chunking import checkpointed_chunk_reduce
 from specforge.modeling.draft.dflash import DFlashDraftModel
+from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
 
 try:
     from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -94,6 +95,7 @@ def create_dflash_block_mask(
     S: int,
     block_size: int,
     device: torch.device,
+    flex_block_size=None,
     sliding_window: Optional[int] = None,
 ):
     """Construct a full or sliding Flex Attention mask for DFlash training."""
@@ -128,8 +130,17 @@ def create_dflash_block_mask(
     Q_LEN = N * block_size
     KV_LEN = S + N * block_size
 
+    kwargs = {}
+    if flex_block_size is not None:
+        kwargs["BLOCK_SIZE"] = flex_block_size
     return create_block_mask(
-        dflash_mask_mod, B=B, H=None, Q_LEN=Q_LEN, KV_LEN=KV_LEN, device=device
+        dflash_mask_mod,
+        B=B,
+        H=None,
+        Q_LEN=Q_LEN,
+        KV_LEN=KV_LEN,
+        device=device,
+        **kwargs,
     )
 
 
@@ -309,6 +320,12 @@ class OnlineDFlashModel(nn.Module):
             "block_size": self.block_size,
             "device": device,
         }
+        if (
+            self.attention_backend == "flex_attention"
+            and flex_attention_backend() == "FLASH"
+        ):
+            # FLASH requires a minimum of this block size.
+            mask_args["flex_block_size"] = (256, 128)
         full_attn_mask = mask_builder(**mask_args)
         sliding_window = self.draft_model.sliding_window
         dflash_attn_mask = full_attn_mask

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -54,6 +54,9 @@ def create_dflash_sdpa_mask(
     sliding_window: Optional[int] = None,
 ):
     """Construct a full or sliding dense boolean DFlash mask."""
+
+    if sliding_window is not None and sliding_window <= 0:
+        raise ValueError("sliding_window must be > 0")
     B, N = anchor_positions.shape
     Q_LEN = N * block_size
     KV_LEN = S + N * block_size
@@ -99,6 +102,9 @@ def create_dflash_block_mask(
     sliding_window: Optional[int] = None,
 ):
     """Construct a full or sliding Flex Attention mask for DFlash training."""
+
+    if sliding_window is not None and sliding_window <= 0:
+        raise ValueError("sliding_window must be > 0")
 
     def dflash_mask_mod(b, h, q_idx, kv_idx):
         q_block_id = q_idx // block_size

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 from transformers import DynamicCache
 from transformers.cache_utils import Cache
+from transformers.integrations.flex_attention import compile_friendly_flex_attention
 from transformers.modeling_outputs import CausalLMOutputWithPast
 from transformers.models.qwen3.modeling_qwen3 import (
     ALL_ATTENTION_FUNCTIONS,
@@ -18,6 +19,7 @@ from transformers.models.qwen3.modeling_qwen3 import (
 from typing_extensions import Tuple, Unpack
 
 from .dflash_kernels import DEFAULT_DFLASH_KERNELS, DFlashKernels
+from .flex_attention_backend import flex_attention_backend
 from .registry import register_draft
 
 FULL_ATTENTION = "full_attention"
@@ -114,6 +116,10 @@ class Qwen3DFlashAttention(nn.Module):
         )
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
+        if config._attn_implementation == "flex_attention":
+            assert (
+                config.attention_dropout == 0.0
+            ), "DFlash FlexAttention requires attention_dropout=0.0"
         self.is_causal = False
         self.q_proj = nn.Linear(
             config.hidden_size,
@@ -176,27 +182,44 @@ class Qwen3DFlashAttention(nn.Module):
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
         valid_queries = None
-        attn_fn: Callable = eager_attention_forward
-        if self.config._attn_implementation == "eager":
-            attention_mask, valid_queries = _prepare_dflash_eager_mask(
-                attention_mask,
-                q.dtype,
-            )
+        if self.config._attn_implementation == "flex_attention":
+            kernel_options = dict(kwargs.pop("kernel_options", None) or {})
+            backend = flex_attention_backend()
+            if backend is not None:
+                kernel_options["BACKEND"] = backend
+
+            attn_output = compile_friendly_flex_attention(
+                q,
+                k,
+                v,
+                block_mask=attention_mask,
+                enable_gqa=True,
+                scale=self.scaling,
+                kernel_options=kernel_options or None,
+            ).transpose(1, 2)
+            attn_weights = None
         else:
-            attn_fn = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
-        attn_output, attn_weights = attn_fn(
-            self,
-            q,
-            k,
-            v,
-            attention_mask,
-            dropout=0.0 if not self.training else self.attention_dropout,
-            scaling=self.scaling,
-            sliding_window=self.sliding_window,
-            **kwargs,
-        )
-        if valid_queries is not None and attn_weights is not None:
-            attn_weights = attn_weights.masked_fill(~valid_queries, 0)
+            attn_fn: Callable = eager_attention_forward
+            if self.config._attn_implementation == "eager":
+                attention_mask, valid_queries = _prepare_dflash_eager_mask(
+                    attention_mask,
+                    q.dtype,
+                )
+            else:
+                attn_fn = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+            attn_output, attn_weights = attn_fn(
+                self,
+                q,
+                k,
+                v,
+                attention_mask,
+                dropout=0.0 if not self.training else self.attention_dropout,
+                scaling=self.scaling,
+                sliding_window=self.sliding_window,
+                **kwargs,
+            )
+            if valid_queries is not None and attn_weights is not None:
+                attn_weights = attn_weights.masked_fill(~valid_queries, 0)
         attn_output = attn_output.reshape(bsz, q_len, -1)
         attn_output = self.o_proj(attn_output)
         if valid_queries is not None:

--- a/specforge/modeling/draft/flex_attention_backend.py
+++ b/specforge/modeling/draft/flex_attention_backend.py
@@ -1,0 +1,28 @@
+"""FlexAttention backend selection shared by DFlash training components."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from specforge.torch_compat import patch_inductor_cutedsl_lowerings
+
+_VALID_BACKENDS = {"AUTO", "TRITON", "FLASH", "TRITON_DECODE"}
+_BACKEND_ENV = "SPECFORGE_FLEX_ATTENTION_BACKEND"
+
+
+def flex_attention_backend() -> Optional[str]:
+    backend = os.environ.get(_BACKEND_ENV, "").upper()
+    if not backend:
+        return None
+    if backend not in _VALID_BACKENDS:
+        raise ValueError(
+            f"{_BACKEND_ENV} must be one of {sorted(_VALID_BACKENDS)}, "
+            f"got {backend!r}"
+        )
+    if backend == "FLASH":
+        patch_inductor_cutedsl_lowerings()
+    return backend
+
+
+__all__ = ["flex_attention_backend"]

--- a/specforge/torch_compat.py
+++ b/specforge/torch_compat.py
@@ -1,0 +1,62 @@
+"""PyTorch compatibility shims used by optional fast paths."""
+
+from __future__ import annotations
+
+import importlib
+
+import sympy
+import torch
+from packaging.version import InvalidVersion, Version
+
+
+def patch_inductor_cutedsl_lowerings() -> bool:
+    """Backfill CuteDSL lowering needed by Torch 2.11 FLASH FlexAttention."""
+    try:
+        torch_version = Version(torch.__version__.split("+", 1)[0])
+    except InvalidVersion:
+        return False
+    if torch_version.major != 2 or torch_version.minor != 11:
+        return False
+
+    try:
+        module = importlib.import_module(
+            "torch._inductor.codegen.cutedsl.cutedsl_op_overrides"
+        )
+    except ImportError:
+        return False
+    from torch._inductor.utils import get_bounds_index_expr
+    from torch._inductor.virtualized import V
+
+    overrides = module.CuteDSLOpOverrides
+    if getattr(overrides, "_specforge_cutedsl_patch", False):
+        return True
+
+    def _minimum(a, b):
+        return overrides.where(overrides.lt(a, b), a, b)
+
+    def _maximum(a, b):
+        return overrides.where(overrides.gt(a, b), a, b)
+
+    def _index_expr(expr: sympy.Expr, dtype: torch.dtype):
+        if isinstance(expr, (int, sympy.Integer)):
+            return overrides.constant(int(expr), dtype)
+
+        idx_str = V.kernel.kexpr(V.kernel.rename_indexing(expr))
+        result = V.kernel.cse.generate(
+            V.kernel.body,
+            idx_str,
+            bounds=get_bounds_index_expr(expr),
+            dtype=dtype,
+        )
+        result.is_scalar_expr = True
+        result.index_expr = V.graph.sizevars.simplify(expr)
+        return result
+
+    overrides.minimum = staticmethod(_minimum)
+    overrides.maximum = staticmethod(_maximum)
+    overrides.index_expr = staticmethod(_index_expr)
+    overrides._specforge_cutedsl_patch = True
+    return True
+
+
+__all__ = ["patch_inductor_cutedsl_lowerings"]

--- a/tests/test_modeling/test_flex_attention_backend.py
+++ b/tests/test_modeling/test_flex_attention_backend.py
@@ -1,0 +1,173 @@
+import os
+import unittest
+from unittest import mock
+
+import torch
+from torch.nn.attention.flex_attention import flex_attention
+from transformers import Qwen3Config
+
+from specforge.algorithms.common.dflash_family_model import create_dflash_block_mask
+from specforge.modeling.draft.dflash import Qwen3DFlashAttention
+from specforge.modeling.draft.dflash_kernels import DEFAULT_DFLASH_KERNELS
+from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
+
+
+class FlexAttentionBackendTest(unittest.TestCase):
+    # This correctness regression test can be deleted when we require
+    # torch>=2.13; it tests the Torch 2.11 Inductor monkeypatch for CuteDSL
+    # operations in patch_inductor_cutedsl_lowerings().
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10,
+        "FLASH FlexAttention correctness requires a Blackwell CUDA device",
+    )
+    def test_flash_matches_triton_forward_and_backward(self):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        batch_size, num_query_heads, num_key_value_heads = 1, 3, 1
+        context_len, head_dim = 256, 64
+        num_blocks, draft_block_size = 4, 64
+        query_len = num_blocks * draft_block_size
+        kv_len = context_len + query_len
+        anchors = torch.tensor([[64, 128, 192, 224]], device=device)
+        keep_blocks = torch.ones(
+            (batch_size, num_blocks), dtype=torch.bool, device=device
+        )
+
+        inputs = (
+            torch.randn(
+                batch_size,
+                num_query_heads,
+                query_len,
+                head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+            torch.randn(
+                batch_size,
+                num_key_value_heads,
+                kv_len,
+                head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+            torch.randn(
+                batch_size,
+                num_key_value_heads,
+                kv_len,
+                head_dim,
+                device=device,
+                dtype=dtype,
+            ),
+        )
+
+        def run_backend(backend, flex_block_size=None):
+            block_mask = create_dflash_block_mask(
+                anchor_positions=anchors,
+                block_keep_mask=keep_blocks,
+                S=context_len,
+                block_size=draft_block_size,
+                device=device,
+                flex_block_size=flex_block_size,
+            )
+
+            compiled_attention = torch.compile(
+                lambda query, key, value, mask: flex_attention(
+                    query,
+                    key,
+                    value,
+                    block_mask=mask,
+                    enable_gqa=True,
+                    kernel_options={"BACKEND": backend},
+                ),
+                fullgraph=True,
+            )
+
+            query, key, value = [
+                tensor.detach().clone().requires_grad_(True) for tensor in inputs
+            ]
+            output = compiled_attention(query, key, value, block_mask)
+            output.float().square().mean().backward()
+            torch.cuda.synchronize()
+            return output.detach(), tuple(
+                tensor.grad.detach() for tensor in (query, key, value)
+            )
+
+        triton_output, triton_grads = run_backend("TRITON")
+        with mock.patch.dict(os.environ, {"SPECFORGE_FLEX_ATTENTION_BACKEND": "FLASH"}):
+            self.assertEqual(flex_attention_backend(), "FLASH")
+            flash_output, flash_grads = run_backend("FLASH", (256, 128))
+
+        self.assertTrue(torch.isfinite(flash_output).all())
+        torch.testing.assert_close(flash_output, triton_output, atol=3e-3, rtol=2e-2)
+        for flash_grad, triton_grad in zip(flash_grads, triton_grads):
+            self.assertTrue(torch.isfinite(flash_grad).all())
+            torch.testing.assert_close(flash_grad, triton_grad, atol=5e-6, rtol=2e-2)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10,
+        "FLASH FlexAttention correctness requires a Blackwell CUDA device",
+    )
+    def test_dflash_flash_attention_forward_backward_smoke(self):
+        config = Qwen3Config(
+            hidden_size=256,
+            intermediate_size=512,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=1,
+            head_dim=64,
+            layer_types=["full_attention"],
+            attention_dropout=0.0,
+        )
+        config._attn_implementation = "flex_attention"
+        attention = Qwen3DFlashAttention(
+            config,
+            layer_idx=0,
+            kernels=DEFAULT_DFLASH_KERNELS,
+        ).to(device="cuda", dtype=torch.bfloat16)
+        hidden_states = torch.randn(
+            1,
+            256,
+            config.hidden_size,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        target_hidden = torch.randn(
+            1,
+            256,
+            config.hidden_size,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=True,
+        )
+        block_mask = create_dflash_block_mask(
+            anchor_positions=torch.tensor([[64, 128, 192, 224]], device="cuda"),
+            block_keep_mask=torch.ones(1, 4, dtype=torch.bool, device="cuda"),
+            S=256,
+            block_size=64,
+            device=torch.device("cuda"),
+            flex_block_size=(256, 128),
+        )
+        cos = torch.ones(1, 512, config.head_dim, device="cuda", dtype=torch.bfloat16)
+        sin = torch.zeros_like(cos)
+
+        with mock.patch.dict(os.environ, {"SPECFORGE_FLEX_ATTENTION_BACKEND": "FLASH"}):
+            output, weights = attention(
+                hidden_states=hidden_states,
+                target_hidden=target_hidden,
+                position_embeddings=(cos, sin),
+                attention_mask=block_mask,
+            )
+            output.float().square().mean().backward()
+            torch.cuda.synchronize()
+
+        self.assertIsNone(weights)
+        self.assertIsNotNone(hidden_states.grad)
+        self.assertIsNotNone(target_hidden.grad)
+        self.assertTrue(torch.isfinite(hidden_states.grad).all())
+        self.assertTrue(torch.isfinite(target_hidden.grad).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling/test_flex_attention_backend.py
+++ b/tests/test_modeling/test_flex_attention_backend.py
@@ -6,13 +6,155 @@ import torch
 from torch.nn.attention.flex_attention import flex_attention
 from transformers import Qwen3Config
 
-from specforge.algorithms.common.dflash_family_model import create_dflash_block_mask
-from specforge.modeling.draft.dflash import Qwen3DFlashAttention
+from specforge.algorithms.common.dflash_family_model import (
+    create_dflash_block_mask,
+    create_dflash_sdpa_mask,
+)
+from specforge.modeling.draft.dflash import DFlashDraftModel, Qwen3DFlashAttention
 from specforge.modeling.draft.dflash_kernels import DEFAULT_DFLASH_KERNELS
 from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
 
 
 class FlexAttentionBackendTest(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "FlexAttention requires CUDA")
+    def test_sliding_block_mask_matches_sdpa(self):
+        torch.manual_seed(0)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        context_len, draft_block_size = 16, 4
+        anchors = torch.tensor([[8, 12]], device=device)
+        keep_blocks = torch.ones(1, 2, dtype=torch.bool, device=device)
+        query_len = anchors.shape[1] * draft_block_size
+        kv_len = context_len + query_len
+        query = torch.randn(1, 2, query_len, 64, device=device, dtype=dtype)
+        key = torch.randn(1, 2, kv_len, 64, device=device, dtype=dtype)
+        value = torch.randn(1, 2, kv_len, 64, device=device, dtype=dtype)
+
+        block_mask = create_dflash_block_mask(
+            anchor_positions=anchors,
+            block_keep_mask=keep_blocks,
+            S=context_len,
+            block_size=draft_block_size,
+            device=device,
+            sliding_window=8,
+        )
+        dense_mask = create_dflash_sdpa_mask(
+            anchor_positions=anchors,
+            block_keep_mask=keep_blocks,
+            S=context_len,
+            block_size=draft_block_size,
+            device=device,
+            sliding_window=8,
+        )
+        compiled_attention = torch.compile(
+            lambda q, k, v, mask: flex_attention(
+                q,
+                k,
+                v,
+                block_mask=mask,
+            ),
+            fullgraph=True,
+        )
+
+        flex_output = compiled_attention(query, key, value, block_mask)
+        sdpa_output = torch.nn.functional.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=dense_mask,
+        )
+        torch.testing.assert_close(
+            flex_output,
+            sdpa_output,
+            atol=3e-3,
+            rtol=2e-2,
+        )
+
+    def test_mixed_layer_types_select_their_own_masks(self):
+        config = Qwen3Config(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            num_hidden_layers=2,
+            num_target_layers=4,
+            head_dim=8,
+            layer_types=["sliding_attention", "full_attention"],
+            use_sliding_window=True,
+            sliding_window=8,
+            attention_dropout=0.0,
+            block_size=2,
+            dflash_config={"target_layer_ids": [1, 2]},
+        )
+        config._attn_implementation = "eager"
+        model = DFlashDraftModel(config)
+        sliding_mask = torch.ones(1, 1, 2, 5, dtype=torch.bool)
+        full_mask = torch.ones(1, 1, 2, 5, dtype=torch.bool)
+
+        for layer in model.layers:
+            layer.self_attn.forward = mock.Mock(
+                side_effect=lambda hidden_states, **kwargs: (hidden_states, None)
+            )
+
+        model(
+            position_ids=torch.arange(5).unsqueeze(0),
+            noise_embedding=torch.randn(1, 2, config.hidden_size),
+            target_hidden=torch.randn(1, 3, 2 * config.hidden_size),
+            attention_mask={
+                "sliding_attention": sliding_mask,
+                "full_attention": full_mask,
+            },
+        )
+
+        self.assertIs(
+            model.layers[0].self_attn.forward.call_args.kwargs["attention_mask"],
+            sliding_mask,
+        )
+        self.assertIs(
+            model.layers[1].self_attn.forward.call_args.kwargs["attention_mask"],
+            full_mask,
+        )
+
+    def test_eager_converts_boolean_mask_to_additive_mask(self):
+        config = Qwen3Config(
+            hidden_size=8,
+            intermediate_size=16,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+            num_hidden_layers=1,
+            head_dim=8,
+            layer_types=["sliding_attention"],
+            sliding_window=8,
+            attention_dropout=0.0,
+        )
+        config._attn_implementation = "eager"
+        attention = Qwen3DFlashAttention(
+            config,
+            layer_idx=0,
+            kernels=DEFAULT_DFLASH_KERNELS,
+        )
+        boolean_mask = torch.tensor([[[[True, False]]]])
+        cos = torch.ones(1, 2, config.head_dim)
+        sin = torch.zeros_like(cos)
+
+        with mock.patch(
+            "specforge.modeling.draft.dflash.eager_attention_forward",
+            return_value=(torch.zeros(1, 1, 1, config.head_dim), None),
+        ) as eager:
+            attention(
+                hidden_states=torch.randn(1, 1, config.hidden_size),
+                target_hidden=torch.randn(1, 1, config.hidden_size),
+                position_embeddings=(cos, sin),
+                attention_mask=boolean_mask,
+            )
+
+        additive_mask = eager.call_args.args[4]
+        self.assertEqual(additive_mask[0, 0, 0, 0].item(), 0.0)
+        self.assertEqual(
+            additive_mask[0, 0, 0, 1].item(),
+            torch.finfo(additive_mask.dtype).min,
+        )
+
     # This correctness regression test can be deleted when we require
     # torch>=2.13; it tests the Torch 2.11 Inductor monkeypatch for CuteDSL
     # operations in patch_inductor_cutedsl_lowerings().
@@ -69,6 +211,7 @@ class FlexAttentionBackendTest(unittest.TestCase):
                 block_size=draft_block_size,
                 device=device,
                 flex_block_size=flex_block_size,
+                sliding_window=128,
             )
 
             compiled_attention = torch.compile(

--- a/tests/test_utils/test_dflash_mask.py
+++ b/tests/test_utils/test_dflash_mask.py
@@ -1,8 +1,14 @@
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import torch
+from torch import nn
 
 from specforge.algorithms.common.dflash_family_model import (
+    OnlineDFlashModel,
+    OnlineDominoModel,
+    OnlineDSparkModel,
     create_dflash_block_mask,
     create_dflash_sdpa_mask,
 )
@@ -28,6 +34,7 @@ def _reference_dflash_mask(
     for b in range(B):
         for q_idx in range(Q_LEN):
             q_block_id = q_idx // block_size
+            q_offset = q_idx % block_size
             anchor_pos = anchor_positions[b, q_block_id].item()
             is_valid = block_keep_mask[b, q_block_id].item()
             if not is_valid:
@@ -51,6 +58,21 @@ def _reference_dflash_mask(
                 if ctx_visible or draft_visible:
                     mask[b, 0, q_idx, kv_idx] = True
     return mask
+
+
+class _RecordingDraftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(
+            layer_types=["sliding_attention", "full_attention"],
+            sliding_window=8,
+        )
+        self.sliding_window = 8
+        self.attention_mask = None
+
+    def forward(self, noise_embedding, attention_mask, **kwargs):
+        self.attention_mask = attention_mask
+        return noise_embedding
 
 
 class TestDFlashMask(unittest.TestCase):
@@ -108,6 +130,7 @@ class TestDFlashMask(unittest.TestCase):
         block_keep_mask,
         S,
         block_size,
+        sliding_window=None,
     ):
         """Verify create_dflash_block_mask block-level mask is consistent with reference."""
         anchor_positions = anchor_positions.to(self.device)
@@ -119,6 +142,7 @@ class TestDFlashMask(unittest.TestCase):
             S=S,
             block_size=block_size,
             device=self.device,
+            sliding_window=sliding_window,
         )
 
         ref_mask = _reference_dflash_mask(
@@ -127,6 +151,7 @@ class TestDFlashMask(unittest.TestCase):
             S=S,
             block_size=block_size,
             device=self.device,
+            sliding_window=sliding_window,
         )
 
         dense_blocks = block_mask.to_dense()  # (B, H, Q_blocks, KV_blocks)
@@ -241,6 +266,62 @@ class TestDFlashMask(unittest.TestCase):
             block_size=3,
             sliding_window=1,
         )
+
+    def test_sliding_window_block_mask_consistency(self):
+        anchor_positions = torch.tensor([[12, 24]])
+        block_keep_mask = torch.tensor([[True, True]])
+        self._compare_block_mask_consistency(
+            anchor_positions,
+            block_keep_mask,
+            S=32,
+            block_size=4,
+            sliding_window=8,
+        )
+
+    def test_invalid_sliding_window(self):
+        anchor_positions = torch.tensor([[12]], device=self.device)
+        block_keep_mask = torch.tensor([[True]], device=self.device)
+        for factory in (create_dflash_sdpa_mask, create_dflash_block_mask):
+            with self.subTest(factory=factory.__name__):
+                with self.assertRaisesRegex(ValueError, "sliding_window must be > 0"):
+                    factory(
+                        anchor_positions=anchor_positions,
+                        block_keep_mask=block_keep_mask,
+                        S=16,
+                        block_size=4,
+                        device=self.device,
+                        sliding_window=0,
+                    )
+
+    def test_all_dflash_families_build_mixed_layer_masks(self):
+        anchors = torch.tensor([[12]], device=self.device)
+        keep = torch.tensor([[True]], device=self.device)
+        for model_class in (OnlineDFlashModel, OnlineDominoModel, OnlineDSparkModel):
+            with self.subTest(model_class=model_class.__name__):
+                draft_model = _RecordingDraftModel().to(self.device)
+                model = model_class(
+                    draft_model=draft_model,
+                    target_lm_head=nn.Identity(),
+                    target_embed_tokens=nn.Embedding(32, 8).to(self.device),
+                    mask_token_id=31,
+                    block_size=4,
+                    attention_backend="sdpa",
+                )
+                with mock.patch.object(
+                    model,
+                    "_sample_anchor_positions",
+                    return_value=(anchors, keep),
+                ):
+                    model._forward_draft_blocks(
+                        input_ids=torch.arange(16, device=self.device).unsqueeze(0),
+                        hidden_states=torch.randn(1, 16, 8, device=self.device),
+                        loss_mask=torch.ones(1, 16, device=self.device),
+                    )
+
+                masks = draft_model.attention_mask
+                self.assertEqual(set(masks), {"full_attention", "sliding_attention"})
+                self.assertTrue(masks["full_attention"][0, 0, 0, 0].item())
+                self.assertFalse(masks["sliding_attention"][0, 0, 0, 0].item())
 
     def test_mixed_validity_multi_batch(self):
         """Multi-batch with mixed block validity patterns."""


### PR DESCRIPTION
Adds an option to turn on FAv4 backend for FlexAttention (it remains off by default). This is significantly faster on Blackwell than the default backend (which is triton). We unfortunately need to monkey-patch PyTorch (in 2.11, which is what SGLang is pinned to right now). Whenever SpecForge can upgrade to PyTorch >= 2.13 then we can get rid of the monkeypatches (and also the correctness test).

This PR also cleans up the attention implementation a little.