### PR TITLE
fix(offline): list feature files at assembly instead of reading every one

### DIFF
--- a/specforge/runtime/data_plane/offline_reader.py
+++ b/specforge/runtime/data_plane/offline_reader.py
@@ -15,6 +15,19 @@ metadata-only ``SampleRef`` per file, referencing the file in place via a
 through the controller). The strategy registry selects the raw feature keys and
 the FeatureDataLoader applies the strategy's per-sample normalization, keeping
 this reader independent of model code.
+
+Assembly only *lists* filenames; no feature file is opened. Filling
+``SampleRef.feature_specs`` instead costs a full read of every file — tensor
+pages for a ``.ckpt``, and for a ``.ckpt.gz`` a decompression of the whole
+stream, since gzip has no random access and the zip central directory
+``torch.load`` needs sits at the end. That is one serial pass over the dataset,
+in the trainer process, on every rank, before the first step, with no log line
+in between: minutes on a plain dataset and hours on a gzipped one. So the
+tensors are read lazily by the loader's prefetch workers during training,
+overlapped with compute.
+
+Set ``SPECFORGE_VALIDATE_OFFLINE_FEATURES=1`` (or pass ``validate_files=True``)
+to opt back into the eager pass and check a suspect dataset up front.
 """
 
 from __future__ import annotations
@@ -31,6 +44,7 @@ from specforge.runtime.data_plane.feature_store import (
 _FEATURE_SUFFIXES = (".ckpt", ".ckpt.gz")
 # Raw keys present in a SpecForge offline EAGLE3 feature file.
 _OFFLINE_EAGLE3_KEYS = ("input_ids", "loss_mask", "hidden_state", "aux_hidden_state")
+_VALIDATE_ENV = "SPECFORGE_VALIDATE_OFFLINE_FEATURES"
 
 
 def _inspect_feature_file(
@@ -83,7 +97,7 @@ class OfflineManifestReader:
         ttt_length: int = 7,
         max_len: int = 2048,
         target_repr: Optional[str] = "hidden_state",
-        validate_files: bool = True,
+        validate_files: Optional[bool] = None,
     ) -> None:
         self.hidden_states_path = hidden_states_path
         self.run_id = run_id
@@ -94,7 +108,15 @@ class OfflineManifestReader:
         self.ttt_length = ttt_length
         self.max_len = max_len
         self.target_repr = target_repr
-        self.validate_files = validate_files
+        # Spec-less refs stay usable: FeatureDataLoader._validate_refs skips
+        # spec comparison when no ref carries specs, the store resolves tensors
+        # through feature_keys rather than specs, and nothing reads num_tokens
+        # or estimated_bytes off a file:// ref. The cost of skipping the eager
+        # pass is that a missing key or a non-tensor value surfaces on first
+        # access instead of at assembly time.
+        if validate_files is None:
+            validate_files = os.environ.get(_VALIDATE_ENV, "0") == "1"
+        self.validate_files = bool(validate_files)
 
     def _ref_for(self, index: int, path: str) -> SampleRef:
         sample_id = f"{self.run_id}:{index:08d}"

--- a/tests/test_algorithms/test_builtin_parity.py
+++ b/tests/test_algorithms/test_builtin_parity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 
@@ -302,13 +303,16 @@ class BuiltinProviderParityTest(unittest.TestCase):
                 os.path.join(path, "0000.ckpt"),
             )
 
-            with self.assertRaisesRegex(KeyError, "target_last_hidden_states"):
-                provider.build_reader(
-                    path,
-                    run_id="dspark-offline-reader",
-                    ttt_length=4,
-                    max_len=3,
-                ).read()
+            with mock.patch.dict(
+                os.environ, {"SPECFORGE_VALIDATE_OFFLINE_FEATURES": "1"}
+            ):
+                with self.assertRaisesRegex(KeyError, "target_last_hidden_states"):
+                    provider.build_reader(
+                        path,
+                        run_id="dspark-offline-reader",
+                        ttt_length=4,
+                        max_len=3,
+                    ).read()
 
     def test_small_normalizers_match_retained_implementations(self):
         from specforge.data.preprocessing import (

--- a/tests/test_runtime/test_fault_injection.py
+++ b/tests/test_runtime/test_fault_injection.py
@@ -120,7 +120,7 @@ class TestOfflineManifestFaults(unittest.TestCase):
                 os.path.join(d, "bad.ckpt"),
             )
             with self.assertRaises(TypeError):
-                OfflineManifestReader(d, run_id="off").read()
+                OfflineManifestReader(d, run_id="off", validate_files=True).read()
 
     def test_mixed_schema_version_batch_rejected(self):
         store = LocalFeatureStore("st")

--- a/tests/test_runtime/test_feature_store.py
+++ b/tests/test_runtime/test_feature_store.py
@@ -161,7 +161,7 @@ class TestLocalFeatureStore(unittest.TestCase):
                 "aux_hidden_state": torch.randn(1, 8, 12),
             }
             torch.save(raw, os.path.join(d, "000.ckpt"))
-            refs = OfflineManifestReader(d, run_id="off").read()
+            refs = OfflineManifestReader(d, run_id="off", validate_files=True).read()
             self.assertEqual(len(refs), 1)
             self.assertTrue(refs[0].feature_store_uri.startswith("file://"))
             self.assertEqual(set(refs[0].feature_specs), set(raw))
@@ -176,10 +176,12 @@ class TestLocalFeatureStore(unittest.TestCase):
             store.release(handle)
 
     def test_offline_reader_rejects_missing_required_key(self):
+        # Eager validation is opt-in; by default a missing key surfaces on the
+        # first store.get() instead of during assembly.
         with tempfile.TemporaryDirectory() as d:
             torch.save({"input_ids": torch.arange(4)}, os.path.join(d, "bad.ckpt"))
             with self.assertRaises(KeyError):
-                OfflineManifestReader(d, run_id="off").read()
+                OfflineManifestReader(d, run_id="off", validate_files=True).read()
 
     def test_mem_ref_carries_generation_and_rejects_stale_ref(self):
         # The mem:// ref carries the generation it was minted for; once a sample

--- a/tests/test_runtime/test_offline_reader_lazy.py
+++ b/tests/test_runtime/test_offline_reader_lazy.py
@@ -1,0 +1,179 @@
+# coding=utf-8
+"""OfflineManifestReader must not read feature files during assembly.
+
+Filling ``SampleRef.feature_specs`` costs a full read of every file — tensor
+pages for a ``.ckpt``, a whole-stream decompression for the ``.ckpt.gz`` that
+``prepare_hidden_states --compress`` writes, since gzip has no random access.
+Paid during assembly that is one serial pass over the dataset per rank before
+the first step. So the reader lists filenames and nothing else, and the loader's
+prefetch workers read tensors lazily, overlapped with compute.
+
+Refs without specs stay usable: the store resolves tensors through
+``feature_keys``, and ``FeatureDataLoader._validate_refs`` skips spec comparison
+for them.
+"""
+
+import contextlib
+import gzip
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+
+from specforge.runtime.data_plane.feature_dataloader import FeatureDataLoader
+from specforge.runtime.data_plane.feature_store import LocalFeatureStore
+from specforge.runtime.data_plane.offline_reader import OfflineManifestReader
+
+_KEYS = ("input_ids", "loss_mask", "hidden_states")
+_SEQ = 8
+
+
+def _write_features(directory: str, *, compress: bool, n: int = 3):
+    os.makedirs(directory, exist_ok=True)
+    for index in range(n):
+        payload = {
+            "input_ids": torch.arange(_SEQ) + index,
+            "loss_mask": torch.ones(_SEQ, dtype=torch.long),
+            "hidden_states": torch.randn(_SEQ, 4).to(torch.bfloat16),
+        }
+        suffix = ".ckpt.gz" if compress else ".ckpt"
+        path = os.path.join(directory, f"data_{index}{suffix}")
+        if compress:
+            with gzip.open(path, "wb") as stream:
+                torch.save(payload, stream)
+        else:
+            torch.save(payload, path)
+    return directory
+
+
+def _features(**kwargs):
+    directory = os.path.join(tempfile.mkdtemp(prefix="offline_lazy_"), "features")
+    return _write_features(directory, **kwargs)
+
+
+def _reader(path: str, **kwargs) -> OfflineManifestReader:
+    return OfflineManifestReader(
+        path,
+        run_id="lazy",
+        strategy="dflash",
+        feature_keys=_KEYS,
+        target_repr=None,
+        max_len=_SEQ,
+        **kwargs,
+    )
+
+
+@contextlib.contextmanager
+def _no_file_reads():
+    """Fail if anything opens a feature file through either read path."""
+    boom = AssertionError("assembly must not read feature files")
+    with (
+        mock.patch("torch.load", side_effect=boom),
+        mock.patch("gzip.open", side_effect=boom),
+    ):
+        yield
+
+
+class TestOfflineReaderIsLazy(unittest.TestCase):
+    def test_assembly_reads_no_uncompressed_file(self):
+        directory = _features(compress=False)
+        with _no_file_reads():
+            refs = _reader(directory).read()
+
+        self.assertEqual(len(refs), 3)
+        for ref in refs:
+            self.assertTrue(ref.feature_store_uri.startswith("file://"))
+            self.assertEqual(set(ref.feature_keys), set(_KEYS))
+            self.assertEqual(ref.feature_specs, {})
+            self.assertEqual(ref.num_tokens, 0)
+
+    def test_assembly_reads_no_compressed_file(self):
+        directory = _features(compress=True)
+        with _no_file_reads():
+            refs = _reader(directory).read()
+
+        self.assertEqual(len(refs), 3)
+        for ref in refs:
+            self.assertEqual(ref.feature_specs, {})
+
+
+class TestSpecLessRefsRemainUsable(unittest.TestCase):
+    def _assert_materializes(self, directory: str):
+        refs = _reader(directory).read()
+        store = LocalFeatureStore("lazy")
+
+        for index, ref in enumerate(refs):
+            tensors, handle = store.get(ref)
+            try:
+                self.assertEqual(set(tensors), set(_KEYS))
+                self.assertTrue(
+                    torch.equal(tensors["input_ids"], torch.arange(_SEQ) + index)
+                )
+                self.assertEqual(tensors["hidden_states"].shape, (_SEQ, 4))
+            finally:
+                store.release(handle, reason="test")
+
+    def test_uncompressed_refs_materialize(self):
+        self._assert_materializes(_features(compress=False))
+
+    def test_compressed_refs_materialize(self):
+        self._assert_materializes(_features(compress=True))
+
+    def test_dataloader_accepts_spec_less_refs(self):
+        refs = _reader(_features(compress=True, n=4)).read()
+        loader = FeatureDataLoader(
+            LocalFeatureStore("lazy"),
+            refs=refs,
+            batch_size=2,
+            collate_fn=lambda samples: {
+                "input_ids": torch.stack([s["input_ids"] for s in samples])
+            },
+            strategy="dflash",
+        )
+
+        batches = list(loader)
+        self.assertEqual(len(batches), 2)
+        self.assertEqual(batches[0].tensors["input_ids"].shape, (2, _SEQ))
+
+    def test_missing_key_surfaces_on_access(self):
+        directory = os.path.join(tempfile.mkdtemp(prefix="offline_bad_"), "features")
+        os.makedirs(directory)
+        torch.save({"input_ids": torch.arange(_SEQ)}, os.path.join(directory, "b.ckpt"))
+        ref = _reader(directory).read()[0]
+
+        # Assembly accepted the incomplete file; the loss lands here instead.
+        with self.assertRaises(KeyError):
+            LocalFeatureStore("lazy").get(ref)
+
+
+class TestEagerValidationIsOptIn(unittest.TestCase):
+    def test_explicit_flag_fills_specs(self):
+        refs = _reader(_features(compress=False), validate_files=True).read()
+
+        for ref in refs:
+            self.assertEqual(set(ref.feature_specs), set(_KEYS))
+            self.assertEqual(ref.num_tokens, _SEQ)
+            self.assertGreater(ref.estimated_bytes, 0)
+
+    def test_env_var_fills_specs(self):
+        directory = _features(compress=False)
+        with mock.patch.dict(os.environ, {"SPECFORGE_VALIDATE_OFFLINE_FEATURES": "1"}):
+            refs = _reader(directory).read()
+
+        for ref in refs:
+            self.assertEqual(set(ref.feature_specs), set(_KEYS))
+
+    def test_env_var_default_stays_lazy(self):
+        directory = _features(compress=False)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SPECFORGE_VALIDATE_OFFLINE_FEATURES", None)
+            with _no_file_reads():
+                refs = _reader(directory).read()
+
+        self.assertEqual([ref.feature_specs for ref in refs], [{}] * 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`OfflineManifestReader` opened and fully deserialized **every** feature file during assembly, only to fill `SampleRef.feature_specs` / `num_tokens` / `estimated_bytes`. That is a serial pass over the entire dataset, in the trainer process, on every rank, before the first training step — and with no log line in between, so the run simply looks hung.

It is worst for the `.ckpt.gz` that `scripts/prepare_hidden_states.py --compress` writes. gzip has no random access, and the zip central directory `torch.load` needs sits at the *end* of the stream, so `load_feature_file` has to inflate each file in full:

```python
# specforge/runtime/data_plane/feature_store.py
def load_feature_file(path: str) -> Dict[str, torch.Tensor]:
    if path.endswith(".gz"):
        with gzip.open(path, "rb") as f:
            return torch.load(io.BytesIO(f.read()), weights_only=False)  # whole file
    return torch.load(path, weights_only=False, mmap=True)               # header only
```

The uncompressed path is cheaper only by a constant — it is still one `open()` plus a header read per file, which on network-backed storage is dominated by per-file latency.

`py-spy dump` on a stuck rank of a 2-node × 8-GPU offline run over a 600k-sample gzipped dataset:

```
Thread 458 (active): "MainThread"
    read (gzip.py)
    load_feature_file (specforge/runtime/data_plane/feature_store.py)
    _inspect_feature_file (specforge/runtime/data_plane/offline_reader.py)
    _ref_for (specforge/runtime/data_plane/offline_reader.py)
    __iter__ (specforge/runtime/data_plane/offline_reader.py)
    read (specforge/runtime/data_plane/offline_reader.py)
    build_offline_runtime (specforge/launch.py)
    build_training_run (specforge/training/assembly.py)
```

All ranks sat at 97–99% CPU with wall time ≈ CPU time, i.e. CPU-bound inflate, not I/O.

## Modifications

Assembly now only walks the directory for filenames; no feature file is opened. Tensors are read lazily by the loader's prefetch workers during training, overlapped with compute.

Spec-less refs stay usable, which is what makes this safe:

* `FeatureDataLoader._validate_refs` already skips spec comparison when no ref carries specs (`if not spec_sets: return`);
* the store resolves tensors through `feature_keys`, not through specs (`wanted = names or list(sample_ref.feature_keys.keys())`);
* no caller reads `num_tokens` or `estimated_bytes` off a `file://` ref — `launch.py` and `mooncake_store.py` read `estimated_bytes` only on online-producer and mooncake-put refs, which are built by a different path and still carry specs.

The tradeoff is that a missing key or a non-tensor value now surfaces on first access rather than at assembly time. `validate_files=True`, or `SPECFORGE_VALIDATE_OFFLINE_FEATURES=1`, keeps the old eager pass for checking a suspect dataset up front — so the validation branch stays reachable in production rather than becoming dead code.

## Related Issues

Fixes #733

## Accuracy Test

Not applicable — no model-side code is touched. The change only moves *when* the same tensors are read; `SampleRef.feature_store_uri` and `feature_keys` are unchanged, so the loader materializes byte-identical tensors.

## Benchmark & Profiling

`OfflineManifestReader.read()` over 40 synthetic feature files (~4 MB each: `input_ids`, `loss_mask`, `hidden_state` `[512, 1024]` bf16, `aux_hidden_state` `[3, 512, 1024]` bf16), local SSD:

| dataset | before | after | speedup |
| --- | --- | --- | --- |
| plain `.ckpt` (168 MB) | 0.17 ms/file | 0.005 ms/file | 37× |
| gzipped `.ckpt.gz` (133 MB) | 10.4 ms/file | 0.005 ms/file | 1889× |

Extrapolated to a 600k-sample dataset, per rank, before a single step runs:

| dataset | before | after |
| --- | --- | --- |
| plain `.ckpt` | ~1.7 min | ~2.7 s |
| gzipped `.ckpt.gz` | ~1.7 h | ~3.3 s |

On network-backed storage the per-file `open` latency is one to two orders of magnitude higher, so the plain-`.ckpt` case lands in the same range as the gzipped one measured here.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).

### Tests

`tests/test_runtime/test_offline_reader_lazy.py` (new, 9 tests) replaces `test_offline_reader_gz.py`. It patches both read paths to raise, so assembly reading *any* feature file is a hard failure:

```python
@contextlib.contextmanager
def _no_file_reads():
    boom = AssertionError("assembly must not read feature files")
    with mock.patch("torch.load", side_effect=boom), mock.patch(
        "gzip.open", side_effect=boom
    ):
        yield
```

and covers: assembly opens no plain file and no gzipped file; spec-less refs still materialize correct tensors through both formats; `FeatureDataLoader` batches them; a missing key raises `KeyError` on first `store.get`; and the eager pass is reachable via both the explicit flag and the env var, with the default staying lazy.

`tests/test_runtime/test_feature_store.py` and `test_fault_injection.py` pass `validate_files=True` where they assert on the eager behaviour.
