### PR TITLE
feat(dspark): add offline USP training support

### DIFF
--- a/specforge/algorithms/common/dflash_family_data.py
+++ b/specforge/algorithms/common/dflash_family_data.py
@@ -87,6 +87,59 @@ def normalize_dspark_offline_sample(raw, max_len: int):
     }
 
 
+def normalize_dspark_usp_offline_sample(
+    raw,
+    max_len: int,
+    *,
+    sp_rank: int,
+    sp_size: int,
+):
+    """Shard all DSpark sequence tensors once per rank for offline USP.
+
+    The feature store remains one full record per sample.  Each draft-SP rank
+    slices its own sequence range at load time, including the final target state
+    used by DSpark L1 and confidence supervision.  The final shard is padded to
+    an equal length so HCCL all-gather has a static tensor shape.
+    """
+    if sp_size <= 1 or not 0 <= sp_rank < sp_size:
+        raise ValueError(f"invalid DSpark USP shard rank={sp_rank}, size={sp_size}")
+    import torch
+    import torch.nn.functional as F
+
+    normalized = normalize_dspark_offline_sample(raw, max_len)
+    global_length = int(normalized["input_ids"].shape[1])
+    chunk_length = (global_length + sp_size - 1) // sp_size
+    start = sp_rank * chunk_length
+    end = min(start + chunk_length, global_length)
+    valid_length = max(0, end - start)
+
+    def _slice(tensor: torch.Tensor) -> torch.Tensor:
+        sliced = tensor[:, start:end]
+        if valid_length < chunk_length:
+            if tensor.ndim == 2:
+                sliced = F.pad(sliced, (0, chunk_length - valid_length))
+            elif tensor.ndim == 3:
+                sliced = F.pad(sliced, (0, 0, 0, chunk_length - valid_length))
+            else:  # normalize_dspark_offline_sample fixes all supported ranks.
+                raise ValueError(f"unexpected DSpark USP tensor rank {tensor.ndim}")
+        return sliced.contiguous()
+
+    attention_mask = torch.zeros(
+        1,
+        chunk_length,
+        dtype=torch.long,
+        device=normalized["input_ids"].device,
+    )
+    attention_mask[:, :valid_length] = 1
+    return {
+        "input_ids": _slice(normalized["input_ids"]),
+        "loss_mask": _slice(normalized["loss_mask"]),
+        "hidden_states": _slice(normalized["hidden_states"]),
+        "target_last_hidden_states": _slice(normalized["target_last_hidden_states"]),
+        "attention_mask": attention_mask,
+    }
+
+
 def build_offline_reader(
     strategy,
     hidden_states_path,
@@ -140,7 +193,23 @@ def build_offline_normalizer(max_len, **_topology):
     return partial(normalize_offline_sample, max_len=max_len)
 
 
-def build_dspark_offline_normalizer(max_len, **_topology):
+def build_dspark_offline_normalizer(max_len, *, use_usp_preprocess=False, **_topology):
+    if use_usp_preprocess:
+        import torch.distributed as dist
+
+        from specforge.distributed import get_draft_sp_group
+
+        if not dist.is_available() or not dist.is_initialized():
+            raise RuntimeError("DSpark USP preprocessing requires process groups")
+        group = get_draft_sp_group()
+        if group is None:
+            raise RuntimeError("DSpark USP preprocessing requires a draft SP group")
+        return partial(
+            normalize_dspark_usp_offline_sample,
+            max_len=max_len,
+            sp_rank=dist.get_rank(group),
+            sp_size=dist.get_world_size(group),
+        )
     return partial(normalize_dspark_offline_sample, max_len=max_len)
 
 
@@ -161,6 +230,19 @@ def build_collator():
 
 def build_dspark_collator():
     def collate(features):
+        required_keys = (
+            "input_ids",
+            "loss_mask",
+            "hidden_states",
+            "target_last_hidden_states",
+        )
+        has_attention_masks = ["attention_mask" in feature for feature in features]
+        if any(has_attention_masks) and not all(has_attention_masks):
+            raise ValueError(
+                "DSpark USP batches must either all include attention_mask or none"
+            )
+        if all(has_attention_masks):
+            required_keys = (*required_keys, "attention_mask")
         return pad_and_concatenate_features(
             features,
             sequence_axes={
@@ -168,13 +250,9 @@ def build_dspark_collator():
                 "loss_mask": 1,
                 "hidden_states": 1,
                 "target_last_hidden_states": 1,
+                "attention_mask": 1,
             },
-            required_keys=(
-                "input_ids",
-                "loss_mask",
-                "hidden_states",
-                "target_last_hidden_states",
-            ),
+            required_keys=required_keys,
         )
 
     return collate
@@ -190,5 +268,6 @@ __all__ = [
     "build_offline_normalizer",
     "build_offline_reader",
     "normalize_dspark_offline_sample",
+    "normalize_dspark_usp_offline_sample",
     "normalize_offline_sample",
 ]

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -33,6 +33,74 @@ _VALID_LOSS_TYPES = {
 _DPACE_LOSS_TYPES = _VALID_LOSS_TYPES - {"dflash"}
 
 
+class _GatherSequenceShards(torch.autograd.Function):
+    """All-gather sequence shards while returning remote gradients to owners."""
+
+    @staticmethod
+    def forward(ctx, local_states: torch.Tensor, group, global_sequence_length: int):
+        import torch.distributed as dist
+
+        world_size = dist.get_world_size(group)
+        rank = dist.get_rank(group)
+        ctx.group = group
+        ctx.world_size = world_size
+        ctx.rank = rank
+        ctx.local_sequence_length = int(local_states.shape[1])
+        ctx.global_sequence_length = int(global_sequence_length)
+        gathered = [torch.empty_like(local_states) for _ in range(world_size)]
+        dist.all_gather(gathered, local_states.contiguous(), group=group)
+        return torch.cat(gathered, dim=1)[:, :global_sequence_length]
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        import torch.distributed as dist
+
+        full_length = ctx.world_size * ctx.local_sequence_length
+        complete_grad = grad_output.new_zeros(
+            grad_output.shape[0],
+            full_length,
+            grad_output.shape[2],
+        )
+        complete_grad[:, : ctx.global_sequence_length] = grad_output
+        # Each rank's ``grad_output`` contains every source shard. Reduce the
+        # complete gradient and scatter its rank-owned sequence piece; reducing
+        # a rank-local slice directly would incorrectly add different source
+        # positions (rank 0's shard plus rank 1's shard, and so on).
+        backend = str(dist.get_backend(ctx.group)).lower()
+        if backend == "gloo":
+            # Gloo does not provide reduce_scatter_tensor on every supported
+            # PyTorch build. This fallback is numerical-reference only.
+            dist.all_reduce(complete_grad, group=ctx.group)
+            local_grad = complete_grad.split(ctx.local_sequence_length, dim=1)[
+                ctx.rank
+            ].contiguous()
+        else:
+            local_grad = torch.empty_like(complete_grad[:, : ctx.local_sequence_length])
+            dist.reduce_scatter_tensor(
+                local_grad,
+                complete_grad.contiguous(),
+                op=dist.ReduceOp.SUM,
+                group=ctx.group,
+            )
+        return local_grad, None, None
+
+
+def gather_sequence_shards(
+    local_states: torch.Tensor,
+    *,
+    group,
+    global_sequence_length: int,
+) -> torch.Tensor:
+    """Gather equally padded sequence shards with an autograd-correct backward."""
+    import torch.distributed as dist
+
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError("DSpark USP requires initialized process groups")
+    if dist.get_world_size(group) <= 1:
+        return local_states[:, :global_sequence_length]
+    return _GatherSequenceShards.apply(local_states, group, global_sequence_length)
+
+
 def compute_accept_len(
     pred_ids_4d: torch.Tensor,
     target_ids_4d: torch.Tensor,
@@ -269,46 +337,122 @@ class OnlineDFlashModel(nn.Module):
         input_ids: torch.Tensor,
         hidden_states: torch.Tensor,
         loss_mask: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         bsz, seq_len = input_ids.shape
         device = input_ids.device
 
-        anchor_positions, block_keep_mask = self._sample_anchor_positions(
-            seq_len, loss_mask, device
-        )
+        sequence_start = 0
+        context_length = seq_len
+        target_hidden = hidden_states
+        target_hidden_is_projected = False
+        minimum_anchor_width = None
+        if self.attention_backend == "usp":
+            if attention_mask is None:
+                raise ValueError("DSpark USP requires a local attention_mask")
+            if attention_mask.shape != input_ids.shape:
+                raise ValueError(
+                    "DSpark USP attention_mask must match input_ids, got "
+                    f"{tuple(attention_mask.shape)} and {tuple(input_ids.shape)}"
+                )
+            if bsz != 1:
+                raise ValueError("DSpark USP requires batch_size=1")
+            import torch.distributed as dist
+
+            from specforge.distributed import get_draft_sp_group
+
+            group = get_draft_sp_group()
+            if group is None or not dist.is_initialized():
+                raise RuntimeError("DSpark USP requires initialized draft SP groups")
+            world_size = dist.get_world_size(group)
+            if world_size <= 1:
+                raise ValueError("DSpark USP requires a draft SP group larger than one")
+            local_valid_length = attention_mask.to(dtype=torch.long).sum().reshape(1)
+            valid_lengths = [
+                torch.zeros_like(local_valid_length) for _ in range(world_size)
+            ]
+            dist.all_gather(valid_lengths, local_valid_length, group=group)
+            lengths = [int(length.item()) for length in valid_lengths]
+            sequence_start = sum(lengths[: dist.get_rank(group)])
+            context_length = sum(lengths)
+            if context_length <= 0:
+                raise ValueError("DSpark USP sample has no valid context tokens")
+            # The stored feature is [capture_layers * hidden_size]. Projecting
+            # before HCCL exchange cuts the communicated width to hidden_size.
+            projected_target_hidden = self.draft_model.encode_target_hidden(
+                hidden_states
+            )
+            target_hidden = gather_sequence_shards(
+                projected_target_hidden,
+                group=group,
+                global_sequence_length=context_length,
+            )
+            target_hidden_is_projected = True
+
+            if self.loss_type == "dspark":
+                local_valid = (
+                    self._build_anchor_candidate_mask(seq_len, loss_mask)
+                    .sum(dim=1)
+                    .max()
+                    .to(dtype=torch.long)
+                )
+                dist.all_reduce(local_valid, op=dist.ReduceOp.MAX, group=group)
+                minimum_anchor_width = min(self.num_anchors, int(local_valid.item()))
+                if minimum_anchor_width <= 0:
+                    raise ValueError(
+                        "DSpark USP found no valid anchor with two consecutive loss tokens"
+                    )
+
+        if minimum_anchor_width is None:
+            anchor_positions, block_keep_mask = self._sample_anchor_positions(
+                seq_len, loss_mask, device
+            )
+        else:
+            anchor_positions, block_keep_mask = self._sample_anchor_positions(
+                seq_len,
+                loss_mask,
+                device,
+                minimum_anchor_width=minimum_anchor_width,
+            )
 
         noise_embedding = self._create_noise_embed(
             input_ids, anchor_positions, block_keep_mask
         )
 
         context_position_ids = (
-            torch.arange(seq_len, device=device).unsqueeze(0).expand(bsz, -1)
+            torch.arange(context_length, device=device).unsqueeze(0).expand(bsz, -1)
         )
-        draft_position_ids = self._create_position_ids(anchor_positions)
+        attention_anchor_positions = anchor_positions + sequence_start
+        draft_position_ids = self._create_position_ids(attention_anchor_positions)
         full_position_ids = torch.cat([context_position_ids, draft_position_ids], dim=1)
 
         if self.attention_backend == "flex_attention":
             dflash_attn_mask = create_dflash_block_mask(
-                anchor_positions=anchor_positions,
+                anchor_positions=attention_anchor_positions,
                 block_keep_mask=block_keep_mask,
-                S=seq_len,
+                S=context_length,
                 block_size=self.block_size,
                 device=device,
             )
         else:
             dflash_attn_mask = create_dflash_sdpa_mask(
-                anchor_positions=anchor_positions,
+                anchor_positions=attention_anchor_positions,
                 block_keep_mask=block_keep_mask,
-                S=seq_len,
+                S=context_length,
                 block_size=self.block_size,
                 device=device,
             )
 
+        draft_kwargs = {
+            "position_ids": full_position_ids,
+            "noise_embedding": noise_embedding,
+            "target_hidden": target_hidden,
+            "attention_mask": dflash_attn_mask,
+        }
+        if target_hidden_is_projected:
+            draft_kwargs["target_hidden_is_projected"] = True
         output_hidden = self.draft_model(
-            position_ids=full_position_ids,
-            noise_embedding=noise_embedding,
-            target_hidden=hidden_states,
-            attention_mask=dflash_attn_mask,
+            **draft_kwargs,
         )
         return anchor_positions, block_keep_mask, output_hidden
 
@@ -776,15 +920,26 @@ class OnlineDSparkModel(OnlineDFlashModel):
         return anchor_valid & first_target_valid
 
     def _sample_anchor_positions(
-        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
+        self,
+        seq_len: int,
+        loss_mask: torch.Tensor,
+        device: torch.device,
+        *,
+        minimum_anchor_width: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Sample only anchors with a valid first target, without dummy width."""
+        """Sample valid anchors, padding USP-local empty shards when required."""
 
         valid = self._build_anchor_candidate_mask(seq_len, loss_mask)
         if valid.shape[1] == 0:
             raise ValueError("DSpark needs sequences with at least two tokens")
         valid_counts = valid.sum(dim=1)
-        width = min(self.num_anchors, int(valid_counts.max().item()))
+        local_width = min(self.num_anchors, int(valid_counts.max().item()))
+        width = local_width if minimum_anchor_width is None else minimum_anchor_width
+        if width > self.num_anchors:
+            raise ValueError(
+                "DSpark minimum_anchor_width exceeds configured num_anchors: "
+                f"{width} > {self.num_anchors}"
+            )
         if width <= 0:
             raise ValueError(
                 "DSpark found no valid anchor with two consecutive loss tokens"
@@ -1128,6 +1283,7 @@ class OnlineDSparkModel(OnlineDFlashModel):
         hidden_states: torch.Tensor,
         loss_mask: torch.Tensor,
         target_last_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, object]]:
         """Parallel DSpark training forward pass."""
         if self.attention_backend == "flex_attention" and not FLEX_ATTENTION_AVAILABLE:
@@ -1138,6 +1294,7 @@ class OnlineDSparkModel(OnlineDFlashModel):
             input_ids=input_ids,
             hidden_states=hidden_states,
             loss_mask=loss_mask,
+            attention_mask=attention_mask,
         )
 
         (

--- a/specforge/algorithms/dspark/providers.py
+++ b/specforge/algorithms/dspark/providers.py
@@ -137,7 +137,7 @@ def algorithm_spec() -> AlgorithmSpec:
             ),
         ),
         capabilities=AlgorithmCapabilities(
-            attention_backends={"eager", "sdpa", "flex_attention"},
+            attention_backends={"eager", "sdpa", "flex_attention", "usp"},
         ),
     )
 

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -61,6 +61,18 @@ def _device():
     return get_local_device()
 
 
+def _transformers_attention_implementation(attention_backend: str) -> str:
+    """Map SpecForge topology names to Transformers attention dispatchers."""
+
+    if attention_backend == "usp":
+        # USP controls how training ranks shard a sequence. Transformers still
+        # needs a concrete local attention implementation for draft creation.
+        return "sdpa"
+    if attention_backend == "fa":
+        return "flash_attention_2"
+    return attention_backend
+
+
 def _warm_start(
     cfg: Config,
     draft_model: Any,
@@ -161,7 +173,9 @@ def _finish_registered_draft(
 def build_registered_draft(cfg: Config, draft_config: PretrainedConfig):
     from specforge.modeling.auto import AutoDraftModel
 
-    draft_config._attn_implementation = cfg.training.attention_backend
+    draft_config._attn_implementation = _transformers_attention_implementation(
+        cfg.training.attention_backend
+    )
     draft_model = AutoDraftModel.from_config(
         draft_config,
         torch_dtype=_torch_dtype(cfg),
@@ -176,7 +190,9 @@ def build_dflash_draft(
 ):
     from specforge.modeling.auto import AutoDraftModel
 
-    draft_config._attn_implementation = cfg.training.attention_backend
+    draft_config._attn_implementation = _transformers_attention_implementation(
+        cfg.training.attention_backend
+    )
     draft_model = AutoDraftModel.from_config(
         draft_config,
         torch_dtype=_torch_dtype(cfg),

--- a/specforge/cli.py
+++ b/specforge/cli.py
@@ -134,6 +134,12 @@ def _train(resolved) -> int:
         tp_size=cfg.training.tp_size,
         sp_ulysses_size=cfg.training.sp_ulysses_size,
         sp_ring_size=cfg.training.sp_ring_size,
+        # DSpark USP uses the typed draft-SP mesh plus HCCL collectives; it
+        # intentionally does not import CUDA-only yunchang Flash Attention.
+        enable_sequence_parallel=not (
+            cfg.training.strategy == "dspark"
+            and cfg.training.attention_backend == "usp"
+        ),
     )
     try:
         import torch.distributed as dist

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -360,18 +360,29 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         draft_logits = target.lm_head(draft_hidden[:, -self.block_size + 1 :, :])
         return sample(draft_logits)
 
+    def encode_target_hidden(self, target_hidden: torch.Tensor) -> torch.Tensor:
+        """Project captured target layers into the draft attention width.
+
+        Offline USP gathers this lower-width representation instead of the
+        concatenated capture tensor.  Keeping the projection here preserves the
+        same parameters and numerics as the ordinary DFlash forward path.
+        """
+        return self.hidden_norm(self.fc(target_hidden))
+
     def forward(
         self,
         position_ids: torch.LongTensor,
         attention_mask: Optional[torch.Tensor] = None,
         noise_embedding: Optional[torch.Tensor] = None,
         target_hidden: Optional[torch.Tensor] = None,
+        target_hidden_is_projected: bool = False,
         past_key_values: Optional[Cache] = None,
         use_cache: bool = False,
         **kwargs,
     ) -> CausalLMOutputWithPast:
         hidden_states = noise_embedding
-        target_hidden = self.hidden_norm(self.fc(target_hidden))
+        if not target_hidden_is_projected:
+            target_hidden = self.encode_target_hidden(target_hidden)
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
         for layer in self.layers:
             hidden_states = layer(

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -484,6 +484,9 @@ class DSparkTrainStrategy(DraftTrainStrategy):
             hidden_states=t["hidden_states"].to(device),
             loss_mask=t["loss_mask"].to(device),
             target_last_hidden_states=t["target_last_hidden_states"].to(device),
+            attention_mask=(
+                t["attention_mask"].to(device) if "attention_mask" in t else None
+            ),
         )
         metrics = {
             "accuracy": accuracy.detach(),

--- a/tests/test_algorithms/test_dspark_usp.py
+++ b/tests/test_algorithms/test_dspark_usp.py
@@ -1,0 +1,162 @@
+import os
+import socket
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+
+from specforge.algorithms.common.dflash_family_data import (
+    build_dspark_collator,
+    build_dspark_offline_normalizer,
+    normalize_dspark_usp_offline_sample,
+)
+from specforge.algorithms.common.dflash_family_model import gather_sequence_shards
+
+
+def _raw_sequence(length=5):
+    return {
+        "input_ids": torch.arange(length, dtype=torch.long),
+        "loss_mask": torch.ones(length, dtype=torch.long),
+        "hidden_states": torch.arange(length * 4, dtype=torch.float32).reshape(
+            1, length, 4
+        ),
+        "target_last_hidden_states": torch.arange(
+            length * 2, dtype=torch.float32
+        ).reshape(1, length, 2),
+    }
+
+
+def _can_bind_loopback() -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+        return True
+    except OSError:
+        return False
+
+
+def _gather_worker(rank: int, init_file: str, output_dir: str) -> None:
+    import torch.distributed as dist
+
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=2,
+    )
+    try:
+        local = torch.tensor([[[float(rank + 1)]]], requires_grad=True)
+        gathered = gather_sequence_shards(
+            local,
+            group=dist.group.WORLD,
+            global_sequence_length=2,
+        )
+        gathered.square().sum().backward()
+        torch.save(
+            {"gathered": gathered.detach(), "grad": local.grad.detach()},
+            os.path.join(output_dir, f"rank{rank}.pt"),
+        )
+    finally:
+        dist.destroy_process_group()
+
+
+class TestDSparkUSPData(unittest.TestCase):
+    def test_shards_both_target_hidden_tensors_with_static_padding(self):
+        raw = _raw_sequence()
+        left = normalize_dspark_usp_offline_sample(raw, 5, sp_rank=0, sp_size=2)
+        right = normalize_dspark_usp_offline_sample(raw, 5, sp_rank=1, sp_size=2)
+        self.assertEqual(
+            {
+                "input_ids",
+                "loss_mask",
+                "hidden_states",
+                "target_last_hidden_states",
+                "attention_mask",
+            },
+            set(left),
+        )
+        self.assertEqual([0, 1, 2], left["input_ids"][0].tolist())
+        self.assertEqual([3, 4, 0], right["input_ids"][0].tolist())
+        self.assertEqual([1, 1, 1], left["attention_mask"][0].tolist())
+        self.assertEqual([1, 1, 0], right["attention_mask"][0].tolist())
+        self.assertTrue(
+            torch.equal(raw["hidden_states"][0, 3:5], right["hidden_states"][0, :2])
+        )
+        self.assertTrue(
+            torch.equal(
+                raw["target_last_hidden_states"][0, 3:5],
+                right["target_last_hidden_states"][0, :2],
+            )
+        )
+        self.assertTrue(torch.all(right["hidden_states"][0, 2] == 0))
+        self.assertTrue(torch.all(right["target_last_hidden_states"][0, 2] == 0))
+
+    def test_usp_collator_keeps_attention_mask(self):
+        raw = _raw_sequence()
+        features = [
+            normalize_dspark_usp_offline_sample(raw, 5, sp_rank=rank, sp_size=2)
+            for rank in range(2)
+        ]
+        batch = build_dspark_collator()(features)
+        self.assertEqual((2, 3), tuple(batch["attention_mask"].shape))
+        self.assertEqual([1, 1, 0], batch["attention_mask"][1].tolist())
+        self.assertEqual((2, 3, 2), tuple(batch["target_last_hidden_states"].shape))
+
+    def test_provider_normalizer_resolves_rank_local_usp_shard(self):
+        group = object()
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_rank", return_value=1),
+            mock.patch("torch.distributed.get_world_size", return_value=2),
+            mock.patch("specforge.distributed.get_draft_sp_group", return_value=group),
+        ):
+            normalizer = build_dspark_offline_normalizer(5, use_usp_preprocess=True)
+            result = normalizer(_raw_sequence())
+        self.assertEqual([3, 4, 0], result["input_ids"][0].tolist())
+
+    def test_single_rank_gather_is_identity_with_gradient(self):
+        local = torch.randn(1, 3, 4, requires_grad=True)
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=1),
+        ):
+            gathered = gather_sequence_shards(
+                local, group=object(), global_sequence_length=2
+            )
+        gathered.sum().backward()
+        self.assertTrue(torch.equal(gathered, local[:, :2]))
+        self.assertTrue(
+            torch.equal(local.grad[:, :2], torch.ones_like(local.grad[:, :2]))
+        )
+        self.assertTrue(
+            torch.equal(local.grad[:, 2:], torch.zeros_like(local.grad[:, 2:]))
+        )
+
+    @unittest.skipUnless(
+        _can_bind_loopback(),
+        "distributed collective test requires local loopback socket permission",
+    )
+    def test_two_rank_collective_reconstructs_sequence_and_routes_gradients(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            init_file = os.path.join(tmp, "init")
+            with mock.patch.dict(os.environ, {"GLOO_SOCKET_IFNAME": "lo"}):
+                torch.multiprocessing.spawn(
+                    _gather_worker,
+                    args=(init_file, tmp),
+                    nprocs=2,
+                    join=True,
+                )
+            rank0 = torch.load(os.path.join(tmp, "rank0.pt"), weights_only=True)
+            rank1 = torch.load(os.path.join(tmp, "rank1.pt"), weights_only=True)
+        expected = torch.tensor([[[1.0], [2.0]]])
+        self.assertTrue(torch.equal(rank0["gathered"], expected))
+        self.assertTrue(torch.equal(rank1["gathered"], expected))
+        self.assertTrue(torch.equal(rank0["grad"], torch.tensor([[[4.0]]])))
+        self.assertTrue(torch.equal(rank1["grad"], torch.tensor([[[8.0]]])))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_algorithms/test_model_providers.py
+++ b/tests/test_algorithms/test_model_providers.py
@@ -1,0 +1,18 @@
+import unittest
+
+from specforge.algorithms.model_providers import _transformers_attention_implementation
+
+
+class TransformersAttentionImplementationTest(unittest.TestCase):
+    def test_usp_uses_sdpa_for_transformers_model_construction(self):
+        self.assertEqual("sdpa", _transformers_attention_implementation("usp"))
+
+    def test_concrete_backend_is_preserved(self):
+        self.assertEqual(
+            "flex_attention",
+            _transformers_attention_implementation("flex_attention"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -773,6 +773,30 @@ class TestDFlashLosses(unittest.TestCase):
         self.assertEqual(anchors[0, 0].item(), 4)
         self.assertEqual(keep[0].tolist(), [True, False])
 
+    def test_dspark_sampler_pads_empty_usp_shard_to_shared_width(self):
+        model = _make_dspark_model(
+            self.logits,
+            self.anchors,
+            self.keep_mask,
+        )
+        empty_local_mask = torch.zeros(1, 6)
+        anchors, keep = OnlineDSparkModel._sample_anchor_positions(
+            model,
+            seq_len=6,
+            loss_mask=empty_local_mask,
+            device=empty_local_mask.device,
+            minimum_anchor_width=2,
+        )
+        self.assertEqual(anchors.tolist(), [[0, 0]])
+        self.assertEqual(keep.tolist(), [[False, False]])
+        _, eval_mask, _ = model._build_dspark_labels_and_mask(
+            input_ids=torch.arange(6, dtype=torch.long).unsqueeze(0),
+            loss_mask=empty_local_mask,
+            anchor_positions=anchors,
+            block_keep_mask=keep,
+        )
+        self.assertFalse(eval_mask.any())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

DSpark offline training currently processes the full sequence on every draft
sequence-parallel rank, which limits the usable sequence length and duplicates
target hidden-state storage and compute.

This PR adds a USP-backed offline training path for DSpark. It shards sequence
tensors across the draft-SP group while preserving global sequence semantics
for draft attention and loss computation.

## Modifications

- Add rank-local DSpark offline sample normalization for USP:
  - shard `input_ids`, `loss_mask`, `hidden_states`, and
    `target_last_hidden_states`;
  - pad the final shard to a static sequence length for collective
    communication;
  - carry a local `attention_mask` through the collator and training strategy.
- Add an autograd-correct sequence all-gather helper:
  - reconstruct global projected target hidden states for draft attention;
  - route gradients back to the owner rank with `reduce_scatter_tensor`;
  - retain a Gloo-compatible reference fallback.
- Add `usp` as a DSpark attention backend:
  - use SDPA only for local Transformers draft-model construction;
  - keep USP topology and sequence communication under SpecForge control;
  - avoid importing CUDA-only sequence-parallel dependencies for this path.
- Project target hidden states before the HCCL exchange to reduce communication
  width.
- Synchronize valid anchor width across draft-SP ranks and support empty local
  shards safely.
- Add focused coverage for data sharding, padding, collator propagation,
  distributed gather/backward behavior, backend mapping, and empty-shard anchor
  handling.

## Related Issues

N/A

## Accuracy Test

This PR changes DSpark training infrastructure rather than model architecture
or inference kernels.

Accuracy validation has not been run yet. A multi-rank DSpark offline training
comparison against the non-USP baseline is required before merge.

## Benchmark & Profiling

This PR is intended to enable longer offline training sequences and reduce
per-rank sequence-state memory.

Benchmark and profiling results have not been collected yet. Suggested
follow-up measurements:

- maximum trainable sequence length;
- peak device memory per rank;
- HCCL communication time;
- tokens/s versus the non-USP DSpark offline baseline.

## Checklist

- [ ] Format code with pre-commit.
- [x] Add focused unit tests.
- [ ] Run the focused test suite:
  `pytest tests/test_algorithms/test_dspark_usp.py tests/test_algorithms/test_model_providers.py tests/test_utils/test_dflash_losses.py`
- [ ] Update documentation / examples as needed.
- [ ] Provide multi-rank accuracy and throughput / latency results before merge.
- [x] Add a DCO sign-off:
  `Signed-off-by: calyoung80 <zsucal@hotmail.com>`
