### PR TITLE
fix(data): parse tools JSON only for strings, not native lists

### DIFF
--- a/specforge/data/preprocessing.py
+++ b/specforge/data/preprocessing.py
@@ -257,7 +257,7 @@ def build_eagle3_dataset(
                 # Parse tools: handle JSON strings from safe_conversations_generator
                 tools = []
                 for tool_item in tools_raw:
-                    if isinstance(tool_item, (str, list)):
+                    if isinstance(tool_item, str):
                         try:
                             tools.append(json.loads(tool_item))
                         except json.JSONDecodeError:


### PR DESCRIPTION
## Motivation

`build_eagle3_dataset` treated `tools` rows as JSON-parseable whenever they were `str` **or** `list`. HuggingFace datasets usually deliver `tools` as native Python lists, so those rows entered `json.loads`, raised `TypeError` (not caught by `JSONDecodeError`), and crashed preprocessing for any tool-bearing corpus. The `elif isinstance(tool_item, list)` branch below was unreachable dead code.

## Modifications

- Narrow the `json.loads` path to `isinstance(tool_item, str)` only.
- Leave native lists, `None`, and unexpected types on their existing branches (passthrough / empty / warn).

## Related Issues

N/A

## Accuracy Test

N/A — data preprocessing control-flow only; no model or loss change.

## Benchmark & Profiling

N/A — no expected throughput/latency impact; only avoids a TypeError on list-typed `tools` rows.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.