### PR TITLE
docs: add DSpark backbone and long-context recipes

### DIFF
--- a/docs/dspark_draft_backbone_recipe.md
+++ b/docs/dspark_draft_backbone_recipe.md
@@ -1,0 +1,65 @@
+# DSpark draft backbone recipe
+
+Design rules for sizing a DSpark/DFlash draft against a new target,
+distilled from the Inkling-Small v2 program (+17.6% mean accept length
+over a v1 draft trained on identical data; see
+`docs/inkling_small_dspark_v2_results.md`).
+
+## Attention geometry: match the target
+
+Use the target's head geometry for the draft: same `head_dim`, same
+GQA ratio (e.g. 32 query heads / 8 KV heads at head_dim 128). The draft
+consumes fused target hidden states through KV injection at every layer;
+matching geometry lets those features project into attention without an
+impedance mismatch, and it reuses the target's serving kernel shapes.
+
+## Target taps: uniform coverage
+
+Take aux hidden states from N layers spread uniformly over `[1, L-3]` of
+the target (8 taps for a 42-layer target: `[1, 6, 12, 17, 23, 28, 34, 39]`).
+Avoid clustering taps near the output — early- and mid-stack features
+carry the context signal the draft cannot recompute. Keep the tap list in
+the draft config (`dflash_config.target_layer_ids`) as the single source
+of truth for training, probing, and serving.
+
+## Depth vs width
+
+A 6-layer draft with a wide FFN (12288 at hidden 4096, ~3x) outperformed
+a 5-layer narrower one at comparable parameter count. With KV injection
+delivering target features to every layer, marginal depth buys less than
+FFN capacity for absorbing them.
+
+## Attention pattern: serve-ability first
+
+All draft layers full attention unless the serving kernel supports SWA
+for the draft path. A hybrid-SWA draft that cannot serve is a science
+project; check the serving kernel BEFORE choosing the pattern.
+
+## Block size: train = serve
+
+Train at the block size you will serve (e.g. 7). Training at a larger
+block and serving smaller leaves accept length on the table and makes
+the confidence head miscalibrated for the deployed horizon. Adapt the
+within-block loss decay to the block size (γ=4 at block 7 — steeper
+decay than γ≈9 at block 15, since position-1 correctness dominates the
+expected accept length of a short block).
+
+## Objective and schedule
+
+- 0.1 CE + 0.9 L1 feature distillation + 1.0 confidence BCE, ~512
+  sampled anchors per sequence.
+- Constant LR (5e-4) with a short warmup (4%) then hold beats cosine for
+  drafters: the objective is stationary distillation, and decay mostly
+  slows late-run absorption of hard examples. Keep global batch fixed
+  (e.g. 512) across stages.
+
+## Checklist for a new target
+
+1. Read the target's config: layer count, head geometry, addressable
+   context, quantization.
+2. Pick taps uniformly; write them into the draft config.
+3. Clone the target's attention geometry; size FFN ~3x hidden; 6 layers.
+4. Confirm the serving kernel supports the attention pattern and block
+   size; set `block_size` = serve block.
+5. Probe capture parity before the first smoke (per-layer scale + stream
+   distinctness), then smoke the worst-case batch shape for memory.

--- a/docs/dspark_draft_backbone_recipe.md
+++ b/docs/dspark_draft_backbone_recipe.md
@@ -2,8 +2,7 @@
 
 Design rules for sizing a DSpark/DFlash draft against a new target,
 distilled from the Inkling-Small v2 program (+17.6% mean accept length
-over a v1 draft trained on identical data; see
-`docs/inkling_small_dspark_v2_results.md`).
+over a v1 draft trained on identical data).
 
 ## Attention geometry: match the target
 

--- a/docs/dspark_two_stage_rope_recipe.md
+++ b/docs/dspark_two_stage_rope_recipe.md
@@ -1,0 +1,49 @@
+# Two-stage RoPE recipe: native-context training, then YaRN long-context adaptation
+
+How to train a DSpark/DFlash drafter that holds its accept length out to
+the target's full addressable context without paying long-sequence cost
+for the whole run.
+
+## The recipe
+
+**Stage 1 — native RoPE, short sequences.** Train the drafter at the
+target's original context (e.g. `rope_scaling: null`,
+`max_position_embeddings: 8192`, `max_length: 8192`) for the bulk of the
+token budget. Short sequences keep iteration fast and memory low, so this
+stage carries all the epochs.
+
+**Stage 2 — YaRN, long sequences, weights-only warm start.** Switch the
+draft config to YaRN (e.g. `factor: 128`,
+`original_max_position_embeddings: 8192`, no mscale keys →
+`max_position_embeddings: 1048576`) and raise `max_length` (e.g. 65536).
+Warm start from the stage-1 final weights ONLY — RoPE is parameter-free,
+so the weights are bit-compatible across the config change; drop the
+optimizer/scheduler state entirely. One epoch over the stage-1 corpus
+plus upsampled genuinely-long data (agentic trajectories) suffices.
+
+Match the YaRN factor and `max_position_embeddings` to the TARGET's
+addressable range, not to the longest training sequence — serving will
+position-embed wherever the target does.
+
+## Why weights-only
+
+Restoring Adam moments across a sequence-length and data-distribution
+change transplants stale curvature estimates; a short LR re-warm (~64
+optimizer steps) from fresh moments is cheaper and stabler. It also makes
+the warm start world-size-independent (no optimizer resharding concerns).
+
+## Checkpoint schema pitfall
+
+transformers 5.x `save_pretrained` writes only the new `rope_parameters`
+schema and drops legacy `rope_scaling`. Serving stacks and older
+transformers that read only the legacy key silently lose YaRN — the draft
+falls back to unscaled RoPE at serve time and accept length collapses
+beyond the original context. Ship checkpoints with BOTH schemas present.
+
+## Validation
+
+Evaluate accept length bucketed by prompt length on held-out long data
+(full conversation prefixes, not synthetic fill). A successful adaptation
+is FLAT across buckets. Reference run (Inkling-Small v2, block 7,
+temperature 0): 3.59 at 8–16K, 3.56 at 16–32K, 3.53 at ≥32K — within
+noise of each other; see `docs/inkling_small_dspark_v2_results.md`.

--- a/docs/dspark_two_stage_rope_recipe.md
+++ b/docs/dspark_two_stage_rope_recipe.md
@@ -45,5 +45,5 @@ beyond the original context. Ship checkpoints with BOTH schemas present.
 Evaluate accept length bucketed by prompt length on held-out long data
 (full conversation prefixes, not synthetic fill). A successful adaptation
 is FLAT across buckets. Reference run (Inkling-Small v2, block 7,
-temperature 0): 3.59 at 8–16K, 3.56 at 16–32K, 3.53 at ≥32K — within
-noise of each other; see `docs/inkling_small_dspark_v2_results.md`.
+temperature 0): 3.59 at 8–16K, 3.56 at 16–32K, and 3.53 at ≥32K — within
+noise of each other.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,8 @@ SpecForge is an ecosystem project developed by the SGLang team. It is a framewor
    :caption: Advanced Features
 
    advanced_features/customization.md
+   dspark_draft_backbone_recipe.md
+   dspark_two_stage_rope_recipe.md
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## What changed

- Adds practical DSpark draft-backbone sizing guidance: target-matched GQA, uniform target taps, FFN/depth tradeoffs, serving constraints, block-size alignment, and objective defaults.
- Adds a two-stage native-RoPE to YaRN training recipe for long-context draft adaptation.
- Links both pages from the documentation navigation.

## Why

The Inkling-Small v2 program exposed repeatable design and operational rules that are useful when adapting DSpark/DFlash to a new target. These rules were previously captured only in an old development branch.

## Impact

Users get concrete, reviewable guidance for choosing a draft architecture and adapting it to long contexts without training every stage at the maximum sequence length.

## Validation

- `git diff --check upstream/main...HEAD`
- `make -C docs html SPHINXOPTS='-W --keep-going'` reads and renders both new pages successfully; the command exits nonzero on the pre-existing `docs/basic_usage/training.md:19` header-level warning.
