### PR TITLE
misc(train): rely on tokenizer-owned chat templates; drop the packaged Inkling template plan

### DIFF
--- a/specforge/training/assembly.py
+++ b/specforge/training/assembly.py
@@ -317,7 +317,18 @@ def _close_configured_logger(logger) -> None:
         close()
 
 
-def _prompt_cache_key(cfg: Config, *, path: Optional[str] = None) -> str:
+def _tokenizer_chat_template_hash(tokenizer) -> Optional[str]:
+    """Hash the tokenizer's effective chat template so cached tokenizations
+    are invalidated when the model repository updates its template."""
+    template = getattr(tokenizer, "chat_template", None)
+    if not template:
+        return None
+    return hashlib.sha256(str(template).encode("utf-8")).hexdigest()[:12]
+
+
+def _prompt_cache_key(
+    cfg: Config, *, tokenizer=None, path: Optional[str] = None
+) -> str:
     source_path = path or cfg.data.prompts_path or cfg.data.train_data_path
     content_hash = None
     if source_path and os.path.isfile(source_path):
@@ -332,6 +343,7 @@ def _prompt_cache_key(cfg: Config, *, path: Optional[str] = None) -> str:
         "content_hash": content_hash,
         "max_length": cfg.data.max_length,
         "chat_template": cfg.data.chat_template,
+        "tokenizer_chat_template_hash": _tokenizer_chat_template_hash(tokenizer),
         "is_preformatted": cfg.data.is_preformatted,
         "train_only_last_turn": cfg.data.train_only_last_turn,
         "max_prompts": cfg.data.max_prompts,
@@ -376,7 +388,7 @@ def _prepare_prompts(
         cache_key = (
             cfg.data.cache_key
             if path is None and cfg.data.cache_key is not None
-            else _prompt_cache_key(cfg, path=source_path)
+            else _prompt_cache_key(cfg, tokenizer=tokenizer, path=source_path)
         )
     min_loss_tokens = algorithm.providers.model.minimum_loss_tokens(cfg, draft_config)
     return prepare_prompt_tasks(

--- a/tests/test_data/test_parser_normalization.py
+++ b/tests/test_data/test_parser_normalization.py
@@ -1,6 +1,6 @@
 import unittest
 
-from specforge.data.parse import GeneralParser
+from specforge.data.parse import GeneralParser, ThinkingParser
 from specforge.data.template import ChatTemplate
 
 
@@ -82,6 +82,32 @@ class TestParserNormalization(unittest.TestCase):
                 {"role": "assistant", "content": "answer"},
             ],
         )
+
+    def test_thinking_parser_sanitize_keeps_tool_identity_and_drops_extras(self):
+        # Tool-result rendering needs `name`/`tool_call_id` to survive
+        # sanitization; chat templates place the tool name inside the block.
+        parser = ThinkingParser(
+            DummyTokenizer(),
+            ChatTemplate(
+                assistant_header="<assistant>",
+                user_header="<user>",
+                system_prompt=None,
+                end_of_turn_token="</eot>",
+                parser_type="thinking",
+            ),
+        )
+        cleaned = parser._sanitize_message(
+            {
+                "role": "tool",
+                "content": "sunny",
+                "name": "weather",
+                "tool_call_id": "call-7",
+                "private": "discard",
+            }
+        )
+        self.assertEqual(cleaned["name"], "weather")
+        self.assertEqual(cleaned["tool_call_id"], "call-7")
+        self.assertNotIn("private", cleaned)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime/test_prompt_cache_key.py
+++ b/tests/test_runtime/test_prompt_cache_key.py
@@ -1,10 +1,10 @@
+"""Prompt-cache identity: keys must change when any tokenization input changes."""
+
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
-from specforge.data.parse import ThinkingParser
-from specforge.data.template import TEMPLATE_REGISTRY
 from specforge.training.assembly import _prompt_cache_key
 
 
@@ -14,43 +14,25 @@ def _cache_config(path: str):
             prompts_path="",
             train_data_path=path,
             max_length=4096,
-            chat_template="inkling-thinking",
+            chat_template="llama3",
             is_preformatted=False,
             train_only_last_turn=False,
             max_prompts=None,
         ),
         model=SimpleNamespace(
-            target_model_path="thinkingmachines/Inkling",
-            draft_model_config="configs/inkling-dspark.json",
+            target_model_path="org/target-model",
+            draft_model_config="configs/draft.json",
             draft_checkpoint_path=None,
             draft_num_hidden_layers=None,
             draft_block_size=None,
             input_modality="text",
         ),
-        training=SimpleNamespace(strategy="dspark"),
+        training=SimpleNamespace(strategy="eagle3"),
     )
 
 
-class TestInklingTemplate(unittest.TestCase):
-    def test_tool_response_identity_survives_sanitization(self):
-        parser = ThinkingParser(
-            SimpleNamespace(),
-            TEMPLATE_REGISTRY.get("inkling-thinking"),
-        )
-        cleaned = parser._sanitize_message(
-            {
-                "role": "tool",
-                "content": "sunny",
-                "name": "weather",
-                "tool_call_id": "call-7",
-                "private": "discard",
-            }
-        )
-        self.assertEqual(cleaned["name"], "weather")
-        self.assertEqual(cleaned["tool_call_id"], "call-7")
-        self.assertNotIn("private", cleaned)
-
-    def test_prompt_cache_key_tracks_source_content(self):
+class TestPromptCacheKey(unittest.TestCase):
+    def test_tracks_source_content(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp, "prompts.jsonl")
             path.write_text('{"text":"first"}\n', encoding="utf-8")
@@ -60,6 +42,22 @@ class TestInklingTemplate(unittest.TestCase):
             second = _prompt_cache_key(config)
 
         self.assertNotEqual(first, second)
+
+    def test_tracks_tokenizer_chat_template(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp, "prompts.jsonl")
+            path.write_text('{"text":"same"}\n', encoding="utf-8")
+            config = _cache_config(str(path))
+            first = _prompt_cache_key(
+                config, tokenizer=SimpleNamespace(chat_template="template-a")
+            )
+            second = _prompt_cache_key(
+                config, tokenizer=SimpleNamespace(chat_template="template-b")
+            )
+            missing = _prompt_cache_key(config, tokenizer=None)
+
+        self.assertNotEqual(first, second)
+        self.assertNotEqual(first, missing)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add the tokenizer's effective `chat_template` content hash to `_prompt_cache_key`, so tokenized prompt caches are invalidated whenever the model repository updates its template (generic; applies to all models).
- Remove `tests/test_data/test_inkling_template.py` and relocate its generic assertions: `ThinkingParser` tool-identity sanitization → `test_parser_normalization.py`; cache-key identity tests (neutral fixtures) → new `tests/test_runtime/test_prompt_cache_key.py`.
- Supersedes the packaged-template approach (`feat(data): package the Inkling chat template`): no SpecForge-owned copy of the Inkling template is shipped.

## Motivation

We verified that `thinkingmachines/Inkling` ships a `chat_template.jinja` that transformers v5 auto-loads onto the tokenizer, and that it renders **byte-identically** to the Python renderer SGLang main uses at serving time (`srt/parser/inkling_renderer.py`, merged in sgl-project/sglang#31681) — confirmed on multi-turn conversations with tool calls.

The previously packaged template matched the *legacy* `inkling-support` renderer instead, which diverges from main in three places: thinking-effort message placement, `<|content_model_end_sampling|>` after historical assistant turns, and the function name inside tool-call blocks. Owning a repository copy of the template therefore adds a drift risk without adding correctness — the tokenizer-owned template is the right source of truth once serving runs on SGLang main.

With the packaged-template mechanism gone, Inkling has no dedicated machinery left in SpecForge (only the standard `TEMPLATE_REGISTRY` entry and `assistant_pattern_type` branch, the same extension points glm/longcat use), so its model-named test file is dissolved into topical suites.

## Rollout note

Do **not** start new Inkling training runs from this branch until the deployment migrates from sglang 0.5.14 + inkling-support to a build containing sgl-project/sglang#31681: the tokenizer template renders the *main* format, while the pinned deployment still serves the legacy format. The cache-key change makes the switch safe (old tokenized caches self-invalidate).

## Test plan

- [x] `pytest tests/test_data` (32 passed)
- [x] `pytest tests/test_runtime/test_prompt_cache_key.py tests/test_runtime/test_offline_vocab_mapping.py`
- [ ] After the SGLang migration: one Inkling smoke run confirming prompt-cache regeneration and serving-format alignment