### PR TITLE
Correctness fixes for DFlash training path

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -154,6 +154,31 @@ model:
   draft_block_size: 8         # DFlash only
 ```
 
+For DFlash, configure the attention layout in the referenced draft JSON. Each
+entry corresponds to one draft layer; sliding layers share one positive window:
+
+```json
+{
+  "num_hidden_layers": 5,
+  "layer_types": [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "full_attention"
+  ],
+  "use_sliding_window": true,
+  "sliding_window": 2048
+}
+```
+
+Use `"full_attention"` for every entry, `"use_sliding_window": false`, and
+`"sliding_window": null` for a full-only draft. The layout length must equal
+`num_hidden_layers`. A layer-count override may resize a uniform layout, but a
+mixed layout must be edited explicitly in the draft JSON.
+
+The `eager`, `sdpa`, and `flex_attention` backends support both layouts.
+
 Domino and DSpark need their projector/head metadata, so they require an
 explicit draft config (or a pretrained warm-start source that contains
 `config.json`). The old Domino parser exposed an optional config flag, but its

--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -50,7 +50,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional
+from typing import Callable, Dict, List, Mapping, Optional
 
 import torch
 import torch.distributed as dist
@@ -92,6 +92,7 @@ class OfflineCapturePlan:
     capture_method: str
     capture_layers: tuple[int, ...]
     layout: OfflineCaptureLayout
+    loss_mask_filter: Optional[Callable[[object], bool]]
 
 
 def parse_args():
@@ -341,6 +342,7 @@ def resolve_offline_capture_plan(
         capture_method=resolved.capture_method,
         capture_layers=resolved.capture_layers,
         layout=resolved.layout,
+        loss_mask_filter=resolved.loss_mask_filter,
     )
 
 
@@ -826,7 +828,7 @@ def main():
             ),
             num_proc=min(args.build_dataset_num_proc, 32),
         )
-    if args.num_samples is not None:
+    if args.num_samples is not None and capture_plan.loss_mask_filter is None:
         dataset = dataset.select(range(args.num_samples))
     # Tokenizer and cache key
     tokenizer = load_tokenizer(
@@ -847,6 +849,15 @@ def main():
             cache_key=cache_key,
             is_preformatted=args.is_preformatted,
             num_proc=args.build_dataset_num_proc,
+            loss_mask_filter=capture_plan.loss_mask_filter,
+        )
+    if capture_plan.loss_mask_filter is not None and args.num_samples is not None:
+        eagle3_dataset = eagle3_dataset.select(
+            range(min(args.num_samples, len(eagle3_dataset)))
+        )
+    if not len(eagle3_dataset):
+        raise ValueError(
+            f"no samples satisfy {capture_plan.strategy} training eligibility"
         )
     print_with_rank(f"Dataset prepared with {len(eagle3_dataset)} samples.")
 

--- a/specforge/algorithms/common/dflash_family_data.py
+++ b/specforge/algorithms/common/dflash_family_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from functools import partial
 
 from specforge.algorithms.common.collation import pad_and_concatenate_features
+from specforge.data.loss_mask import has_consecutive_supervised_tokens
 
 NORMALIZER_ID = "dflash_family_offline_v1"
 DSPARK_NORMALIZER_ID = "dspark_offline_v1"
@@ -55,6 +56,10 @@ def normalize_offline_sample(raw, max_len: int):
             f"after truncation: input_ids={input_ids.shape[1]}, "
             f"loss_mask={loss_mask.shape[1]}, "
             f"hidden_states={hidden_states.shape[1]}"
+        )
+    if not has_consecutive_supervised_tokens(loss_mask[0]):
+        raise ValueError(
+            "offline DFlash-family samples require two consecutive supervised tokens"
         )
     return {
         "input_ids": input_ids,

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -179,40 +179,35 @@ class OnlineDFlashModel(nn.Module):
     def _sample_anchor_positions(
         self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Randomly sample anchor positions per sample; returns (anchors, keep_mask)."""
-        bs = self.block_size
-        bsz = loss_mask.shape[0]
-        max_anchor = max(seq_len - bs, 0)
+        """Sample anchors whose clean token and first target are supervised."""
 
-        valid = loss_mask[:, : max_anchor + 1] > 0.5
+        num_candidates = max(seq_len - 1, 0)
+        valid = (loss_mask[:, :num_candidates] > 0.5) & (
+            loss_mask[:, 1 : num_candidates + 1] > 0.5
+        )
         valid_counts = valid.sum(dim=1)
-        max_n = min(self.num_anchors, int(valid_counts.max().item()) - 1)
+        width = min(self.num_anchors, int(valid_counts.max().item()))
+        if width == 0:
+            raise ValueError(
+                "DFlash-family training requires two consecutive supervised tokens"
+            )
 
-        if max_n <= 0:
-            raise ValueError("should preprocess the data.")
-
-        indices = (
-            torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)
-        )
-        masked_indices = torch.where(
-            valid, indices, torch.tensor(seq_len + 1, device=device)
-        )
-
-        random_vals = torch.rand(bsz, max_anchor + 1, device=device)
-        random_vals = torch.where(valid, random_vals, torch.tensor(2.0, device=device))
-
-        _, sorted_idx = random_vals.sort(dim=1)
-        gathered = torch.gather(masked_indices, 1, sorted_idx)
-        anchors = gathered[:, :max_n].sort(dim=1).values
-
-        keep_mask = torch.arange(max_n, device=device).unsqueeze(
+        random_values = torch.rand(valid.shape, device=device)
+        random_values.masked_fill_(~valid, 2.0)
+        candidates = random_values.argsort(dim=1)[:, :width]
+        keep_mask = torch.arange(width, device=device).unsqueeze(
             0
-        ) < valid_counts.unsqueeze(1).clamp(max=max_n)
-        anchors = torch.where(
-            keep_mask, anchors, torch.tensor(0, dtype=torch.long, device=device)
-        )
+        ) < valid_counts.clamp(max=width).unsqueeze(1)
 
-        return anchors, keep_mask
+        sentinel = valid.shape[1]
+        anchors = torch.where(
+            keep_mask,
+            candidates,
+            torch.full_like(candidates, sentinel),
+        )
+        anchors = anchors.sort(dim=1).values
+        keep_mask = anchors < sentinel
+        return torch.where(keep_mask, anchors, 0), keep_mask
 
     def _create_position_ids(self, anchor_positions: torch.Tensor) -> torch.Tensor:
         """Create absolute position IDs for parallel draft blocks."""
@@ -392,7 +387,7 @@ class OnlineDFlashModel(nn.Module):
         input_ids: torch.Tensor,
         hidden_states: torch.Tensor,
         loss_mask: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, torch.Tensor]]:
+    ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, object]]:
         """Parallel block-wise training forward pass; returns
         (loss, accuracy, metrics) — same shape as Domino's forward."""
         if self.attention_backend == "flex_attention" and not FLEX_ATTENTION_AVAILABLE:
@@ -450,13 +445,20 @@ class OnlineDFlashModel(nn.Module):
             chunk_size=self.objective_chunk_blocks,
             dim=1,
         )
-        if self.loss_type == "dflash":
-            loss = loss_num / (loss_den + 1e-6)
-        else:
-            loss = loss_num / float(bsz)
-        accuracy = correct_num / (accuracy_denom + 1e-6)
-
-        return loss, accuracy, {"accuracy_denom": accuracy_denom.detach()}
+        ratio_metrics = {
+            "acc": (correct_num.detach(), accuracy_denom.detach()),
+        }
+        metrics: Dict[str, object] = {
+            "accuracy_denom": accuracy_denom.detach(),
+            "ratio_metrics": ratio_metrics,
+        }
+        loss_denominator = (
+            loss_den if self.loss_type == "dflash" else loss_num.new_tensor(float(bsz))
+        )
+        loss = loss_num / loss_denominator
+        metrics["loss_terms"] = (loss_num, loss_denominator.detach())
+        accuracy = correct_num / accuracy_denom
+        return loss, accuracy, metrics
 
 
 class OnlineDominoModel(OnlineDFlashModel):
@@ -488,41 +490,6 @@ class OnlineDominoModel(OnlineDFlashModel):
             loss_type="dflash",
         )
         self.shift_label = shift_label
-
-    def _sample_anchor_positions(
-        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Randomly sample anchor positions per sample; returns (anchors, keep_mask)."""
-        bs = self.block_size
-        bsz = loss_mask.shape[0]
-        max_anchor = max(seq_len - bs, 0)
-
-        valid = loss_mask[:, : max_anchor + 1] > 0.5
-        valid_counts = valid.sum(dim=1)
-        max_n = max(1, min(self.num_anchors, int(valid_counts.max().item()) - 1))
-
-        indices = (
-            torch.arange(max_anchor + 1, device=device).unsqueeze(0).expand(bsz, -1)
-        )
-        masked_indices = torch.where(
-            valid, indices, torch.tensor(seq_len + 1, device=device)
-        )
-
-        random_vals = torch.rand(bsz, max_anchor + 1, device=device)
-        random_vals = torch.where(valid, random_vals, torch.tensor(2.0, device=device))
-
-        _, sorted_idx = random_vals.sort(dim=1)
-        gathered = torch.gather(masked_indices, 1, sorted_idx)
-        anchors = gathered[:, :max_n].sort(dim=1).values
-
-        keep_mask = torch.arange(max_n, device=device).unsqueeze(
-            0
-        ) < valid_counts.unsqueeze(1).clamp(max=max_n)
-        anchors = torch.where(
-            keep_mask, anchors, torch.tensor(0, dtype=torch.long, device=device)
-        )
-
-        return anchors, keep_mask
 
     def _build_domino_head_inputs(
         self,
@@ -784,55 +751,6 @@ class OnlineDSparkModel(OnlineDFlashModel):
         self.dspark_ce_loss_alpha = float(dspark_ce_loss_alpha)
         self.dspark_l1_loss_alpha = float(dspark_l1_loss_alpha)
         self.dspark_confidence_head_alpha = float(dspark_confidence_head_alpha)
-
-    def _build_anchor_candidate_mask(
-        self,
-        seq_len: int,
-        loss_mask: torch.Tensor,
-    ) -> torch.Tensor:
-        num_candidates = max(seq_len - 1, 0)
-        if num_candidates == 0:
-            return loss_mask[:, :0].bool()
-        anchor_valid = loss_mask[:, :num_candidates] > 0.5
-        first_target_valid = loss_mask[:, 1 : num_candidates + 1] > 0.5
-        return anchor_valid & first_target_valid
-
-    def _sample_anchor_positions(
-        self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Sample only anchors with a valid first target, without dummy width."""
-
-        valid = self._build_anchor_candidate_mask(seq_len, loss_mask)
-        if valid.shape[1] == 0:
-            raise ValueError("DSpark needs sequences with at least two tokens")
-        valid_counts = valid.sum(dim=1)
-        width = min(self.num_anchors, int(valid_counts.max().item()))
-        if width <= 0:
-            raise ValueError(
-                "DSpark found no valid anchor with two consecutive loss tokens"
-            )
-        indices = torch.arange(valid.shape[1], device=device).expand(
-            loss_mask.shape[0], -1
-        )
-        random_values = torch.rand(valid.shape, device=device)
-        random_values.masked_fill_(~valid, 2.0)
-        order = random_values.argsort(dim=1)
-        candidates = torch.gather(indices, 1, order)[:, :width]
-        keep_mask = torch.arange(width, device=device).unsqueeze(
-            0
-        ) < valid_counts.clamp(max=width).unsqueeze(1)
-        anchors = (
-            torch.where(
-                keep_mask,
-                candidates,
-                torch.full_like(candidates, valid.shape[1]),
-            )
-            .sort(dim=1)
-            .values
-        )
-        keep_mask = anchors < valid.shape[1]
-        anchors = torch.where(keep_mask, anchors, torch.zeros_like(anchors))
-        return anchors, keep_mask
 
     def _build_dspark_labels_and_mask(
         self,

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -44,7 +44,15 @@ def compute_accept_len(
     return accept_prefix.sum(dim=2).float()
 
 
-def create_dflash_sdpa_mask(anchor_positions, block_keep_mask, S, block_size, device):
+def create_dflash_sdpa_mask(
+    anchor_positions,
+    block_keep_mask,
+    S,
+    block_size,
+    device,
+    sliding_window: Optional[int] = None,
+):
+    """Construct a full or sliding dense boolean DFlash mask."""
     B, N = anchor_positions.shape
     Q_LEN = N * block_size
     KV_LEN = S + N * block_size
@@ -55,16 +63,24 @@ def create_dflash_sdpa_mask(anchor_positions, block_keep_mask, S, block_size, de
     )  # (1, 1, 1, KV_LEN)
 
     q_block_ids = q_indices // block_size
+    q_block_offsets = q_indices % block_size
 
     anchor_expanded = anchor_positions.view(B, 1, N, 1).repeat_interleave(
         block_size, dim=2
     )
 
     mask_context = (kv_indices < S) & (kv_indices < anchor_expanded)
+    if sliding_window is not None:
+        # The current draft token occupies one slot in the window.
+        context_lower_bound = anchor_expanded + q_block_offsets - (sliding_window - 1)
+        mask_context = mask_context & (kv_indices >= context_lower_bound)
 
     is_draft = kv_indices >= S
     kv_block_ids = (kv_indices - S) // block_size
     mask_draft = is_draft & (q_block_ids == kv_block_ids)
+    if sliding_window is not None:
+        kv_block_offsets = (kv_indices - S) % block_size
+        mask_draft = mask_draft & (kv_block_offsets <= q_block_offsets)
 
     valid_block = block_keep_mask.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
 
@@ -78,21 +94,13 @@ def create_dflash_block_mask(
     S: int,
     block_size: int,
     device: torch.device,
+    sliding_window: Optional[int] = None,
 ):
-    """Construct Flex Attention BlockMask for DFlash training.
-
-    KV: [Context (S tokens) | Block_0 | Block_1 | ... | Block_{n-1}]
-    Q:  [Block_0 | Block_1 | ... | Block_{n-1}]
-
-    Rules:
-      1. Each block sees context strictly before its anchor (kv_idx < anchor_pos).
-      2. Intra-block attention is bidirectional.
-      3. Different blocks are invisible to each other.
-      4. Invalid blocks (block_keep_mask=False) see nothing.
-    """
+    """Construct a full or sliding Flex Attention mask for DFlash training."""
 
     def dflash_mask_mod(b, h, q_idx, kv_idx):
         q_block_id = q_idx // block_size
+        q_block_offset = q_idx % block_size
         safe_q_block_id = q_block_id.clamp(max=N - 1)
         anchor_pos = anchor_positions[b, safe_q_block_id]
 
@@ -100,10 +108,17 @@ def create_dflash_block_mask(
         # Strictly less than: matches inference where target_hidden[anchor_pos]
         # is not available as context.
         mask_context = is_context & (kv_idx < anchor_pos)
+        if sliding_window is not None:
+            # The current draft token occupies one slot in the window.
+            context_lower_bound = anchor_pos + q_block_offset - (sliding_window - 1)
+            mask_context = mask_context & (kv_idx >= context_lower_bound)
 
         is_draft = kv_idx >= S
         kv_block_id = (kv_idx - S) // block_size
         mask_draft = is_draft & (q_block_id == kv_block_id)
+        if sliding_window is not None:
+            kv_block_offset = (kv_idx - S) % block_size
+            mask_draft = mask_draft & (kv_block_offset <= q_block_offset)
 
         is_valid_block = block_keep_mask[b, safe_q_block_id]
         in_bounds = q_block_id < N
@@ -287,22 +302,29 @@ class OnlineDFlashModel(nn.Module):
         draft_position_ids = self._create_position_ids(anchor_positions)
         full_position_ids = torch.cat([context_position_ids, draft_position_ids], dim=1)
 
-        if self.attention_backend == "flex_attention":
-            dflash_attn_mask = create_dflash_block_mask(
-                anchor_positions=anchor_positions,
-                block_keep_mask=block_keep_mask,
-                S=seq_len,
-                block_size=self.block_size,
-                device=device,
-            )
-        else:
-            dflash_attn_mask = create_dflash_sdpa_mask(
-                anchor_positions=anchor_positions,
-                block_keep_mask=block_keep_mask,
-                S=seq_len,
-                block_size=self.block_size,
-                device=device,
-            )
+        mask_builder = (
+            create_dflash_block_mask
+            if self.attention_backend == "flex_attention"
+            else create_dflash_sdpa_mask
+        )
+        mask_args = {
+            "anchor_positions": anchor_positions,
+            "block_keep_mask": block_keep_mask,
+            "S": seq_len,
+            "block_size": self.block_size,
+            "device": device,
+        }
+        full_attn_mask = mask_builder(**mask_args)
+        sliding_window = self.draft_model.sliding_window
+        dflash_attn_mask = full_attn_mask
+        if sliding_window is not None:
+            dflash_attn_mask = {
+                "full_attention": full_attn_mask,
+                "sliding_attention": mask_builder(
+                    **mask_args,
+                    sliding_window=sliding_window,
+                ),
+            }
 
         output_hidden = self.draft_model(
             position_ids=full_position_ids,

--- a/specforge/algorithms/common/providers.py
+++ b/specforge/algorithms/common/providers.py
@@ -361,6 +361,7 @@ class ModelProvider:
     needs_input_tools: Factory
     default_dataloader_num_workers: int
     allow_missing_warm_start_embedding: bool = False
+    loss_mask_filter: Factory | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.draft_config, DraftConfigProvider):
@@ -384,6 +385,8 @@ class ModelProvider:
             )
         if not isinstance(self.allow_missing_warm_start_embedding, bool):
             raise TypeError("allow_missing_warm_start_embedding must be a bool")
+        if self.loss_mask_filter is not None and not callable(self.loss_mask_filter):
+            raise TypeError("loss_mask_filter must be callable or None")
 
 
 @dataclass(frozen=True)

--- a/specforge/algorithms/dflash/providers.py
+++ b/specforge/algorithms/dflash/providers.py
@@ -34,6 +34,7 @@ from specforge.algorithms.contracts import (
     FeatureMode,
     OfflineStorageContract,
 )
+from specforge.data.loss_mask import has_consecutive_supervised_tokens
 
 ALGORITHM_NAME = "dflash"
 DRAFT_ARCHITECTURE = "DFlashDraftModel"
@@ -190,6 +191,7 @@ def algorithm_providers() -> AlgorithmProviders:
             minimum_loss_tokens=minimum_loss_tokens,
             needs_input_tools=needs_input_tools,
             default_dataloader_num_workers=8,
+            loss_mask_filter=has_consecutive_supervised_tokens,
         ),
         offline=(
             OfflineDataProvider(

--- a/specforge/algorithms/domino/providers.py
+++ b/specforge/algorithms/domino/providers.py
@@ -30,6 +30,7 @@ from specforge.algorithms.contracts import (
     FeatureMode,
     OfflineStorageContract,
 )
+from specforge.data.loss_mask import has_consecutive_supervised_tokens
 
 ALGORITHM_NAME = "domino"
 DRAFT_ARCHITECTURE = "DominoDraftModel"
@@ -169,6 +170,7 @@ def algorithm_providers() -> AlgorithmProviders:
             minimum_loss_tokens=minimum_loss_tokens,
             needs_input_tools=needs_input_tools,
             default_dataloader_num_workers=8,
+            loss_mask_filter=has_consecutive_supervised_tokens,
         ),
         offline=(
             OfflineDataProvider(

--- a/specforge/algorithms/dspark/providers.py
+++ b/specforge/algorithms/dspark/providers.py
@@ -33,6 +33,7 @@ from specforge.algorithms.contracts import (
     FeatureMode,
     OfflineStorageContract,
 )
+from specforge.data.loss_mask import has_consecutive_supervised_tokens
 
 ALGORITHM_NAME = "dspark"
 DRAFT_ARCHITECTURE = "DSparkDraftModel"
@@ -163,6 +164,7 @@ def algorithm_providers() -> AlgorithmProviders:
             minimum_loss_tokens=minimum_loss_tokens,
             needs_input_tools=needs_input_tools,
             default_dataloader_num_workers=8,
+            loss_mask_filter=has_consecutive_supervised_tokens,
         ),
         offline=(
             OfflineDataProvider(

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -211,6 +211,22 @@ def resolve_eagle_capture_layers(
     return layers
 
 
+def _validate_dflash_block_size(draft_config: Any) -> None:
+    block_size = (
+        draft_config.get("block_size")
+        if isinstance(draft_config, dict)
+        else getattr(draft_config, "block_size", None)
+    )
+    if (
+        not isinstance(block_size, int)
+        or isinstance(block_size, bool)
+        or block_size < 2
+    ):
+        raise ValueError(
+            "DFlash-family draft config must define an integer block_size >= 2"
+        )
+
+
 def resolve_dflash_capture_layers(
     _cfg: Config, draft_config: Any, _target_config: Any
 ) -> List[int]:
@@ -318,6 +334,7 @@ def _build_dflash_family_model(
 ) -> AlgorithmModelParts:
     from specforge.modeling.target.target_utils import TargetEmbeddingsAndHead
 
+    _validate_dflash_block_size(draft_model)
     mask_token_id = _resolve_mask_token_id(cfg, draft_model, tokenizer)
     draft_model.mask_token_id = mask_token_id
     method_config = getattr(draft_model.config, "dflash_config", None)
@@ -432,16 +449,8 @@ def domino_strategy_kwargs(cfg: Config) -> Dict[str, Any]:
 
 
 def dflash_min_loss_tokens(_cfg: Config, draft_config: Any) -> int:
-    block_size = getattr(draft_config, "block_size", None)
-    if (
-        not isinstance(block_size, int)
-        or isinstance(block_size, bool)
-        or block_size < 1
-    ):
-        raise ValueError(
-            "DFlash-family draft config must define a positive integer block_size"
-        )
-    return 2 * block_size
+    _validate_dflash_block_size(draft_config)
+    return 2
 
 
 def populate_dflash_generated_config(

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -457,22 +457,41 @@ def populate_dflash_generated_config(
         )
     payload["num_target_layers"] = target_layers
     payload["block_size"] = 16
+    payload["layer_types"] = ["full_attention"] * int(payload["num_hidden_layers"])
+    payload["sliding_window"] = None
+    payload["use_sliding_window"] = False
     payload["dflash_config"] = {
         "target_layer_ids": build_target_layer_ids(target_layers, 1)
     }
 
 
 def apply_dflash_overrides(cfg: Config, draft_config: Any) -> None:
-    if cfg.model.draft_num_hidden_layers is None:
-        return
-    from specforge.modeling.draft.dflash import build_target_layer_ids
-
-    target_layers = int(draft_config.num_target_layers)
-    method_config = dict(getattr(draft_config, "dflash_config", None) or {})
-    method_config["target_layer_ids"] = build_target_layer_ids(
-        target_layers, cfg.model.draft_num_hidden_layers
+    from specforge.modeling.draft.dflash import (
+        build_target_layer_ids,
+        resolve_dflash_attention_layout,
     )
-    draft_config.dflash_config = method_config
+
+    requested_layers = cfg.model.draft_num_hidden_layers
+    if requested_layers is not None:
+        layer_types = draft_config.layer_types
+        if len(layer_types) != requested_layers:
+            if len(set(layer_types)) > 1:
+                raise ValueError(
+                    "model.draft_num_hidden_layers cannot resize a mixed "
+                    "DFlash layer_types layout; provide a draft config with "
+                    "exactly the requested per-layer layout"
+                )
+            draft_config.layer_types = [layer_types[0]] * requested_layers
+
+        draft_config.dflash_config = {
+            **dict(getattr(draft_config, "dflash_config", None) or {}),
+            "target_layer_ids": build_target_layer_ids(
+                int(draft_config.num_target_layers),
+                requested_layers,
+            ),
+        }
+
+    resolve_dflash_attention_layout(draft_config)
 
 
 __all__ = [

--- a/specforge/application/composition.py
+++ b/specforge/application/composition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Callable
 
 from specforge.algorithms.common.providers import OfflineCaptureLayout
 from specforge.algorithms.registry import AlgorithmRegistration, AlgorithmRegistry
@@ -26,6 +27,7 @@ class ResolvedOfflineCapture:
     capture_method: str
     capture_layers: tuple[int, ...]
     layout: OfflineCaptureLayout
+    loss_mask_filter: Callable[[object], bool] | None
 
 
 def bind_run(cfg: Config, algorithm: AlgorithmRegistration) -> ResolvedRun:
@@ -127,6 +129,7 @@ def resolve_offline_capture(
         capture_method=offline.capture_layout.capture_method,
         capture_layers=layers,
         layout=offline.capture_layout,
+        loss_mask_filter=model_provider.loss_mask_filter,
     )
 
 

--- a/specforge/data/loss_mask.py
+++ b/specforge/data/loss_mask.py
@@ -1,0 +1,21 @@
+"""Loss-mask predicates shared by online and offline data paths."""
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def has_consecutive_supervised_tokens(loss_mask: Any) -> bool:
+    """Return whether one sample contains adjacent supervised tokens."""
+
+    values = loss_mask.tolist() if hasattr(loss_mask, "tolist") else list(loss_mask)
+    if values and isinstance(values[0], Sequence):
+        if len(values) != 1:
+            raise ValueError("expected one loss-mask row")
+        values = list(values[0])
+    return any(
+        bool(current) and bool(following)
+        for current, following in zip(values, values[1:])
+    )
+
+
+__all__ = ["has_consecutive_supervised_tokens"]

--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -27,7 +27,7 @@ import os
 import re
 import warnings
 from collections import Counter
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -36,6 +36,7 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizer
 
 from ..distributed import get_draft_sp_group, get_sp_ring_group
+from .loss_mask import has_consecutive_supervised_tokens
 from .parse import GeneralParser, GLMParser, HarmonyParser, ThinkingParser
 from .template import TEMPLATE_REGISTRY, ChatTemplate
 
@@ -180,6 +181,7 @@ def build_eagle3_dataset(
     is_preformatted: Optional[bool] = False,
     train_only_last_turn: Optional[bool] = False,
     minimum_valid_tokens: Optional[int] = None,
+    loss_mask_filter: Optional[Callable[[object], bool]] = None,
 ) -> HFDataset:
     """
     build eagle3 dataset
@@ -206,12 +208,16 @@ def build_eagle3_dataset(
         train_only_last_turn: If True, only the last assistant turn contributes to the loss.
                              Useful for thinking models where history may not contain thoughts.
         minimum_valid_tokens: If set, drops samples with fewer trainable tokens.
+        loss_mask_filter: Optional algorithm-owned predicate applied after
+                          tokenization and truncation.
 
     Returns:
         The processed HF dataset.
     """
     if minimum_valid_tokens is not None and minimum_valid_tokens < 0:
         raise ValueError("minimum_valid_tokens must be >= 0")
+    if loss_mask_filter is not None and not callable(loss_mask_filter):
+        raise TypeError("loss_mask_filter must be callable or None")
 
     # Validate chat_template requirement
     if chat_template is None:
@@ -342,6 +348,21 @@ def build_eagle3_dataset(
         )
         print(
             f"Filtered dataset by trainable tokens: {before_filter} -> {len(dataset)}"
+        )
+
+    if loss_mask_filter is not None:
+        before_filter = len(dataset)
+
+        def has_eligible_loss_mask(example):
+            return loss_mask_filter(example["loss_mask"])
+
+        dataset = dataset.filter(
+            has_eligible_loss_mask,
+            num_proc=num_proc,
+            desc="Filtering samples by algorithm loss-mask eligibility",
+        )
+        print(
+            f"Filtered dataset by loss-mask eligibility: {before_filter} -> {len(dataset)}"
         )
 
     dataset.set_format(type="torch")
@@ -684,6 +705,10 @@ def process_offline_dflash_sample(
             f"truncation: input_ids={input_ids.shape[1]}, "
             f"loss_mask={loss_mask.shape[1]}, "
             f"hidden_states={hidden_states.shape[1]}"
+        )
+    if not has_consecutive_supervised_tokens(loss_mask[0]):
+        raise ValueError(
+            "offline DFlash samples require two consecutive supervised tokens"
         )
     return {
         "input_ids": input_ids,

--- a/specforge/data/prompt_builder.py
+++ b/specforge/data/prompt_builder.py
@@ -12,7 +12,7 @@ import json
 import os
 from collections.abc import Iterable, Iterator, Mapping, Sequence
 from numbers import Integral
-from typing import Any
+from typing import Any, Callable
 
 PromptTaskDict = dict[str, Any]
 
@@ -30,6 +30,7 @@ def prepare_prompt_tasks(
     num_proc: int | None,
     min_loss_tokens: int = 1,
     max_prompts: int | None = None,
+    loss_mask_filter: Callable[[Sequence[int]], bool] | None = None,
 ) -> list[PromptTaskDict]:
     """Prepare runtime prompt dictionaries from a JSONL file.
 
@@ -48,6 +49,7 @@ def prepare_prompt_tasks(
         max_prompts=max_prompts,
         cache_dir=cache_dir,
         cache_key=cache_key,
+        loss_mask_filter=loss_mask_filter,
     )
     path_string = os.fspath(path)
     first_record = next(_iter_records(path_string), None)
@@ -75,6 +77,7 @@ def prepare_prompt_tasks(
             max_length=max_length,
             min_loss_tokens=min_loss_tokens,
             limit=limit,
+            loss_mask_filter=loss_mask_filter,
         )
 
     return _prepare_raw_prompts(
@@ -89,6 +92,7 @@ def prepare_prompt_tasks(
         num_proc=num_proc,
         min_loss_tokens=min_loss_tokens,
         limit=limit,
+        loss_mask_filter=loss_mask_filter,
     )
 
 
@@ -105,6 +109,7 @@ def _prepare_raw_prompts(
     num_proc: int | None,
     min_loss_tokens: int,
     limit: int | None,
+    loss_mask_filter: Callable[[Sequence[int]], bool] | None,
 ) -> list[PromptTaskDict]:
     try:
         from datasets import load_dataset
@@ -116,7 +121,7 @@ def _prepare_raw_prompts(
     from .preprocessing import build_eagle3_dataset
 
     dataset = load_dataset("json", data_files=path, split="train")
-    if limit is not None and limit < len(dataset):
+    if loss_mask_filter is None and limit is not None and limit < len(dataset):
         dataset = dataset.select(range(limit))
 
     processed_dataset = build_eagle3_dataset(
@@ -130,6 +135,7 @@ def _prepare_raw_prompts(
         is_preformatted=is_preformatted,
         train_only_last_turn=train_only_last_turn,
         minimum_valid_tokens=min_loss_tokens,
+        loss_mask_filter=loss_mask_filter,
     )
     rows = (
         (record, f"processed dataset row {index}")
@@ -140,6 +146,7 @@ def _prepare_raw_prompts(
         max_length=max_length,
         min_loss_tokens=min_loss_tokens,
         limit=limit,
+        loss_mask_filter=None,
     )
 
 
@@ -149,6 +156,7 @@ def _materialize_prompt_tasks(
     max_length: int,
     min_loss_tokens: int,
     limit: int | None,
+    loss_mask_filter: Callable[[Sequence[int]], bool] | None,
 ) -> list[PromptTaskDict]:
     prompts: list[PromptTaskDict] = []
     for record, source in rows:
@@ -172,6 +180,8 @@ def _materialize_prompt_tasks(
         input_ids = input_ids[:max_length]
         loss_mask = loss_mask[:max_length]
         if sum(loss_mask) < min_loss_tokens:
+            continue
+        if loss_mask_filter is not None and not loss_mask_filter(loss_mask):
             continue
 
         prompts.append(
@@ -275,6 +285,7 @@ def _validate_options(
     max_prompts: int | None,
     cache_dir: str | None,
     cache_key: str | None,
+    loss_mask_filter: Callable[[Sequence[int]], bool] | None,
 ) -> None:
     if (
         not isinstance(max_length, int)
@@ -300,6 +311,8 @@ def _validate_options(
         )
     if (cache_dir is None) != (cache_key is None):
         raise ValueError("cache_dir and cache_key must be provided together")
+    if loss_mask_filter is not None and not callable(loss_mask_filter):
+        raise TypeError("loss_mask_filter must be callable or None")
 
 
 __all__ = ["PromptTaskDict", "prepare_prompt_tasks"]

--- a/specforge/eval/evaluator.py
+++ b/specforge/eval/evaluator.py
@@ -39,10 +39,10 @@ class Evaluator:
     ) -> Dict[str, Any]:
         """Run the pass; returns ``{}`` if zero batches were processed globally.
 
-        Scalar accuracy is weighted by ``metrics['accuracy_denom']`` when present,
-        else by the loss-token count — only approximately batch-size invariant
-        when the accuracy counts a different token set than the loss. In a mixed
-        pass, scalar batches feed avg_loss only; their accuracy is not merged.
+        Additive loss and accuracy terms are used directly when the strategy
+        provides them. Scalar fallbacks use ``metrics['accuracy_denom']`` when
+        present, else the loss-token count. In a mixed pass, scalar batches feed
+        avg_loss only; their accuracy is not merged.
         """
         # pp rows: [correct, denom, acceptance_rate*w, ploss*w] per TTT
         # position, float64 so counts stay exact past 2**24.
@@ -63,8 +63,13 @@ class Evaluator:
                 if sums is None:
                     sums = torch.zeros(7, dtype=torch.float64, device=loss.device)
                 tokens = self._token_count(batch, m, device=sums.device)
-                sums[0] += loss.to(sums.device) * tokens
-                sums[1] += tokens
+                if out.loss_terms is None:
+                    sums[0] += loss.to(sums.device) * tokens
+                    sums[1] += tokens
+                else:
+                    loss_numerator, loss_denominator = out.loss_terms
+                    sums[0] += self._sum64(loss_numerator, sums.device)
+                    sums[1] += self._sum64(loss_denominator, sums.device)
                 sums[4] += 1.0
 
                 if "acc_corrects" in m and "acc_denoms" in m:
@@ -86,6 +91,10 @@ class Evaluator:
                     if "plosses" in m:
                         pp[3] += self._stack(m["plosses"]) * w
                         sums[6] += tokens
+                elif "acc" in out.ratio_metrics:
+                    accuracy_numerator, accuracy_denominator = out.ratio_metrics["acc"]
+                    sums[2] += self._sum64(accuracy_numerator, sums.device)
+                    sums[3] += self._sum64(accuracy_denominator, sums.device)
                 elif "accuracy" in m:
                     acc = m["accuracy"]
                     acc = (
@@ -96,11 +105,7 @@ class Evaluator:
                         )
                     )
                     denom = m.get("accuracy_denom")
-                    w = (
-                        torch.as_tensor(denom).detach().double().sum().to(sums.device)
-                        if denom is not None
-                        else tokens
-                    )
+                    w = self._sum64(denom, sums.device) if denom is not None else tokens
                     sums[2] += acc * w
                     sums[3] += w
 
@@ -161,6 +166,10 @@ class Evaluator:
     @staticmethod
     def _stack(values: Iterable[Any]) -> torch.Tensor:
         return torch.stack([torch.as_tensor(v).detach().double() for v in values])
+
+    @staticmethod
+    def _sum64(value: Any, device: torch.device) -> torch.Tensor:
+        return torch.as_tensor(value).detach().double().sum().to(device)
 
     @staticmethod
     def _comm_device() -> torch.device:

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -20,6 +20,10 @@ from typing_extensions import Tuple, Unpack
 from .dflash_kernels import DEFAULT_DFLASH_KERNELS, DFlashKernels
 from .registry import register_draft
 
+FULL_ATTENTION = "full_attention"
+SLIDING_ATTENTION = "sliding_attention"
+_VALID_DFLASH_LAYER_TYPES = {FULL_ATTENTION, SLIDING_ATTENTION}
+
 
 def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
     if temperature < 1e-5:
@@ -31,6 +35,39 @@ def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
     return torch.multinomial(probs, num_samples=1).view(bsz, seq_len)
 
 
+def resolve_dflash_attention_layout(
+    config: Qwen3Config,
+) -> tuple[tuple[str, ...], Optional[int]]:
+    """Validate and return the configured per-layer DFlash attention layout."""
+
+    num_hidden_layers = config.num_hidden_layers
+    layer_types = tuple(config.layer_types)
+
+    if len(layer_types) != num_hidden_layers:
+        raise ValueError(
+            "DFlash config.layer_types must contain exactly "
+            f"num_hidden_layers={num_hidden_layers} entries, got "
+            f"{len(layer_types)}"
+        )
+    invalid = set(layer_types) - _VALID_DFLASH_LAYER_TYPES
+    if invalid:
+        raise ValueError(
+            "DFlash config.layer_types supports only full_attention and "
+            f"sliding_attention, got {sorted(invalid)}"
+        )
+
+    if SLIDING_ATTENTION not in layer_types:
+        return layer_types, None
+
+    sliding_window = config.sliding_window
+    if sliding_window is None or sliding_window <= 0:
+        raise ValueError(
+            "DFlash sliding_attention layers require use_sliding_window=true "
+            "and a positive config.sliding_window"
+        )
+    return layer_types, sliding_window
+
+
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     cos = cos.unsqueeze(unsqueeze_dim)
     sin = sin.unsqueeze(unsqueeze_dim)
@@ -38,6 +75,23 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     q_embed = (q * cos[..., -q_len:, :]) + (rotate_half(q) * sin[..., -q_len:, :])
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed, k_embed
+
+
+def _prepare_dflash_eager_mask(
+    attention_mask: Optional[torch.Tensor],
+    dtype: torch.dtype,
+) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """Convert a boolean allow-mask to eager's additive representation."""
+
+    if attention_mask is None or attention_mask.dtype != torch.bool:
+        return attention_mask, None
+
+    valid_queries = attention_mask.any(dim=-1, keepdim=True)
+    # A finite minimum keeps eager softmax stable. Fully masked query rows are
+    # explicitly zeroed after attention so they cannot average forbidden values.
+    additive_mask = torch.zeros_like(attention_mask, dtype=dtype)
+    additive_mask.masked_fill_(~attention_mask, torch.finfo(dtype).min)
+    return additive_mask, valid_queries
 
 
 class Qwen3DFlashAttention(nn.Module):
@@ -85,7 +139,7 @@ class Qwen3DFlashAttention(nn.Module):
         self.k_norm = kernels.make_rms_norm(self.head_dim, config.rms_norm_eps)
         self.sliding_window = (
             config.sliding_window
-            if config.layer_types[layer_idx] == "sliding_attention"
+            if config.layer_types[layer_idx] == SLIDING_ATTENTION
             else None
         )
 
@@ -121,8 +175,14 @@ class Qwen3DFlashAttention(nn.Module):
         if past_key_values is not None:
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
             k, v = past_key_values.update(k, v, self.layer_idx, cache_kwargs)
+        valid_queries = None
         attn_fn: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
+        if self.config._attn_implementation == "eager":
+            attention_mask, valid_queries = _prepare_dflash_eager_mask(
+                attention_mask,
+                q.dtype,
+            )
+        else:
             attn_fn = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
         attn_output, attn_weights = attn_fn(
             self,
@@ -135,8 +195,15 @@ class Qwen3DFlashAttention(nn.Module):
             sliding_window=self.sliding_window,
             **kwargs,
         )
+        if valid_queries is not None and attn_weights is not None:
+            attn_weights = attn_weights.masked_fill(~valid_queries, 0)
         attn_output = attn_output.reshape(bsz, q_len, -1)
         attn_output = self.o_proj(attn_output)
+        if valid_queries is not None:
+            attn_output = attn_output.masked_fill(
+                ~valid_queries.any(dim=1),
+                0,
+            )
         return attn_output, attn_weights
 
 
@@ -277,6 +344,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
     ) -> None:
         super().__init__(config)
         self.config = config
+        self.layer_types, self.sliding_window = resolve_dflash_attention_layout(config)
         kernels = dflash_kernels or DEFAULT_DFLASH_KERNELS
         self.layers = nn.ModuleList(
             [
@@ -363,7 +431,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
     def forward(
         self,
         position_ids: torch.LongTensor,
-        attention_mask: Optional[torch.Tensor] = None,
+        attention_mask: Optional[object] = None,
         noise_embedding: Optional[torch.Tensor] = None,
         target_hidden: Optional[torch.Tensor] = None,
         past_key_values: Optional[Cache] = None,
@@ -373,11 +441,16 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         hidden_states = noise_embedding
         target_hidden = self.hidden_norm(self.fc(target_hidden))
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
-        for layer in self.layers:
+        for layer_type, layer in zip(self.layer_types, self.layers):
+            layer_attention_mask = (
+                attention_mask[layer_type]
+                if isinstance(attention_mask, dict)
+                else attention_mask
+            )
             hidden_states = layer(
                 hidden_states=hidden_states,
                 target_hidden=target_hidden,
-                attention_mask=attention_mask,
+                attention_mask=layer_attention_mask,
                 position_ids=position_ids,
                 past_key_value=past_key_values,
                 use_cache=use_cache,

--- a/specforge/training/assembly.py
+++ b/specforge/training/assembly.py
@@ -391,6 +391,7 @@ def _prepare_prompts(
         num_proc=cfg.data.build_dataset_num_proc,
         min_loss_tokens=min_loss_tokens,
         max_prompts=cfg.data.max_prompts,
+        loss_mask_filter=algorithm.providers.model.loss_mask_filter,
     )
 
 

--- a/specforge/training/backend.py
+++ b/specforge/training/backend.py
@@ -132,6 +132,12 @@ class TrainingBackend(abc.ABC):
     @abc.abstractmethod
     def backward(self, loss: torch.Tensor, *, is_boundary: bool = True) -> None: ...
 
+    def scale_gradients(self, factor: torch.Tensor) -> None:
+        """Scale synchronized gradients before clipping and stepping."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement gradient scaling"
+        )
+
     @abc.abstractmethod
     def step(self) -> Optional[torch.Tensor]: ...
 
@@ -312,6 +318,14 @@ class FSDPTrainingBackend(TrainingBackend):
         else:
             with self.module.no_sync():
                 loss.backward()
+
+    def scale_gradients(self, factor: torch.Tensor) -> None:
+        if self.module is None:
+            raise RuntimeError("scale_gradients called before prepare_model")
+        with torch.no_grad():
+            for parameter in self.module.parameters():
+                if parameter.grad is not None:
+                    parameter.grad.mul_(factor)
 
     def step(self) -> Optional[torch.Tensor]:
         """Run the optimizer step, which clips and returns the global grad norm."""

--- a/specforge/training/controller.py
+++ b/specforge/training/controller.py
@@ -139,10 +139,16 @@ def _reduce_ratio_metrics(
         import torch.distributed as dist
 
         if dist.is_available() and dist.is_initialized():
-            if process_group is None:
-                dist.all_reduce(packed)
-            else:
-                dist.all_reduce(packed, group=process_group)
+            world = (
+                dist.get_world_size()
+                if process_group is None
+                else dist.get_world_size(group=process_group)
+            )
+            if world > 1:
+                if process_group is None:
+                    dist.all_reduce(packed)
+                else:
+                    dist.all_reduce(packed, group=process_group)
 
     output: Dict[str, float] = {}
     cursor = 0

--- a/specforge/training/controller.py
+++ b/specforge/training/controller.py
@@ -311,6 +311,7 @@ class TrainerCore:
         self.backend = backend
         self.accumulation_steps = max(1, accumulation_steps)
         self._micro = 0
+        self._ratio_totals: Dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
 
     @property
     def accumulation_remainder(self) -> int:
@@ -321,16 +322,79 @@ class TrainerCore:
         self, batch: TrainBatch, ctx: Optional[StepContext] = None
     ) -> StepResult:
         out: StepOutput = self.strategy.forward_loss(batch, ctx)
-        loss = out.loss / self.accumulation_steps
+        loss = out.loss
+        ratio_metrics = dict(out.ratio_metrics)
+        if out.loss_terms is not None:
+            numerator, denominator = out.loss_terms
+            if numerator.numel() != 1 or denominator.numel() != 1:
+                raise ValueError("loss_terms must contain scalar tensors")
+            loss = numerator.reshape(())
+            denominator = denominator.detach().reshape(())
+            ratio_metrics["loss"] = (
+                numerator.detach().reshape(()),
+                denominator,
+            )
+        self._accumulate_ratio_metrics(ratio_metrics)
+        loss = loss / self.accumulation_steps
         self._micro += 1
         # The boundary is known before backward so the backend can defer the FSDP
         # gradient reduction (no_sync) on non-boundary micro-steps.
         stepped = self._micro % self.accumulation_steps == 0
         self.backend.backward(loss, is_boundary=stepped)
+        if stepped and out.loss_terms is not None:
+            self._normalize_gradients(self._ratio_totals["loss"][1])
         grad_norm = self.backend.step() if stepped else None
-        return self._result(out, grad_norm, stepped)
+        result_ratio_metrics = self._ratio_totals if stepped else ratio_metrics
+        result = self._result(
+            out,
+            grad_norm,
+            stepped,
+            ratio_metrics=result_ratio_metrics,
+        )
+        if stepped:
+            self._ratio_totals = {}
+        return result
 
-    def _result(self, out: StepOutput, grad_norm, stepped: bool) -> StepResult:
+    def _accumulate_ratio_metrics(self, values: Dict[str, Any]) -> None:
+        for name, (raw_numerator, raw_denominator) in values.items():
+            numerator = torch.as_tensor(raw_numerator).detach()
+            denominator = torch.as_tensor(raw_denominator).detach()
+            previous = self._ratio_totals.get(name)
+            if previous is not None:
+                numerator = previous[0] + numerator
+                denominator = previous[1] + denominator
+            self._ratio_totals[name] = (numerator, denominator)
+
+    def _normalize_gradients(self, local_denominator: torch.Tensor) -> None:
+        import torch.distributed as dist
+
+        denominator = local_denominator.clone()
+        parallel_config = getattr(self.backend, "parallel_config", None)
+        process_group = getattr(parallel_config, "fsdp_process_group", None)
+        world_size = 1
+        if dist.is_available() and dist.is_initialized():
+            world_size = dist.get_world_size(group=process_group)
+            if world_size > 1:
+                dist.all_reduce(
+                    denominator,
+                    op=dist.ReduceOp.SUM,
+                    group=process_group,
+                )
+        if denominator.item() <= 0:
+            raise ValueError("global loss denominator must be positive")
+        scale = (
+            denominator.new_tensor(world_size * self.accumulation_steps) / denominator
+        )
+        self.backend.scale_gradients(scale)
+
+    def _result(
+        self,
+        out: StepOutput,
+        grad_norm,
+        stepped: bool,
+        *,
+        ratio_metrics: Optional[Dict[str, Any]] = None,
+    ) -> StepResult:
         # EAGLE3 carries per-TTT numerators and denominators.  Preserve those
         # positions and reduce counts before ratios; scalarizing its lists here
         # would both collapse the TTT structure and log one rank's local data.
@@ -353,7 +417,7 @@ class TrainerCore:
         metrics: Dict[str, Any] = dict(structured or {})
         metrics.update(
             _reduce_ratio_metrics(
-                out.ratio_metrics,
+                out.ratio_metrics if ratio_metrics is None else ratio_metrics,
                 device=metric_device,
                 process_group=process_group,
                 reduce=stepped,
@@ -374,7 +438,11 @@ class TrainerCore:
         # the generic trainer their algorithm-specific names. Move CPU schedule
         # scalars (for example Domino's lambda_base) onto the loss device before
         # the DP reduction so NCCL-backed runs do not all-reduce a CPU tensor.
-        reserved_metric_keys = _EAGLE3_STRUCTURED_METRIC_KEYS | {"accuracy", "loss"}
+        reserved_metric_keys = _EAGLE3_STRUCTURED_METRIC_KEYS | {
+            "accuracy",
+            "accuracy_denom",
+            "loss",
+        }
         for key, value in out.metrics.items():
             if key in reserved_metric_keys:
                 continue

--- a/specforge/training/disaggregated.py
+++ b/specforge/training/disaggregated.py
@@ -561,6 +561,10 @@ def _build_online(
                 input_tools,
                 draft_config=draft_config,
             )
+        if not prompts:
+            raise ValueError(
+                f"no prompts satisfy {algorithm.name} training eligibility"
+            )
         if cfg.training.total_steps is None and cfg.training.max_steps is None:
             schedule = _online_schedule_payload(cfg, num_prompts=len(prompts))
             _write_control(

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -29,11 +29,17 @@ from specforge.runtime.contracts import TrainBatch
 @dataclass(frozen=True)
 class StepOutput:
     """Per-step result: loss + strategy-specific metrics, kept generic so
-    per-position (TTT) and single-scalar strategies share one trainer loop."""
+    per-position (TTT) and single-scalar strategies share one trainer loop.
+
+    ``loss_terms`` carries an additive objective numerator and denominator when
+    gradients and reported loss must be normalized across the full optimizer
+    window.
+    """
 
     loss: torch.Tensor
     metrics: Dict[str, Any]
     ratio_metrics: Dict[str, Tuple[Any, Any]] = field(default_factory=dict)
+    loss_terms: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
 
 
 @dataclass(frozen=True)
@@ -441,7 +447,12 @@ class DFlashTrainStrategy(DraftTrainStrategy):
         metrics = {"accuracy": accuracy.detach()}
         if "accuracy_denom" in model_metrics:
             metrics["accuracy_denom"] = model_metrics["accuracy_denom"]
-        return StepOutput(loss=loss, metrics=metrics)
+        return StepOutput(
+            loss=loss,
+            metrics=metrics,
+            ratio_metrics=model_metrics.get("ratio_metrics", {}),
+            loss_terms=model_metrics.get("loss_terms"),
+        )
 
     def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
         # Everything trainable lives under draft_model.; the target

--- a/tests/test_algorithms/test_builtin_providers.py
+++ b/tests/test_algorithms/test_builtin_providers.py
@@ -55,6 +55,19 @@ class BuiltinProviderContractTest(unittest.TestCase):
                 }
                 self.assertEqual(contract_keys, provider_keys)
 
+    def test_dflash_family_requires_a_trainable_block_size(self):
+        for algorithm in ("dflash", "domino", "dspark"):
+            minimum_loss_tokens = self.registry.resolve(
+                algorithm
+            ).providers.model.minimum_loss_tokens
+            with self.subTest(algorithm=algorithm):
+                self.assertEqual(
+                    minimum_loss_tokens(None, SimpleNamespace(block_size=2)),
+                    2,
+                )
+                with self.assertRaisesRegex(ValueError, "block_size >= 2"):
+                    minimum_loss_tokens(None, SimpleNamespace(block_size=1))
+
     def test_algorithm_metadata_has_no_factories_or_topology_flags(self):
         field_names = {field.name for field in fields(AlgorithmSpec)}
         self.assertEqual(

--- a/tests/test_algorithms/test_offline_capture_layout.py
+++ b/tests/test_algorithms/test_offline_capture_layout.py
@@ -98,6 +98,23 @@ class OfflineCaptureLayoutTest(unittest.TestCase):
                         record["hidden_states"].shape[-1],
                     )
 
+    def test_dflash_family_normalizers_require_adjacent_supervision(self):
+        raw = {
+            "input_ids": torch.tensor([1, 2, 3]),
+            "loss_mask": torch.tensor([1, 0, 1]),
+            "hidden_states": torch.randn(1, 3, 8),
+            "target_last_hidden_states": torch.randn(1, 3, 8),
+        }
+        for strategy in ("dflash", "domino", "dspark"):
+            with self.subTest(strategy=strategy):
+                normalizer = (
+                    self.registry.resolve(strategy)
+                    .providers.offline_for("text")
+                    .build_normalizer(3)
+                )
+                with self.assertRaisesRegex(ValueError, "two consecutive"):
+                    normalizer(raw)
+
     def test_duplicate_output_names_are_rejected(self):
         with self.assertRaisesRegex(ValueError, "duplicate.*hidden_states"):
             OfflineCaptureLayout(

--- a/tests/test_data/test_prompt_builder.py
+++ b/tests/test_data/test_prompt_builder.py
@@ -6,6 +6,7 @@ import types
 import unittest
 from unittest.mock import patch
 
+from specforge.data.loss_mask import has_consecutive_supervised_tokens
 from specforge.data.prompt_builder import prepare_prompt_tasks
 
 
@@ -84,6 +85,35 @@ class TestPreparePromptTasks(unittest.TestCase):
                 {"payload": {"input_ids": [1, 2, 3], "loss_mask": [0, 1, 1]}},
                 {"payload": {"input_ids": [7, 8], "loss_mask": [1, 1]}},
             ],
+        )
+
+    def test_algorithm_loss_mask_filter_applies_after_truncation(self):
+        records = [
+            {"input_ids": [1, 2, 3, 4, 5], "loss_mask": [1, 0, 0, 1, 1]},
+            {"input_ids": [4, 5, 6, 7], "loss_mask": [0, 0, 1, 1]},
+        ]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = os.path.join(tmp_dir, "prompts.jsonl")
+            _write_jsonl(path, records)
+
+            prompts = prepare_prompt_tasks(
+                path,
+                tokenizer=None,
+                chat_template=None,
+                max_length=4,
+                is_preformatted=False,
+                train_only_last_turn=False,
+                cache_dir=None,
+                cache_key=None,
+                num_proc=1,
+                min_loss_tokens=2,
+                max_prompts=1,
+                loss_mask_filter=has_consecutive_supervised_tokens,
+            )
+
+        self.assertEqual(
+            prompts,
+            [{"payload": {"input_ids": [4, 5, 6, 7], "loss_mask": [0, 0, 1, 1]}}],
         )
 
     def test_raw_conversations_use_lazy_dataset_preprocessing(self):

--- a/tests/test_modeling/test_dflash_eager_attention.py
+++ b/tests/test_modeling/test_dflash_eager_attention.py
@@ -1,0 +1,120 @@
+import unittest
+
+import torch
+from torch import nn
+from torch.testing import assert_close
+from transformers import Qwen3Config
+
+from specforge.algorithms.common.dflash_family_model import create_dflash_sdpa_mask
+from specforge.modeling.draft.dflash import Qwen3DFlashAttention
+from specforge.modeling.draft.dflash_kernels import DFlashKernels
+
+
+def _make_attention(layer_type, implementation, sliding_window):
+    config = Qwen3Config(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_hidden_layers=1,
+        head_dim=4,
+        max_position_embeddings=64,
+        vocab_size=32,
+        layer_types=[layer_type],
+        sliding_window=sliding_window,
+        use_sliding_window=sliding_window is not None,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = implementation
+    kernels = DFlashKernels(
+        make_rms_norm=lambda *_: nn.Identity(),
+        make_mlp=lambda *_: nn.Identity(),
+    )
+    return Qwen3DFlashAttention(config, layer_idx=0, kernels=kernels).eval()
+
+
+def _forward(attention, hidden_states, target_hidden, attention_mask):
+    total_length = target_hidden.shape[1] + hidden_states.shape[1]
+    position_embeddings = (
+        hidden_states.new_ones(1, total_length, attention.head_dim),
+        hidden_states.new_zeros(1, total_length, attention.head_dim),
+    )
+    return attention(
+        hidden_states=hidden_states,
+        target_hidden=target_hidden,
+        position_embeddings=position_embeddings,
+        attention_mask=attention_mask,
+    )
+
+
+class TestDFlashEagerAttentionMasking(unittest.TestCase):
+    def test_eager_matches_sdpa_for_full_and_sliding_masks(self):
+        for layer_type, sliding_window in (
+            ("full_attention", None),
+            ("sliding_attention", 2),
+        ):
+            with self.subTest(layer_type=layer_type):
+                torch.manual_seed(17)
+                eager = _make_attention(layer_type, "eager", sliding_window)
+                sdpa = _make_attention(layer_type, "sdpa", sliding_window)
+                sdpa.load_state_dict(eager.state_dict())
+
+                mask = create_dflash_sdpa_mask(
+                    anchor_positions=torch.tensor([[2, 4]]),
+                    block_keep_mask=torch.tensor([[True, False]]),
+                    S=4,
+                    block_size=2,
+                    device=torch.device("cpu"),
+                    sliding_window=sliding_window,
+                )
+                eager_hidden = torch.randn(1, 4, 8, requires_grad=True)
+                eager_target = torch.randn(1, 4, 8, requires_grad=True)
+                sdpa_hidden = eager_hidden.detach().clone().requires_grad_(True)
+                sdpa_target = eager_target.detach().clone().requires_grad_(True)
+
+                eager_output, eager_weights = _forward(
+                    eager,
+                    eager_hidden,
+                    eager_target,
+                    mask,
+                )
+                sdpa_output, _ = _forward(
+                    sdpa,
+                    sdpa_hidden,
+                    sdpa_target,
+                    mask,
+                )
+                assert_close(eager_output, sdpa_output, rtol=1e-5, atol=1e-6)
+
+                allowed = mask.expand_as(eager_weights)
+                forbidden_weights = eager_weights.masked_select(~allowed)
+                assert_close(
+                    forbidden_weights,
+                    torch.zeros_like(forbidden_weights),
+                    rtol=0,
+                    atol=0,
+                )
+                invalid_rows = ~mask.any(dim=-1).squeeze(1)
+                assert_close(
+                    eager_output[invalid_rows],
+                    torch.zeros_like(eager_output[invalid_rows]),
+                    rtol=0,
+                    atol=0,
+                )
+
+                output_grad = torch.randn_like(eager_output)
+                eager_grads = torch.autograd.grad(
+                    (eager_output * output_grad).sum(),
+                    (eager_hidden, eager_target),
+                )
+                sdpa_grads = torch.autograd.grad(
+                    (sdpa_output * output_grad).sum(),
+                    (sdpa_hidden, sdpa_target),
+                )
+                for eager_grad, sdpa_grad in zip(eager_grads, sdpa_grads):
+                    assert_close(eager_grad, sdpa_grad, rtol=1e-5, atol=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_modeling/test_dflash_sliding.py
+++ b/tests/test_modeling/test_dflash_sliding.py
@@ -1,0 +1,192 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from specforge.algorithms.common.dflash_family_model import OnlineDFlashModel
+from specforge.modeling.draft.dflash import (
+    DFlashDraftModel,
+    resolve_dflash_attention_layout,
+)
+
+
+def _draft_config(layer_types, sliding_window=None):
+    config = Qwen3Config(
+        architectures=["DFlashDraftModel"],
+        block_size=2,
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_hidden_layers=len(layer_types),
+        num_target_layers=6,
+        head_dim=4,
+        max_position_embeddings=64,
+        vocab_size=32,
+        layer_types=list(layer_types),
+        sliding_window=sliding_window,
+        use_sliding_window=sliding_window is not None,
+    )
+    config._attn_implementation = "sdpa"
+    return config
+
+
+class _CaptureLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attention_mask = None
+
+    def forward(self, *, hidden_states, attention_mask, **_):
+        self.attention_mask = attention_mask
+        return hidden_states
+
+
+class _RotaryStub(nn.Module):
+    def forward(self, *_):
+        return (torch.empty(0), torch.empty(0))
+
+
+def _capture_model(layer_types, sliding_window=None):
+    model = DFlashDraftModel(_draft_config(layer_types, sliding_window))
+    capture_layers = [_CaptureLayer() for _ in layer_types]
+    model.layers = nn.ModuleList(capture_layers)
+    model.fc = nn.Identity()
+    model.hidden_norm = nn.Identity()
+    model.norm = nn.Identity()
+    model.rotary_emb = _RotaryStub()
+    return model, capture_layers
+
+
+def _forward(model, attention_mask):
+    noise_embedding = torch.randn(1, 2, model.config.hidden_size)
+    target_hidden = torch.randn(1, 4, model.config.hidden_size)
+    position_ids = torch.arange(6).unsqueeze(0)
+    return model(
+        position_ids=position_ids,
+        noise_embedding=noise_embedding,
+        target_hidden=target_hidden,
+        attention_mask=attention_mask,
+    )
+
+
+class TestDFlashSlidingDispatch(unittest.TestCase):
+    def test_full_only_model_keeps_single_mask_compatibility(self):
+        model, layers = _capture_model(["full_attention", "full_attention"])
+        full_mask = torch.tensor([1])
+
+        _forward(model, full_mask)
+
+        self.assertIs(layers[0].attention_mask, full_mask)
+        self.assertIs(layers[1].attention_mask, full_mask)
+
+    def test_online_wrapper_builds_both_masks_for_hybrid_model(self):
+        model, layers = _capture_model(
+            ["sliding_attention", "full_attention"],
+            sliding_window=4,
+        )
+        wrapper = OnlineDFlashModel(
+            draft_model=model,
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(32, model.config.hidden_size),
+            mask_token_id=31,
+            block_size=2,
+            attention_backend="sdpa",
+            num_anchors=1,
+        )
+        anchors = torch.tensor([[2]])
+        keep = torch.tensor([[True]])
+        noise_embedding = torch.randn(1, 2, model.config.hidden_size)
+        full_mask = torch.tensor([1])
+        sliding_mask = torch.tensor([2])
+
+        with (
+            mock.patch.object(
+                wrapper,
+                "_sample_anchor_positions",
+                return_value=(anchors, keep),
+            ),
+            mock.patch.object(
+                wrapper,
+                "_create_noise_embed",
+                return_value=noise_embedding,
+            ),
+            mock.patch(
+                "specforge.algorithms.common.dflash_family_model."
+                "create_dflash_sdpa_mask",
+                side_effect=(full_mask, sliding_mask),
+            ) as create_mask,
+        ):
+            wrapper._forward_draft_blocks(
+                input_ids=torch.ones(1, 4, dtype=torch.long),
+                hidden_states=torch.randn(1, 4, model.config.hidden_size),
+                loss_mask=torch.ones(1, 4),
+            )
+
+        self.assertEqual(create_mask.call_count, 2)
+        self.assertIs(layers[0].attention_mask, sliding_mask)
+        self.assertIs(layers[1].attention_mask, full_mask)
+
+
+class TestDFlashSlidingConfig(unittest.TestCase):
+    def test_checked_in_qwen36_config_preserves_hybrid_layout(self):
+        config_path = (
+            Path(__file__).resolve().parents[2] / "configs" / "qwen3.6-27b-dflash.json"
+        )
+        config = Qwen3Config.from_json_file(str(config_path))
+
+        layer_types, sliding_window = resolve_dflash_attention_layout(config)
+
+        self.assertEqual(
+            list(layer_types),
+            [
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "sliding_attention",
+                "full_attention",
+            ],
+        )
+        self.assertEqual(sliding_window, 2048)
+
+    def test_configures_attention_modules_from_layer_types(self):
+        model = DFlashDraftModel(
+            _draft_config(
+                ["sliding_attention", "full_attention", "sliding_attention"],
+                sliding_window=7,
+            )
+        )
+
+        self.assertEqual(
+            list(model.layer_types),
+            ["sliding_attention", "full_attention", "sliding_attention"],
+        )
+        self.assertEqual(model.sliding_window, 7)
+        self.assertEqual(model.layers[0].self_attn.sliding_window, 7)
+        self.assertIsNone(model.layers[1].self_attn.sliding_window)
+        self.assertEqual(model.layers[2].self_attn.sliding_window, 7)
+
+    def test_rejects_invalid_attention_layouts(self):
+        cases = (
+            (["full_attention"], None),
+            (["full_attention", "unknown"], None),
+            (["sliding_attention", "full_attention"], None),
+            (["sliding_attention", "full_attention"], 0),
+            (["sliding_attention", "full_attention"], -1),
+        )
+        for layer_types, sliding_window in cases:
+            with self.subTest(
+                layer_types=layer_types,
+                sliding_window=sliding_window,
+            ):
+                config = _draft_config(["full_attention", "full_attention"])
+                config.layer_types = layer_types
+                config.sliding_window = sliding_window
+                with self.assertRaises(ValueError):
+                    resolve_dflash_attention_layout(config)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -308,6 +308,7 @@ def build_dflash(
 
     draft_config = AutoConfig.from_pretrained(target_dir)
     draft_config.num_hidden_layers = draft_layers
+    draft_config.layer_types = ["full_attention"] * draft_layers
     draft_config.block_size = block_size
     draft_config.num_target_layers = target_layers
     draft_config.dflash_config = {"mask_token_id": mask_token_id}
@@ -375,6 +376,7 @@ def build_domino(
 
     draft_config = AutoConfig.from_pretrained(target_dir)
     draft_config.num_hidden_layers = draft_layers
+    draft_config.layer_types = ["full_attention"] * draft_layers
     draft_config.block_size = block_size
     draft_config.num_target_layers = target_layers
     draft_config.dflash_config = {
@@ -445,6 +447,7 @@ def build_dspark(
 
     draft_config = AutoConfig.from_pretrained(target_dir)
     draft_config.num_hidden_layers = draft_layers
+    draft_config.layer_types = ["full_attention"] * draft_layers
     draft_config.block_size = block_size
     draft_config.num_target_layers = target_layers
     draft_config.dflash_config = {

--- a/tests/test_runtime/test_evaluator_aggregation.py
+++ b/tests/test_runtime/test_evaluator_aggregation.py
@@ -54,6 +54,19 @@ def _scalar_out(loss, acc, tokens, denom=None):
     return StepOutput(loss=torch.tensor(float(loss)), metrics=metrics)
 
 
+def _additive_scalar_out(loss_num, loss_den, accuracy_num, accuracy_den):
+    loss_num = torch.tensor(float(loss_num))
+    loss_den = torch.tensor(float(loss_den))
+    accuracy_num = torch.tensor(float(accuracy_num))
+    accuracy_den = torch.tensor(float(accuracy_den))
+    return StepOutput(
+        loss=loss_num / loss_den,
+        metrics={"accuracy": accuracy_num / accuracy_den},
+        ratio_metrics={"acc": (accuracy_num, accuracy_den)},
+        loss_terms=(loss_num, loss_den),
+    )
+
+
 class TestEvaluatorAggregation(unittest.TestCase):
     def _run(self, outputs):
         from specforge.eval import Evaluator
@@ -170,6 +183,19 @@ class TestEvaluatorAggregation(unittest.TestCase):
             self.assertAlmostEqual(m["eval/simulated_acc_len"], 4 / 6, places=6)
             # loss-token weighting would skew to (0.75*10 + 0.5*50)/60 ~ 0.542
             self.assertNotAlmostEqual(m["eval/avg_acc"], 32.5 / 60, places=2)
+
+    def test_additive_scalar_terms_are_partition_invariant(self):
+        split = self._run(
+            [
+                _additive_scalar_out(2, 1, 1, 1),
+                _additive_scalar_out(30, 3, 1, 3),
+            ]
+        )
+        combined = self._run([_additive_scalar_out(32, 4, 2, 4)])
+
+        self.assertEqual(split, combined)
+        self.assertEqual(split["eval/avg_loss"], 8.0)
+        self.assertEqual(split["eval/avg_acc"], 0.5)
 
     def test_reports_per_position_acceptance(self):
         m = self._run([_step_output(1.0, corrects=[3, 2], denoms=[4, 4])])

--- a/tests/test_runtime/test_model_loading.py
+++ b/tests/test_runtime/test_model_loading.py
@@ -157,6 +157,9 @@ assert not torch.cuda.is_initialized()
                     self.assertEqual(resolved.block_size, block_size)
                     self.assertEqual(resolved.num_target_layers, 12)
                     self.assertEqual(len(resolved.dflash_config["target_layer_ids"]), 1)
+                    self.assertEqual(resolved.layer_types, ["full_attention"])
+                    self.assertIsNone(resolved.sliding_window)
+                    self.assertFalse(resolved.use_sliding_window)
                 else:
                     self.assertEqual(resolved.draft_vocab_size, 32000)
 
@@ -180,6 +183,36 @@ assert not torch.cuda.is_initialized()
         self.assertEqual(resolved.num_hidden_layers, 2)
         self.assertEqual(resolved.block_size, 8)
         self.assertEqual(len(resolved.dflash_config["target_layer_ids"]), 2)
+        self.assertEqual(
+            resolved.layer_types,
+            ["full_attention", "full_attention"],
+        )
+
+    def test_dflash_layer_override_rejects_ambiguous_hybrid_resize(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "draft.json")
+            payload = _draft_payload("DFlashDraftModel", layers=3, block_size=16)
+            payload.update(
+                layer_types=[
+                    "sliding_attention",
+                    "sliding_attention",
+                    "full_attention",
+                ],
+                sliding_window=128,
+                use_sliding_window=True,
+            )
+            with open(path, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream)
+            cfg = _run_config(
+                "dflash",
+                draft_model_config=path,
+                draft_num_hidden_layers=2,
+            )
+            with self.assertRaisesRegex(ValueError, "mixed DFlash layer_types"):
+                resolve_draft_config(
+                    cfg,
+                    provider=_draft_config_provider("dflash"),
+                )
 
     def test_local_json_and_directory_are_equivalent_sources(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_runtime/test_seam_fixes.py
+++ b/tests/test_runtime/test_seam_fixes.py
@@ -106,6 +106,16 @@ class TestParallelConfigHandles(unittest.TestCase):
 
         self.assertEqual(ignored, (model.lm_head, model.embed_tokens))
 
+    def test_backend_scales_gradients_before_optimizer_step(self):
+        model = nn.Linear(2, 1, bias=False)
+        backend = FSDPTrainingBackend(ParallelConfig())
+        backend.prepare_model(model, wrap=False)
+        model.weight.grad = torch.tensor([[4.0, 8.0]])
+
+        backend.scale_gradients(torch.tensor(0.25))
+
+        torch.testing.assert_close(model.weight.grad, torch.tensor([[1.0, 2.0]]))
+
 
 class _FakeBackend(TrainingBackend):
     name = "fake"

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -286,33 +286,57 @@ class TestTrainerCore(unittest.TestCase):
         self.assertEqual(result.metrics["ce_position_0"], 0.5)
         self.assertEqual(result.metrics["ce_position_1"], 0.5)
 
+    _RATIO_INPUTS = {
+        "acc": (torch.tensor(2.0), torch.tensor(4.0)),
+        "ce_position": (
+            torch.tensor([1.0, 3.0]),
+            torch.tensor([2.0, 6.0]),
+        ),
+    }
+
     def test_ratio_metrics_sum_numerators_and_denominators_before_dividing(self):
         remote = torch.tensor([8.0, 6.0, 3.0, 1.0, 2.0, 2.0])
+        reduced_groups = []
 
         def all_reduce(packed, *, group):
-            self.assertEqual(group, "dp")
+            reduced_groups.append(group)
             packed.add_(remote)
 
         with (
             mock.patch("torch.distributed.is_available", return_value=True),
             mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=2),
             mock.patch("torch.distributed.all_reduce", side_effect=all_reduce),
         ):
             metrics = _reduce_ratio_metrics(
-                {
-                    "acc": (torch.tensor(2.0), torch.tensor(4.0)),
-                    "ce_position": (
-                        torch.tensor([1.0, 3.0]),
-                        torch.tensor([2.0, 6.0]),
-                    ),
-                },
+                self._RATIO_INPUTS,
                 device=torch.device("cpu"),
                 process_group="dp",
                 reduce=True,
             )
 
+        self.assertEqual(reduced_groups, ["dp"])
         self.assertEqual(metrics["acc"], 1.0)
         self.assertEqual(metrics["ce_position_0"], 1.0)
+        self.assertEqual(metrics["ce_position_1"], 0.5)
+
+    def test_ratio_metrics_skip_all_reduce_when_world_size_is_one(self):
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=1),
+            mock.patch("torch.distributed.all_reduce") as all_reduce_mock,
+        ):
+            metrics = _reduce_ratio_metrics(
+                self._RATIO_INPUTS,
+                device=torch.device("cpu"),
+                process_group="dp",
+                reduce=True,
+            )
+
+        all_reduce_mock.assert_not_called()
+        self.assertEqual(metrics["acc"], 0.5)
+        self.assertEqual(metrics["ce_position_0"], 0.5)
         self.assertEqual(metrics["ce_position_1"], 0.5)
 
     @staticmethod

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -61,6 +61,23 @@ class RecordingStrategy(FakeStrategy):
         return super().forward_loss(batch, ctx)
 
 
+class WeightedStrategy(FakeStrategy):
+    def forward_loss(self, batch, ctx=None):
+        self.validate_batch(batch)
+        coefficient = batch.tensors["x"].reshape(())
+        denominator = batch.tensors["denominator"].reshape(())
+        correct = batch.tensors["correct"].reshape(())
+        numerator = self.model.w.reshape(()) * coefficient
+        return StepOutput(
+            loss=numerator / denominator,
+            metrics={"accuracy": correct / denominator},
+            ratio_metrics={
+                "acc": (correct, denominator),
+            },
+            loss_terms=(numerator, denominator),
+        )
+
+
 class FakeBackend(TrainingBackend):
     name = "fake"
 
@@ -77,6 +94,11 @@ class FakeBackend(TrainingBackend):
         self.backwards += 1
         self.boundaries.append(is_boundary)
         loss.backward()
+
+    def scale_gradients(self, factor):
+        for parameter in self.model.parameters():
+            if parameter.grad is not None:
+                parameter.grad.mul_(factor)
 
     def step(self):
         self.steps += 1
@@ -100,6 +122,19 @@ class RetryableCloseQueue(SampleRefQueue):
 def _batch():
     return TrainBatch(
         sample_ids=["s"], strategy="fake", tensors={"x": torch.ones(2)}, metadata={}
+    )
+
+
+def _weighted_batch(coefficient, denominator, correct):
+    return TrainBatch(
+        sample_ids=["s"],
+        strategy="fake",
+        tensors={
+            "x": torch.tensor(float(coefficient)),
+            "denominator": torch.tensor(float(denominator)),
+            "correct": torch.tensor(float(correct)),
+        },
+        metadata={},
     )
 
 
@@ -148,6 +183,60 @@ class TestTrainerCore(unittest.TestCase):
         rep = core.train_step(_batch())
         self.assertNotIn("mode", rep.metrics)
 
+    def test_global_loss_normalization_matches_combined_batch(self):
+        split_strategy = WeightedStrategy()
+        split_core = TrainerCore(
+            split_strategy,
+            FakeBackend(split_strategy.model),
+            accumulation_steps=2,
+        )
+        split_core.train_step(_weighted_batch(2, 1, 1))
+        split_result = split_core.train_step(_weighted_batch(30, 3, 1))
+
+        combined_strategy = WeightedStrategy()
+        combined_core = TrainerCore(
+            combined_strategy,
+            FakeBackend(combined_strategy.model),
+        )
+        combined_result = combined_core.train_step(_weighted_batch(32, 4, 2))
+
+        torch.testing.assert_close(
+            split_strategy.model.w.grad,
+            combined_strategy.model.w.grad,
+        )
+        self.assertEqual(split_strategy.model.w.grad.item(), 8.0)
+        self.assertEqual(split_result.loss, combined_result.loss)
+        self.assertEqual(split_result.metrics["acc"], 0.5)
+        self.assertEqual(combined_result.metrics["acc"], 0.5)
+
+    def test_global_loss_normalization_compensates_rank_averaging(self):
+        strategy = FakeStrategy()
+        backend = FakeBackend(strategy.model)
+        backend.parallel_config = mock.Mock(fsdp_process_group="dp")
+        core = TrainerCore(strategy, backend)
+        strategy.model.w.grad = torch.tensor([9.0])
+
+        def add_remote_denominator(denominator, *, op, group):
+            self.assertEqual(op, torch.distributed.ReduceOp.SUM)
+            self.assertEqual(group, "dp")
+            denominator.add_(7.0)
+
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=2),
+            mock.patch(
+                "torch.distributed.all_reduce",
+                side_effect=add_remote_denominator,
+            ),
+        ):
+            core._normalize_gradients(torch.tensor(3.0))
+
+        torch.testing.assert_close(
+            strategy.model.w.grad,
+            torch.tensor([1.8]),
+        )
+
     def test_strategy_scalar_metrics_are_preserved(self):
         strat = FakeStrategy()
         core = TrainerCore(strat, FakeBackend(strat.model), accumulation_steps=1)
@@ -157,6 +246,7 @@ class TestTrainerCore(unittest.TestCase):
                 metrics={
                     "loss": torch.tensor(99.0),
                     "accuracy": torch.tensor(0.5),
+                    "accuracy_denom": torch.tensor(4.0),
                     "ce_loss": torch.tensor(1.25),
                     "lambda_base": 0.75,
                     "non_scalar_debug": torch.tensor([1.0, 2.0]),
@@ -170,6 +260,7 @@ class TestTrainerCore(unittest.TestCase):
         self.assertEqual(result.metrics["acc"], 0.5)
         self.assertEqual(result.metrics["ce_loss"], 1.25)
         self.assertEqual(result.metrics["lambda_base"], 0.75)
+        self.assertNotIn("accuracy_denom", result.metrics)
         self.assertNotIn("non_scalar_debug", result.metrics)
 
     def test_ratio_metrics_override_mean_of_means_accuracy(self):

--- a/tests/test_scripts/test_expand_reasoning_conversations.py
+++ b/tests/test_scripts/test_expand_reasoning_conversations.py
@@ -34,7 +34,7 @@ def _load_preprocessing_stack():
     distributed_module.get_sp_ring_group = lambda: None
     sys.modules[f"{package_name}.distributed"] = distributed_module
 
-    for module_name in ("template", "parse", "preprocessing"):
+    for module_name in ("template", "parse", "loss_mask", "preprocessing"):
         full_name = f"{data_package_name}.{module_name}"
         module_path = repo_root / "specforge" / "data" / f"{module_name}.py"
         spec = importlib.util.spec_from_file_location(full_name, module_path)

--- a/tests/test_scripts/test_prepare_hidden_states.py
+++ b/tests/test_scripts/test_prepare_hidden_states.py
@@ -115,6 +115,11 @@ class PrepareHiddenStatesCaptureLayersTest(unittest.TestCase):
                 )
                 self.assertEqual(layers, plan.capture_layers)
                 self.assertEqual(feature_names, set(plan.layout.output_names))
+                if strategy == "eagle3":
+                    self.assertIsNone(plan.loss_mask_filter)
+                else:
+                    self.assertTrue(plan.loss_mask_filter([0, 1, 1]))
+                    self.assertFalse(plan.loss_mask_filter([1, 0, 1]))
 
     def test_build_uses_dedicated_offline_loader(self):
         config = SimpleNamespace(num_hidden_layers=32, dtype=None)

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -68,6 +68,7 @@ class _FixedDraft(nn.Module):
     def __init__(self, hidden_size: int):
         super().__init__()
         self.hidden_size = hidden_size
+        self.sliding_window = None
 
     def forward(self, position_ids, noise_embedding, target_hidden, attention_mask):
         bsz, draft_len = noise_embedding.shape[:2]

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -64,6 +64,10 @@ OnlineDFlashModel = _dflash_module.OnlineDFlashModel
 OnlineDSparkModel = _dflash_module.OnlineDSparkModel
 
 
+def _anchor_sampler_subject(num_anchors: int = 8):
+    return types.SimpleNamespace(num_anchors=num_anchors)
+
+
 class _FixedDraft(nn.Module):
     def __init__(self, hidden_size: int):
         super().__init__()
@@ -318,7 +322,7 @@ def _naive_dflash_loss(neg_log_q, binary_mask, gamma):
         positions = torch.arange(block_size, dtype=neg_log_q.dtype).view(1, 1, -1)
         decay = torch.exp(-(positions - 1).clamp(min=0) / gamma)
         weight = weight * decay
-    return (neg_log_q * weight).sum() / (weight.sum() + 1e-6)
+    return (neg_log_q * weight).sum() / weight.sum()
 
 
 class TestDFlashLosses(unittest.TestCase):
@@ -363,6 +367,49 @@ class TestDFlashLosses(unittest.TestCase):
         want = _naive_dflash_loss(self.neg_log_q, self.binary_mask, gamma=gamma)
         torch.testing.assert_close(got, want, rtol=0, atol=1e-8)
 
+    def test_dflash_exposes_additive_loss_and_accuracy_terms(self):
+        head = nn.Linear(4, self.logits.shape[-1], bias=False).double()
+        model = _make_model(
+            self.logits,
+            self.anchors,
+            self.keep_mask,
+            draft_model=_LearnableDSparkDraft(4).double(),
+            lm_head=head,
+        )
+
+        loss, accuracy, metrics = model(
+            input_ids=self.input_ids,
+            hidden_states=self.hidden_states,
+            loss_mask=self.loss_mask,
+        )
+
+        loss_num, loss_den = metrics["loss_terms"]
+        self.assertTrue(loss_num.requires_grad)
+        torch.testing.assert_close(loss, loss_num / loss_den)
+        accuracy_num, accuracy_den = metrics["ratio_metrics"]["acc"]
+        torch.testing.assert_close(accuracy, accuracy_num / accuracy_den)
+
+    def test_dflash_partial_tail_has_one_finite_target(self):
+        vocab_size = 7
+        logits = torch.randn(1, 1, 5, vocab_size, dtype=torch.double)
+        input_ids = torch.tensor([[1, 2, 3, 4]])
+        loss_mask = torch.ones_like(input_ids, dtype=torch.double)
+        model = _make_model(
+            logits,
+            anchors=torch.tensor([[2]]),
+            keep_mask=torch.tensor([[True]]),
+        )
+
+        loss, _accuracy, metrics = model(
+            input_ids=input_ids,
+            hidden_states=torch.zeros(1, 4, 4, dtype=torch.double),
+            loss_mask=loss_mask,
+        )
+
+        expected = F.cross_entropy(logits[0, 0, 1].unsqueeze(0), input_ids[:, 3])
+        torch.testing.assert_close(loss, expected)
+        torch.testing.assert_close(metrics["loss_terms"][1], loss.new_tensor(1.0))
+
     def test_dpace_full_matches_naive_reference(self):
         alpha = 0.5
         got = self._forward_loss(loss_type="dpace", dpace_alpha=alpha)
@@ -406,12 +453,28 @@ class TestDFlashLosses(unittest.TestCase):
 
     def test_dpace_loss_reduces_by_batch_size(self):
         alpha = 0.5
-        got = self._forward_loss(loss_type="dpace", dpace_alpha=alpha)
+        model = _make_model(
+            self.logits,
+            self.anchors,
+            self.keep_mask,
+            loss_type="dpace",
+            dpace_alpha=alpha,
+        )
+        got, _accuracy, metrics = model(
+            input_ids=self.input_ids,
+            hidden_states=self.hidden_states,
+            loss_mask=self.loss_mask,
+        )
         weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
         weighted_sum = (self.neg_log_q * weight * self.binary_mask).sum()
         token_count_loss = weighted_sum / ((weight * self.binary_mask).sum() + 1e-6)
         batch_loss = weighted_sum / float(self.input_ids.shape[0])
         torch.testing.assert_close(got, batch_loss, rtol=0, atol=1e-10)
+        torch.testing.assert_close(metrics["loss_terms"][0], weighted_sum)
+        torch.testing.assert_close(
+            metrics["loss_terms"][1],
+            got.new_tensor(float(self.input_ids.shape[0])),
+        )
         self.assertFalse(torch.allclose(got, token_count_loss))
 
     def test_alpha_changes_dpace_loss(self):
@@ -773,6 +836,59 @@ class TestDFlashLosses(unittest.TestCase):
         )
         self.assertEqual(anchors[0, 0].item(), 4)
         self.assertEqual(keep[0].tolist(), [True, False])
+
+    def test_shared_sampler_uses_adjacent_targets_and_partial_tails(self):
+        sampler = OnlineDFlashModel._sample_anchor_positions
+        model = _anchor_sampler_subject()
+        loss_mask = torch.tensor([[1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0]])
+
+        anchors, keep = sampler(
+            model,
+            seq_len=loss_mask.shape[1],
+            loss_mask=loss_mask,
+            device=loss_mask.device,
+        )
+
+        self.assertEqual(anchors[keep].tolist(), [0, 5])
+
+    def test_shared_sampler_is_batch_padding_invariant(self):
+        sampler = OnlineDFlashModel._sample_anchor_positions
+        model = _anchor_sampler_subject()
+        short_mask = torch.tensor([[0.0, 0.0, 1.0, 1.0]])
+        short_anchors, short_keep = sampler(
+            model,
+            seq_len=4,
+            loss_mask=short_mask,
+            device=short_mask.device,
+        )
+        padded_batch = torch.tensor(
+            [
+                [0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        batch_anchors, batch_keep = sampler(
+            model,
+            seq_len=7,
+            loss_mask=padded_batch,
+            device=padded_batch.device,
+        )
+
+        self.assertEqual(short_anchors[short_keep].tolist(), [2])
+        self.assertEqual(batch_anchors[0][batch_keep[0]].tolist(), [2])
+        self.assertFalse(batch_keep[2].any())
+
+    def test_shared_sampler_rejects_a_batch_without_adjacent_targets(self):
+        model = _anchor_sampler_subject()
+        loss_mask = torch.tensor([[1.0, 0.0, 1.0]])
+        with self.assertRaisesRegex(ValueError, "two consecutive"):
+            OnlineDFlashModel._sample_anchor_positions(
+                model,
+                seq_len=loss_mask.shape[1],
+                loss_mask=loss_mask,
+                device=loss_mask.device,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/test_dflash_mask.py
+++ b/tests/test_utils/test_dflash_mask.py
@@ -8,8 +8,15 @@ from specforge.algorithms.common.dflash_family_model import (
 )
 
 
-def _reference_dflash_mask(anchor_positions, block_keep_mask, S, block_size, device):
-    """Element-level reference mask mirroring the mask_mod inside create_dflash_block_mask.
+def _reference_dflash_mask(
+    anchor_positions,
+    block_keep_mask,
+    S,
+    block_size,
+    device,
+    sliding_window=None,
+):
+    """Element-level reference for full and sliding DFlash attention.
 
     This uses plain Python loops so correctness is obvious by inspection.
     """
@@ -27,11 +34,19 @@ def _reference_dflash_mask(anchor_positions, block_keep_mask, S, block_size, dev
                 continue
             for kv_idx in range(KV_LEN):
                 is_context = kv_idx < S
-                ctx_visible = is_context and (kv_idx < anchor_pos)
+                ctx_visible = is_context and kv_idx < anchor_pos
 
                 is_draft = kv_idx >= S
                 kv_block_id = (kv_idx - S) // block_size
                 draft_visible = is_draft and (q_block_id == kv_block_id)
+
+                if sliding_window is not None:
+                    q_offset = q_idx % block_size
+                    kv_offset = (kv_idx - S) % block_size
+                    ctx_visible = ctx_visible and (
+                        kv_idx >= anchor_pos + q_offset - (sliding_window - 1)
+                    )
+                    draft_visible = draft_visible and kv_offset <= q_offset
 
                 if ctx_visible or draft_visible:
                     mask[b, 0, q_idx, kv_idx] = True
@@ -44,7 +59,14 @@ class TestDFlashMask(unittest.TestCase):
         torch.manual_seed(42)
         self.device = torch.device("cuda")
 
-    def _compare_masks(self, anchor_positions, block_keep_mask, S, block_size):
+    def _compare_masks(
+        self,
+        anchor_positions,
+        block_keep_mask,
+        S,
+        block_size,
+        sliding_window=None,
+    ):
         """Compare create_dflash_sdpa_mask against element-level reference (ground truth)."""
         anchor_positions = anchor_positions.to(self.device)
         block_keep_mask = block_keep_mask.to(self.device)
@@ -55,6 +77,7 @@ class TestDFlashMask(unittest.TestCase):
             S=S,
             block_size=block_size,
             device=self.device,
+            sliding_window=sliding_window,
         )
 
         ref_mask = _reference_dflash_mask(
@@ -63,6 +86,7 @@ class TestDFlashMask(unittest.TestCase):
             S=S,
             block_size=block_size,
             device=self.device,
+            sliding_window=sliding_window,
         )
 
         self.assertEqual(
@@ -73,12 +97,17 @@ class TestDFlashMask(unittest.TestCase):
         self.assertTrue(
             torch.equal(sdpa_mask, ref_mask),
             f"Mask mismatch with S={S}, block_size={block_size}, "
-            f"anchors={anchor_positions.tolist()}, keep={block_keep_mask.tolist()}\n"
+            f"sliding_window={sliding_window}, anchors={anchor_positions.tolist()}, "
+            f"keep={block_keep_mask.tolist()}\n"
             f"Diff positions: {(sdpa_mask != ref_mask).nonzero(as_tuple=False).tolist()}",
         )
 
     def _compare_block_mask_consistency(
-        self, anchor_positions, block_keep_mask, S, block_size
+        self,
+        anchor_positions,
+        block_keep_mask,
+        S,
+        block_size,
     ):
         """Verify create_dflash_block_mask block-level mask is consistent with reference."""
         anchor_positions = anchor_positions.to(self.device)
@@ -118,12 +147,11 @@ class TestDFlashMask(unittest.TestCase):
                     k_end = min(k_start + BM_BLOCK, KV_LEN)
                     has_nonzero = ref_int[b, q_start:q_end, k_start:k_end].any().item()
                     block_val = dense_blocks[b, 0, qi, ki].item()
-                    if has_nonzero:
-                        self.assertEqual(
-                            block_val,
-                            1,
-                            f"Block ({qi},{ki}) for batch {b} should be 1 but got 0",
-                        )
+                    self.assertEqual(
+                        block_val,
+                        int(has_nonzero),
+                        f"Block ({qi},{ki}) for batch {b} has incorrect occupancy",
+                    )
 
     def test_basic_single_batch_single_block(self):
         """Single batch, single draft block."""
@@ -178,6 +206,41 @@ class TestDFlashMask(unittest.TestCase):
         anchor_positions = torch.tensor([[10, 30, 50]])
         block_keep_mask = torch.tensor([[True, True, True]])
         self._compare_masks(anchor_positions, block_keep_mask, S=64, block_size=1)
+
+    def test_sliding_window_moves_with_query_offset(self):
+        """The context window advances while the draft block stays causal."""
+        anchor_positions = torch.tensor([[6]])
+        block_keep_mask = torch.tensor([[True]])
+        mask = create_dflash_sdpa_mask(
+            anchor_positions=anchor_positions.to(self.device),
+            block_keep_mask=block_keep_mask.to(self.device),
+            S=12,
+            block_size=4,
+            device=self.device,
+            sliding_window=4,
+        )
+        expected_visible_keys = (
+            [3, 4, 5, 12],
+            [4, 5, 12, 13],
+            [5, 12, 13, 14],
+            [12, 13, 14, 15],
+        )
+        for query_offset, expected in enumerate(expected_visible_keys):
+            with self.subTest(query_offset=query_offset):
+                actual = mask[0, 0, query_offset].nonzero().flatten().tolist()
+                self.assertEqual(actual, expected)
+
+    def test_sliding_window_one_has_no_context_and_causal_draft(self):
+        """A one-token window removes context but keeps causal own-block keys."""
+        anchor_positions = torch.tensor([[4, 9]])
+        block_keep_mask = torch.tensor([[True, True]])
+        self._compare_masks(
+            anchor_positions,
+            block_keep_mask,
+            S=12,
+            block_size=3,
+            sliding_window=1,
+        )
 
     def test_mixed_validity_multi_batch(self):
         """Multi-batch with mixed block validity patterns."""
@@ -262,6 +325,25 @@ class TestDFlashMask(unittest.TestCase):
         self._compare_block_mask_consistency(
             anchor_positions, block_keep_mask, S=128, block_size=8
         )
+
+    def test_sliding_block_mask_matches_element_reference(self):
+        """Flex and dense masks implement the same sliding-layer rule."""
+        anchors = torch.tensor([[6, 12]], device=self.device)
+        keep = torch.tensor([[True, False]], device=self.device)
+        mask_args = {
+            "anchor_positions": anchors,
+            "block_keep_mask": keep,
+            "S": 16,
+            "block_size": 4,
+            "device": self.device,
+            "sliding_window": 5,
+        }
+        dense_mask = create_dflash_sdpa_mask(**mask_args)
+        block_mask = create_dflash_block_mask(**mask_args)
+        q_idx = torch.arange(8, device=self.device).unsqueeze(1)
+        kv_idx = torch.arange(24, device=self.device).unsqueeze(0)
+        flex_mask = block_mask.mask_mod(0, 0, q_idx, kv_idx)
+        self.assertTrue(torch.equal(flex_mask, dense_mask[0, 0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Upstreaming some correctness fixes to the DFlash training path:
- Add support for sliding window attention (causal)
- Allow for per layer configuration of the draft model for either sliding or full attention
- Fix eager attention mask construction for both sliding and full attention layers
- Fix anchor sampling so anchors are drawn from valid supervised positions
- Normalize dflash loss globally across distributed ranks and gradient accumulation steps
- Adds regression tests for the updated masks, anchor sampling, and distributed loss normalization
