### PR TITLE
docs: document CUDA allocator fragmentation mitigation

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -509,4 +509,3 @@ export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 Set this before chasing data or numeric bugs that match the symptoms above. The
 Ascend equivalent (`PYTORCH_NPU_ALLOC_CONF`) is already set in the NPU recipes
 earlier in this page.
-

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -483,3 +483,30 @@ specforge export --to hf \
 
 Pass `--vocab-mapping /path/to/mapping.pt` when the checkpoint predates the
 mapping buffers or when you intentionally need to refresh them.
+
+## Troubleshooting
+
+### Late OOM or non-finite hidden states on online runs
+
+**Symptoms.** An online job starts cleanly, then fails well into training with a
+CUDA OOM that reports a large "reserved but unallocated" pool and only a few
+MiB free (for example, unable to serve a 388 MiB request with 58.3 GiB reserved
+and 34 MiB free). The same fragmentation can also surface first as non-finite
+target hidden states or as an anchor-sampling error that names the data rather
+than the allocator.
+
+**Cause.** Online training feeds the draft one micro-batch per step whose rows
+vary in length, so the caching allocator is asked for a differently sized block
+almost every step. Without expandable segments, reserved-but-unallocated memory
+accumulates until a modest allocation fails.
+
+**Fix.** Enable expandable segments before launch:
+
+```bash
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+```
+
+Set this before chasing data or numeric bugs that match the symptoms above. The
+Ascend equivalent (`PYTORCH_NPU_ALLOC_CONF`) is already set in the NPU recipes
+earlier in this page.
+


### PR DESCRIPTION
## What changed

- Documents `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` for variable-length online training.
- Adds diagnostics for allocator fragmentation that can surface as late OOMs, non-finite target states, or misleading anchor-sampling failures.

## Why

Variable-length microbatches repeatedly request differently sized CUDA allocations. Long runs can strand large amounts of reserved-but-unallocated memory unless expandable segments are enabled.

## Impact

Operators get a concrete mitigation and a quick way to distinguish allocator fragmentation from data or model failures.

## Validation

- `git diff --check upstream/main...origin/docs/cuda-allocator-fragmentation`
