### PR TITLE
Fuse Domino cross entropy with Triton

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """DFlash-family training models and shared masking helpers."""
 
+import os
 from typing import Dict, Optional, Tuple
 
 import torch
@@ -466,6 +467,9 @@ class OnlineDominoModel(OnlineDFlashModel):
             loss_type="dflash",
         )
         self.shift_label = shift_label
+        self._use_fused_domino_ce = (
+            os.environ.get("SPECFORGE_DOMINO_TRITON_CE", "1") == "1"
+        )
 
     def _sample_anchor_positions(
         self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
@@ -528,21 +532,6 @@ class OnlineDominoModel(OnlineDFlashModel):
 
         return hidden4d, prev_ids
 
-    def _apply_domino_head(
-        self,
-        base_logits4d: torch.Tensor,
-        hidden4d: torch.Tensor,
-        prev_ids: torch.Tensor,
-        target_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        head_token_ids = prev_ids if self.shift_label else target_ids
-        head_token_embeddings = self.embed_tokens(head_token_ids)
-        return self.draft_model.apply_logits_head(
-            base_logits4d,
-            hidden_states=hidden4d,
-            prev_token_embeddings=head_token_embeddings,
-        )
-
     def _domino_objective_chunk_terms(
         self,
         hidden: torch.Tensor,
@@ -552,34 +541,34 @@ class OnlineDominoModel(OnlineDFlashModel):
         eval_weight_mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, ...]:
         """Return additive Domino loss and telemetry terms for one block slice."""
+        from specforge.core.domino_loss import domino_weighted_cross_entropy
 
         batch_size, num_blocks, block_size, hidden_size = hidden.shape
         base_logits = self.lm_head(
             hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
         ).reshape(batch_size, num_blocks, block_size, -1)
-        final_logits = self._apply_domino_head(
-            base_logits4d=base_logits,
-            hidden4d=hidden,
-            prev_ids=prev_ids,
-            target_ids=target_ids,
+        head_token_ids = prev_ids if self.shift_label else target_ids
+        head_token_embeddings = self.embed_tokens(head_token_ids)
+        correction_logits = self.draft_model.compute_correction_logits(
+            hidden_states=hidden,
+            prev_token_embeddings=head_token_embeddings,
         )
-        final_ce = F.cross_entropy(
-            final_logits.reshape(-1, final_logits.shape[-1]),
-            target_ids.reshape(-1),
-            reduction="none",
-        ).reshape_as(target_ids)
-        base_ce = F.cross_entropy(
-            base_logits.reshape(-1, base_logits.shape[-1]),
-            target_ids.reshape(-1),
-            reduction="none",
-        ).reshape_as(target_ids)
-        final_num = (final_ce * weight_mask).sum()
-        base_num = (base_ce * weight_mask).sum()
+        final_num, base_num, predicted_ids, base_predicted_ids = (
+            domino_weighted_cross_entropy(
+                base_logits.reshape(-1, base_logits.shape[-1]),
+                correction_logits.reshape(-1, correction_logits.shape[-1]),
+                target_ids.reshape(-1),
+                weight_mask.reshape(-1),
+                block_size=block_size,
+                suffix_start=self.draft_model.suffix_start,
+                use_fused=self._use_fused_domino_ce and base_logits.is_cuda,
+            )
+        )
         loss_den = weight_mask.sum()
 
         with torch.no_grad():
-            predicted_ids = final_logits.argmax(dim=-1)
-            base_predicted_ids = base_logits.argmax(dim=-1)
+            predicted_ids = predicted_ids.reshape_as(target_ids)
+            base_predicted_ids = base_predicted_ids.reshape_as(target_ids)
             binary_accuracy_mask = eval_weight_mask > 0.5
             correct_num = (
                 ((predicted_ids == target_ids) & binary_accuracy_mask).sum().float()
@@ -704,9 +693,9 @@ class OnlineDominoModel(OnlineDFlashModel):
             dim=1,
         )
 
-        valid_token_count = loss_den + 1e-6
-        final_loss = final_num / valid_token_count
-        base_loss = base_num / valid_token_count
+        loss_denominator = loss_den + 1e-6
+        final_loss = final_num / loss_denominator
+        base_loss = base_num / loss_denominator
         loss = (1.0 - lambda_base) * final_loss + lambda_base * base_loss
         accuracy = correct_num / (accuracy_denom + 1e-6)
         metrics = {

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """DFlash-family training models and shared masking helpers."""
 
+import os
 from typing import Dict, Optional, Tuple
 
 import torch
@@ -537,6 +538,9 @@ class OnlineDominoModel(OnlineDFlashModel):
             loss_type="dflash",
         )
         self.shift_label = shift_label
+        self._use_fused_domino_ce = (
+            os.environ.get("SPECFORGE_DOMINO_TRITON_CE", "1") == "1"
+        )
 
     def _build_domino_head_inputs(
         self,
@@ -564,21 +568,6 @@ class OnlineDominoModel(OnlineDFlashModel):
 
         return hidden4d, prev_ids
 
-    def _apply_domino_head(
-        self,
-        base_logits4d: torch.Tensor,
-        hidden4d: torch.Tensor,
-        prev_ids: torch.Tensor,
-        target_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        head_token_ids = prev_ids if self.shift_label else target_ids
-        head_token_embeddings = self.embed_tokens(head_token_ids)
-        return self.draft_model.apply_logits_head(
-            base_logits4d,
-            hidden_states=hidden4d,
-            prev_token_embeddings=head_token_embeddings,
-        )
-
     def _domino_objective_chunk_terms(
         self,
         hidden: torch.Tensor,
@@ -588,34 +577,34 @@ class OnlineDominoModel(OnlineDFlashModel):
         eval_weight_mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, ...]:
         """Return additive Domino loss and telemetry terms for one block slice."""
+        from specforge.core.domino_loss import domino_weighted_cross_entropy
 
         batch_size, num_blocks, block_size, hidden_size = hidden.shape
         base_logits = self.lm_head(
             hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
         ).reshape(batch_size, num_blocks, block_size, -1)
-        final_logits = self._apply_domino_head(
-            base_logits4d=base_logits,
-            hidden4d=hidden,
-            prev_ids=prev_ids,
-            target_ids=target_ids,
+        head_token_ids = prev_ids if self.shift_label else target_ids
+        head_token_embeddings = self.embed_tokens(head_token_ids)
+        correction_logits = self.draft_model.compute_correction_logits(
+            hidden_states=hidden,
+            prev_token_embeddings=head_token_embeddings,
         )
-        final_ce = F.cross_entropy(
-            final_logits.reshape(-1, final_logits.shape[-1]),
-            target_ids.reshape(-1),
-            reduction="none",
-        ).reshape_as(target_ids)
-        base_ce = F.cross_entropy(
-            base_logits.reshape(-1, base_logits.shape[-1]),
-            target_ids.reshape(-1),
-            reduction="none",
-        ).reshape_as(target_ids)
-        final_num = (final_ce * weight_mask).sum()
-        base_num = (base_ce * weight_mask).sum()
+        final_num, base_num, predicted_ids, base_predicted_ids = (
+            domino_weighted_cross_entropy(
+                base_logits.reshape(-1, base_logits.shape[-1]),
+                correction_logits.reshape(-1, correction_logits.shape[-1]),
+                target_ids.reshape(-1),
+                weight_mask.reshape(-1),
+                block_size=block_size,
+                suffix_start=self.draft_model.suffix_start,
+                use_fused=self._use_fused_domino_ce and base_logits.is_cuda,
+            )
+        )
         loss_den = weight_mask.sum()
 
         with torch.no_grad():
-            predicted_ids = final_logits.argmax(dim=-1)
-            base_predicted_ids = base_logits.argmax(dim=-1)
+            predicted_ids = predicted_ids.reshape_as(target_ids)
+            base_predicted_ids = base_predicted_ids.reshape_as(target_ids)
             binary_accuracy_mask = eval_weight_mask > 0.5
             correct_num = (
                 ((predicted_ids == target_ids) & binary_accuracy_mask).sum().float()

--- a/specforge/core/domino_loss.py
+++ b/specforge/core/domino_loss.py
@@ -1,0 +1,441 @@
+"""Fused Domino cross-entropy without vocabulary-sized intermediates.
+
+The CUDA path processes base and compact-correction logits in vocabulary tiles.
+It never writes full corrected logits, padded corrections, base/final softmax or
+log-softmax tensors, or a separate corrected-logit gradient. Backward rebuilds
+each probability tile from the saved row maximum and shifted exponential sum,
+then writes only the required base and compact-correction gradients.
+
+The unfused reference path materializes corrected logits for readability and
+non-CUDA execution.
+"""
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+def domino_weighted_cross_entropy(
+    base_logits, correction_logits, targets, weights,
+    block_size, suffix_start, *, use_fused: bool,
+):
+    """Return weighted final/base loss sums and predictions for Domino logits.
+
+    ``use_fused=True`` requires CUDA; otherwise the reference path materializes
+    final logits. ``suffix_start`` is the first corrected position in each
+    block. Only the two logit tensors are differentiable; targets, weights, and
+    layout arguments are treated as fixed inputs. Incompatible inputs raise
+    ``ValueError``.
+
+    Tensor layout:
+        ``num_rows = num_blocks * block_size``
+        ``base_logits``: ``[num_rows, vocab_size]``
+        ``correction_logits``: ``[num_blocks * suffix_size, vocab_size]``
+        ``targets`` and ``weights``: ``[num_rows]``
+
+    Returns:
+        ``final_loss_sum``: weighted corrected-logit losses summed over rows.
+        ``base_loss_sum``: weighted base-logit losses summed over rows.
+        ``final_pred``: ``[num_rows]`` predictions from corrected logits.
+        ``base_pred``: ``[num_rows]`` predictions from base logits.
+    """
+    if base_logits.dim() != 2 or correction_logits.dim() != 2:
+        raise ValueError("Domino cross entropy expects 2D logits")
+    if block_size < 1 or not 0 <= suffix_start < block_size:
+        raise ValueError("suffix_start must select a non-empty Domino suffix")
+    num_rows, vocab_size = base_logits.shape
+    if num_rows % block_size:
+        raise ValueError("base-logit rows must be divisible by block_size")
+    num_blocks = num_rows // block_size
+    suffix_size = block_size - suffix_start
+    expected_correction_rows = num_blocks * suffix_size
+    if correction_logits.shape != (expected_correction_rows, vocab_size):
+        raise ValueError("correction logits do not match the configured suffix width")
+    if targets.shape != (num_rows,) or weights.shape != (num_rows,):
+        raise ValueError("targets and weights must have one value per logit row")
+    if base_logits.device != correction_logits.device or any(
+        tensor.device != base_logits.device for tensor in (targets, weights)
+    ):
+        raise ValueError("Domino cross-entropy inputs must be on the same device")
+    if base_logits.dtype != correction_logits.dtype:
+        raise ValueError("base and correction logits must have the same dtype")
+
+    if not use_fused:
+        return _domino_weighted_cross_entropy_reference(
+            base_logits, correction_logits, targets, weights,
+            block_size, suffix_start,
+        )
+    if not base_logits.is_cuda:
+        raise ValueError("Fused Domino cross entropy requires CUDA logits")
+
+    return _DominoCrossEntropy.apply(
+        base_logits, correction_logits, targets, weights,
+        block_size, suffix_start,
+    )
+
+
+def _domino_weighted_cross_entropy_reference(
+    base_logits, correction_logits, targets, weights,
+    block_size, suffix_start,
+):
+    """Reference implementation that materializes the corrected logits.
+
+    Tensor shapes:
+        base_logits: ``[num_blocks * block_size, vocab_size]``
+        correction_logits:
+            ``[num_blocks * (block_size - suffix_start), vocab_size]``
+        targets: ``[num_blocks * block_size]``
+        weights: ``[num_blocks * block_size]``
+    """
+    num_blocks = base_logits.shape[0] // block_size
+    suffix_size = block_size - suffix_start
+    base_logits_3d = base_logits.reshape(num_blocks, block_size, -1)
+    correction_logits_3d = correction_logits.reshape(
+        num_blocks, suffix_size, -1
+    )
+    final_logits = torch.cat(
+        [
+            base_logits_3d[:, :suffix_start],
+            base_logits_3d[:, suffix_start:] + correction_logits_3d,
+        ],
+        dim=1,
+    ).reshape_as(base_logits)
+    final_losses = F.cross_entropy(final_logits, targets, reduction="none")
+    base_losses = F.cross_entropy(base_logits, targets, reduction="none")
+    final_loss_sum = (final_losses * weights).sum()
+    base_loss_sum = (base_losses * weights).sum()
+    return (
+        final_loss_sum, base_loss_sum,
+        final_logits.argmax(-1), base_logits.argmax(-1),
+    )
+
+
+class _DominoCrossEntropy(torch.autograd.Function):
+    """Return weighted loss sums and predictions from the fused kernels.
+
+    Saves each row's maximum logit and shifted exponential sum so backward can
+    reconstruct both softmaxes without saving full probability tensors.
+    """
+
+    @staticmethod
+    def forward(
+        ctx, base_logits, correction_logits, targets, weights,
+        block_size, suffix_start,
+    ):
+        num_rows, vocab_size = base_logits.shape
+        base_logits = base_logits.contiguous()
+        correction_logits = correction_logits.contiguous()
+        targets = targets.contiguous()
+        weights = weights.contiguous()
+
+        device = base_logits.device
+
+        # kernel outputs
+        final_losses = torch.empty(num_rows, device=device, dtype=torch.float32)
+        base_losses = torch.empty_like(final_losses)
+        final_max = torch.empty_like(final_losses)
+        final_exp_sum = torch.empty_like(final_losses)
+        base_max = torch.empty_like(final_losses)
+        base_exp_sum = torch.empty_like(final_losses)
+        final_pred = torch.empty(num_rows, device=device, dtype=torch.long)
+        base_pred = torch.empty_like(final_pred)
+
+        vocab_block_size, num_warps = _calculate_domino_ce_settings(vocab_size)
+        _domino_cross_entropy_forward_kernel[(num_rows,)](
+            base_logits, base_logits.stride(0),
+            correction_logits, correction_logits.stride(0),
+            targets, weights,
+            final_losses, base_losses,
+            final_max, final_exp_sum, base_max, base_exp_sum,
+            final_pred, base_pred, vocab_size,
+            BLOCK_SIZE=block_size,
+            SUFFIX_START=suffix_start,
+            VOCAB_BLOCK_SIZE=vocab_block_size,
+            num_warps=num_warps,
+        )
+
+        ctx.block_size = block_size
+        ctx.suffix_start = suffix_start
+        ctx.save_for_backward(
+            base_logits, correction_logits, targets, weights,
+            final_max, final_exp_sum, base_max, base_exp_sum,
+        )
+        ctx.mark_non_differentiable(final_pred, base_pred)
+        return (
+            final_losses.sum(), base_losses.sum(),
+            final_pred, base_pred,
+        )
+
+    @staticmethod
+    def backward(
+        ctx, grad_final_loss, grad_base_loss, _grad_final_pred, _grad_base_pred,
+    ):
+        (
+            base_logits, correction_logits, targets, weights,
+            final_max, final_exp_sum, base_max, base_exp_sum,
+        ) = ctx.saved_tensors
+        num_rows, vocab_size = base_logits.shape
+        grad_base_logits = torch.empty_like(base_logits)
+        grad_correction_logits = torch.empty_like(correction_logits)
+        vocab_block_size, num_warps = _calculate_domino_ce_settings(vocab_size)
+        _domino_cross_entropy_backward_kernel[(num_rows,)](
+            base_logits, base_logits.stride(0),
+            correction_logits, correction_logits.stride(0),
+            targets, weights,
+            grad_final_loss, grad_base_loss,
+            grad_base_logits, grad_base_logits.stride(0),
+            grad_correction_logits, grad_correction_logits.stride(0),
+            final_max, final_exp_sum, base_max, base_exp_sum, vocab_size,
+            BLOCK_SIZE=ctx.block_size,
+            SUFFIX_START=ctx.suffix_start,
+            VOCAB_BLOCK_SIZE=vocab_block_size,
+            num_warps=num_warps,
+        )
+        return (
+            grad_base_logits, grad_correction_logits,
+            None, None, None, None,
+        )
+
+
+def _calculate_domino_ce_settings(vocab_size):
+    """Choose the vocabulary tile and warp count for the active GPU backend."""
+    vocab_block_size = min(triton.next_power_of_2(vocab_size), 2048)
+    num_warps = 8 if vocab_block_size >= 2048 else 4
+
+    # Preserve the NVIDIA thread count on AMD targets with 64-lane wavefronts.
+    # Note: this isn't tested, someone should tune this
+    if hasattr(torch.version, "hip") and torch.version.hip is not None:
+        warp_size = triton.runtime.driver.active.get_current_target().warp_size
+        num_warps = num_warps * 32 // warp_size
+
+    return vocab_block_size, max(num_warps, 1)
+
+
+@triton.jit
+def _domino_cross_entropy_forward_kernel(
+    base_logits_ptr, base_logits_stride,
+    correction_logits_ptr, correction_logits_stride,
+    targets_ptr, weights_ptr,
+    final_losses_ptr, base_losses_ptr,
+    final_max_ptr, final_exp_sum_ptr, base_max_ptr, base_exp_sum_ptr,
+    final_pred_ptr, base_pred_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    SUFFIX_START: tl.constexpr,
+    VOCAB_BLOCK_SIZE: tl.constexpr,
+):
+    """Write one set of outputs per flattened logit row.
+
+    For each row, the kernel writes:
+
+    - ``final_losses`` / ``base_losses``: weighted cross-entropy per row.
+      ``_DominoCrossEntropy.forward`` sums them for its scalar loss outputs.
+    - ``final_max`` / ``base_max``: largest logit in the row.
+    - ``final_exp_sum`` / ``base_exp_sum``: sum of
+      ``exp(logit - largest_logit)`` over the row.
+    - ``final_pred`` / ``base_pred``: index of the largest logit.
+
+    For corrected logits ``[2, 5, 4]`` with target index 2 and weight 1:
+
+    - ``final_max[row] = 5``
+    - ``final_exp_sum[row] = exp(2 - 5) + exp(5 - 5) + exp(4 - 5)``
+    - ``final_losses[row] = 5 + log(final_exp_sum[row]) - 4``
+    - ``final_pred[row] = 1``
+
+    Backward reconstructs each probability as
+    ``exp(logit - final_max) / final_exp_sum``. The base outputs use the same
+    calculation with uncorrected base logits.
+    """
+    row = tl.program_id(0).to(tl.int64)
+    has_correction, correction_row = _domino_correction_mapping(
+        row, BLOCK_SIZE, SUFFIX_START,
+    )
+
+    base_logits_ptr += row * base_logits_stride
+    correction_logits_ptr += correction_row * correction_logits_stride
+    target = tl.load(targets_ptr + row)
+    weight = tl.load(weights_ptr + row).to(tl.float32)
+    base_target_raw = tl.load(base_logits_ptr + target)
+    correction_target_raw = tl.load(
+        correction_logits_ptr + target, mask=has_correction, other=0.0,
+    )
+    base_target = base_target_raw.to(tl.float32)
+    final_target = (base_target_raw + correction_target_raw).to(tl.float32)
+
+    final_max = float("-inf")
+    final_exp_sum = 0.0
+    final_argmax = 0
+    base_max = float("-inf")
+    base_exp_sum = 0.0
+    base_argmax = 0
+
+    # Iterates over the one row of base logits.
+    # Each iteration:
+    # - loads one chunk of base_logits
+    # - loads the corresponding correction_logits chunk (or zeros if base-only row).
+    # - updates the {base/final}{max, exp_sum, argmax} variables
+    for i in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+        offsets = i + tl.arange(0, VOCAB_BLOCK_SIZE)
+        mask = offsets < vocab_size
+        base_block_raw = tl.load(
+            base_logits_ptr + offsets, mask=mask, other=float("-inf"),
+        )
+        correction_block_raw = tl.load(
+            correction_logits_ptr + offsets, mask=mask & has_correction, other=0.0,
+        )
+        base_block = base_block_raw.to(tl.float32)
+        final_block = (base_block_raw + correction_block_raw).to(tl.float32)
+
+        final_max, final_exp_sum, final_argmax = _update_online_logsumexp_and_argmax(
+            final_block, mask, i, final_max, final_exp_sum, final_argmax,
+        )
+        base_max, base_exp_sum, base_argmax = _update_online_logsumexp_and_argmax(
+            base_block, mask, i, base_max, base_exp_sum, base_argmax,
+        )
+
+    final_loss = weight * (tl.log(final_exp_sum) + final_max - final_target)
+    base_loss = weight * (tl.log(base_exp_sum) + base_max - base_target)
+    tl.store(final_losses_ptr + row, final_loss)
+    tl.store(base_losses_ptr + row, base_loss)
+    tl.store(final_max_ptr + row, final_max.to(tl.float32))
+    tl.store(final_exp_sum_ptr + row, final_exp_sum.to(tl.float32))
+    tl.store(base_max_ptr + row, base_max.to(tl.float32))
+    tl.store(base_exp_sum_ptr + row, base_exp_sum.to(tl.float32))
+    tl.store(final_pred_ptr + row, final_argmax)
+    tl.store(base_pred_ptr + row, base_argmax)
+
+
+@triton.jit
+def _domino_cross_entropy_backward_kernel(
+    base_logits_ptr, base_logits_stride,
+    correction_logits_ptr, correction_logits_stride,
+    targets_ptr, weights_ptr,
+    grad_final_loss_ptr, grad_base_loss_ptr,
+    grad_base_logits_ptr, grad_base_logits_stride,
+    grad_correction_logits_ptr, grad_correction_logits_stride,
+    final_max_ptr, final_exp_sum_ptr, base_max_ptr, base_exp_sum_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    SUFFIX_START: tl.constexpr,
+    VOCAB_BLOCK_SIZE: tl.constexpr,
+):
+    """Reconstruct both softmaxes and write one row of input gradients.
+
+    For one ``x[vocab_size]`` logit row and fixed scalar target index ``y``::
+
+        CE(x, y) = logsumexp(x) - x[y]
+        d CE(x, y) / d x[j] = softmax(x)[j] - 1[j == y]
+
+    ``logsumexp(x)`` reduces the vocabulary row to one scalar, as does selecting
+    ``x[y]``. Their difference is the row's scalar cross-entropy; its gradient
+    with respect to ``x`` has shape ``[vocab_size]``.
+
+    The kernel evaluates the softmax term stably using the forward statistics:
+    ``softmax(x)[j] = exp(x[j] - row_max) / row_exp_sum``.
+
+    Including the row weight and upstream loss gradients gives::
+
+        grad_from_final_loss = grad_final_loss * weight
+                               * (softmax(final_logits) - one_hot(y))
+        grad_base_logits = grad_from_final_loss
+                           + grad_base_loss * weight
+                             * (softmax(base_logits) - one_hot(y))
+        grad_correction_logits = grad_from_final_loss
+
+    Any normalization applied to the returned loss sums is already included in
+    the incoming ``grad_final_loss`` and ``grad_base_loss`` values.
+
+    Base logits feed both losses. Correction logits feed only the final loss
+    and exist only for suffix rows; prefix rows have no correction to update.
+    """
+    row = tl.program_id(0).to(tl.int64)
+    has_correction, correction_row = _domino_correction_mapping(
+        row, BLOCK_SIZE, SUFFIX_START,
+    )
+
+    base_logits_ptr += row * base_logits_stride
+    grad_base_logits_ptr += row * grad_base_logits_stride
+    correction_logits_ptr += correction_row * correction_logits_stride
+    grad_correction_logits_ptr += correction_row * grad_correction_logits_stride
+
+    target = tl.load(targets_ptr + row)
+    weight = tl.load(weights_ptr + row).to(tl.float32)
+    final_scale = tl.load(grad_final_loss_ptr).to(tl.float32) * weight
+    base_scale = tl.load(grad_base_loss_ptr).to(tl.float32) * weight
+    final_max = tl.load(final_max_ptr + row).to(tl.float32)
+    final_exp_sum = tl.load(final_exp_sum_ptr + row).to(tl.float32)
+    base_max = tl.load(base_max_ptr + row).to(tl.float32)
+    base_exp_sum = tl.load(base_exp_sum_ptr + row).to(tl.float32)
+
+    # Iterates over one row of base logits.
+    # Each iteration:
+    # - loads base_logits and correction_logits chunks
+    # - reconstructs the base and final softmax probabilities
+    # - writes grad_base_logits with contributions from both losses
+    # - writes grad_correction_logits from the final loss for suffix rows
+    for i in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+        offsets = i + tl.arange(0, VOCAB_BLOCK_SIZE)
+        mask = offsets < vocab_size
+        base_block_raw = tl.load(
+            base_logits_ptr + offsets, mask=mask, other=0.0,
+        )
+        correction_block_raw = tl.load(
+            correction_logits_ptr + offsets, mask=mask & has_correction, other=0.0,
+        )
+        base_block = base_block_raw.to(tl.float32)
+        final_block = (base_block_raw + correction_block_raw).to(tl.float32)
+        target_grad = tl.where(offsets == target, 1.0, 0.0)
+        final_grad = final_scale * (
+            tl.exp(final_block - final_max) / final_exp_sum - target_grad
+        )
+        base_grad = final_grad + base_scale * (
+            tl.exp(base_block - base_max) / base_exp_sum - target_grad
+        )
+        tl.store(grad_base_logits_ptr + offsets, base_grad, mask=mask)
+        tl.store(
+            grad_correction_logits_ptr + offsets,
+            final_grad, mask=mask & has_correction,
+        )
+
+
+@triton.jit
+def _domino_correction_mapping(
+    row, BLOCK_SIZE: tl.constexpr, SUFFIX_START: tl.constexpr,
+):
+    """Map a flattened base row to Domino's compact correction layout.
+
+    For ``BLOCK_SIZE=4`` and ``SUFFIX_START=1``::
+
+        base row:        0  1  2  3 | 4  5  6  7
+        correction row:  -  0  1  2 | -  3  4  5
+
+    ``-`` marks a base-only row with no correction.
+    """
+    row_in_block = row % BLOCK_SIZE
+    suffix_size: tl.constexpr = BLOCK_SIZE - SUFFIX_START
+    has_correction = row_in_block >= SUFFIX_START
+    correction_row = (row // BLOCK_SIZE) * suffix_size + (
+        row_in_block - SUFFIX_START
+    )
+    correction_row = tl.where(has_correction, correction_row, 0)
+    return has_correction, correction_row
+
+
+@triton.jit
+def _update_online_logsumexp_and_argmax(
+    logits, mask, block_offset, previous_max, previous_exp_sum, previous_argmax,
+):
+    """Update the row maximum, shifted exponential sum, and leftmost argmax."""
+    block_max, block_argmax = tl.max(
+        tl.where(mask, logits, float("-inf")),
+        axis=0, return_indices=True, return_indices_tie_break_left=True,
+    )
+    block_argmax += block_offset
+    take_block = block_max > previous_max
+    argmax = tl.where(take_block, block_argmax, previous_argmax)
+    max_logit = tl.maximum(previous_max, block_max)
+    exp_sum = previous_exp_sum * tl.exp(previous_max - max_logit) + tl.sum(
+        tl.where(mask, tl.exp(logits - max_logit), 0.0)
+    )
+    return max_logit, exp_sum, argmax

--- a/specforge/core/domino_loss.py
+++ b/specforge/core/domino_loss.py
@@ -1,0 +1,144 @@
+"""Domino cross-entropy with a portable reference and optional Triton path."""
+
+import torch
+import torch.nn.functional as F
+
+
+def domino_weighted_cross_entropy(
+    base_logits,
+    correction_logits,
+    targets,
+    weights,
+    block_size,
+    suffix_start,
+    *,
+    use_fused: bool,
+):
+    """Return weighted final/base loss sums and predictions for Domino logits.
+
+    ``use_fused=True`` requires CUDA and imports the Triton implementation
+    lazily. Otherwise, the reference path materializes final logits without
+    requiring Triton. Only the two logit tensors are differentiable; targets,
+    weights, and layout arguments are treated as fixed inputs.
+
+    Tensor layout:
+        ``num_rows = num_blocks * block_size``
+        ``base_logits``: ``[num_rows, vocab_size]``
+        ``correction_logits``: ``[num_blocks * suffix_size, vocab_size]``
+        ``targets``: ``[num_rows]`` integer indices in ``[0, vocab_size)``
+        ``weights``: ``[num_rows]``
+
+    Returns:
+        ``final_loss_sum``: weighted corrected-logit losses summed over rows.
+        ``base_loss_sum``: weighted base-logit losses summed over rows.
+        ``final_pred``: ``[num_rows]`` predictions from corrected logits.
+        ``base_pred``: ``[num_rows]`` predictions from base logits.
+    """
+    if base_logits.dim() != 2 or correction_logits.dim() != 2:
+        raise ValueError("Domino cross entropy expects 2D logits")
+    if block_size < 1 or not 0 <= suffix_start < block_size:
+        raise ValueError("suffix_start must select a non-empty Domino suffix")
+    num_rows, vocab_size = base_logits.shape
+    if vocab_size < 1:
+        raise ValueError("Domino cross entropy requires a non-empty vocabulary")
+    if num_rows % block_size:
+        raise ValueError("base-logit rows must be divisible by block_size")
+    num_blocks = num_rows // block_size
+    suffix_size = block_size - suffix_start
+    expected_correction_rows = num_blocks * suffix_size
+    if correction_logits.shape != (expected_correction_rows, vocab_size):
+        raise ValueError("correction logits do not match the configured suffix width")
+    if targets.shape != (num_rows,) or weights.shape != (num_rows,):
+        raise ValueError("targets and weights must have one value per logit row")
+    if targets.dtype != torch.long:
+        raise ValueError("targets must contain torch.long class indices")
+    if base_logits.device != correction_logits.device or any(
+        tensor.device != base_logits.device for tensor in (targets, weights)
+    ):
+        raise ValueError("Domino cross-entropy inputs must be on the same device")
+    if base_logits.dtype != correction_logits.dtype:
+        raise ValueError("base and correction logits must have the same dtype")
+    if not base_logits.is_floating_point():
+        raise ValueError("base and correction logits must be floating point")
+
+    if not use_fused:
+        return _domino_weighted_cross_entropy_reference(
+            base_logits,
+            correction_logits,
+            targets,
+            weights,
+            block_size,
+            suffix_start,
+        )
+    if not base_logits.is_cuda:
+        raise ValueError("Fused Domino cross entropy requires CUDA logits")
+    if base_logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(
+            "Fused Domino cross entropy requires FP16, BF16, or FP32 logits"
+        )
+
+    try:
+        from specforge.core.domino_loss_triton import (
+            domino_weighted_cross_entropy_fused,
+        )
+    except ModuleNotFoundError as exc:
+        if exc.name == "triton" or exc.name.startswith("triton."):
+            raise ImportError(
+                "Fused Domino cross entropy requires Triton; install Triton or "
+                "call with use_fused=False."
+            ) from exc
+        raise
+
+    return domino_weighted_cross_entropy_fused(
+        base_logits,
+        correction_logits,
+        targets,
+        weights,
+        block_size,
+        suffix_start,
+    )
+
+
+def _domino_weighted_cross_entropy_reference(
+    base_logits,
+    correction_logits,
+    targets,
+    weights,
+    block_size,
+    suffix_start,
+):
+    """Reference implementation that materializes the corrected logits."""
+    num_blocks = base_logits.shape[0] // block_size
+    suffix_size = block_size - suffix_start
+    base_logits_3d = base_logits.reshape(num_blocks, block_size, -1)
+    correction_logits_3d = correction_logits.reshape(num_blocks, suffix_size, -1)
+    final_logits = torch.cat(
+        [
+            base_logits_3d[:, :suffix_start],
+            base_logits_3d[:, suffix_start:] + correction_logits_3d,
+        ],
+        dim=1,
+    ).reshape_as(base_logits)
+    loss_logits = (
+        final_logits.float()
+        if final_logits.dtype in (torch.float16, torch.bfloat16)
+        else final_logits
+    )
+    base_loss_logits = (
+        base_logits.float()
+        if base_logits.dtype in (torch.float16, torch.bfloat16)
+        else base_logits
+    )
+    final_losses = F.cross_entropy(loss_logits, targets, reduction="none")
+    base_losses = F.cross_entropy(base_loss_logits, targets, reduction="none")
+    final_loss_sum = (final_losses * weights).sum()
+    base_loss_sum = (base_losses * weights).sum()
+    return (
+        final_loss_sum,
+        base_loss_sum,
+        final_logits.argmax(-1),
+        base_logits.argmax(-1),
+    )
+
+
+__all__ = ["domino_weighted_cross_entropy"]

--- a/specforge/core/domino_loss_triton.py
+++ b/specforge/core/domino_loss_triton.py
@@ -1,0 +1,464 @@
+"""Triton implementation of Domino cross-entropy.
+
+The CUDA path processes base and compact-correction logits in vocabulary tiles.
+It never writes full corrected logits, padded corrections, base/final softmax or
+log-softmax tensors, or a separate corrected-logit gradient. Backward rebuilds
+each probability tile from the saved row maximum and shifted exponential sum,
+then writes only the required base and compact-correction gradients.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+__all__ = ["domino_weighted_cross_entropy_fused"]
+
+
+def domino_weighted_cross_entropy_fused(
+    base_logits,
+    correction_logits,
+    targets,
+    weights,
+    block_size,
+    suffix_start,
+):
+    """Launch the fused autograd implementation after public validation."""
+    return _DominoCrossEntropy.apply(
+        base_logits,
+        correction_logits,
+        targets,
+        weights,
+        block_size,
+        suffix_start,
+    )
+
+
+class _DominoCrossEntropy(torch.autograd.Function):
+    """Return weighted loss sums and predictions from the fused kernels.
+
+    Saves each row's maximum logit and shifted exponential sum so backward can
+    reconstruct both softmaxes without saving full probability tensors.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        base_logits,
+        correction_logits,
+        targets,
+        weights,
+        block_size,
+        suffix_start,
+    ):
+        num_rows, vocab_size = base_logits.shape
+        base_logits = base_logits.contiguous()
+        correction_logits = correction_logits.contiguous()
+        targets = targets.contiguous()
+        weights = weights.contiguous()
+
+        device = base_logits.device
+
+        # kernel outputs
+        final_losses = torch.empty(num_rows, device=device, dtype=torch.float32)
+        base_losses = torch.empty_like(final_losses)
+        final_max = torch.empty_like(final_losses)
+        final_exp_sum = torch.empty_like(final_losses)
+        base_max = torch.empty_like(final_losses)
+        base_exp_sum = torch.empty_like(final_losses)
+        final_pred = torch.empty(num_rows, device=device, dtype=torch.long)
+        base_pred = torch.empty_like(final_pred)
+
+        vocab_block_size, num_warps = _calculate_domino_ce_settings(vocab_size)
+        _domino_cross_entropy_forward_kernel[(num_rows,)](
+            base_logits,
+            base_logits.stride(0),
+            correction_logits,
+            correction_logits.stride(0),
+            targets,
+            weights,
+            final_losses,
+            base_losses,
+            final_max,
+            final_exp_sum,
+            base_max,
+            base_exp_sum,
+            final_pred,
+            base_pred,
+            vocab_size,
+            BLOCK_SIZE=block_size,
+            SUFFIX_START=suffix_start,
+            VOCAB_BLOCK_SIZE=vocab_block_size,
+            num_warps=num_warps,
+        )
+
+        ctx.block_size = block_size
+        ctx.suffix_start = suffix_start
+        ctx.save_for_backward(
+            base_logits,
+            correction_logits,
+            targets,
+            weights,
+            final_max,
+            final_exp_sum,
+            base_max,
+            base_exp_sum,
+        )
+        ctx.mark_non_differentiable(final_pred, base_pred)
+        return (
+            final_losses.sum(),
+            base_losses.sum(),
+            final_pred,
+            base_pred,
+        )
+
+    @staticmethod
+    def backward(
+        ctx,
+        grad_final_loss,
+        grad_base_loss,
+        _grad_final_pred,
+        _grad_base_pred,
+    ):
+        (
+            base_logits,
+            correction_logits,
+            targets,
+            weights,
+            final_max,
+            final_exp_sum,
+            base_max,
+            base_exp_sum,
+        ) = ctx.saved_tensors
+        num_rows, vocab_size = base_logits.shape
+        grad_base_logits = torch.empty_like(base_logits)
+        grad_correction_logits = torch.empty_like(correction_logits)
+        vocab_block_size, num_warps = _calculate_domino_ce_settings(vocab_size)
+        _domino_cross_entropy_backward_kernel[(num_rows,)](
+            base_logits,
+            base_logits.stride(0),
+            correction_logits,
+            correction_logits.stride(0),
+            targets,
+            weights,
+            grad_final_loss,
+            grad_base_loss,
+            grad_base_logits,
+            grad_base_logits.stride(0),
+            grad_correction_logits,
+            grad_correction_logits.stride(0),
+            final_max,
+            final_exp_sum,
+            base_max,
+            base_exp_sum,
+            vocab_size,
+            BLOCK_SIZE=ctx.block_size,
+            SUFFIX_START=ctx.suffix_start,
+            VOCAB_BLOCK_SIZE=vocab_block_size,
+            num_warps=num_warps,
+        )
+        return (
+            grad_base_logits,
+            grad_correction_logits,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def _calculate_domino_ce_settings(vocab_size):
+    """Choose the vocabulary tile and warp count for the active GPU backend."""
+    vocab_block_size = min(triton.next_power_of_2(vocab_size), 2048)
+    num_warps = 8 if vocab_block_size >= 2048 else 4
+
+    # Preserve the NVIDIA thread count on AMD targets with 64-lane wavefronts.
+    # Note: this isn't tested, someone should tune this
+    if hasattr(torch.version, "hip") and torch.version.hip is not None:
+        warp_size = triton.runtime.driver.active.get_current_target().warp_size
+        num_warps = num_warps * 32 // warp_size
+
+    return vocab_block_size, max(num_warps, 1)
+
+
+@triton.jit
+def _domino_cross_entropy_forward_kernel(
+    base_logits_ptr,
+    base_logits_stride,
+    correction_logits_ptr,
+    correction_logits_stride,
+    targets_ptr,
+    weights_ptr,
+    final_losses_ptr,
+    base_losses_ptr,
+    final_max_ptr,
+    final_exp_sum_ptr,
+    base_max_ptr,
+    base_exp_sum_ptr,
+    final_pred_ptr,
+    base_pred_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    SUFFIX_START: tl.constexpr,
+    VOCAB_BLOCK_SIZE: tl.constexpr,
+):
+    """Write one set of outputs per flattened logit row.
+
+    For each row, the kernel writes:
+
+    - ``final_losses`` / ``base_losses``: weighted cross-entropy per row.
+      ``_DominoCrossEntropy.forward`` sums them for its scalar loss outputs.
+    - ``final_max`` / ``base_max``: largest logit in the row.
+    - ``final_exp_sum`` / ``base_exp_sum``: sum of
+      ``exp(logit - largest_logit)`` over the row.
+    - ``final_pred`` / ``base_pred``: index of the largest logit.
+
+    For corrected logits ``[2, 5, 4]`` with target index 2 and weight 1:
+
+    - ``final_max[row] = 5``
+    - ``final_exp_sum[row] = exp(2 - 5) + exp(5 - 5) + exp(4 - 5)``
+    - ``final_losses[row] = 5 + log(final_exp_sum[row]) - 4``
+    - ``final_pred[row] = 1``
+
+    Backward reconstructs each probability as
+    ``exp(logit - final_max) / final_exp_sum``. The base outputs use the same
+    calculation with uncorrected base logits.
+    """
+    row = tl.program_id(0).to(tl.int64)
+    has_correction, correction_row = _domino_correction_mapping(
+        row,
+        BLOCK_SIZE,
+        SUFFIX_START,
+    )
+
+    base_logits_ptr += row * base_logits_stride
+    correction_logits_ptr += correction_row * correction_logits_stride
+    target = tl.load(targets_ptr + row)
+    target_in_bounds = (target >= 0) & (target < vocab_size)
+    tl.device_assert(target_in_bounds, "target index is outside the vocabulary")
+    weight = tl.load(weights_ptr + row).to(tl.float32)
+    base_target_raw = tl.load(
+        base_logits_ptr + target,
+        mask=target_in_bounds,
+        other=float("nan"),
+    )
+    correction_target_raw = tl.load(
+        correction_logits_ptr + target,
+        mask=has_correction & target_in_bounds,
+        other=0.0,
+    )
+    base_target = base_target_raw.to(tl.float32)
+    final_target = (base_target_raw + correction_target_raw).to(tl.float32)
+
+    final_max = float("-inf")
+    final_exp_sum = 0.0
+    final_argmax = 0
+    base_max = float("-inf")
+    base_exp_sum = 0.0
+    base_argmax = 0
+
+    # Iterates over the one row of base logits.
+    # Each iteration:
+    # - loads one chunk of base_logits
+    # - loads the corresponding correction_logits chunk (or zeros if base-only row).
+    # - updates the {base/final}{max, exp_sum, argmax} variables
+    for i in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+        offsets = i + tl.arange(0, VOCAB_BLOCK_SIZE)
+        mask = offsets < vocab_size
+        base_block_raw = tl.load(
+            base_logits_ptr + offsets,
+            mask=mask,
+            other=float("-inf"),
+        )
+        correction_block_raw = tl.load(
+            correction_logits_ptr + offsets,
+            mask=mask & has_correction,
+            other=0.0,
+        )
+        base_block = base_block_raw.to(tl.float32)
+        final_block = (base_block_raw + correction_block_raw).to(tl.float32)
+
+        final_max, final_exp_sum, final_argmax = _update_online_logsumexp_and_argmax(
+            final_block,
+            mask,
+            i,
+            final_max,
+            final_exp_sum,
+            final_argmax,
+        )
+        base_max, base_exp_sum, base_argmax = _update_online_logsumexp_and_argmax(
+            base_block,
+            mask,
+            i,
+            base_max,
+            base_exp_sum,
+            base_argmax,
+        )
+
+    final_loss = weight * (tl.log(final_exp_sum) + final_max - final_target)
+    base_loss = weight * (tl.log(base_exp_sum) + base_max - base_target)
+    tl.store(final_losses_ptr + row, final_loss)
+    tl.store(base_losses_ptr + row, base_loss)
+    tl.store(final_max_ptr + row, final_max.to(tl.float32))
+    tl.store(final_exp_sum_ptr + row, final_exp_sum.to(tl.float32))
+    tl.store(base_max_ptr + row, base_max.to(tl.float32))
+    tl.store(base_exp_sum_ptr + row, base_exp_sum.to(tl.float32))
+    tl.store(final_pred_ptr + row, final_argmax)
+    tl.store(base_pred_ptr + row, base_argmax)
+
+
+@triton.jit
+def _domino_cross_entropy_backward_kernel(
+    base_logits_ptr,
+    base_logits_stride,
+    correction_logits_ptr,
+    correction_logits_stride,
+    targets_ptr,
+    weights_ptr,
+    grad_final_loss_ptr,
+    grad_base_loss_ptr,
+    grad_base_logits_ptr,
+    grad_base_logits_stride,
+    grad_correction_logits_ptr,
+    grad_correction_logits_stride,
+    final_max_ptr,
+    final_exp_sum_ptr,
+    base_max_ptr,
+    base_exp_sum_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+    SUFFIX_START: tl.constexpr,
+    VOCAB_BLOCK_SIZE: tl.constexpr,
+):
+    """Reconstruct both softmaxes and write one row of input gradients.
+
+    For one ``x[vocab_size]`` logit row and fixed scalar target index ``y``::
+
+        CE(x, y) = logsumexp(x) - x[y]
+        d CE(x, y) / d x[j] = softmax(x)[j] - 1[j == y]
+
+    ``logsumexp(x)`` reduces the vocabulary row to one scalar, as does selecting
+    ``x[y]``. Their difference is the row's scalar cross-entropy; its gradient
+    with respect to ``x`` has shape ``[vocab_size]``.
+
+    The kernel evaluates the softmax term stably using the forward statistics:
+    ``softmax(x)[j] = exp(x[j] - row_max) / row_exp_sum``.
+
+    Including the row weight and upstream loss gradients gives::
+
+        grad_from_final_loss = grad_final_loss * weight
+                               * (softmax(final_logits) - one_hot(y))
+        grad_base_logits = grad_from_final_loss
+                           + grad_base_loss * weight
+                             * (softmax(base_logits) - one_hot(y))
+        grad_correction_logits = grad_from_final_loss
+
+    Any normalization applied to the returned loss sums is already included in
+    the incoming ``grad_final_loss`` and ``grad_base_loss`` values.
+
+    Base logits feed both losses. Correction logits feed only the final loss
+    and exist only for suffix rows; prefix rows have no correction to update.
+    """
+    row = tl.program_id(0).to(tl.int64)
+    has_correction, correction_row = _domino_correction_mapping(
+        row,
+        BLOCK_SIZE,
+        SUFFIX_START,
+    )
+
+    base_logits_ptr += row * base_logits_stride
+    grad_base_logits_ptr += row * grad_base_logits_stride
+    correction_logits_ptr += correction_row * correction_logits_stride
+    grad_correction_logits_ptr += correction_row * grad_correction_logits_stride
+
+    target = tl.load(targets_ptr + row)
+    weight = tl.load(weights_ptr + row).to(tl.float32)
+    final_scale = tl.load(grad_final_loss_ptr).to(tl.float32) * weight
+    base_scale = tl.load(grad_base_loss_ptr).to(tl.float32) * weight
+    final_max = tl.load(final_max_ptr + row).to(tl.float32)
+    final_exp_sum = tl.load(final_exp_sum_ptr + row).to(tl.float32)
+    base_max = tl.load(base_max_ptr + row).to(tl.float32)
+    base_exp_sum = tl.load(base_exp_sum_ptr + row).to(tl.float32)
+
+    # Iterates over one row of base logits.
+    # Each iteration:
+    # - loads base_logits and correction_logits chunks
+    # - reconstructs the base and final softmax probabilities
+    # - writes grad_base_logits with contributions from both losses
+    # - writes grad_correction_logits from the final loss for suffix rows
+    for i in range(0, vocab_size, VOCAB_BLOCK_SIZE):
+        offsets = i + tl.arange(0, VOCAB_BLOCK_SIZE)
+        mask = offsets < vocab_size
+        base_block_raw = tl.load(
+            base_logits_ptr + offsets,
+            mask=mask,
+            other=0.0,
+        )
+        correction_block_raw = tl.load(
+            correction_logits_ptr + offsets,
+            mask=mask & has_correction,
+            other=0.0,
+        )
+        base_block = base_block_raw.to(tl.float32)
+        final_block = (base_block_raw + correction_block_raw).to(tl.float32)
+        target_grad = tl.where(offsets == target, 1.0, 0.0)
+        final_grad = final_scale * (
+            tl.exp(final_block - final_max) / final_exp_sum - target_grad
+        )
+        base_grad = final_grad + base_scale * (
+            tl.exp(base_block - base_max) / base_exp_sum - target_grad
+        )
+        tl.store(grad_base_logits_ptr + offsets, base_grad, mask=mask)
+        tl.store(
+            grad_correction_logits_ptr + offsets,
+            final_grad,
+            mask=mask & has_correction,
+        )
+
+
+@triton.jit
+def _domino_correction_mapping(
+    row,
+    BLOCK_SIZE: tl.constexpr,
+    SUFFIX_START: tl.constexpr,
+):
+    """Map a flattened base row to Domino's compact correction layout.
+
+    For ``BLOCK_SIZE=4`` and ``SUFFIX_START=1``::
+
+        base row:        0  1  2  3 | 4  5  6  7
+        correction row:  -  0  1  2 | -  3  4  5
+
+    ``-`` marks a base-only row with no correction.
+    """
+    row_in_block = row % BLOCK_SIZE
+    suffix_size: tl.constexpr = BLOCK_SIZE - SUFFIX_START
+    has_correction = row_in_block >= SUFFIX_START
+    correction_row = (row // BLOCK_SIZE) * suffix_size + (row_in_block - SUFFIX_START)
+    correction_row = tl.where(has_correction, correction_row, 0)
+    return has_correction, correction_row
+
+
+@triton.jit
+def _update_online_logsumexp_and_argmax(
+    logits,
+    mask,
+    block_offset,
+    previous_max,
+    previous_exp_sum,
+    previous_argmax,
+):
+    """Update the row maximum, shifted exponential sum, and leftmost argmax."""
+    block_max, block_argmax = tl.max(
+        tl.where(mask, logits, float("-inf")),
+        axis=0,
+        return_indices=True,
+        return_indices_tie_break_left=True,
+    )
+    block_argmax += block_offset
+    take_block = block_max > previous_max
+    argmax = tl.where(take_block, block_argmax, previous_argmax)
+    max_logit = tl.maximum(previous_max, block_max)
+    exp_sum = previous_exp_sum * tl.exp(previous_max - max_logit) + tl.sum(
+        tl.where(mask, tl.exp(logits - max_logit), 0.0)
+    )
+    return max_logit, exp_sum, argmax

--- a/specforge/modeling/draft/domino.py
+++ b/specforge/modeling/draft/domino.py
@@ -113,10 +113,25 @@ class DominoDraftModel(DFlashDraftModel):
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
         del prev_token_ids
+        correction_logits = self.compute_correction_logits(
+            prev_token_embeddings=prev_token_embeddings,
+            hidden_states=hidden_states,
+        )
+        prefix_logits = base_logits[:, :, : self.suffix_start, :]
+        suffix_logits = base_logits[:, :, self.suffix_start :, :] + correction_logits
+        return torch.cat([prefix_logits, suffix_logits], dim=2)
+
+    def compute_correction_logits(
+        self,
+        *,
+        prev_token_embeddings: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return suffix-only Domino logits without materializing final logits."""
         if prev_token_embeddings is None:
             raise ValueError("DominoDraftModel requires prev_token_embeddings")
 
-        bsz, n_blocks, block_size = base_logits.shape[:3]
+        bsz, n_blocks, block_size = hidden_states.shape[:3]
         if self.shift_label:
             gru_inputs = prev_token_embeddings.reshape(bsz * n_blocks, block_size, -1)
             gru_out = self._run_gru(gru_inputs)
@@ -132,11 +147,7 @@ class DominoDraftModel(DFlashDraftModel):
 
         z_n = hidden_states[:, :, self.suffix_start :, :]
         concat_features = torch.cat([z_n, prefix_states], dim=-1)
-        logits_e = self.embed_proj(concat_features)
-
-        prefix_logits = base_logits[:, :, : self.suffix_start, :]
-        suffix_logits = base_logits[:, :, self.suffix_start :, :] + logits_e
-        return torch.cat([prefix_logits, suffix_logits], dim=2)
+        return self.embed_proj(concat_features)
 
 
 __all__ = ["DominoDraftModel"]

--- a/tests/test_modeling/test_domino_model.py
+++ b/tests/test_modeling/test_domino_model.py
@@ -220,6 +220,82 @@ class TestDominoDraftModel(unittest.TestCase):
                             atol=1e-7,
                         )
 
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton loss requires CUDA")
+    def test_fused_loss_matches_standard_model_path(self):
+        from specforge.algorithms.common.dflash_family_model import OnlineDominoModel
+
+        torch.manual_seed(19)
+        hidden_size, vocab_size, block_size = 4, 7, 4
+        draft = _bare_domino(
+            hidden_size=hidden_size,
+            gru_hidden_size=3,
+            embedding_size=2,
+            vocab_size=vocab_size,
+            block_size=block_size,
+        )
+        model = OnlineDominoModel(
+            draft_model=draft,
+            target_lm_head=nn.Linear(hidden_size, vocab_size, bias=False),
+            target_embed_tokens=nn.Embedding(vocab_size, hidden_size),
+            mask_token_id=0,
+            block_size=block_size,
+            attention_backend="sdpa",
+            num_anchors=2,
+            objective_chunk_blocks=1,
+            shift_label=False,
+        ).cuda()
+        fixed_hidden = torch.randn(
+            1, 2 * block_size, hidden_size, device="cuda", requires_grad=True
+        )
+
+        def fixed_draft_blocks(self, input_ids, hidden_states, loss_mask):
+            del hidden_states, loss_mask
+            return (
+                torch.tensor([[0, 4]], device=input_ids.device),
+                torch.ones(1, 2, dtype=torch.bool, device=input_ids.device),
+                fixed_hidden,
+            )
+
+        model._forward_draft_blocks = MethodType(fixed_draft_blocks, model)
+        inputs = {
+            "input_ids": torch.tensor([[1, 2, 3, 4, 5, 6, 0, 1]], device="cuda"),
+            "hidden_states": torch.zeros(
+                1, 2 * block_size, hidden_size, device="cuda"
+            ),
+            "loss_mask": torch.ones(1, 2 * block_size, device="cuda"),
+            "lambda_base": 0.25,
+        }
+        model._use_fused_domino_ce = False
+        standard = model(**inputs)
+        standard[0].backward()
+        standard_hidden_grad = fixed_hidden.grad.clone()
+        standard_parameter_grads = {
+            name: None if parameter.grad is None else parameter.grad.clone()
+            for name, parameter in model.named_parameters()
+        }
+        fixed_hidden.grad = None
+        model.zero_grad(set_to_none=True)
+
+        model._use_fused_domino_ce = True
+        fused = model(**inputs)
+        fused[0].backward()
+
+        torch.testing.assert_close(fused[0], standard[0])
+        torch.testing.assert_close(fused[1], standard[1])
+        for key in standard[2]:
+            torch.testing.assert_close(fused[2][key], standard[2][key])
+
+        torch.testing.assert_close(
+            fixed_hidden.grad, standard_hidden_grad, rtol=1e-4, atol=1e-4
+        )
+        for name, parameter in model.named_parameters():
+            standard_grad = standard_parameter_grads[name]
+            self.assertEqual(parameter.grad is None, standard_grad is None, name)
+            if standard_grad is not None:
+                torch.testing.assert_close(
+                    parameter.grad, standard_grad, rtol=1e-4, atol=1e-4
+                )
+
     def test_npu_bf16_gru_gradients_reach_registered_weights(self):
         torch.manual_seed(7)
         model = _bare_domino().to(dtype=torch.bfloat16)

--- a/tests/test_modeling/test_domino_model.py
+++ b/tests/test_modeling/test_domino_model.py
@@ -239,6 +239,86 @@ class TestDominoDraftModel(unittest.TestCase):
                             atol=1e-7,
                         )
 
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton loss requires CUDA")
+    def test_fused_loss_matches_standard_model_path(self):
+        from specforge.algorithms.common.dflash_family_model import OnlineDominoModel
+
+        torch.manual_seed(19)
+        hidden_size, vocab_size, block_size = 4, 7, 4
+        draft = _bare_domino(
+            hidden_size=hidden_size,
+            gru_hidden_size=3,
+            embedding_size=2,
+            vocab_size=vocab_size,
+            block_size=block_size,
+        )
+        model = OnlineDominoModel(
+            draft_model=draft,
+            target_lm_head=nn.Linear(hidden_size, vocab_size, bias=False),
+            target_embed_tokens=nn.Embedding(vocab_size, hidden_size),
+            mask_token_id=0,
+            block_size=block_size,
+            attention_backend="sdpa",
+            num_anchors=2,
+            objective_chunk_blocks=1,
+            shift_label=False,
+        ).cuda()
+        fixed_hidden = torch.randn(
+            1, 2 * block_size, hidden_size, device="cuda", requires_grad=True
+        )
+
+        def fixed_draft_blocks(
+            self,
+            input_ids,
+            hidden_states,
+            loss_mask,
+            max_valid_anchors=None,
+        ):
+            del hidden_states, loss_mask, max_valid_anchors
+            return (
+                torch.tensor([[0, 4]], device=input_ids.device),
+                torch.ones(1, 2, dtype=torch.bool, device=input_ids.device),
+                fixed_hidden,
+            )
+
+        model._forward_draft_blocks = MethodType(fixed_draft_blocks, model)
+        inputs = {
+            "input_ids": torch.tensor([[1, 2, 3, 4, 5, 6, 0, 1]], device="cuda"),
+            "hidden_states": torch.zeros(1, 2 * block_size, hidden_size, device="cuda"),
+            "loss_mask": torch.ones(1, 2 * block_size, device="cuda"),
+            "lambda_base": 0.25,
+        }
+        model._use_fused_domino_ce = False
+        standard = model(**inputs)
+        standard[0].backward()
+        standard_hidden_grad = fixed_hidden.grad.clone()
+        standard_parameter_grads = {
+            name: None if parameter.grad is None else parameter.grad.clone()
+            for name, parameter in model.named_parameters()
+        }
+        fixed_hidden.grad = None
+        model.zero_grad(set_to_none=True)
+
+        model._use_fused_domino_ce = True
+        fused = model(**inputs)
+        fused[0].backward()
+
+        torch.testing.assert_close(fused[0], standard[0])
+        torch.testing.assert_close(fused[1], standard[1])
+        for key in standard[2]:
+            torch.testing.assert_close(fused[2][key], standard[2][key])
+
+        torch.testing.assert_close(
+            fixed_hidden.grad, standard_hidden_grad, rtol=1e-4, atol=1e-4
+        )
+        for name, parameter in model.named_parameters():
+            standard_grad = standard_parameter_grads[name]
+            self.assertEqual(parameter.grad is None, standard_grad is None, name)
+            if standard_grad is not None:
+                torch.testing.assert_close(
+                    parameter.grad, standard_grad, rtol=1e-4, atol=1e-4
+                )
+
     def test_npu_bf16_gru_gradients_reach_registered_weights(self):
         torch.manual_seed(7)
         model = _bare_domino().to(dtype=torch.bfloat16)

--- a/tests/test_utils/test_domino_cross_entropy.py
+++ b/tests/test_utils/test_domino_cross_entropy.py
@@ -1,0 +1,140 @@
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from specforge.core.domino_loss import domino_weighted_cross_entropy
+
+
+def _reference(base, correction, targets, weights, block_size, suffix_start):
+    """Materialize corrected logits using the original PyTorch path."""
+    num_blocks = base.shape[0] // block_size
+    base_3d = base.reshape(num_blocks, block_size, -1)
+    suffix_size = block_size - suffix_start
+    final = torch.cat(
+        (
+            base_3d[:, :suffix_start],
+            base_3d[:, suffix_start:]
+            + correction.reshape(num_blocks, suffix_size, -1),
+        ),
+        dim=1,
+    ).reshape_as(base)
+    final_loss_sum = (
+        F.cross_entropy(final, targets, reduction="none") * weights
+    ).sum()
+    base_loss_sum = (
+        F.cross_entropy(base, targets, reduction="none") * weights
+    ).sum()
+    return (
+        final_loss_sum,
+        base_loss_sum,
+        final.argmax(dim=-1),
+        base.argmax(dim=-1),
+    )
+
+
+class DominoCrossEntropyTest(unittest.TestCase):
+    def _compare(
+        self, device, *, block_size=4, suffix_start=1,
+        num_blocks=3, vocab_size=19,
+    ):
+        torch.manual_seed(7)
+        rows = num_blocks * block_size
+        correction_rows = num_blocks * (block_size - suffix_start)
+        targets = torch.randint(vocab_size, (rows,), device=device)
+        weights = torch.rand(rows, device=device)
+        weights[::5] = 0
+
+        actual_base = torch.randn(rows, vocab_size, device=device, requires_grad=True)
+        actual_correction = torch.randn(
+            correction_rows, vocab_size, device=device, requires_grad=True
+        )
+        expected_base = actual_base.detach().clone().requires_grad_(True)
+        expected_correction = actual_correction.detach().clone().requires_grad_(True)
+
+        actual = domino_weighted_cross_entropy(
+            actual_base, actual_correction, targets, weights,
+            block_size, suffix_start,
+            use_fused=device.type == "cuda",
+        )
+        expected = _reference(
+            expected_base, expected_correction, targets, weights,
+            block_size, suffix_start,
+        )
+        torch.testing.assert_close(actual[0], expected[0], rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(actual[1], expected[1], rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(actual[2], expected[2])
+        torch.testing.assert_close(actual[3], expected[3])
+
+        (0.7 * actual[0] + 0.3 * actual[1]).backward()
+        (0.7 * expected[0] + 0.3 * expected[1]).backward()
+        torch.testing.assert_close(
+            actual_base.grad, expected_base.grad, rtol=1e-4, atol=1e-4
+        )
+        torch.testing.assert_close(
+            actual_correction.grad,
+            expected_correction.grad,
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+    def test_cpu_fallback_matches_pytorch(self):
+        self._compare(torch.device("cpu"))
+
+    def test_invalid_correction_shape_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "correction logits"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8),
+                torch.randn(4, 8),
+                torch.zeros(4, dtype=torch.long),
+                torch.ones(4),
+                block_size=4,
+                suffix_start=1,
+                use_fused=False,
+            )
+
+    def test_fused_path_requires_cuda(self):
+        with self.assertRaisesRegex(ValueError, "requires CUDA"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8),
+                torch.randn(3, 8),
+                torch.zeros(4, dtype=torch.long),
+                torch.ones(4),
+                block_size=4,
+                suffix_start=1,
+                use_fused=True,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton loss requires CUDA")
+    def test_triton_matches_pytorch(self):
+        device = torch.device("cuda")
+        self._compare(device)
+        self._compare(
+            device, block_size=4, suffix_start=0,
+            num_blocks=2, vocab_size=2053,
+        )
+        self._compare(
+            device, block_size=4, suffix_start=3,
+            num_blocks=2, vocab_size=2053,
+        )
+
+        # Both reductions must preserve PyTorch's leftmost tie break.
+        base = torch.zeros(8, 2053, device=device)
+        correction = torch.zeros(6, 2053, device=device)
+        targets = torch.arange(8, device=device)
+        weights = torch.ones(8, device=device)
+        actual = domino_weighted_cross_entropy(
+            base,
+            correction,
+            targets,
+            weights,
+            block_size=4,
+            suffix_start=1,
+            use_fused=True,
+        )
+        torch.testing.assert_close(actual[2], torch.zeros_like(actual[2]))
+        torch.testing.assert_close(actual[3], torch.zeros_like(actual[3]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils/test_domino_cross_entropy.py
+++ b/tests/test_utils/test_domino_cross_entropy.py
@@ -1,0 +1,238 @@
+import subprocess
+import sys
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from specforge.core.domino_loss import domino_weighted_cross_entropy
+
+
+def _reference(base, correction, targets, weights, block_size, suffix_start):
+    """Materialize corrected logits and accumulate cross-entropy in FP32."""
+    num_blocks = base.shape[0] // block_size
+    base_3d = base.reshape(num_blocks, block_size, -1)
+    suffix_size = block_size - suffix_start
+    final = torch.cat(
+        (
+            base_3d[:, :suffix_start],
+            base_3d[:, suffix_start:] + correction.reshape(num_blocks, suffix_size, -1),
+        ),
+        dim=1,
+    ).reshape_as(base)
+    final_loss_sum = (
+        F.cross_entropy(final.float(), targets, reduction="none") * weights
+    ).sum()
+    base_loss_sum = (
+        F.cross_entropy(base.float(), targets, reduction="none") * weights
+    ).sum()
+    return (
+        final_loss_sum,
+        base_loss_sum,
+        final.argmax(dim=-1),
+        base.argmax(dim=-1),
+    )
+
+
+class DominoCrossEntropyTest(unittest.TestCase):
+    def _compare(
+        self,
+        device,
+        *,
+        block_size=4,
+        suffix_start=1,
+        num_blocks=3,
+        vocab_size=19,
+        dtype=torch.float32,
+    ):
+        torch.manual_seed(7)
+        rows = num_blocks * block_size
+        correction_rows = num_blocks * (block_size - suffix_start)
+        targets = torch.randint(vocab_size, (rows,), device=device)
+        weights = torch.rand(rows, device=device)
+        weights[::5] = 0
+
+        actual_base = torch.randn(
+            rows,
+            vocab_size,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        actual_correction = torch.randn(
+            correction_rows,
+            vocab_size,
+            device=device,
+            dtype=dtype,
+            requires_grad=True,
+        )
+        expected_base = actual_base.detach().clone().requires_grad_(True)
+        expected_correction = actual_correction.detach().clone().requires_grad_(True)
+
+        actual = domino_weighted_cross_entropy(
+            actual_base,
+            actual_correction,
+            targets,
+            weights,
+            block_size,
+            suffix_start,
+            use_fused=device.type == "cuda",
+        )
+        expected = _reference(
+            expected_base,
+            expected_correction,
+            targets,
+            weights,
+            block_size,
+            suffix_start,
+        )
+        rtol, atol = (1e-2, 5e-3) if dtype == torch.bfloat16 else (1e-4, 1e-4)
+        torch.testing.assert_close(actual[0], expected[0], rtol=rtol, atol=atol)
+        torch.testing.assert_close(actual[1], expected[1], rtol=rtol, atol=atol)
+        torch.testing.assert_close(actual[2], expected[2])
+        torch.testing.assert_close(actual[3], expected[3])
+
+        (0.7 * actual[0] + 0.3 * actual[1]).backward()
+        (0.7 * expected[0] + 0.3 * expected[1]).backward()
+        torch.testing.assert_close(
+            actual_base.grad, expected_base.grad, rtol=rtol, atol=atol
+        )
+        torch.testing.assert_close(
+            actual_correction.grad,
+            expected_correction.grad,
+            rtol=rtol,
+            atol=atol,
+        )
+
+    def test_cpu_fallback_matches_pytorch(self):
+        self._compare(torch.device("cpu"))
+
+    def test_cpu_fallback_does_not_import_triton(self):
+        script = """
+import builtins
+import torch
+
+real_import = builtins.__import__
+
+def guarded_import(name, *args, **kwargs):
+    if name == "triton" or name.startswith("triton."):
+        raise AssertionError("CPU fallback imported Triton")
+    return real_import(name, *args, **kwargs)
+
+builtins.__import__ = guarded_import
+from specforge.core.domino_loss import domino_weighted_cross_entropy
+
+domino_weighted_cross_entropy(
+    torch.randn(4, 8),
+    torch.randn(3, 8),
+    torch.zeros(4, dtype=torch.long),
+    torch.ones(4),
+    block_size=4,
+    suffix_start=1,
+    use_fused=False,
+)
+"""
+        subprocess.run([sys.executable, "-c", script], check=True)
+
+    def test_invalid_correction_shape_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "correction logits"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8),
+                torch.randn(4, 8),
+                torch.zeros(4, dtype=torch.long),
+                torch.ones(4),
+                block_size=4,
+                suffix_start=1,
+                use_fused=False,
+            )
+
+    def test_non_integer_targets_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "torch.long"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8),
+                torch.randn(3, 8),
+                torch.zeros(4),
+                torch.ones(4),
+                block_size=4,
+                suffix_start=1,
+                use_fused=False,
+            )
+
+    def test_fused_path_requires_cuda(self):
+        with self.assertRaisesRegex(ValueError, "requires CUDA"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8),
+                torch.randn(3, 8),
+                torch.zeros(4, dtype=torch.long),
+                torch.ones(4),
+                block_size=4,
+                suffix_start=1,
+                use_fused=True,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton loss requires CUDA")
+    def test_fused_path_rejects_unsupported_logit_dtype(self):
+        with self.assertRaisesRegex(ValueError, "FP16, BF16, or FP32"):
+            domino_weighted_cross_entropy(
+                torch.randn(4, 8, device="cuda", dtype=torch.float64),
+                torch.randn(3, 8, device="cuda", dtype=torch.float64),
+                torch.zeros(4, device="cuda", dtype=torch.long),
+                torch.ones(4, device="cuda"),
+                block_size=4,
+                suffix_start=1,
+                use_fused=True,
+            )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "Triton loss requires CUDA")
+    def test_triton_matches_pytorch(self):
+        device = torch.device("cuda")
+        self._compare(device)
+        self._compare(
+            device,
+            block_size=4,
+            suffix_start=0,
+            num_blocks=2,
+            vocab_size=2053,
+        )
+        self._compare(
+            device,
+            block_size=4,
+            suffix_start=3,
+            num_blocks=2,
+            vocab_size=2053,
+        )
+
+        # Both reductions must preserve PyTorch's leftmost tie break.
+        base = torch.zeros(8, 2053, device=device)
+        correction = torch.zeros(6, 2053, device=device)
+        targets = torch.arange(8, device=device)
+        weights = torch.ones(8, device=device)
+        actual = domino_weighted_cross_entropy(
+            base,
+            correction,
+            targets,
+            weights,
+            block_size=4,
+            suffix_start=1,
+            use_fused=True,
+        )
+        torch.testing.assert_close(actual[2], torch.zeros_like(actual[2]))
+        torch.testing.assert_close(actual[3], torch.zeros_like(actual[3]))
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.cuda.is_bf16_supported(),
+        "Triton BF16 loss requires a BF16 CUDA device",
+    )
+    def test_triton_bfloat16_matches_float32_reference(self):
+        self._compare(
+            torch.device("cuda"),
+            dtype=torch.bfloat16,
+            block_size=16,
+            suffix_start=2,
+            num_blocks=2,
+            vocab_size=5003,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Domino previously materialized corrected logits before computing its final and base cross-entropy losses. At production vocabulary sizes, that creates large corrected-logit and softmax intermediates and requires additional vocabulary passes.

Add a fused Triton implementation that consumes base logits and compact suffix corrections directly. The forward kernel computes both weighted losses and predictions in one vocabulary scan. It saves per-row maximum and shifted exponential-sum statistics so backward can reconstruct softmax tiles and write base and correction gradients without materializing corrected logits or probability tensors.

On an NVIDIA GB300 with Torch 2.11.0, CUDA 13.0, BF16, block size 16, and vocabulary size 248320, a forward-plus-backward microbenchmark measured 11.17 ms eager versus 1.82 ms fused at 2048 rows (6.1x), and 21.91 ms versus 3.27 ms at 4096 rows (6.7x). At 4096 rows, incremental peak allocation fell from 7.58 GiB to 3.67 GiB. These are loss-kernel measurements, not end-to-end training results.


Keep a readable PyTorch reference path behind the explicit use_fused argument, and route OnlineDominoModel through the same API for both paths. Add focused comparisons of losses, predictions, and gradients across correction layouts and vocabulary tiles, plus a model-level integration test.