### PR TITLE
perf: make reference channel polling linear

### DIFF
--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -41,6 +41,7 @@ import json
 import os
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Sequence
 
@@ -114,7 +115,8 @@ class StreamingRefChannel:
         self._published = 0
         # consumer-side
         self._read_offset = 0
-        self._buf = ""
+        self._partial_line = ""
+        self._complete_lines = deque[str]()
         self._consumed = 0
         # ``mark_consumed`` is called from both the trainer thread (batch acks)
         # and the prefetch worker (failure settlement), so the increment and
@@ -327,15 +329,16 @@ class StreamingRefChannel:
         except FileNotFoundError:
             chunk = ""
         if chunk:
-            self._buf += chunk
-        # parse the buffer even when no new bytes arrived -- a previous max_n call
-        # may have left complete lines buffered.
+            lines = (self._partial_line + chunk).split("\n")
+            self._partial_line = lines.pop()
+            self._complete_lines.extend(lines)
+        # Parse queued lines even when no new bytes arrived -- a previous max_n
+        # call may have left complete lines buffered.
         out: List[SampleRef] = []
-        while "\n" in self._buf:
+        while self._complete_lines:
             if max_n is not None and len(out) >= max_n:
                 break
-            line, self._buf = self._buf.split("\n", 1)
-            line = line.strip()
+            line = self._complete_lines.popleft().strip()
             if line:
                 out.append(ref_from_dict(json.loads(line)))
         return out


### PR DESCRIPTION
## Motivation

`StreamingRefChannel.poll()` repeatedly splits the first line from the remaining string buffer. Each split copies the unparsed suffix, making the cost of draining a large buffered manifest O(n²), where `n` is the number of complete JSONL lines buffered for parsing.

This is particularly expensive during final cleanup of an online producer. The cleanup path creates a fresh `StreamingRefChannel` and scans the complete reference manifest in batches of 1,024. Although `max_n` limits the number of returned references per call, all remaining complete lines stay in the string buffer and continue to be copied on subsequent calls.

For manifests containing hundreds of thousands of records, this quadratic behavior can make parsing alone take hours.

## Modifications

- Store complete JSONL records in a `deque`.
- Retain only the final incomplete record in `_partial_line`.
- Split each newly read chunk once and append its complete records to the deque.
- Consume complete records with `popleft()` in O(1) time.
- Preserve the existing ordering, partial-line, blank-line, incremental-read, and `max_n` behavior.

This changes the total parsing complexity from O(n²) to O(n), assuming bounded average record size.

## Related Issues

N/A

## Accuracy Test

Not applicable to model accuracy. This change only affects control-plane JSONL buffering and does not modify model inputs or outputs.

## Benchmark & Profiling

This is easy to reproduce with a local microbenchmark: parsing several thousand buffered JSONL lines of about 2 KB each takes several seconds with the old implementation. Given the observed quadratic growth, extrapolating to the 500,000-line scale reaches hours. The deque-based implementation avoids repeatedly copying the unparsed suffix and scales linearly.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
