### PR TITLE
Support Inkling managed capture

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -159,6 +159,7 @@ should make their training strategy and topology explicit.
 | `model.tokenizer_pad_token_id` | `null` | Explicit non-negative tokenizer pad ID. Use it for released tokenizers that omit padding metadata. |
 | `model.sglang_attention_backend` | `flashinfer` | SGLang attention implementation for an in-process or managed capture server. |
 | `model.sglang_mem_fraction_static` | `0.4` | SGLang static-memory fraction in `(0, 1]`; inherited by managed capture servers unless they override it. |
+| `model.sglang_disable_radix_cache` | `true` | Preserve the historical managed-capture behavior. Set `false` for hybrid targets such as Inkling that require the radix tree. Unique per-attempt cache namespaces still force complete capture prefills. |
 | `model.sglang_context_length` | `null` | Positive explicit context limit. Managed capture requires at least `data.max_length + 7`; omitting it derives that value. |
 | `model.sglang_enable_nccl_nvls` | `false` | Pass the matching SGLang NCCL NVLS optimization flag. |
 | `model.sglang_enable_symm_mem` | `false` | Pass the matching SGLang symmetric-memory flag. |

--- a/examples/configs/inkling-dspark-disaggregated.yaml
+++ b/examples/configs/inkling-dspark-disaggregated.yaml
@@ -2,9 +2,22 @@ model:
   target_model_path: thinkingmachines/Inkling
   draft_model_config: configs/inkling-dspark.json
   target_backend: sglang
+  trust_remote_code: true
   tokenizer_pad_token_id: 200006
   embedding_key: model.llm.embed.weight
   lm_head_key: model.llm.unembed.weight
+  # Inkling's hybrid cache path requires the unified radix tree. These values
+  # match the SGLang #31847 configuration validated by the two-node launcher.
+  sglang_attention_backend: fa4
+  sglang_mem_fraction_static: 0.85
+  sglang_disable_radix_cache: false
+  sglang_context_length: 4103
+  sglang_moe_runner_backend: flashinfer_trtllm_routed
+  sglang_page_size: 128
+  sglang_quantization: modelopt_fp4
+  sglang_mamba_radix_cache_strategy: extra_buffer
+  sglang_max_mamba_cache_size: 64
+  sglang_swa_full_tokens_ratio: 0.2
 data:
   train_data_path: ./cache/dataset/inkling_dspark_train.jsonl
   max_length: 4096
@@ -20,6 +33,7 @@ training:
   learning_rate: 0.0006
   warmup_ratio: 0.04
   max_grad_norm: 1.0
+  attention_backend: eager
   num_anchors: 512
   loss_decay_gamma: 4.0
   objective_chunk_blocks: 128

--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -159,12 +159,6 @@ That opt-in profile starts, health-checks, and cleans up the owned local
 services. It does not change the default external-service boundary or attempt
 to schedule services on remote hosts.
 
-The strict e2e gate at
-`scripts/gates/run_disaggregated_overfit_gate.sh` retains full local test-stack
-automation: it starts and health-checks Mooncake and SGLang, runs the unified
-producer/consumer entry, verifies training and serving, and cleans up owned
-processes. That test harness is not the production service supervisor.
-
 Online configs use Mooncake. Offline configs may use either a typed
 `shared_dir` store or Mooncake. `deployment.disaggregated.control_dir` is the
 one attempt root from which the launcher derives the reference channel or

--- a/examples/disagg/README.md
+++ b/examples/disagg/README.md
@@ -90,6 +90,27 @@ The consumer's SQLite/WAL and rank inboxes default to the trainer-node-local
 `DISAGG_CONSUMER_STATE_DIR` or `LOCAL_SCRATCH` when `/tmp` is unsuitable.
 Node-local consumer state currently supports one trainer node only.
 
+The Inkling DSpark variant uses the same two-node lifecycle with the target
+settings validated against SGLang
+[#31847](https://github.com/sgl-project/sglang/pull/31847):
+
+```bash
+export DISAGG_STORE_ID=inkling-two-node-attempt-001
+export DISAGG_RUN_ROOT=/shared/specforge/$DISAGG_STORE_ID
+
+rcli exec --per-node <job> \
+  'bash examples/disagg/run_inkling_dspark_disagg_2node.sh'
+```
+
+Rank 0 uses four GPUs for TP4 ModelOpt-FP4 capture; rank 1 defaults to four
+FSDP trainer ranks. Override `TARGET_MODEL_PATH`, `SERVER_GPUS`,
+`TRAINER_GPUS`, or `TRAINER_NPROC` for another allocation. The launcher keeps
+the unified radix tree enabled and does not pass `--disable-radix-cache`.
+Until #31847 is available in a supported SGLang release, install that PR's
+checkout into both nodes' environment. The wrapper applies SpecForge's
+checked-in capture patch before starting the server; the patch is dry-run
+validated against both v0.5.14 and #31847 commit `b7252cc`.
+
 ## External and managed-local services
 
 By default, online capture requires an already-running Mooncake deployment and

--- a/examples/disagg/run_inkling_dspark_disagg_2node.sh
+++ b/examples/disagg/run_inkling_dspark_disagg_2node.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Two-node Inkling DSpark recipe:
+#   rank 0: Mooncake + SGLang #31847 TP4 capture + CPU producer
+#   rank 1: four-rank FSDP consumer/trainer
+#
+# Launch this command on both nodes. The cluster launcher supplies
+# RCLI_NODE_RANK, RCLI_NUM_NODES, and RCLI_HEAD_IP; both nodes must share the
+# fresh DISAGG_RUN_ROOT. Install SGLang #31847 in the active environment; the
+# shared launcher applies the checked-in SpecForge capture patch before start.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+
+export CONFIG="${CONFIG:-$ROOT_DIR/examples/configs/inkling-dspark-disaggregated.yaml}"
+export RUN_LABEL="${RUN_LABEL:-inkling-dspark-2node}"
+export TARGET_MODEL_PATH="${TARGET_MODEL_PATH:-thinkingmachines/Inkling}"
+
+export SERVER_GPUS="${SERVER_GPUS:-0,1,2,3}"
+export SERVER_TP="${SERVER_TP:-4}"
+export SERVER_MEM_FRACTION="${SERVER_MEM_FRACTION:-0.85}"
+export CAPTURE_LAYER_IDS="${CAPTURE_LAYER_IDS:-5 17 35 47 59}"
+
+export TRAINER_GPUS="${TRAINER_GPUS:-0,1,2,3}"
+export TRAINER_NPROC="${TRAINER_NPROC:-4}"
+TRAINER_ACCUMULATION_STEPS="${TRAINER_ACCUMULATION_STEPS:-128}"
+
+export APPLY_SGLANG_CAPTURE_PATCH="${APPLY_SGLANG_CAPTURE_PATCH:-1}"
+export SGLANG_ENABLE_UNIFIED_RADIX_TREE="${SGLANG_ENABLE_UNIFIED_RADIX_TREE:-1}"
+export SGLANG_OPT_USE_INKLING_CUSTOM_AR="${SGLANG_OPT_USE_INKLING_CUSTOM_AR:-1}"
+
+DEFAULT_SERVER_EXTRA_ARGS="--dtype bfloat16 --attention-backend fa4"
+DEFAULT_SERVER_EXTRA_ARGS+=" --context-length 4103 --quantization modelopt_fp4"
+DEFAULT_SERVER_EXTRA_ARGS+=" --moe-runner-backend flashinfer_trtllm_routed"
+DEFAULT_SERVER_EXTRA_ARGS+=" --page-size 128"
+DEFAULT_SERVER_EXTRA_ARGS+=" --mamba-radix-cache-strategy extra_buffer"
+DEFAULT_SERVER_EXTRA_ARGS+=" --max-mamba-cache-size 64"
+DEFAULT_SERVER_EXTRA_ARGS+=" --swa-full-tokens-ratio 0.2"
+export SERVER_EXTRA_ARGS="${SERVER_EXTRA_ARGS:-$DEFAULT_SERVER_EXTRA_ARGS}"
+
+exec "$SCRIPT_DIR/run_qwen3_8b_dflash_disagg_2node.sh" \
+    "training.accumulation_steps=$TRAINER_ACCUMULATION_STEPS" \
+    "$@"

--- a/examples/disagg/run_qwen3_8b_dflash_disagg_2node.sh
+++ b/examples/disagg/run_qwen3_8b_dflash_disagg_2node.sh
@@ -18,6 +18,7 @@ RUN_ID="${DISAGG_STORE_ID:-}"
 RUN_ROOT="${DISAGG_RUN_ROOT:-}"
 CONSUMER_STATE_DIR="${DISAGG_CONSUMER_STATE_DIR:-${LOCAL_SCRATCH:-/tmp}/specforge/$RUN_ID/consumer-state}"
 CONFIG="${CONFIG:-$ROOT_DIR/examples/configs/qwen3-8b-dflash-disaggregated.yaml}"
+RUN_LABEL="${RUN_LABEL:-qwen3-8b-dflash-2node}"
 
 SERVER_GPUS="${SERVER_GPUS:-0}"
 SERVER_TP="${SERVER_TP:-1}"
@@ -27,6 +28,15 @@ CAPTURE_LAYER_IDS="${CAPTURE_LAYER_IDS:-1 9 17 25 33}"
 TRAINER_GPUS="${TRAINER_GPUS:-0,1,2,3}"
 TRAINER_NPROC="${TRAINER_NPROC:-4}"
 TARGET_MODEL_PATH="${TARGET_MODEL_PATH:-Qwen/Qwen3-8B}"
+# Whitespace-separated SGLang CLI tokens for model-specific server settings.
+# Each flag and value must be one shell token; embedded whitespace is
+# unsupported.
+SERVER_EXTRA_ARGS="${SERVER_EXTRA_ARGS:-}"
+APPLY_SGLANG_CAPTURE_PATCH="${APPLY_SGLANG_CAPTURE_PATCH:-1}"
+SERVER_EXTRA_ARGV=()
+if [[ -n "$SERVER_EXTRA_ARGS" ]]; then
+    read -r -a SERVER_EXTRA_ARGV <<< "$SERVER_EXTRA_ARGS"
+fi
 
 MOONCAKE_RPC_PORT="${MOONCAKE_RPC_PORT:-35551}"
 MOONCAKE_HTTP_PORT="${MOONCAKE_HTTP_PORT:-35880}"
@@ -36,7 +46,7 @@ START_TIMEOUT_S="${START_TIMEOUT_S:-1800}"
 PEER_TIMEOUT_S="${PEER_TIMEOUT_S:-1800}"
 
 log() {
-    printf '[qwen3-8b-dflash-2node][rank=%s] %s\n' "${NODE_RANK:-?}" "$*"
+    printf '[%s][rank=%s] %s\n' "$RUN_LABEL" "${NODE_RANK:-?}" "$*"
 }
 
 fail() {
@@ -120,6 +130,9 @@ validate_identity() {
     [[ "$SERVER_TP" =~ ^[1-9][0-9]*$ ]] || fail "SERVER_TP must be positive"
     [[ "$TRAINER_NPROC" =~ ^[1-9][0-9]*$ ]] || \
         fail "TRAINER_NPROC must be positive"
+    [[ "$APPLY_SGLANG_CAPTURE_PATCH" == "0" || \
+        "$APPLY_SGLANG_CAPTURE_PATCH" == "1" ]] || \
+        fail "APPLY_SGLANG_CAPTURE_PATCH must be 0 or 1"
     [[ "$(count_devices "$SERVER_GPUS")" == "$SERVER_TP" ]] || \
         fail "SERVER_GPUS must contain exactly SERVER_TP=$SERVER_TP devices"
     [[ "$(count_devices "$TRAINER_GPUS")" == "$TRAINER_NPROC" ]] || \
@@ -161,17 +174,28 @@ run_inference_node() {
     local producer_result=1
 
     if [[ "${DRY_RUN:-0}" == "1" ]]; then
+        local -a dry_run_server_command=(
+            python -m sglang.launch_server --host 0.0.0.0
+            --model-path "$TARGET_MODEL_PATH"
+            --trust-remote-code
+            --skip-tokenizer-init
+            --tp-size "$SERVER_TP"
+            --mem-fraction-static "$SERVER_MEM_FRACTION"
+            --chunked-prefill-size -1
+            --enable-spec-capture --spec-capture-method dflash
+            --spec-capture-aux-layer-ids $CAPTURE_LAYER_IDS
+            --port "$SERVER_PORT"
+        )
+        if [[ -n "$SERVER_EXTRA_ARGS" ]]; then
+            dry_run_server_command+=("${SERVER_EXTRA_ARGV[@]}")
+        fi
         print_command mooncake_master --enable_http_metadata_server=true \
             --http_metadata_server_host=0.0.0.0 \
             --rpc_port="$MOONCAKE_RPC_PORT" \
             --http_metadata_server_port="$MOONCAKE_HTTP_PORT" \
             --metrics_port="$MOONCAKE_METRICS_PORT"
         print_command env "CUDA_VISIBLE_DEVICES=$SERVER_GPUS" \
-            python -m sglang.launch_server --host 0.0.0.0 \
-            --model-path "$TARGET_MODEL_PATH" --tp-size "$SERVER_TP" \
-            --enable-spec-capture --spec-capture-method dflash \
-            --spec-capture-aux-layer-ids $CAPTURE_LAYER_IDS \
-            --port "$SERVER_PORT"
+            "${dry_run_server_command[@]}"
         print_command env CUDA_VISIBLE_DEVICES= specforge train -c "$CONFIG" \
             --role producer "${COMMON_OVERRIDES[@]}" "$@"
         result=0
@@ -195,7 +219,9 @@ run_inference_node() {
 
     command -v mooncake_master >/dev/null || fail "mooncake_master is not on PATH"
     command -v curl >/dev/null || fail "curl is not on PATH"
-    "$ROOT_DIR/scripts/apply_sglang_spec_capture_patch.sh"
+    if [[ "$APPLY_SGLANG_CAPTURE_PATCH" == "1" ]]; then
+        "$ROOT_DIR/scripts/apply_sglang_spec_capture_patch.sh"
+    fi
     export MOONCAKE_LOCAL_HOSTNAME="${INFERENCE_NODE_IP:-$HEAD_IP}"
     export MOONCAKE_GLOBAL_SEGMENT_SIZE="${MOONCAKE_GLOBAL_SEGMENT_SIZE:-$((32 << 30))}"
     export MOONCAKE_LOCAL_BUFFER_SIZE="${MOONCAKE_LOCAL_BUFFER_SIZE:-$((1 << 30))}"
@@ -227,19 +253,25 @@ run_inference_node() {
     done
 
     read -r -a capture_layers <<< "$CAPTURE_LAYER_IDS"
+    local -a server_command=(
+        python -m sglang.launch_server
+        --host 0.0.0.0
+        --model-path "$TARGET_MODEL_PATH"
+        --trust-remote-code
+        --skip-tokenizer-init
+        --tp-size "$SERVER_TP"
+        --mem-fraction-static "$SERVER_MEM_FRACTION"
+        --chunked-prefill-size -1
+        --enable-spec-capture
+        --spec-capture-method dflash
+        --spec-capture-aux-layer-ids "${capture_layers[@]}"
+        --port "$SERVER_PORT"
+    )
+    if [[ -n "$SERVER_EXTRA_ARGS" ]]; then
+        server_command+=("${SERVER_EXTRA_ARGV[@]}")
+    fi
     setsid env CUDA_VISIBLE_DEVICES="$SERVER_GPUS" \
-        python -m sglang.launch_server \
-        --host 0.0.0.0 \
-        --model-path "$TARGET_MODEL_PATH" \
-        --trust-remote-code \
-        --skip-tokenizer-init \
-        --tp-size "$SERVER_TP" \
-        --mem-fraction-static "$SERVER_MEM_FRACTION" \
-        --chunked-prefill-size -1 \
-        --enable-spec-capture \
-        --spec-capture-method dflash \
-        --spec-capture-aux-layer-ids "${capture_layers[@]}" \
-        --port "$SERVER_PORT" \
+        "${server_command[@]}" \
         > "$RUN_ROOT/sglang-server.log" 2>&1 &
     server_pid="$!"
 

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -67,14 +67,15 @@ diff --git a/python/sglang/srt/managers/io_struct.py b/python/sglang/srt/manager
 index 951f35495..2359c31b7 100644
 --- a/python/sglang/srt/managers/io_struct.py
 +++ b/python/sglang/srt/managers/io_struct.py
-@@ -283,3 +283,7 @@ class GenerateReqInput(BaseReq):
+@@ -189,4 +189,8 @@ class GenerateReqInput(BaseReq):
+     # Whether to return hidden states
+     return_hidden_states: Union[List[bool], bool] = False
 +    # Spec-training capture sink instructions (see spec_capture_sink.py).
 +    # Batch-level: List[Optional[dict]]; per-request after __getitem__.
 +    spec_capture: Optional[Union[List[Optional[Dict]], Dict]] = None
 +
-     # Pre-computed delimiter indices for multi-item scoring.
-     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
-     multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
+     # Whether to return captured routed experts
+     return_routed_experts: bool = False
 @@ -743,6 +747,11 @@ class GenerateReqInput(BaseReq):
                  if self.multi_item_delimiter_indices is not None
                  else None
@@ -295,7 +296,8 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
 index 1cff5c983..a5935fa3c 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -518,3 +518,29 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -518,3 +518,30 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+-        # Apply the rank zero filter to logger
 +        if server_args.enable_spec_capture and not self.is_draft_worker:
 +            # Aux capture without a draft worker, routed to the strategy's own
 +            # capture method (they wire different submodules — e.g. VL models
@@ -322,7 +324,8 @@ index 1cff5c983..a5935fa3c 100644
 +                    self.spec_aux_config.eagle_aux_hidden_state_layer_ids = (
 +                        server_args.spec_capture_aux_layer_ids
 +                    )
-         # Apply the rank zero filter to logger
++
++        # Apply the rank zero filter to logger
          if server_args.show_time_cost:
              enable_show_time_cost()
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py

--- a/patches/sglang/v0.5.14/spec-capture.patch
+++ b/patches/sglang/v0.5.14/spec-capture.patch
@@ -12,7 +12,7 @@ index a99d25267..f5d0b35e7 100644
  
      ## Part 2: This part will be assigned in python/sglang/srt/layers/sampler.py::Sampler
      # he log probs of output tokens, if SGLANG_RETURN_ORIGINAL_LOGPROB = True, will get the log probs before applying temperature. If False, will get the log probs before applying temperature.
-@@ -361,6 +364,16 @@ class LogitsProcessor(nn.Module):
+@@ -361,6 +364,30 @@ class LogitsProcessor(nn.Module):
              sample_indices,
              logits_metadata,
          )
@@ -26,6 +26,20 @@ index a99d25267..f5d0b35e7 100644
 +            )
 +            else None
 +        )
++        # muP targets pass LM-head-scaled hidden states into LogitsProcessor,
++        # while SpecForge folds the same multiplier into its frozen target
++        # head. Restore the pre-head-scale representation before capture so
++        # the multiplier is applied exactly once when training recomputes logits.
++        logits_mup_width_multiplier = getattr(
++            self.config, "logits_mup_width_multiplier", None
++        )
++        if (
++            last_hidden_states_to_store is not None
++            and logits_mup_width_multiplier
++        ):
++            last_hidden_states_to_store = (
++                last_hidden_states_to_store * float(logits_mup_width_multiplier)
++            )
          del hidden_states
  
          if not logits_metadata.extend_return_logprob:
@@ -281,7 +295,7 @@ diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/sr
 index 1cff5c983..a5935fa3c 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -518,3 +518,19 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -518,3 +518,29 @@ class ModelRunner(ModelRunnerKVCacheMixin):
 +        if server_args.enable_spec_capture and not self.is_draft_worker:
 +            # Aux capture without a draft worker, routed to the strategy's own
 +            # capture method (they wire different submodules — e.g. VL models
@@ -289,6 +303,11 @@ index 1cff5c983..a5935fa3c 100644
 +            if getattr(server_args, "spec_capture_method", "eagle3") == "dflash":
 +                self.dflash_use_aux_hidden_state = True
 +                self.dflash_target_layer_ids = server_args.spec_capture_aux_layer_ids
++                if hasattr(self, "spec_aux_config"):
++                    self.spec_aux_config.dflash_use_aux_hidden_state = True
++                    self.spec_aux_config.dflash_target_layer_ids = (
++                        server_args.spec_capture_aux_layer_ids
++                    )
 +                self.dflash_family_use_aux_hidden_state = True
 +                self.dflash_family_target_layer_ids = (
 +                    server_args.spec_capture_aux_layer_ids
@@ -298,6 +317,11 @@ index 1cff5c983..a5935fa3c 100644
 +                self.eagle_aux_hidden_state_layer_ids = (
 +                    server_args.spec_capture_aux_layer_ids
 +                )
++                if hasattr(self, "spec_aux_config"):
++                    self.spec_aux_config.eagle_use_aux_hidden_state = True
++                    self.spec_aux_config.eagle_aux_hidden_state_layer_ids = (
++                        server_args.spec_capture_aux_layer_ids
++                    )
          # Apply the rank zero filter to logger
          if server_args.show_time_cost:
              enable_show_time_cost()

--- a/specforge/config/schema.py
+++ b/specforge/config/schema.py
@@ -80,6 +80,9 @@ class ModelConfig(StrictConfigModel):
     #: SGLang target-engine tuning. Ignored by hf/custom backends.
     sglang_attention_backend: str = "flashinfer"
     sglang_mem_fraction_static: float = Field(default=0.4, gt=0.0, le=1.0)
+    #: Keep the historical managed-local behavior by default. Hybrid targets
+    #: such as Inkling require the radix tree and can opt back in explicitly.
+    sglang_disable_radix_cache: bool = True
     sglang_context_length: Optional[int] = Field(default=None, gt=0)
     sglang_enable_nccl_nvls: bool = False
     sglang_enable_symm_mem: bool = False

--- a/specforge/inference/sglang_patch_inventory.md
+++ b/specforge/inference/sglang_patch_inventory.md
@@ -22,8 +22,8 @@ providers map generic server artifacts (`aux`, `last_hidden`, passthrough
 inputs) to training feature names. No trainer or producer process imports
 SGLang model-runner internals or loads a target model.
 
-The same patch is dry-run validated against the v0.5.14 tag and the public
-Inkling integration. Capture requests carry a unique `extra_key`, so every
+The same patch is dry-run validated against the v0.5.14 tag and SGLang #31847
+commit `b7252cc`. Capture requests carry a unique `extra_key`, so every
 training sample executes a full prefill even when radix cache support is
 present. Managed-local launch preserves the historical disabled-cache default;
 hybrid targets that require the unified radix tree set

--- a/specforge/inference/sglang_patch_inventory.md
+++ b/specforge/inference/sglang_patch_inventory.md
@@ -23,10 +23,16 @@ inputs) to training feature names. No trainer or producer process imports
 SGLang model-runner internals or loads a target model.
 
 The same patch is dry-run validated against the v0.5.14 tag and the public
-`inkling-support` branch. Capture requests carry a unique `extra_key`, so every
+Inkling integration. Capture requests carry a unique `extra_key`, so every
 training sample executes a full prefill even when radix cache support is
-present. Capture launch configs therefore leave radix cache enabled, including
-for hybrid targets that require the unified radix tree.
+present. Managed-local launch preserves the historical disabled-cache default;
+hybrid targets that require the unified radix tree set
+`model.sglang_disable_radix_cache: false`.
+
+For targets that declare `logits_mup_width_multiplier`, the SGLang model passes
+an LM-head-scaled hidden state into the logits processor. The capture patch
+restores the pre-head-scale post-norm representation because SpecForge folds
+the same multiplier into the frozen target head used during training.
 
 Apply the patch with `scripts/apply_sglang_spec_capture_patch.sh`. The
 server-capture unit and GPU gates must pass before updating the SGLang pin.

--- a/specforge/launch_plan.py
+++ b/specforge/launch_plan.py
@@ -451,7 +451,6 @@ def _managed_local_services(
                 str(server.tp_size),
                 "--chunked-prefill-size",
                 "-1",
-                "--disable-radix-cache",
                 "--enable-spec-capture",
                 "--spec-capture-method",
                 contract.method,

--- a/tests/test_runtime/test_launch_plan.py
+++ b/tests/test_runtime/test_launch_plan.py
@@ -539,7 +539,7 @@ class LaunchPlanTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValidationError, message):
                     Config.model_validate(raw)
 
-    def test_managed_local_accepts_minimum_context_and_disables_radix_cache(self):
+    def test_managed_local_accepts_minimum_context_and_configures_radix_cache(self):
         with tempfile.TemporaryDirectory() as root:
             cfg = _managed_config(os.path.join(root, "attempt"))
             raw = cfg.model_dump()
@@ -555,6 +555,19 @@ class LaunchPlanTest(unittest.TestCase):
         argv = plan.services[1].command.argv
         self.assertEqual(argv[argv.index("--context-length") + 1], "135")
         self.assertIn("--disable-radix-cache", argv)
+
+        with tempfile.TemporaryDirectory() as root:
+            cfg = _managed_config(os.path.join(root, "attempt"))
+            raw = cfg.model_dump()
+            raw["model"]["sglang_disable_radix_cache"] = False
+            validated = Config.model_validate(raw)
+            with mock.patch(
+                "specforge.training.capture_contract.resolve_server_capture_contract",
+                return_value=CAPTURE_CONTRACT,
+            ):
+                plan = build_launch_plan(validated, config_path="run.yaml", env={})
+
+        self.assertNotIn("--disable-radix-cache", plan.services[1].command.argv)
 
     def test_managed_local_plan_owns_mooncake_and_multiple_capture_servers(self):
         servers = [

--- a/tests/test_runtime/test_package_architecture.py
+++ b/tests/test_runtime/test_package_architecture.py
@@ -751,6 +751,7 @@ class TestPackageArchitecture(unittest.TestCase):
             Path("examples/disagg/run_offline.sh"),
             Path("examples/disagg/run_offline_2node.sh"),
             Path("examples/disagg/run_qwen3_8b_dflash_disagg_2node.sh"),
+            Path("examples/disagg/run_inkling_dspark_disagg_2node.sh"),
         }
         bypasses = []
         train_command = re.compile(r"\btrain\s+(?:--config|-c)\b")

--- a/tests/test_scripts/test_disagg_launchers.py
+++ b/tests/test_scripts/test_disagg_launchers.py
@@ -13,6 +13,9 @@ ONLINE = ROOT / "examples" / "disagg" / "run_online.sh"
 OFFLINE = ROOT / "examples" / "disagg" / "run_offline.sh"
 OFFLINE_TWO_NODE = ROOT / "examples" / "disagg" / "run_offline_2node.sh"
 TWO_NODE = ROOT / "examples" / "disagg" / "run_qwen3_8b_dflash_disagg_2node.sh"
+INKLING_TWO_NODE = (
+    ROOT / "examples" / "disagg" / "run_inkling_dspark_disagg_2node.sh"
+)
 
 
 class DisaggregatedWrapperTest(unittest.TestCase):
@@ -178,6 +181,54 @@ class DisaggregatedWrapperTest(unittest.TestCase):
         self.assertNotIn("run_disagg_dflash.py", "".join(outputs.values()))
         self.assertNotIn("torchrun", "".join(outputs.values()))
         self.assertFalse(shared_root.exists())
+
+    def test_inkling_two_node_wrapper_pins_the_validated_server_contract(self):
+        self.assertTrue(os.access(INKLING_TWO_NODE, os.X_OK))
+        syntax = subprocess.run(
+            ["bash", "-n", str(INKLING_TWO_NODE)],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+
+        env = self._env()
+        env.update(
+            {
+                "NODE_RANK": "0",
+                "NUM_NODES": "2",
+                "HEAD_IP": "10.0.0.1",
+                "DISAGG_STORE_ID": "inkling-two-node-test",
+                "DISAGG_RUN_ROOT": str(self.root / "inkling-shared-attempt"),
+                "DRY_RUN": "1",
+            }
+        )
+        result = subprocess.run(
+            [str(INKLING_TWO_NODE), "training.max_steps=1"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = result.stdout
+        for expected in (
+            "thinkingmachines/Inkling",
+            "--tp-size 4",
+            "--spec-capture-aux-layer-ids 5 17 35 47 59",
+            "--attention-backend fa4",
+            "--quantization modelopt_fp4",
+            "--mamba-radix-cache-strategy extra_buffer",
+            "training.accumulation_steps=128",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, output)
+        self.assertNotIn("--disable-radix-cache", output)
+
+        source = INKLING_TWO_NODE.read_text(encoding="utf-8")
+        self.assertIn("SGLANG_ENABLE_UNIFIED_RADIX_TREE", source)
+        self.assertIn("SGLANG_OPT_USE_INKLING_CUSTOM_AR", source)
 
     def test_offline_two_node_wrapper_dispatches_roles_to_the_unified_cli(self):
         self.assertTrue(os.access(OFFLINE_TWO_NODE, os.X_OK))

--- a/tests/test_scripts/test_disagg_launchers.py
+++ b/tests/test_scripts/test_disagg_launchers.py
@@ -13,9 +13,7 @@ ONLINE = ROOT / "examples" / "disagg" / "run_online.sh"
 OFFLINE = ROOT / "examples" / "disagg" / "run_offline.sh"
 OFFLINE_TWO_NODE = ROOT / "examples" / "disagg" / "run_offline_2node.sh"
 TWO_NODE = ROOT / "examples" / "disagg" / "run_qwen3_8b_dflash_disagg_2node.sh"
-INKLING_TWO_NODE = (
-    ROOT / "examples" / "disagg" / "run_inkling_dspark_disagg_2node.sh"
-)
+INKLING_TWO_NODE = ROOT / "examples" / "disagg" / "run_inkling_dspark_disagg_2node.sh"
 
 
 class DisaggregatedWrapperTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- make managed-local radix-cache disabling configurable while preserving the existing default
- support SGLang's refactored `spec_aux_config` fields used by Inkling support
- restore pre-LM-head-scale hidden states for targets with `logits_mup_width_multiplier`
- add a production-shaped Inkling DSpark config and two-node launcher for SGLang #31847

## Why

Inkling requires the unified radix tree, so the managed-local server cannot always pass `--disable-radix-cache`. Its model also divides the post-norm hidden state before the LM head. SpecForge already folds that same multiplier into the frozen training head, so capturing the divided hidden state applied the multiplier twice and produced incorrectly scaled teacher logits.

The new config defaults to the historical disabled-cache behavior. Inkling-style hybrid targets opt in with:

```yaml
model:
  sglang_disable_radix_cache: false
```

## Validation

- `git apply --check` against SGLang v0.5.14
- GNU `patch --dry-run` against clean SGLang #31847 commit `b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19`
- 32 recipe, launcher, topology, and package-architecture tests passed in the RunPod runtime
- 83 relevant tests passed in the RunPod runtime (2 opt-in GPU gates skipped)
- managed-local 8x B300 smoke test using SpecForge `4be2f92a7e10281ab518e1ef9dca91616ed6aaba` plus this change and SGLang PR #31847 at `b7252cc6b0c78b25ecea7ee5efa91a6ae37d0f19`
  - SGLang TP=4 on GPUs 0-3; FSDP trainer world size 4 on GPUs 4-7
  - 8/8 prompts captured; zero failures
  - all four ranks completed training step 1 and wrote a checkpoint
  - teacher top-1 probability was `0.0620225` after the scaling fix (the double-scaled path produced approximately `1.0e-5`)
  - managed supervisor exited cleanly and released all GPUs

Depends on sgl-project/sglang#31847 for Inkling serving support.
