### PR TITLE
Fix blog diagram text alignment

### DIFF
--- a/blog/specforge-disaggregated-architecture.svg
+++ b/blog/specforge-disaggregated-architecture.svg
@@ -46,6 +46,8 @@
       .card-text { font-size: 15px; fill: #64748B; }
       .small-title { font-size: 15px; font-weight: 700; }
       .small-text { font-size: 13px; fill: #64748B; }
+      .capture-title { font-size: 14px; font-weight: 700; }
+      .capture-caption { font-size: 12px; fill: #64748B; }
       .edge-label { font-size: 14px; font-weight: 650; }
       .legend { font-size: 14px; fill: #475569; }
     </style>
@@ -62,12 +64,12 @@
     <rect x="932" y="135" width="620" height="600" rx="28" fill="#F5F3FF" stroke="#DDD6FE" stroke-width="2"/>
 
     <g>
-      <rect x="76" y="158" width="260" height="38" rx="19" fill="#DBEAFE"/>
+      <rect x="76" y="158" width="300" height="38" rx="19" fill="#DBEAFE"/>
       <circle cx="98" cy="177" r="7" fill="#2563EB"/>
       <text x="116" y="183" class="pool-title" fill="#1E40AF">Inference / Producer Pool</text>
     </g>
     <g>
-      <rect x="960" y="158" width="258" height="38" rx="19" fill="#EDE9FE"/>
+      <rect x="960" y="158" width="310" height="38" rx="19" fill="#EDE9FE"/>
       <circle cx="982" cy="177" r="7" fill="#7C3AED"/>
       <text x="1000" y="183" class="pool-title" fill="#5B21B6">Training / Consumer Pool</text>
     </g>
@@ -92,7 +94,7 @@
 
     <g filter="url(#shadow)">
       <rect x="488" y="228" width="150" height="278" rx="22" fill="#FFFFFF" stroke="#67E8F9" stroke-width="2"/>
-      <text x="563" y="260" text-anchor="middle" class="small-title" fill="#0E7490">SGLang capture pool</text>
+      <text x="563" y="260" text-anchor="middle" class="capture-title" fill="#0E7490">SGLang capture pool</text>
 
       <rect x="509" y="280" width="108" height="54" rx="13" fill="#ECFEFF" stroke="#A5F3FC"/>
       <circle cx="530" cy="307" r="8" fill="#06B6D4"/>
@@ -106,7 +108,7 @@
       <circle cx="530" cy="441" r="8" fill="#06B6D4"/>
       <text x="547" y="446" class="small-title" fill="#155E75">Server N</text>
 
-      <text x="563" y="490" text-anchor="middle" class="small-text">target feature capture</text>
+      <text x="563" y="490" text-anchor="middle" class="capture-caption">target feature capture</text>
     </g>
 
     <!-- Bridge cards -->
@@ -128,7 +130,7 @@
 
     <!-- Consumer-side cards -->
     <g filter="url(#shadow)">
-      <rect x="964" y="222" width="222" height="154" rx="22" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
+      <rect x="964" y="222" width="250" height="154" rx="22" fill="#FFFFFF" stroke="#C4B5FD" stroke-width="2"/>
       <rect x="988" y="245" width="44" height="44" rx="13" fill="#EDE9FE"/>
       <path d="M999 256h22v22h-22zM1004 263h12M1004 270h8" fill="none" stroke="#7C3AED" stroke-width="2" stroke-linecap="round"/>
       <text x="988" y="319" class="card-title" fill="#4C1D95">Consumer coordinator</text>
@@ -172,16 +174,16 @@
     <path d="M442 366H478" fill="none" stroke="#2563EB" stroke-width="4" marker-end="url(#arrowBlue)"/>
 
     <path d="M638 288H698" fill="none" stroke="#F59E0B" stroke-width="4" marker-end="url(#arrowOrange)"/>
-    <text x="668" y="273" text-anchor="middle" class="edge-label" fill="#B45309">refs</text>
+    <text x="668" y="265" text-anchor="middle" class="edge-label" fill="#B45309">refs</text>
     <path d="M886 283H954" fill="none" stroke="#F59E0B" stroke-width="4" marker-end="url(#arrowOrange)"/>
 
     <path d="M638 448C668 448 674 527 698 527" fill="none" stroke="#10B981" stroke-width="4" marker-end="url(#arrowGreen)"/>
     <text x="666" y="477" text-anchor="middle" class="edge-label" fill="#047857">tensors</text>
     <path d="M886 527H954" fill="none" stroke="#10B981" stroke-width="4" marker-end="url(#arrowGreen)"/>
-    <text x="920" y="512" text-anchor="middle" class="edge-label" fill="#047857">fetch</text>
+    <text x="920" y="504" text-anchor="middle" class="edge-label" fill="#047857">fetch</text>
 
     <path d="M1075 376V445" fill="none" stroke="#7C3AED" stroke-width="4" marker-end="url(#arrowPurple)"/>
-    <text x="1090" y="415" class="edge-label" fill="#6D28D9">refs</text>
+    <text x="1100" y="407" class="edge-label" fill="#6D28D9">refs</text>
     <path d="M1186 524H1210C1227 524 1222 410 1232 410" fill="none" stroke="#7C3AED" stroke-width="4" marker-end="url(#arrowPurple)"/>
     <path d="M1377 522V555" fill="none" stroke="#EC4899" stroke-width="4" marker-end="url(#arrowPink)"/>
 


### PR DESCRIPTION
## Summary

- widen the producer/consumer pool label backgrounds and consumer coordinator card so their text stays within bounds
- use dedicated smaller typography for the SGLang capture title and caption
- move the orange and purple `refs` labels and green `fetch` label away from their arrows

## Impact

Keeps `blog/specforge-disaggregated-architecture.svg` aligned with the corrected asset in [lm-sys/lm-sys.github.io#381](https://github.com/lm-sys/lm-sys.github.io/pull/381), without changing the diagram content or connections.

## Validation

- `xmllint --noout blog/specforge-disaggregated-architecture.svg`
- `git diff --check`
- rendered at the native 1600×900 size in Chrome and visually inspected
- verified the SVG checksum matches the corrected LMSYS website asset
