### PR TITLE
Reorganize SpecForge runtime blog

### DIFF
--- a/blog/blog.md
+++ b/blog/blog.md
@@ -241,7 +241,7 @@ Our next steps are to publish more ready-to-serve draft checkpoints for popular 
 We thank the SGLang and SpecForge communities, the authors of the supported speculative-decoding methods, and all contributors who helped test the new runtime and algorithm integrations.
 
 - **SpecForge Team:** Jiaping Wang, Shenggui Li, and Xiaoming Dong
-- **RadixArk Team:** Cheng Mao, Yi Sun, and Kan Wu
+- **RadixArk Team:** Mao Cheng, Yi Sun, and Kan Wu
 - **Meta/Pytorch:** Richard Zou
 - **Domino:** Jianuo Huang
 - **Modal Team** 

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -234,5 +234,5 @@ Our next steps are to publish more ready-to-serve draft checkpoints for popular 
 We thank the SGLang and SpecForge communities, the authors of the supported speculative-decoding methods, and all contributors who helped test the new runtime and algorithm integrations.
 
 - **SpecForge Team:** Jiaping Wang, Shenggui Li, and Xiaoming Dong
-- **RadixArk Team:** Cheng Mao
+- **RadixArk Team:** Cheng Mao, Yi Sun
 - **Domino:** Jianuo Huang

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -242,4 +242,6 @@ We thank the SGLang and SpecForge communities, the authors of the supported spec
 
 - **SpecForge Team:** Jiaping Wang, Shenggui Li, and Xiaoming Dong
 - **RadixArk Team:** Cheng Mao, Yi Sun, and Kan Wu
+- **Meta/Pytorch:** Richard Zou
 - **Domino:** Jianuo Huang
+- **Modal Team** 

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -1,149 +1,83 @@
-# SpecForge Evolves: Disaggregated Training and a Unified Stack for Modern Speculative Decoding
+# SpecForge's New Training Runtime: Decoupling Target Inference from Draft Optimization
 
 **The SpecForge Team · July 2026**
 
-When we first released [SpecForge](https://www.lmsys.org/blog/2025-07-25-spec-forge/), our goal was to make EAGLE3 draft-model training practical and directly compatible with SGLang. Since then, speculative decoding has moved quickly: target models have grown, parallel drafting has become increasingly important, and a single training recipe must often span several inference servers and several trainer workers.
+When we first released [SpecForge](https://www.lmsys.org/blog/2025-07-25-spec-forge/), a training job owned both the frozen target model and the draft model being optimized. This made EAGLE3 draft-model training practical and directly compatible with SGLang, but it also tied two very different workloads to the same process lifecycle and resource topology.
 
-Today, we are introducing a major update to SpecForge. The new runtime separates target-model inference from draft-model training, supports a broader family of speculative decoding algorithms, and unifies online, offline, and disaggregated workflows behind one typed training entry point.
+The new SpecForge introduces a clean boundary between **target-feature production** and **draft-model optimization**. Patched SGLang servers generate tokens and capture target features; SpecForge trainers consume those features through lightweight references backed by Mooncake.
 
-## New Feature
+This one architectural change has two important consequences. First, inference and training capacity can be configured and deployed independently. Second, different speculative-drafting algorithms can reuse the same scheduling, dataflow, distributed-training, checkpointing, and failure-handling runtime. EAGLE3, EAGLE3.1, P-EAGLE, DFlash, Domino, and DSpark now share one typed configuration and one public training entry point.
 
-- **Online training is now fully disaggregated.** Patched SGLang servers capture target-model features, Mooncake transports the tensors, and trainer workers consume lightweight references through a separate control plane.
-- **Inference and training can scale independently.** On our 8xH20 testbed, a topology with **3 SGLang servers and 5 trainer workers** improves end-to-end training throughput by approximately **10%** over our previous colocated implementation.
-- **One runtime now supports multiple drafting families:** [EAGLE3](https://arxiv.org/abs/2503.01840), **EAGLE3.1**, [P-EAGLE](https://arxiv.org/abs/2602.01469), [DFlash](https://arxiv.org/abs/2602.06036), [Domino](https://arxiv.org/abs/2605.29707), and [DSpark](https://arxiv.org/abs/2607.05147), together with the optional [D-PACE](https://arxiv.org/abs/2605.18810) objective for DFlash.
+## From a Coupled Trainer to a Training Pipeline
 
-## Why Disaggregate Draft-Model Training?
+Online draft-model training contains two distinct workloads:
 
-Online draft-model training contains two very different workloads.
+- The **target side** runs a large, frozen model to generate tokens and capture hidden states. It is inference-heavy, often uses tensor parallelism, and benefits from a production inference engine.
+- The **draft side** trains a much smaller model with forward and backward passes. It scales through data or sequence parallelism and has a different memory and compute profile.
 
-The **target side** runs a large, frozen model to generate tokens and capture hidden states. It is inference-heavy, often requires tensor parallelism, and benefits from a production inference engine. The **draft side** trains a much smaller model, performs forward and backward passes, and scales through data or sequence parallelism.
+In the previous colocated design, both sides shared one lifecycle and one fixed resource layout. This created three practical limitations:
 
-In the previous colocated design, these two workloads shared one lifecycle and one fixed resource layout. This introduced three practical limitations:
+1. **A fixed inference-to-training ratio.** Scaling trainer workers also affected target-model placement, even when only one side was the bottleneck.
+2. **Resource interference.** Target capture and draft optimization competed inside the same tightly coupled job.
+3. **A shared failure boundary.** Slow or failed feature generation could stall training, while excess production could create unbounded memory pressure.
 
-1. **A fixed inference-to-training ratio.** Adding trainer workers also affected how the target model was placed, even when only one side was the bottleneck.
-2. **Resource interference.** Target-model capture and draft-model optimization competed for memory and compute within the same tightly coupled job.
-3. **Synchronized stalls.** A slowdown or failure in feature generation could directly block the training process, while excess production could create unbounded memory pressure.
+The key observation is simple: **trainers do not need to own the target model**. They only need the token sequences, masks, and target features required by the selected training objective. Making that boundary explicit changes SpecForge from a trainer process containing a target model into a coordinated training pipeline.
 
-The key observation is simple: trainers do not need to own the target model. They only need the token sequences, masks, and target features required by the selected training objective. Once that boundary is explicit, inference and training can become independently scheduled pools.
+## One Boundary, Three Contracts
 
-## The New Disaggregated Architecture
-
-The new online runtime has a producer pool and a consumer pool. The producer schedules prompts across one or more patched SGLang capture servers. SGLang writes captured tensors to Mooncake, while the producer publishes only lightweight `SampleRef` metadata. Consumer rank 0 durably records and distributes those references; each trainer then fetches the corresponding tensors directly from Mooncake.
+The new online runtime has a producer pool and a consumer pool. Producers schedule prompts across patched SGLang capture servers. SGLang writes feature tensors to Mooncake, while SpecForge sends only lightweight `SampleRef` metadata through the control plane. Trainer ranks resolve those references when they are ready to build a batch.
 
 ![SpecForge online-disaggregated training architecture](./specforge-disaggregated-architecture.svg)
 
-*Figure 1. SpecForge's online-disaggregated training flow. Large tensors stay in the data plane; the control plane carries references and lifecycle state only.*
+*Figure 1. The online-disaggregated training flow. Large tensors remain in the data plane; references and lifecycle state travel through the control plane.*
 
-### 1. Server-only target capture
+### 1. The capture contract
 
-The online trainer no longer initializes a colocated target model. Instead, every URL in `deployment.disaggregated.server_urls` creates one rollout worker connected to a patched SGLang server. The workers lease disjoint prompts from a shared controller, so adding a server increases capture capacity without changing the trainer topology.
+Every URL in `deployment.disaggregated.server_urls` creates a rollout worker connected to a patched SGLang server. Workers lease disjoint prompts from a shared controller, so capture capacity can change without changing the trainer topology.
 
-This also establishes a clean ownership boundary: SGLang owns target-model parallelism and feature capture, while SpecForge owns prompt scheduling, reference publication, and draft-model optimization.
+This creates a clear ownership boundary: SGLang owns target-model parallelism and feature capture, while SpecForge owns prompt scheduling, reference publication, and draft-model optimization.
 
-### 2. Tensors and metadata take different paths
+### 2. The delivery contract
 
-Captured hidden states can be large, so forwarding them through a Python queue or a control database would quickly become a bottleneck. SpecForge instead uses a `FeatureStore` abstraction:
+Captured hidden states can be large, so forwarding them through a Python queue or control database would quickly become a bottleneck. SpecForge separates tensor storage from sample coordination:
 
 - SGLang writes feature tensors to Mooncake.
 - The producer publishes tensor-free `SampleRef` records.
-- `FeatureDataLoader` is the only component that resolves references into tensor-carrying training batches.
-- Trainers release feature objects after a durable optimizer-step acknowledgement.
+- `FeatureDataLoader` resolves references into tensor-carrying training batches.
+- Trainers release feature objects after an optimizer-step acknowledgement.
 
-This split keeps the control plane small and makes the training loop independent of the storage transport. The same trainer path can consume local files, a shared directory, or Mooncake-backed features.
+The training loop depends on the `FeatureStore` contract rather than a specific transport. The same consumer path can therefore use local features, a shared directory, or Mooncake-backed online capture.
 
-### 3. Optimizer-aware flow control
+### 3. The lifecycle contract
 
-Distributed training ranks must advance in lockstep. Before capture starts, consumer rank 0 publishes a global dispatch quantum:
+Distributed ranks must advance together. The consumer releases references in complete optimizer-step quanta, so every rank receives the samples it needs for one synchronized update. High and low in-flight watermarks pause and resume capture, preventing the producer from running arbitrarily far ahead of training.
 
-```text
-quantum = world_size × per_rank_batch_size × gradient_accumulation_steps
-```
+At optimizer boundaries, consumer rank 0 records trained sample IDs in a retained SQLite ledger before acknowledgements reduce the in-flight depth and release feature objects. After an interruption, the consumer can use that ledger to skip completed sample IDs and replay the remaining references.
 
-References are released only in complete quantum-sized windows. Each rank therefore receives exactly the samples needed for one optimizer step, and an incomplete tail at end-of-stream is never dispatched as a partial distributed step.
+Failures are explicit on the producer side as well. A failed capture worker returns its leased prompts to the shared controller, allowing healthy workers to continue. The run fails loudly if all capture servers are unavailable or a prompt exhausts its retry budget.
 
-The producer also observes high and low in-flight watermarks. When the number of committed but unacknowledged samples reaches the high watermark, capture pauses; it resumes only after consumption falls below the low watermark. Optional resident-byte limits provide an additional guard against feature-store pressure.
+Together, these contracts keep the trainer independent of feature transport without weakening distributed-step alignment, bounded buffering, or recovery semantics.
 
-### 4. Durable recovery and failure handling
+## What This Separation Unlocks
 
-Consumer rank 0 is the only writer to the retaining SQLite ledger. At every optimizer boundary, SpecForge commits trained sample IDs, removes their feature objects, and then advances the channel counters. A crash before the transaction replays the untrained references; a crash after it skips the already committed samples.
+The new boundary produces two user-visible benefits: infrastructure can be balanced around the workload, and algorithm implementations can share one training runtime.
 
-On the producer side, a failed server returns its leased prompts to the controller, and the remaining workers continue. The run fails loudly when every capture server is unavailable or retry limits are exhausted. This makes server failures explicit without allowing them to silently corrupt the training stream.
+### Independent inference and training pools
 
-### 5. One configuration and one training entry point
+Target-model tensor and expert parallelism now belong to SGLang; draft-model data and sequence parallelism belong to SpecForge. The two pools can run under one local supervisor or as separate scheduler-managed jobs.
 
-The topology is described in the same typed YAML as the model, algorithm, data, and optimizer settings:
+When both pools share a fixed GPU budget, their ratio remains a resource trade-off. The difference is that the trade-off is now explicit and tunable instead of hard-wired into the trainer. When more resources are available, either pool can be expanded without forcing the other to adopt the same topology.
 
-```yaml
-model:
-  target_model_path: zai-org/GLM-5.2-FP8
-  draft_model_config: configs/glm-5.2-dspark.json
-  target_backend: sglang
-  trust_remote_code: true
-data:
-  train_data_path: ./cache/dataset/glm52_dspark_train.jsonl
-  max_length: 4096
-  chat_template: glm-5.2
-  cache_dir: cache
-  build_dataset_num_proc: 64
-training:
-  strategy: dspark
-  num_epochs: 10
-  batch_size: 1
-  accumulation_steps: 512
-  learning_rate: 0.0006
-  warmup_ratio: 0.04
-  max_grad_norm: 1.0
-  num_anchors: 512
-  loss_decay_gamma: 4.0
-  objective_chunk_blocks: 128
-  # Optimizer-step equivalent of about 500 source microsteps at microbatch 16.
-  save_interval: 16
-  dist_timeout: 30
-  seed: 42
-run_id: glm-5.2-dspark-disaggregated
-output_dir: outputs/glm-5.2-dspark-disaggregated
-deployment:
-  mode: disaggregated
-  trainer:
-    nnodes: 1
-    nproc_per_node: 1
-  disaggregated:
-    control_dir: outputs/glm-5.2-dspark-disaggregated/control
-    backend: mooncake
-    server_urls: [http://127.0.0.1:30000]
-    mooncake_metadata_server: http://127.0.0.1:35880/metadata
-    mooncake_master_server_addr: 127.0.0.1:35551
-    mooncake_protocol: rdma
+#### Preliminary system result: 3 capture servers + 5 trainers
 
-```
-
-
-The same public command resolves and launches the selected topology:
-
-```bash
-specforge train --config run.yaml
-```
-
-For scheduler-managed multi-node deployments, the two pools can be launched explicitly without introducing a second trainer implementation:
-
-```bash
-# Inference and ingestion pool
-specforge train --config run.yaml --role producer
-
-# Draft-model training pool
-specforge train --config run.yaml --role consumer
-```
-
-## Preliminary System Result: 3 Servers + 5 Trainers on H20
-
-We evaluated the new runtime on our H20 testbed. Reallocating the workload of Qwen3-8B Domino with 3k context length into three SGLang capture servers and five trainer workers increased end-to-end training throughput by approximately 10% compared with the previous colocated version.
+On an 8×H20 testbed, we evaluated Qwen3-8B Domino training with a 3K-token context length. Reallocating the workload to three SGLang capture servers and five trainer workers improved measured end-to-end training throughput by approximately 10% over the previous colocated implementation.
 
 | Runtime | Target capture | Draft training | Relative end-to-end training throughput |
 | --- | --- | --- | ---: |
 | Previous colocated version | Coupled with the training job | Fixed colocated layout | 1.00× |
 | New disaggregated runtime | 3 SGLang servers | 5 trainer workers | **1.10×** |
 
-The following GPU profiles show representative training windows for Qwen3-8B Domino at a 3k context length under the two runtime topologies.
+The profiles below show representative training windows for the two runtime topologies.
 
 **(a) Colocated baseline**
 
@@ -153,75 +87,141 @@ The following GPU profiles show representative training windows for Qwen3-8B Dom
 
 ![Qwen3-8B Domino 3k-context disaggregated training profile](./disagg.png)
 
-*Figure 2. Qwen3-8B Domino training profiles at a 3k context length. The colocated baseline is shown above and the 3-server/5-trainer disaggregated run is shown below.*
+*Figure 2. Representative Qwen3-8B Domino training windows at a 3K-token context length. The throughput table reports the end-to-end comparison; the traces provide a qualitative view of the two execution patterns.*
 
-The improvement comes from matching resources to the actual pipeline balance: target feature generation and draft optimization can progress concurrently, and neither pool needs to inherit the other's parallelism layout. Just as importantly, the new topology gives us a practical way to tune this balance for different target-model sizes, sequence lengths, and algorithms.
+In this workload, profiling indicates that the gain came from better matching feature-production supply to trainer demand. The broader benefit is configurability: different target sizes, sequence lengths, and drafting algorithms can use different capture-to-training ratios without requiring another trainer implementation.
 
+### One runtime for multiple drafting families
 
-## From EAGLE3 to a Multi-Algorithm Training Stack
+SpecForge began with a strong focus on EAGLE3. The new runtime separates common systems concerns from strategy-specific modeling code.
 
-SpecForge began with a strong focus on EAGLE3. The current release turns the runtime into a common training substrate for autoregressive, parallel, block-diffusion, and semi-autoregressive drafters.
+Every strategy reuses prompt scheduling, feature transport, distributed execution, checkpointing, and process supervision. A strategy defines only the target features it needs, how those features become a training batch, its draft-model architecture, and its objective.
 
-| Method | Core idea | SpecForge support |
+| Method | Strategy-specific idea | SpecForge support |
 | --- | --- | --- |
-| [EAGLE3](https://arxiv.org/abs/2503.01840) | Direct token prediction with training-time test and multi-layer target-feature fusion | Online-disaggregated, colocated offline, and disaggregated offline training |
-| [P-EAGLE](https://arxiv.org/abs/2602.01469) | Parallel multi-token prediction through a shared hidden state, with techniques for scalable long-context training | Online-disaggregated training |
-| EAGLE3.1 | An EAGLE3 configuration variant with per-layer normalization and attention-drift settings | Online-disaggregated training through the `eagle3` strategy |
-| [DFlash](https://arxiv.org/abs/2602.06036) | A lightweight block-diffusion drafter that predicts a token block in parallel while conditioning on target features | Online-disaggregated, colocated offline, and disaggregated offline training |
-| [Domino](https://arxiv.org/abs/2605.29707) | A parallel draft backbone followed by a lightweight causal correction head | Online-disaggregated, colocated offline, and disaggregated offline training |
-| [DSpark](https://arxiv.org/abs/2607.05147) | A semi-autoregressive drafter with confidence modeling for adaptive verification | Online-disaggregated, colocated offline, and disaggregated offline training |
+| [EAGLE3](https://arxiv.org/abs/2503.01840) | Direct token prediction with training-time test and multi-layer target-feature fusion | Online-disaggregated, local offline, and disaggregated offline |
+| [P-EAGLE](https://arxiv.org/abs/2602.01469) | Parallel multi-token prediction through a shared hidden state | Online-disaggregated |
+| EAGLE3.1 | An EAGLE3 configuration variant with per-layer normalization and attention-drift settings | Online-disaggregated through the `eagle3` strategy |
+| [DFlash](https://arxiv.org/abs/2602.06036) | Block-diffusion drafting that predicts a token block in parallel | Online-disaggregated, local offline, and disaggregated offline; optional [D-PACE](https://arxiv.org/abs/2605.18810) objective |
+| [Domino](https://arxiv.org/abs/2605.29707) | A parallel draft backbone followed by a lightweight causal correction head | Online-disaggregated, local offline, and disaggregated offline |
+| [DSpark](https://arxiv.org/abs/2607.05147) | Semi-autoregressive drafting with confidence modeling for adaptive verification | Online-disaggregated, local offline, and disaggregated offline |
 
+Here, *unified* means one configuration schema, launcher, dataflow contract, trainer lifecycle, and checkpoint surface. It does not mean that every strategy supports every data source and topology combination.
 
-## Draft Model Performance
-We have use lateset Specforge to train these draft models: [Qwen3.6-27B-Domino](https://huggingface.co/Huang2020/qwen3.6-27B-domino)、[GLM-5.2-Dspark]()、[Kimi-K3-Dspark]() and so on. The partial models' performance are listed Below.
+## Data Source and Deployment Are Separate Choices
 
-### Qwen3.6-27B-Domino（2 x A100）:
-#### 1. Concurrency = 1
+Online and offline describe where target features come from. Local and disaggregated describe how the training workflow is deployed. Keeping those concepts separate makes the supported combinations easier to understand:
+
+| Feature source | Local/dataflow deployment | Producer/consumer deployment |
+| --- | --- | --- |
+| Online SGLang capture | No | Yes, with Mooncake |
+| Offline feature checkpoints | Yes | Yes, with a shared feature store |
+
+Every online run uses the producer/consumer topology; the trainer never initializes a colocated target model. Offline EAGLE3, DFlash, Domino, and DSpark training can run locally or with separate ingestion and consumer pools. P-EAGLE currently supports online training only.
+
+See the [training guide](../docs/basic_usage/training.md) for the complete strategy matrix and the [disaggregated training guide](../docs/basic_usage/disaggregated_training.md) for deployment details.
+
+## One Configuration, One Entry Point
+
+The topology lives in the same typed YAML document as the model, data, algorithm, and optimizer settings. The following excerpt illustrates the three-server/five-trainer shape used above:
+
+```yaml
+training:
+  strategy: domino
+
+deployment:
+  mode: disaggregated
+  trainer:
+    nnodes: 1
+    nproc_per_node: 5
+  disaggregated:
+    control_dir: outputs/qwen3-8b-domino/control
+    consumer_state_dir: outputs/qwen3-8b-domino/consumer-state
+    backend: mooncake
+    server_urls:
+      - http://capture-0:30000
+      - http://capture-1:30000
+      - http://capture-2:30000
+```
+
+The same command resolves and launches the selected topology:
+
+```bash
+specforge train --config run.yaml
+```
+
+On a single node, the launcher can supervise both SpecForge roles. Under an external scheduler, the pools can be launched independently with the same configuration:
+
+```bash
+# Inference and ingestion pool
+specforge train --config run.yaml --role producer
+
+# Draft-model training pool
+specforge train --config run.yaml --role consumer
+```
+
+There are no method-specific Python training entry points. Full, runnable configurations are available under [`examples/configs`](../examples/configs/).
+
+## Draft-Model Serving Performance
+
+Training-system throughput and draft-model serving speedup answer different questions. The H20 result above measures the efficiency of the training pipeline. The following evaluation measures the end-to-end serving speedup of a draft checkpoint trained with SpecForge; it is not used as evidence for the 10% training-runtime result.
+
+We evaluated [Qwen3.6-27B-Domino](https://huggingface.co/Huang2020/qwen3.6-27B-domino) on 2×A100 GPUs. All values are relative to target-only autoregressive decoding (`AR = 1.00×`). `B8` and `B16` denote draft block sizes of 8 and 16.
+
+### Concurrency = 1
+
 | Dataset | AR | MTP-S3 | MTP-S7 | DFlash-B8 | DFlash-B16 | Domino-B8 | Domino-B16 |
-  |:--|--:|--:|--:|--:|--:|--:|--:|
-  | GSM8K | 1.00× | 2.68× | 3.22× | 3.79× | 4.25× | 4.36× | <font color="red"><b>5.25×</b></font> |
-  | MATH500 | 1.00× | 2.80× | 3.55× | 4.29× | 5.07× | 4.60× | <font color="red"><b>5.72×</b></font> |
-  | HumanEval | 1.00× | 2.65× | 3.18× | 3.98× | 4.47× | 4.20× | <font color="red"><b>4.98×</b></font> |
-  | MBPP | 1.00× | 2.57× | 2.98× | 3.73× | 3.91× | 3.97× | <font color="red"><b>4.49×</b></font> |
-  | MT-Bench | 1.00× | 2.44× | 2.65× | 3.00× | 3.05× | 3.31× | <font color="red"><b>3.44×</b></font> |
-  | Alpaca | 1.00× | 2.38× | 2.54× | 2.87× | 2.84× | 3.18× | <font color="red"><b>3.34×</b></font> |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| GSM8K | 1.00× | 2.68× | 3.22× | 3.79× | 4.25× | 4.36× | **5.25×** |
+| MATH500 | 1.00× | 2.80× | 3.55× | 4.29× | 5.07× | 4.60× | **5.72×** |
+| HumanEval | 1.00× | 2.65× | 3.18× | 3.98× | 4.47× | 4.20× | **4.98×** |
+| MBPP | 1.00× | 2.57× | 2.98× | 3.73× | 3.91× | 3.97× | **4.49×** |
+| MT-Bench | 1.00× | 2.44× | 2.65× | 3.00× | 3.05× | 3.31× | **3.44×** |
+| Alpaca | 1.00× | 2.38× | 2.54× | 2.87× | 2.84× | 3.18× | **3.34×** |
 
-#### 2. Concurrency = 32
-  | Dataset | AR | MTP-S3 | MTP-S7 | DFlash-B8 | DFlash-B16 | Domino-B8 | Domino-B16 |
-  |:--|--:|--:|--:|--:|--:|--:|--:|
-  | GSM8K | 1.00× | 1.80× | 1.73× | 1.86× | 1.41× | <font color="red"><b>2.11×</b></font> | 1.82× |
-  | MATH500 | 1.00× | 1.90× | 1.86× | 1.99× | 1.54× | <font color="red"><b>2.10×</b></font> | 1.78× |
-  | HumanEval | 1.00× | 1.78× | 1.69× | 1.88× | 1.42× | <font color="red"><b>1.97×</b></font> | 1.62× |
-  | MBPP | 1.00× | 1.72× | 1.57× | <font color="red"><b>1.73×</b></font> | 1.33× | 1.68× | 1.46× |
-  | MT-Bench | 1.00× | <font color="red"><b>1.56×</b></font> | 1.32× | 1.35× | 0.94× | 1.48× | 1.06× |
-  | Alpaca | 1.00× | <font color="red"><b>1.76×</b></font> | 1.43× | 1.43× | 1.00× | 1.67× | 1.13× |
+At concurrency 1, Domino-B16 provides the highest speedup on all six datasets, ranging from 3.34× on Alpaca to 5.72× on MATH500.
 
+### Concurrency = 32
 
-### GLM5.2（）:
+| Dataset | AR | MTP-S3 | MTP-S7 | DFlash-B8 | DFlash-B16 | Domino-B8 | Domino-B16 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| GSM8K | 1.00× | 1.80× | 1.73× | 1.86× | 1.41× | **2.11×** | 1.82× |
+| MATH500 | 1.00× | 1.90× | 1.86× | 1.99× | 1.54× | **2.10×** | 1.78× |
+| HumanEval | 1.00× | 1.78× | 1.69× | 1.88× | 1.42× | **1.97×** | 1.62× |
+| MBPP | 1.00× | 1.72× | 1.57× | **1.73×** | 1.33× | 1.68× | 1.46× |
+| MT-Bench | 1.00× | **1.56×** | 1.32× | 1.35× | 0.94× | 1.48× | 1.06× |
+| Alpaca | 1.00× | **1.76×** | 1.43× | 1.43× | 1.00× | 1.67× | 1.13× |
 
+At concurrency 32, the optimal configuration depends on the workload. Domino-B8 leads on GSM8K, MATH500, and HumanEval, while smaller MTP or DFlash configurations lead on MBPP, MT-Bench, and Alpaca. This is why serving concurrency and speculative parameters must be reported together rather than summarized by one acceptance or speedup number.
 
-## How to verify your draft training is true?
-We provide a test to verify the consistency of training and inference, allowing users to easily verify the correctness of algorithms and try out new algorithms. We offer detailed sample [documentation](https://github.com/sgl-project/SpecForge/blob/main/scripts/gates/README.md) for Qwen3.6-27B-Dspark. Its workflow includes the following steps:
+## Verifying Training-Serving Consistency
 
-1. Prepare a dataset generated using the target model and its corresponding thinking mode. If it's a `thinking mode`, it includes `reasoning_content`; otherwise, it doesn't.
+Model-quality benchmarks and correctness gates serve different purposes. A benchmark measures generalization; a gate checks that training, export, and serving implement the same algorithmic contract.
 
-2. Train this dataset online using `specforge` until the `accuracy` equals 1.0. Since dspark's loss consists of both `CE loss` and `L1 loss`, it cannot reach 100%. However, it should ideally reach `0.99`.
+SpecForge provides an end-to-end [training and serving gate](../scripts/gates/README.md) for DFlash-family models, including Domino. It performs three stages:
 
-3. Deploy the trained draft model using sglang and use the trained data at `temperature=0` and the same `thinking mode` to make requests to determine if the accuracy of the first draft block is 100%.
+1. **Select a valid sample.** The gate checks the target chat template, reasoning mode, tokenizer behavior, sequence length, and minimum trainable suffix before producing an auditable prompt artifact.
+2. **Overfit through the public training path.** It repeats that sample for a bounded run launched through `specforge train`, then requires the configured loss and token-accuracy thresholds and the exact final checkpoint.
+3. **Export and serve the checkpoint.** It exports through `specforge export`, launches SGLang with DFlash speculative decoding, and verifies per-request acceptance metadata and agreement with the target-token prefix.
 
+This gate is intentionally strict and narrow. Passing it shows that capture, training, export, and serving agree on one controlled example; it does not replace held-out model-quality or serving-performance evaluation.
 
-## What's next
+## Current Scope
+
+The unified runtime currently supports text training. VLM training is not yet supported, and evaluation is currently available only from precomputed offline features. P-EAGLE is online-only and currently requires a per-rank batch size of one. Strategy-specific attention backends and other constraints are validated before launch rather than silently falling back to an older trainer.
+
+Online capture requires compatible patched SGLang servers and Mooncake. These services may be managed locally for development or operated independently in a scheduler-managed deployment.
+
+## What's Next
 
 This release changes the unit of scaling in SpecForge. A run is no longer a trainer process that happens to contain a target model; it is a coordinated pipeline whose inference capacity, storage, and optimization capacity can be sized independently.
 
-Our next steps are to publish the more draft models of popular models above, and continue expanding the algorithm and model catalog. Besides, we will conduct testing and adaptation across various hardware platforms, including but not limited to AMD and Ascend.
+Our next steps are to publish more ready-to-serve draft checkpoints for popular target models, add reproducible topology studies across model sizes and sequence lengths, and continue expanding the algorithm catalog. We will also extend validation across hardware platforms, including AMD and Ascend, and explore automatically adapting the capture-to-training ratio as workloads change.
 
 ## Acknowledgements
 
-We thank the SGLang and SpecForge communities, the authors of the supported speculative decoding methods, and all contributors who helped test the new runtime and algorithm integrations. 
+We thank the SGLang and SpecForge communities, the authors of the supported speculative-decoding methods, and all contributors who helped test the new runtime and algorithm integrations.
 
-**SpecForge Team**: Jiaping Wang, Shenggui Li, Xiaoming Dong,
-
-**Radixark Team**: Cheng Mao,
-
-**Domino**: Jianuo, Huang
+- **SpecForge Team:** Jiaping Wang, Shenggui Li, and Xiaoming Dong
+- **RadixArk Team:** Cheng Mao
+- **Domino:** Jianuo Huang

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -4,15 +4,20 @@
 
 When we first released [SpecForge](https://www.lmsys.org/blog/2025-07-25-spec-forge/), a training job owned both the frozen target model and the draft model being optimized. This made EAGLE3 draft-model training practical and directly compatible with SGLang, but it also tied two very different workloads to the same process lifecycle and resource topology.
 
-The new SpecForge introduces a clean boundary between **target-feature production** and **draft-model optimization**. Patched SGLang servers generate tokens and capture target features; SpecForge trainers consume those features through lightweight references backed by Mooncake.
+The new SpecForge introduces a clean boundary between **target-feature production** and **draft-model optimization**. Patched SGLang servers capture target features over the training conversations; SpecForge trainers consume those features through lightweight references backed by Mooncake.
 
-This one architectural change has two important consequences. First, inference and training capacity can be configured and deployed independently. Second, different speculative-drafting algorithms can reuse the same scheduling, dataflow, distributed-training, checkpointing, and failure-handling runtime. EAGLE3, EAGLE3.1, P-EAGLE, DFlash, Domino, and DSpark now share one typed configuration and one public training entry point.
+This one architectural change has two important consequences:
+
+- **Inference and training capacity can be configured and deployed independently.** On the same 8×H20 budget, moving Qwen3-8B Domino training to a three-server, five-trainer split improved end-to-end training throughput by approximately 10% over the previous colocated implementation.
+- **Different speculative-drafting algorithms can reuse the same runtime** — the same scheduling, dataflow, distributed training, checkpointing, and failure handling. EAGLE3, EAGLE3.1, P-EAGLE, DFlash, Domino, and DSpark now share one typed configuration and one public training entry point.
+
+This release also ships a training-serving consistency gate that verifies capture, training, export, and SGLang serving agree on a controlled example — a fast correctness check before investing in a full training run.
 
 ## From a Coupled Trainer to a Training Pipeline
 
 Online draft-model training contains two distinct workloads:
 
-- The **target side** runs a large, frozen model to generate tokens and capture hidden states. It is inference-heavy, often uses tensor parallelism, and benefits from a production inference engine.
+- The **target side** runs a large, frozen model over training conversations to capture hidden states. It is inference-heavy, often uses tensor parallelism, and benefits from a production inference engine.
 - The **draft side** trains a much smaller model with forward and backward passes. It scales through data or sequence parallelism and has a different memory and compute profile.
 
 In the previous colocated design, both sides shared one lifecycle and one fixed resource layout. This created three practical limitations:
@@ -34,6 +39,8 @@ The new online runtime has a producer pool and a consumer pool. Producers schedu
 ### 1. The capture contract
 
 Every URL in `deployment.disaggregated.server_urls` creates a rollout worker connected to a patched SGLang server. Workers lease disjoint prompts from a shared controller, so capture capacity can change without changing the trainer topology.
+
+The capture support is a small patch on top of the pinned `sglang==0.5.14`: [`patches/sglang/v0.5.14/spec-capture.patch`](https://github.com/sgl-project/SpecForge/blob/main/patches/sglang/v0.5.14/spec-capture.patch) adds an `--enable-spec-capture` flag and a server-side sink that writes captured tensors directly into Mooncake using the feature store's key layout. A capture server is a stock SGLang server with this patch applied.
 
 This creates a clear ownership boundary: SGLang owns target-model parallelism and feature capture, while SpecForge owns prompt scheduling, reference publication, and draft-model optimization.
 
@@ -119,7 +126,11 @@ Online and offline describe where target features come from. Local and disaggreg
 
 Every online run uses the producer/consumer topology; the trainer never initializes a colocated target model. Offline EAGLE3, DFlash, Domino, and DSpark training can run locally or with separate ingestion and consumer pools. P-EAGLE currently supports online training only.
 
-See the [training guide](../docs/basic_usage/training.md) for the complete strategy matrix and the [disaggregated training guide](../docs/basic_usage/disaggregated_training.md) for deployment details.
+### Feature source is not data policy
+
+One further distinction matters in practice. Capture servers execute a full prefill over the conversations you provide and never generate the training responses, so online capture does not choose whose text the draft learns from — the dataset does. This choice matters more than any topology decision: when dataset responses were written by humans or by a different model, the draft learns to continue text the target itself would rarely produce, and acceptance saturates well below what the same draft reaches on target-generated data. In our training runs, regenerating dataset responses with the target model — greedily, in the reasoning mode that will be served — has been the single largest lever on final acceptance. We recommend target-generated data for every strategy. The consistency gate described below rests on the same property: its serving stage can only pass when the trained sample is text the target reproduces at temperature 0.
+
+See the [training guide](https://github.com/sgl-project/SpecForge/blob/main/docs/basic_usage/training.md) for the complete strategy matrix and the [disaggregated training guide](https://github.com/sgl-project/SpecForge/blob/main/docs/basic_usage/disaggregated_training.md) for deployment details.
 
 ## One Configuration, One Entry Point
 
@@ -160,7 +171,7 @@ specforge train --config run.yaml --role producer
 specforge train --config run.yaml --role consumer
 ```
 
-There are no method-specific Python training entry points. Full, runnable configurations are available under [`examples/configs`](../examples/configs/).
+There are no method-specific Python training entry points. Full, runnable configurations are available under [`examples/configs`](https://github.com/sgl-project/SpecForge/tree/main/examples/configs).
 
 ## Draft-Model Serving Performance
 
@@ -198,7 +209,7 @@ At concurrency 32, the optimal configuration depends on the workload. Domino-B8 
 
 Model-quality benchmarks and correctness gates serve different purposes. A benchmark measures generalization; a gate checks that training, export, and serving implement the same algorithmic contract.
 
-SpecForge provides an end-to-end [training and serving gate](../scripts/gates/README.md) for DFlash-family models, including Domino. It performs three stages:
+SpecForge provides an end-to-end [training and serving gate](https://github.com/sgl-project/SpecForge/blob/main/scripts/gates/README.md) for DFlash-family models, including Domino. It performs three stages:
 
 1. **Select a valid sample.** The gate checks the target chat template, reasoning mode, tokenizer behavior, sequence length, and minimum trainable suffix before producing an auditable prompt artifact.
 2. **Overfit through the public training path.** It repeats that sample for a bounded run launched through `specforge train`, then requires the configured loss and token-accuracy thresholds and the exact final checkpoint.

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -173,6 +173,13 @@ specforge train --config run.yaml --role consumer
 
 There are no method-specific Python training entry points. Full, runnable configurations are available under [`examples/configs`](https://github.com/sgl-project/SpecForge/tree/main/examples/configs).
 
+### Training Example: Qwen3.6-27B
+Start training and inference on a single node using a single command:
+```
+specforge train --config examples/configs/qwen3.6-27b-dspark-disaggregated.yaml
+```
+
+
 ## Draft-Model Serving Performance
 
 Training-system throughput and draft-model serving speedup answer different questions. The H20 result above measures the efficiency of the training pipeline. The following evaluation measures the end-to-end serving speedup of a draft checkpoint trained with SpecForge; it is not used as evidence for the 10% training-runtime result.

--- a/blog/blog.md
+++ b/blog/blog.md
@@ -234,5 +234,5 @@ Our next steps are to publish more ready-to-serve draft checkpoints for popular 
 We thank the SGLang and SpecForge communities, the authors of the supported speculative-decoding methods, and all contributors who helped test the new runtime and algorithm integrations.
 
 - **SpecForge Team:** Jiaping Wang, Shenggui Li, and Xiaoming Dong
-- **RadixArk Team:** Cheng Mao, Yi Sun
+- **RadixArk Team:** Cheng Mao, Yi Sun, and Kan Wu
 - **Domino:** Jianuo Huang


### PR DESCRIPTION
## Summary

- restructure the release blog around one causal story: the old coupled trainer, the new target-feature/draft-optimization boundary, and the two capabilities that boundary unlocks
- distinguish data source (online/offline) from deployment topology (local/disaggregated)
- separate architecture claims, preliminary training throughput, and draft-model serving results
- preserve the architecture/profile assets and all published Qwen3.6-27B Domino performance values
- replace incomplete GLM/Kimi placeholders with the repository's concrete training-serving consistency gate
- tighten scope, limitations, next steps, and acknowledgements

## Why

The previous draft presented disaggregation, the unified CLI, and multi-algorithm support as parallel features. This rewrite makes their relationship explicit: the common feature/training contract enables independent pool sizing and reuse across drafting strategies. It also avoids using serving speedup as evidence for the separate 10% training-runtime result.

## Reader impact

Readers should be able to identify the core architectural change in the opening, follow a problem → boundary → capabilities → evidence → usage flow, and understand precisely what "unified" and "independently scalable" mean.

## Validation

- `git diff --check`
- verified every relative image, documentation, example, and gate path
- verified the previous SpecForge blog and all linked paper pages
- verified the Qwen3.6-27B Domino checkpoint URL returns HTTP 200
- compared every serving-performance value against the upstream draft
- checked Markdown table column consistency and final newline
