### PR TITLE
test(config): make recipe README guard runnable under unittest discover

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -146,6 +146,7 @@ should make their training strategy and topology explicit.
 | `model.input_modality` | `text` | The provider modality. The unified runtime supports text only; VLM modalities such as `qwen2_5_vl` are rejected. |
 | `model.shard_target_output` | `false` | Retained for config migration; leave it false on the server-only online path. |
 | `model.trust_remote_code` | `false` | Enable only for model repositories that require custom loading code. |
+| `model.use_liger_kernel` | `false` | Enable Liger Qwen3 RMSNorm/SwiGLU kernels for DFlash training. Requires the `specforge[liger]` extra. |
 | `model.embedding_key` | `model.embed_tokens.weight` | Target checkpoint key copied into or used by the draft embedding. |
 | `model.lm_head_key` | `lm_head.weight` | Target checkpoint key used for the frozen output head. |
 | `model.vocab_mapping_path` | `""` | Target-to-draft vocabulary mapping. EAGLE3 disaggregated runs require an explicit shared file. |

--- a/tests/test_config/test_recipe_readme.py
+++ b/tests/test_config/test_recipe_readme.py
@@ -1,5 +1,6 @@
 """Keep the user-facing YAML reference synchronized with the typed schema."""
 
+import unittest
 from pathlib import Path
 
 from specforge.config import (
@@ -22,37 +23,40 @@ ROOT = Path(__file__).resolve().parents[2]
 README = ROOT / "examples" / "configs" / "README.md"
 
 
-def test_recipe_readme_names_every_typed_config_field():
-    text = README.read_text(encoding="utf-8")
-    schemas = (
-        ("", Config),
-        ("model", ModelConfig),
-        ("data", DataConfig),
-        ("training", TrainingConfig),
-        ("tracking", TrackingConfig),
-        ("profiling", ProfilingConfig),
-        ("runtime", RuntimeConfig),
-        ("deployment", DeploymentConfig),
-        ("deployment.trainer", TrainerDeploymentConfig),
-        ("deployment.disaggregated", DisaggregatedDeploymentConfig),
-        ("deployment.disaggregated.managed_local", ManagedLocalStackConfig),
-        (
-            "deployment.disaggregated.managed_local.mooncake",
-            ManagedLocalMooncakeConfig,
-        ),
-        (
-            "deployment.disaggregated.managed_local.capture_servers[]",
-            ManagedLocalCaptureServerConfig,
-        ),
-    )
+class TestRecipeReadmeSync(unittest.TestCase):
+    def test_recipe_readme_names_every_typed_config_field(self):
+        text = README.read_text(encoding="utf-8")
+        schemas = (
+            ("", Config),
+            ("model", ModelConfig),
+            ("data", DataConfig),
+            ("training", TrainingConfig),
+            ("tracking", TrackingConfig),
+            ("profiling", ProfilingConfig),
+            ("runtime", RuntimeConfig),
+            ("deployment", DeploymentConfig),
+            ("deployment.trainer", TrainerDeploymentConfig),
+            ("deployment.disaggregated", DisaggregatedDeploymentConfig),
+            ("deployment.disaggregated.managed_local", ManagedLocalStackConfig),
+            (
+                "deployment.disaggregated.managed_local.mooncake",
+                ManagedLocalMooncakeConfig,
+            ),
+            (
+                "deployment.disaggregated.managed_local.capture_servers[]",
+                ManagedLocalCaptureServerConfig,
+            ),
+        )
 
-    missing = []
-    for prefix, schema in schemas:
-        for field_name in schema.model_fields:
-            path = f"{prefix}.{field_name}" if prefix else field_name
-            if f"`{path}`" not in text:
-                missing.append(path)
+        missing = []
+        for prefix, schema in schemas:
+            for field_name in schema.model_fields:
+                path = f"{prefix}.{field_name}" if prefix else field_name
+                if f"`{path}`" not in text:
+                    missing.append(path)
 
-    assert (
-        not missing
-    ), f"examples/configs/README.md is missing config fields: {missing}"
+        self.assertEqual(
+            [],
+            missing,
+            f"examples/configs/README.md is missing config fields: {missing}",
+        )


### PR DESCRIPTION
## Motivation

`tests/test_config/test_recipe_readme.py` has never run in CI: it is a bare module-level function, while CI collects tests via `python -m unittest discover` (TestCase-only). The schema/README guard has been dead code since introduction — #665 added `model.use_liger_kernel` to `ModelConfig` without the README row, and stayed green.

Repro (no GPU needed):

- `python -m unittest tests.test_config.test_recipe_readme` → `Ran 0 tests`
- after this PR: 1 test collected; fails without the README row, passes with it

## Modifications

- `tests/test_config/test_recipe_readme.py`: wrap the check in `TestRecipeReadmeSync(unittest.TestCase)` so `unittest discover` collects it; no CI workflow change.
- `examples/configs/README.md`: add the missing `` `model.use_liger_kernel` `` row — must land in the same PR, otherwise the newly-live guard goes red on main.

## Related Issues

- Fixes #723
- Drift introduced by #665

## Accuracy Test

N/A

## Benchmark & Profiling

N/A

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci). (This PR is a unit-test repair.)
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci). (Adds the missing `model.use_liger_kernel` row.)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.