### PR TITLE
feat(dspark): support a pruned draft vocabulary for the DFlash family

### DIFF
--- a/configs/qwen3-8b-dspark-draftvocab32k.json
+++ b/configs/qwen3-8b-dspark-draftvocab32k.json
@@ -1,0 +1,59 @@
+{
+  "architectures": [
+    "DSparkDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "dspark.DSparkDraftModel"
+  },
+  "block_size": 7,
+  "bos_token_id": 151643,
+  "dflash_config": {
+    "attention_mode": "gqa",
+    "confidence_head_alpha": 1.0,
+    "confidence_head_with_markov": true,
+    "enable_confidence_head": true,
+    "markov_head_type": "vanilla",
+    "markov_rank": 256,
+    "mask_token_id": 151669,
+    "projector_type": "dspark",
+    "target_layer_ids": [
+      1,
+      9,
+      17,
+      25,
+      33
+    ]
+  },
+  "dtype": "bfloat16",
+  "draft_vocab_size": 32000,
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 4096,
+  "initializer_range": 0.02,
+  "intermediate_size": 12288,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "max_position_embeddings": 40960,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 36,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -288,6 +288,53 @@ assembly. In particular:
 
 There is no fallback to a removed training script.
 
+## Draft vocabulary pruning
+
+A draft can predict over a subset of the target vocabulary. This is worth doing
+when the target vocabulary is large relative to the draft: the output head and,
+for DSpark, the Markov head scale with it, while a domain corpus supervises only
+a fraction of the ids.
+
+It is off by default and enabled entirely by the draft config — add
+`draft_vocab_size` below `vocab_size` and change nothing in the run config:
+
+```json
+{
+  "architectures": ["DSparkDraftModel"],
+  "vocab_size": 151936,
+  "draft_vocab_size": 32000
+}
+```
+
+`configs/qwen3-8b-dspark-draftvocab32k.json` and
+`examples/configs/qwen3-8b-dspark-draftvocab32k-offline.yaml` are a complete
+worked pair.
+
+The mapping itself (`t2d`/`d2t`) comes from one of two places:
+
+- **Local offline runs** derive and cache it from the feature corpus when
+  `model.vocab_mapping_path` is empty, the same way EAGLE3 does.
+- **Disaggregated runs** require an explicit `model.vocab_mapping_path`:
+  producer and consumer would otherwise derive different mappings from
+  different shards.
+
+Two constraints are worth knowing before you start a long run:
+
+- A checkpoint that was trained with a pruned vocabulary records its
+  `draft_vocab_size`, and resuming it against a mapping with different contents
+  is rejected — same-sized mappings that select different tokens would silently
+  repoint every draft id at another token. Keep the mapping file next to the
+  checkpoint.
+- `draft_vocab_coverage` and, when the target's hidden states are available,
+  `teacher_kept_mass` are logged during training. They are the ceiling on
+  acceptance: coverage is how often the realized next token is even proposable,
+  and kept mass is how much of the teacher's belief survives pruning. Check them
+  on the first few hundred steps rather than at evaluation time.
+
+A run whose `draft_vocab_size` equals `vocab_size` is not pruned: the draft
+registers no mapping buffers, so `model.vocab_mapping_path` is rejected at
+config validation rather than failing later inside the model.
+
 Step limits are global optimizer updates. `training.max_steps` is a stop cap and,
 when set without `training.total_steps`, the fallback optimizer/loss schedule
 horizon. `training.total_steps` can describe a longer schedule, but does not by

--- a/examples/configs/qwen3-8b-dspark-draftvocab32k-offline.yaml
+++ b/examples/configs/qwen3-8b-dspark-draftvocab32k-offline.yaml
@@ -1,0 +1,42 @@
+# DSpark with a frequency-pruned draft vocabulary (32000 of 151936).
+#
+# Offline/colocated on purpose: the mapping is derived from the run's own
+# features by _ensure_offline_vocab_mapping, so no vocab_mapping_path is needed.
+# A disaggregated pruned run must instead pass model.vocab_mapping_path, because
+# producer and consumer cannot each derive the same mapping independently.
+model:
+  target_model_path: Qwen/Qwen3-8B
+  draft_model_config: configs/qwen3-8b-dspark-draftvocab32k.json
+  target_backend: sglang
+  embedding_key: model.embed_tokens.weight
+  torch_dtype: bfloat16
+
+data:
+  hidden_states_path: ./cache/hidden_states/qwen3-8b-dspark-sharegpt
+  max_length: 3072
+  chat_template: qwen
+  cache_dir: ./cache
+
+training:
+  strategy: dspark
+  num_epochs: 6
+  max_steps: 10000
+  batch_size: 1
+  learning_rate: 6.0e-4
+  warmup_ratio: 0.04
+  max_grad_norm: 1.0
+  attention_backend: flex_attention
+  num_anchors: 512
+  save_interval: 1000
+  log_interval: 50
+  dist_timeout: 30
+  seed: 42
+
+run_id: qwen3-8b-dspark-draftvocab32k-offline
+output_dir: ./outputs/qwen3-8b-dspark-draftvocab32k-offline
+
+deployment:
+  mode: local_colocated
+  trainer:
+    nnodes: 1
+    nproc_per_node: 1

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 from specforge.core.chunking import checkpointed_chunk_reduce
 from specforge.modeling.draft.dflash import DFlashDraftModel
 from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
+from specforge.modeling.draft.vocab_mixin import OUT_OF_DRAFT_VOCAB_LABEL
 
 try:
     from torch.nn.attention.flex_attention import BlockMask, create_block_mask
@@ -24,6 +25,10 @@ except ImportError:
 if hasattr(torch, "npu") and torch.npu.is_available():
     FLEX_ATTENTION_AVAILABLE = False
 
+
+#: Vocabulary rows per chunk when reducing the teacher's full-vocab normalizer.
+#: Bounds a transient [tokens, chunk] tensor only; it does not affect results.
+_TEACHER_NORMALIZER_VOCAB_CHUNK = 32768
 
 _VALID_LOSS_TYPES = {
     "dflash",
@@ -180,6 +185,10 @@ class OnlineDFlashModel(nn.Module):
         self.draft_model = draft_model
         self.lm_head = target_lm_head
         self.embed_tokens = target_embed_tokens
+        self.use_draft_vocab = bool(getattr(draft_model, "use_draft_vocab", False))
+        # (version, pruned_head_weight, target->draft label index); see
+        # _pruned_head_state for why this cannot be built in __init__.
+        self._pruned_head_cache: Optional[Tuple[int, torch.Tensor, torch.Tensor]] = None
         self.block_size = block_size
         self.mask_token_id = mask_token_id
         self.attention_backend = attention_backend
@@ -192,6 +201,64 @@ class OnlineDFlashModel(nn.Module):
         self._cached_block_mask: Optional[BlockMask] = None
         self._cached_seq_len: Optional[int] = None
         self._cached_bsz: Optional[int] = None
+
+    def _pruned_head_state(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return ``(head_weight[K, H], label_index[V])`` for the pruned vocab.
+
+        Built on first use rather than in ``__init__``: the training model is
+        constructed in ``build_model_bundle`` but the t2d/d2t mapping is only
+        installed afterwards (``_ensure_offline_vocab_mapping``, or an explicit
+        ``model.vocab_mapping_path``). Keying the cache on the draft model's
+        ``vocab_mapping_version`` makes a later re-install take effect instead of
+        silently serving a stale slice.
+        """
+        draft = self.draft_model
+        version = int(getattr(draft, "vocab_mapping_version", 0))
+        cache = self._pruned_head_cache
+        if cache is not None and cache[0] == version:
+            return cache[1], cache[2]
+        draft.require_vocab_mapping()
+        weight = self.lm_head.weight
+        mask = draft.t2d.to(device=weight.device, dtype=torch.bool)
+        # Row-slicing keeps the same order as column-slicing the full logits, so
+        # draft index i corresponds to target id nonzero(t2d)[i] on both sides.
+        pruned_weight = weight[mask].contiguous()
+        label_index = draft.draft_vocab_index().to(device=weight.device)
+        self._pruned_head_cache = (version, pruned_weight, label_index)
+        return pruned_weight, label_index
+
+    def apply_objective_head(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Project hidden states onto the vocabulary this objective supervises.
+
+        Unpruned runs call the head module itself, which keeps any head that is
+        not a plain ``nn.Linear`` working. Only pruning needs the raw rows.
+        """
+        if not self.use_draft_vocab:
+            return self.lm_head(hidden_states)
+        weight = self._pruned_head_state()[0]
+        return F.linear(hidden_states.to(weight.dtype), weight)
+
+    def _full_vocab_logsumexp(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """``log sum_v exp(target_logit_v)`` over the FULL target vocabulary.
+
+        Needed to turn pruned logits into true probabilities instead of
+        probabilities conditioned on the token having survived pruning. Only the
+        scalar normalizer is wanted, so the vocabulary is walked in chunks and
+        each chunk is reduced immediately: the ``[..., vocab_size]`` tensor that
+        pruning exists to avoid is never materialized. Callers hold
+        ``torch.no_grad()``, so this costs one extra projection in compute and
+        nothing in activation memory.
+
+        Returns ``hidden_states`` without its feature dimension.
+        """
+        weight = self.lm_head.weight
+        partials = []
+        for start in range(0, int(weight.shape[0]), _TEACHER_NORMALIZER_VOCAB_CHUNK):
+            rows = weight[start : start + _TEACHER_NORMALIZER_VOCAB_CHUNK]
+            chunk_logits = F.linear(hidden_states.to(rows.dtype), rows).float()
+            partials.append(torch.logsumexp(chunk_logits, dim=-1))
+        # logsumexp is associative over any partition of the vocabulary.
+        return torch.logsumexp(torch.stack(partials, dim=-1), dim=-1)
 
     def _sample_anchor_positions(
         self, seq_len: int, loss_mask: torch.Tensor, device: torch.device
@@ -849,13 +916,21 @@ class OnlineDSparkModel(OnlineDFlashModel):
         prev_token_ids: torch.Tensor,
         target_ids: torch.Tensor,
         loss_weights: torch.Tensor,
+        ce_weights: torch.Tensor,
         eval_mask: torch.Tensor,
         aligned_target_hidden: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, ...]:
-        """Return additive loss and telemetry numerators for one block slice."""
+        """Return additive loss and telemetry numerators for one block slice.
+
+        ``target_ids`` are labels in the objective's own vocabulary: real target
+        ids for a full-vocabulary draft, draft ids (with
+        ``OUT_OF_DRAFT_VOCAB_LABEL`` for pruned tokens) when the vocab is pruned.
+        ``prev_token_ids`` are always real target ids -- they index the Markov
+        head's W1, which spans the full target vocabulary either way.
+        """
 
         batch_size, num_blocks, block_size, hidden_size = hidden.shape
-        base_logits = self.lm_head(
+        base_logits = self.apply_objective_head(
             hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
         ).reshape(batch_size, num_blocks, block_size, -1)
         draft_logits = self.draft_model.apply_logits_head(
@@ -864,12 +939,15 @@ class OnlineDSparkModel(OnlineDFlashModel):
             hidden_states=hidden,
         )
         vocab_size = draft_logits.shape[-1]
+        # ignore_index zeroes the pruned-label positions; ce_weights zeroes the
+        # matching entries so they leave the CE denominator too.
         cross_entropy = F.cross_entropy(
             draft_logits.reshape(-1, vocab_size),
             target_ids.reshape(-1),
             reduction="none",
+            ignore_index=OUT_OF_DRAFT_VOCAB_LABEL,
         ).reshape_as(target_ids)
-        ce_num = (cross_entropy * loss_weights).sum()
+        ce_num = (cross_entropy * ce_weights).sum()
 
         zero = ce_num.new_zeros(())
         l1_num = zero
@@ -884,22 +962,57 @@ class OnlineDSparkModel(OnlineDFlashModel):
 
         draft_probabilities = None
         teacher_ids = None
+        kept_mass_num = zero
         if aligned_target_hidden is not None:
-            with torch.no_grad():
-                target_logits = self.lm_head(
-                    aligned_target_hidden.reshape(
-                        batch_size,
-                        num_blocks * block_size,
-                        hidden_size,
-                    )
-                ).reshape_as(draft_logits)
-                target_probabilities = torch.softmax(target_logits.float(), dim=-1)
-                teacher_ids = target_logits.argmax(dim=-1)
-            draft_probabilities = torch.softmax(draft_logits.float(), dim=-1)
-            l1_per_token = (
-                (draft_probabilities - target_probabilities).abs().sum(dim=-1)
+            flat_teacher = aligned_target_hidden.reshape(
+                batch_size,
+                num_blocks * block_size,
+                hidden_size,
             )
-            accept_probability = (1.0 - 0.5 * l1_per_token).clamp(0.0, 1.0)
+            with torch.no_grad():
+                # The teacher must use the SAME head rows as the student: that is
+                # what turns the pruned objective into a match against the target
+                # distribution renormalized over the kept tokens, rather than a
+                # match against a truncated (sub-normalized) one.
+                target_logits = self.apply_objective_head(flat_teacher).reshape_as(
+                    draft_logits
+                )
+                # Distillation target: renormalized over the kept tokens. The
+                # draft cannot place mass outside them, so its distribution sums
+                # to one there; a target summing to the kept mass instead would
+                # give the loss an irreducible floor and bias every gradient.
+                teacher_conditional = torch.softmax(target_logits.float(), dim=-1)
+                teacher_ids = target_logits.argmax(dim=-1)
+                if self.use_draft_vocab:
+                    # Acceptance target: the target's TRUE probabilities, which
+                    # sum to the kept mass, not to one. Renormalizing here would
+                    # claim a token is accepted at the rate it would have if the
+                    # pruned tokens did not exist -- see _full_vocab_logsumexp.
+                    full_log_normalizer = self._full_vocab_logsumexp(
+                        flat_teacher
+                    ).reshape(batch_size, num_blocks, block_size, 1)
+                    target_probabilities = torch.exp(
+                        target_logits.float() - full_log_normalizer
+                    )
+                else:
+                    target_probabilities = teacher_conditional
+            draft_probabilities = torch.softmax(draft_logits.float(), dim=-1)
+            l1_per_token = (draft_probabilities - teacher_conditional).abs().sum(dim=-1)
+            if self.use_draft_vocab:
+                # sum_i min(q_i, p_i) over the kept tokens: the exact single-step
+                # acceptance rate for a draft that can only propose them. Bounded
+                # above by the kept mass, which is the ceiling pruning imposes.
+                accept_probability = (
+                    torch.minimum(draft_probabilities, target_probabilities)
+                    .sum(dim=-1)
+                    .clamp(0.0, 1.0)
+                )
+                kept_mass_num = (target_probabilities.sum(dim=-1) * eval_mask).sum()
+            else:
+                # Algebraically the same quantity when the teacher sums to one.
+                # Kept as the original expression so the unpruned path stays
+                # bit-identical rather than merely equivalent.
+                accept_probability = (1.0 - 0.5 * l1_per_token).clamp(0.0, 1.0)
             if self.dspark_l1_loss_alpha > 0:
                 l1_num = (l1_per_token * loss_weights).sum()
 
@@ -925,10 +1038,19 @@ class OnlineDSparkModel(OnlineDFlashModel):
 
         with torch.no_grad():
             predicted_ids = draft_logits.argmax(dim=-1)
+            # A pruned label is OUT_OF_DRAFT_VOCAB_LABEL, which no predicted id
+            # can equal, so it counts as a miss -- exactly what serving does with
+            # a token the draft cannot propose. Accuracy therefore reports the
+            # real acceptance ceiling instead of hiding the pruning loss.
             correct = ((predicted_ids == target_ids) & eval_mask).float()
             correct_num = correct.sum()
             eval_den = eval_mask.float().sum()
-            ce_position_num = (cross_entropy.detach() * eval_mask).sum(dim=(0, 1))
+            # Cross-entropy is undefined at pruned labels, so its telemetry uses
+            # the in-vocabulary subset; accuracy keeps the full eval set.
+            ce_eval_mask = eval_mask & (target_ids >= 0)
+            ce_eval_den = ce_eval_mask.float().sum()
+            ce_position_num = (cross_entropy.detach() * ce_eval_mask).sum(dim=(0, 1))
+            ce_position_den = ce_eval_mask.float().sum(dim=(0, 1))
             correct_position_num = correct.sum(dim=(0, 1))
             position_den = eval_mask.float().sum(dim=(0, 1))
             if aligned_target_hidden is not None:
@@ -956,7 +1078,9 @@ class OnlineDSparkModel(OnlineDFlashModel):
             confidence_error_num,
             correct_num,
             eval_den,
+            ce_eval_den,
             ce_position_num,
+            ce_position_den,
             correct_position_num,
             position_den,
             teacher_agreement_num,
@@ -964,6 +1088,7 @@ class OnlineDSparkModel(OnlineDFlashModel):
             draft_top1_num,
             tau_num,
             tau_den,
+            kept_mass_num,
         )
 
     def _compute_dspark_loss(
@@ -987,6 +1112,24 @@ class OnlineDSparkModel(OnlineDFlashModel):
         )
         loss_weights = self._dspark_loss_weight_mask(eval_mask)
         local_loss_den = loss_weights.sum()
+        # A pruned vocabulary splits the objective in two. The L1 and confidence
+        # terms compare distributions and stay well defined at every supervised
+        # position. Cross-entropy needs a realizable label, so it drops the
+        # positions whose true token was pruned away -- and must drop them from
+        # its denominator too, or alpha_ce would silently scale with coverage.
+        # Unpruned, the two are the same tensor and the same sum, so reuse them
+        # rather than recomputing: the point is to leave that path's operator
+        # sequence exactly as it was, not merely to compute the same number.
+        objective_target_ids = target_ids
+        ce_weights = loss_weights
+        local_ce_den = local_loss_den
+        if self.use_draft_vocab:
+            label_index = self._pruned_head_state()[1]
+            objective_target_ids = label_index[target_ids]
+            ce_weights = loss_weights * (objective_target_ids >= 0).to(
+                loss_weights.dtype
+            )
+            local_ce_den = ce_weights.sum()
         need_target = self.dspark_l1_loss_alpha > 0 or (
             self.dspark_confidence_head_alpha > 0
             and getattr(self.draft_model, "confidence_head", None) is not None
@@ -1006,8 +1149,9 @@ class OnlineDSparkModel(OnlineDFlashModel):
             self._dspark_objective_chunk_terms,
             hidden_4d,
             prev_token_ids,
-            target_ids,
+            objective_target_ids,
             loss_weights,
+            ce_weights,
             eval_mask,
             aligned_target_hidden,
             chunk_size=self.objective_chunk_blocks,
@@ -1021,7 +1165,9 @@ class OnlineDSparkModel(OnlineDFlashModel):
             confidence_error_num,
             correct_num,
             eval_den,
+            ce_eval_den,
             ce_position_num,
+            ce_position_den,
             correct_position_num,
             position_den,
             teacher_agreement_num,
@@ -1029,31 +1175,74 @@ class OnlineDSparkModel(OnlineDFlashModel):
             draft_top1_num,
             tau_num,
             tau_den,
+            kept_mass_num,
         ) = totals
 
         global_loss_den = local_loss_den.detach().clone()
         world_size = 1
         import torch.distributed as dist
 
-        if dist.is_available() and dist.is_initialized():
+        distributed = dist.is_available() and dist.is_initialized()
+        if distributed:
             world_size = dist.get_world_size()
             if world_size > 1:
                 dist.all_reduce(global_loss_den, op=dist.ReduceOp.SUM)
         if float(global_loss_den) <= 0:
             raise ValueError("DSpark objective has no supervised target tokens")
-        loss = (
-            world_size
-            * (
-                self.dspark_ce_loss_alpha * ce_num
-                + self.dspark_l1_loss_alpha * l1_num
-                + self.dspark_confidence_head_alpha * confidence_num
+
+        # Unpruned, cross-entropy shares the objective's denominator exactly, so
+        # it needs neither its own sum nor its own reduction. Emitting that
+        # second collective unconditionally would change the collective sequence
+        # of every existing run -- ranks must agree on the count and order of
+        # collectives -- so this branch is part of leaving that path alone, not
+        # a micro-optimization.
+        global_ce_den = global_loss_den
+        if self.use_draft_vocab:
+            global_ce_den = local_ce_den.detach().clone()
+            if world_size > 1:
+                dist.all_reduce(global_ce_den, op=dist.ReduceOp.SUM)
+            if self.dspark_ce_loss_alpha > 0 and float(global_ce_den) <= 0:
+                raise ValueError(
+                    "DSpark cross-entropy has no in-vocabulary target tokens; "
+                    "the draft vocabulary covers none of this batch"
+                )
+        if not self.use_draft_vocab:
+            # global_ce_den == global_loss_den here, so the split form below is
+            # algebraically identical -- but not bit-identical: with a decayed
+            # loss_weights the denominator is not an exactly representable value,
+            # and x/D + y/D rounds differently from (x + y)/D. Keeping the
+            # original expression means an existing run's loss curve does not
+            # move by a few ulps for a feature it does not use.
+            loss = (
+                world_size
+                * (
+                    self.dspark_ce_loss_alpha * ce_num
+                    + self.dspark_l1_loss_alpha * l1_num
+                    + self.dspark_confidence_head_alpha * confidence_num
+                )
+                / global_loss_den
             )
-            / global_loss_den
-        )
+        else:
+            # Each term becomes a weighted mean over the positions it is defined
+            # on, so alpha_ce keeps its meaning instead of being scaled by how
+            # much of the batch the draft vocabulary happens to cover.
+            ce_term = (
+                self.dspark_ce_loss_alpha * ce_num / global_ce_den
+                if self.dspark_ce_loss_alpha > 0
+                else ce_num * 0.0
+            )
+            loss = world_size * (
+                ce_term
+                + (
+                    self.dspark_l1_loss_alpha * l1_num
+                    + self.dspark_confidence_head_alpha * confidence_num
+                )
+                / global_loss_den
+            )
 
         ratio_metrics = {
             "acc": (correct_num, eval_den),
-            "ce_loss": (ce_num.detach(), local_loss_den.detach()),
+            "ce_loss": (ce_num.detach(), local_ce_den.detach()),
             "l1_loss": (l1_num.detach(), local_loss_den.detach()),
             "confidence_loss": (
                 confidence_num.detach(),
@@ -1063,9 +1252,14 @@ class OnlineDSparkModel(OnlineDFlashModel):
                 confidence_error_num.detach(),
                 local_loss_den.detach(),
             ),
-            "ce_position": (ce_position_num, position_den),
+            "ce_position": (ce_position_num, ce_position_den),
             "accuracy_position": (correct_position_num, position_den),
         }
+        if self.use_draft_vocab:
+            # Share of supervised tokens the pruned vocabulary can actually
+            # propose. This is the hard ceiling on acceptance, so it belongs in
+            # the training log rather than in a post-hoc audit.
+            ratio_metrics["draft_vocab_coverage"] = (ce_eval_den, eval_den)
         if aligned_target_hidden is not None:
             ratio_metrics.update(
                 {
@@ -1075,6 +1269,16 @@ class OnlineDSparkModel(OnlineDFlashModel):
                     "tau_probabilistic": (tau_num, tau_den),
                 }
             )
+            if self.use_draft_vocab:
+                # Target probability mass the pruned vocabulary can reach, in
+                # probability rather than token counts. draft_vocab_coverage
+                # answers "how often is the realized token proposable"; this
+                # answers "how much of the teacher's belief survives pruning".
+                # It upper-bounds each position's single-step acceptance
+                # probability. It is NOT a bound on tau_probabilistic, which is
+                # 1 + sum_j prod_{k<=j} accept_k -- an anchor token plus
+                # cumulative products of those per-step probabilities.
+                ratio_metrics["teacher_kept_mass"] = (kept_mass_num, eval_den)
         metrics: Dict[str, object] = {
             "ratio_metrics": {
                 name: (numerator.detach(), denominator.detach())

--- a/specforge/algorithms/contracts.py
+++ b/specforge/algorithms/contracts.py
@@ -239,6 +239,12 @@ class AlgorithmCapabilities:
     required_batch_size: int | None = None
     supports_compact_teacher: bool = False
     supports_vocab_mapping: bool = False
+    #: Whether the draft still owns t2d/d2t when draft_vocab_size == vocab_size.
+    #: EAGLE3 and P-EAGLE register the buffers unconditionally, so a redundant
+    #: mapping path merely installs an identity map and is harmless. The DFlash
+    #: family registers them only when pruning -- so for it the same config is a
+    #: hard failure at model construction, and validation must reject it early.
+    keeps_vocab_buffers_when_unpruned: bool = True
     allows_aux_layer_override: bool = False
 
     def __post_init__(self) -> None:
@@ -255,6 +261,7 @@ class AlgorithmCapabilities:
         for field_name in (
             "supports_compact_teacher",
             "supports_vocab_mapping",
+            "keeps_vocab_buffers_when_unpruned",
             "allows_aux_layer_override",
         ):
             if not isinstance(getattr(self, field_name), bool):

--- a/specforge/algorithms/dspark/providers.py
+++ b/specforge/algorithms/dspark/providers.py
@@ -50,7 +50,7 @@ def build_step(wrapped_model, *, target_head=None, **_options):
 def resume_contract(_config, draft_model, training_model):
     """Persist resolved DSpark model, sampling, and objective semantics."""
 
-    return {
+    contract = {
         "dspark_draft_num_hidden_layers": int(draft_model.config.num_hidden_layers),
         "dspark_target_layer_ids": tuple(
             int(layer_id) for layer_id in draft_model.target_layer_ids
@@ -66,6 +66,18 @@ def resume_contract(_config, draft_model, training_model):
             training_model.dspark_confidence_head_alpha
         ),
     }
+    # Only recorded when the run actually prunes. The trainer treats a contract
+    # key that a checkpoint does not carry as fatal, so adding this
+    # unconditionally would make every DSpark checkpoint written before this
+    # feature unresumable -- for a field that, unpruned, could only ever hold
+    # vocab_size. It catches a changed K before any weight loads, and nothing
+    # more: two mappings of the same size select different tokens without
+    # disagreeing here. Which tokens is checked where the buffers actually meet,
+    # in _reject_conflicting_vocab_mapping, since the contract is bound before
+    # the offline mapping is installed and cannot see it.
+    if getattr(draft_model, "use_draft_vocab", False):
+        contract["dspark_draft_vocab_size"] = int(draft_model.draft_vocab_size)
+    return contract
 
 
 def build_draft(config, draft_config):
@@ -140,6 +152,10 @@ def algorithm_spec() -> AlgorithmSpec:
         ),
         capabilities=AlgorithmCapabilities(
             attention_backends={"eager", "sdpa", "flex_attention"},
+            supports_vocab_mapping=True,
+            # DFlash-family drafts register t2d/d2t only when they prune, so an
+            # unpruned run has nowhere to put a mapping. See _validate_vocab_mapping.
+            keeps_vocab_buffers_when_unpruned=False,
         ),
     )
 
@@ -202,6 +218,7 @@ def algorithm_providers() -> AlgorithmProviders:
                 build_collator=build_dspark_collator,
             ),
         ),
+        vocab_mapping_modes=frozenset({FeatureMode.OFFLINE, FeatureMode.STREAMING}),
     )
 
 

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -84,8 +84,14 @@ def _warm_start(
 
 
 def _load_vocab_mapping(cfg: Config, draft_model: Any) -> None:
-    if cfg.model.vocab_mapping_path:
-        draft_model.load_vocab_mapping(cfg.model.vocab_mapping_path)
+    if not cfg.model.vocab_mapping_path:
+        return
+    if not hasattr(draft_model, "load_vocab_mapping"):
+        raise ValueError(
+            f"{type(draft_model).__name__} does not support vocabulary mapping, "
+            "but model.vocab_mapping_path is set"
+        )
+    draft_model.load_vocab_mapping(cfg.model.vocab_mapping_path)
 
 
 def build_eagle3_draft(cfg: Config, draft_config: PretrainedConfig):
@@ -155,6 +161,9 @@ def _finish_registered_draft(
     draft_model: Any,
 ):
     _warm_start(cfg, draft_model, draft_config)
+    # Same order as EAGLE3: warm-started buffers are then overwritten by the
+    # run's own mapping, so an explicit path always wins over the checkpoint's.
+    _load_vocab_mapping(cfg, draft_model)
     return draft_model.to(device=_device(), dtype=_torch_dtype(cfg))
 
 

--- a/specforge/application/planning.py
+++ b/specforge/application/planning.py
@@ -169,15 +169,87 @@ def _validate_training_topology(
         raise ValueError("USP attention currently requires offline features")
 
 
+def _prunes_vocabulary(
+    cfg: Config,
+    algorithm: AlgorithmRegistration,
+) -> Optional[bool]:
+    """Whether this run's draft actually predicts over a pruned vocabulary.
+
+    Declaring ``supports_vocab_mapping`` says the algorithm *can* prune; only
+    ``draft_vocab_size < vocab_size`` in the resolved draft config says this run
+    *does*. Mapping requirements must key off the latter, or turning the
+    capability on would start rejecting full-vocabulary configs that never
+    needed a mapping.
+
+    Returns ``None`` when the draft config cannot be read. Resolving it is not
+    this check's job -- config validation must keep working without the draft
+    config on disk -- so each caller decides what an unknown answer means for
+    the rule it enforces, rather than this guessing an answer for all of them.
+    """
+    if not algorithm.spec.capabilities.supports_vocab_mapping:
+        return False
+
+    from specforge.training.model_loading import draft_config_dict
+
+    try:
+        draft_cfg = draft_config_dict(
+            cfg, provider=algorithm.providers.model.draft_config
+        )
+    except Exception:
+        return None
+    vocab_size = draft_cfg.get("vocab_size")
+    draft_vocab_size = draft_cfg.get("draft_vocab_size") or vocab_size
+    if vocab_size is None or draft_vocab_size is None:
+        return False
+    return int(draft_vocab_size) != int(vocab_size)
+
+
 def _validate_vocab_mapping(
     cfg: Config,
     algorithm: AlgorithmRegistration,
     mode: FeatureMode,
 ) -> None:
+    supports_mapping = algorithm.spec.capabilities.supports_vocab_mapping
+    if cfg.model.vocab_mapping_path and not supports_mapping:
+        raise ValueError(
+            f"algorithm {algorithm.name!r} does not support vocabulary mapping, "
+            "so model.vocab_mapping_path would be silently ignored; remove it"
+        )
+    # Supporting mapping is not the same as being able to consume one. A draft
+    # that only registers t2d/d2t when it prunes cannot load a mapping at full
+    # vocabulary, and without this the path is accepted here and then fails much
+    # later with a "t2d/d2t buffers are not present" error that points at the
+    # model instead of at the config. Drafts that always carry the buffers just
+    # install an identity map, which is redundant but works, so they are left
+    # alone rather than having a shipped config invalidated retroactively.
+    # An unknown answer is not evidence of a full vocabulary, so this rejects
+    # only a config proven to be unpruned; the unreadable draft config then
+    # surfaces at the model-loading boundary with its own error.
+    if (
+        cfg.model.vocab_mapping_path
+        and supports_mapping
+        and not algorithm.spec.capabilities.keeps_vocab_buffers_when_unpruned
+        and _prunes_vocabulary(cfg, algorithm) is False
+    ):
+        raise ValueError(
+            f"algorithm {algorithm.name!r} run has draft_vocab_size == "
+            "vocab_size, so its draft carries no t2d/d2t buffers for "
+            "model.vocab_mapping_path to load into; set a smaller "
+            "draft_vocab_size in the draft config or remove the path"
+        )
+    # An unknown answer falls back to what the algorithm needs by default: a
+    # draft that always carries t2d/d2t always needs the two sides to agree on
+    # one mapping, so an unreadable config must not drop a requirement that held
+    # before pruning was configurable. A draft that carries them only when it
+    # prunes has nothing to share until the config says it prunes.
+    prunes = _prunes_vocabulary(cfg, algorithm)
+    if prunes is None:
+        prunes = algorithm.spec.capabilities.keeps_vocab_buffers_when_unpruned
     if (
         cfg.deployment.mode == "disaggregated"
         and mode in algorithm.providers.vocab_mapping_modes
         and not cfg.model.vocab_mapping_path
+        and prunes
     ):
         raise ValueError(
             f"algorithm {algorithm.name!r} disaggregated runs require "

--- a/specforge/modeling/draft/base.py
+++ b/specforge/modeling/draft/base.py
@@ -33,9 +33,10 @@ from transformers.cache_utils import Cache
 from transformers.modeling_utils import PreTrainedModel
 
 from specforge.modeling._mask_utils import _expand_mask, _make_causal_mask
+from specforge.modeling.draft.vocab_mixin import DraftVocabMappingMixin
 
 
-class Eagle3DraftModel(PreTrainedModel, ABC):
+class Eagle3DraftModel(DraftVocabMappingMixin, PreTrainedModel, ABC):
     """
     This is the base class for the Eagle3 draft model implementation. The child class needs to implement
     the abstract methods to support training with TTT.
@@ -190,17 +191,5 @@ class Eagle3DraftModel(PreTrainedModel, ABC):
             local_cache_path = snapshot_download(repo_id=model_path)
             self.load_embedding(local_cache_path, embedding_key)
 
-    def load_vocab_mapping(self, file_path: str) -> None:
-        """
-        Load the vocab buffers of the draft model.
-
-        Args:
-            file_path (str): The path to the vocab mapping file.
-        """
-        assert hasattr(self, "t2d") and hasattr(
-            self, "d2t"
-        ), "t2d and d2t buffersare not found in the draft model, please check your draft model implementation"
-        vocab_mapping = torch.load(file_path)
-        self.t2d.copy_(vocab_mapping["t2d"])
-        self.d2t.copy_(vocab_mapping["d2t"])
-        self.vocab_mapping_loaded = True
+    # ``load_vocab_mapping`` / ``install_vocab_mapping`` come from
+    # DraftVocabMappingMixin, shared with the DFlash family.

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -21,6 +21,7 @@ from typing_extensions import Tuple, Unpack
 from .dflash_kernels import DEFAULT_DFLASH_KERNELS, DFlashKernels
 from .flex_attention_backend import flex_attention_backend
 from .registry import register_draft
+from .vocab_mixin import DraftVocabMappingMixin
 
 FULL_ATTENTION = "full_attention"
 SLIDING_ATTENTION = "sliding_attention"
@@ -356,7 +357,7 @@ def normalize_draft_head_checkpoint_keys(
 
 
 @register_draft
-class DFlashDraftModel(Qwen3PreTrainedModel):
+class DFlashDraftModel(DraftVocabMappingMixin, Qwen3PreTrainedModel):
     config_class = Qwen3Config
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
 
@@ -395,6 +396,12 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         self.projector_type = dflash_config.get("projector_type", None)
         self.pure_draft_prefix_len = dflash_config.get("pure_draft_prefix_len", 0)
         self.shift_label = dflash_config.get("shift_label", False)
+        # Registers t2d/d2t only when draft_vocab_size < vocab_size, so
+        # full-vocabulary checkpoints keep an unchanged state dict.
+        self.register_draft_vocab_buffers(
+            vocab_size=config.vocab_size,
+            draft_vocab_size=getattr(config, "draft_vocab_size", None),
+        )
         self._init_draft_head(config, dflash_config)
         self.register_load_state_dict_pre_hook(normalize_draft_head_checkpoint_keys)
         self.post_init()
@@ -435,6 +442,30 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         del hidden_states, prev_token_ids
         return None
 
+    def draft_logits_from_target_head(
+        self,
+        target: nn.Module,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Project hidden states through the target head, pruned when configured.
+
+        The DFlash family owns no LM head; it borrows the frozen target one. A
+        pruned draft must borrow only the rows ``t2d`` keeps, so that generation
+        proposes exactly the tokens training supervised. Unpruned drafts call the
+        head module itself, which keeps non-``nn.Linear`` heads working.
+        """
+        if not self.use_draft_vocab:
+            return target.lm_head(hidden_states)
+        self.require_vocab_mapping()
+        weight = target.lm_head.weight[self.t2d.to(dtype=torch.bool)]
+        return nn.functional.linear(hidden_states.to(weight.dtype), weight)
+
+    def draft_ids_to_target_ids(self, draft_ids: torch.Tensor) -> torch.Tensor:
+        """Map draft-vocabulary ids back to target ids (identity when unpruned)."""
+        if not self.use_draft_vocab:
+            return draft_ids
+        return draft_ids + self.d2t[draft_ids]
+
     def _sample_draft_tokens(
         self,
         target: nn.Module,
@@ -448,8 +479,10 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         duplicating the target-cache and acceptance logic in ``spec_generate``.
         """
         del block_output_ids
-        draft_logits = target.lm_head(draft_hidden[:, -self.block_size + 1 :, :])
-        return sample(draft_logits)
+        draft_logits = self.draft_logits_from_target_head(
+            target, draft_hidden[:, -self.block_size + 1 :, :]
+        )
+        return self.draft_ids_to_target_ids(sample(draft_logits))
 
     def forward(
         self,

--- a/specforge/modeling/draft/dspark.py
+++ b/specforge/modeling/draft/dspark.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import torch
 from torch import nn
@@ -33,17 +33,30 @@ class AcceptRatePredictor(nn.Module):
 
 
 class VanillaMarkovHead(nn.Module):
-    """Low-rank previous-token logit bias used by DSpark."""
+    """Low-rank previous-token logit bias used by DSpark.
 
-    def __init__(self, *, vocab_size: int, markov_rank: int):
+    The two factors do not share a vocabulary. ``markov_w1`` is indexed by the
+    preceding *real* token, which can be any target id, so it stays at the full
+    target vocabulary. ``markov_w2`` emits a bias added onto the draft logits,
+    so it follows the (possibly pruned) draft vocabulary.
+    """
+
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        draft_vocab_size: Optional[int] = None,
+    ):
         super().__init__()
         self.vocab_size = int(vocab_size)
+        self.draft_vocab_size = int(draft_vocab_size or vocab_size)
         self.markov_rank = int(markov_rank)
         self.markov_head_type = "vanilla"
         if self.markov_rank <= 0:
             raise ValueError(f"markov_rank must be > 0, got {self.markov_rank}")
         self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
-        self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+        self.markov_w2 = nn.Linear(self.markov_rank, self.draft_vocab_size, bias=False)
 
     def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_w1(token_ids.long())
@@ -86,7 +99,15 @@ class VanillaMarkovHead(nn.Module):
         first_prev_token_ids: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
         temperature: float = 0.0,
+        to_target_ids: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Autoregressively sample one block; returns ids in the TARGET vocabulary.
+
+        ``to_target_ids`` maps a sampled draft id back to its target id. It must
+        be applied before the id is fed back as ``prev_token_ids``: ``markov_w1``
+        is indexed by target ids, and a pruned draft id is a silently valid --
+        but wrong -- index into it.
+        """
         batch_size, proposal_len = base_logits.shape[:2]
         if proposal_len == 0:
             empty_tokens = torch.empty(
@@ -112,14 +133,27 @@ class VanillaMarkovHead(nn.Module):
                 step_logits.unsqueeze(1),
                 temperature=temperature,
             ).squeeze(1)
+            if to_target_ids is not None:
+                next_token_ids = to_target_ids(next_token_ids)
             sampled_tokens.append(next_token_ids)
             prev_token_ids = next_token_ids
         return torch.stack(sampled_tokens, dim=1), torch.cat(corrected_logits, dim=1)
 
 
 class GatedMarkovHead(VanillaMarkovHead):
-    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int):
-        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        hidden_size: int,
+        draft_vocab_size: Optional[int] = None,
+    ):
+        super().__init__(
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            draft_vocab_size=draft_vocab_size,
+        )
         self.markov_head_type = "gated"
         self.gate_proj = nn.Linear(hidden_size + markov_rank, markov_rank)
 
@@ -147,8 +181,19 @@ class GatedMarkovHead(VanillaMarkovHead):
 class RNNMarkovHead(VanillaMarkovHead):
     """Recurrent DSpark Markov head unrolled inside one draft block."""
 
-    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int):
-        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        hidden_size: int,
+        draft_vocab_size: Optional[int] = None,
+    ):
+        super().__init__(
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            draft_vocab_size=draft_vocab_size,
+        )
         self.markov_head_type = "rnn"
         self.state_size = markov_rank
         self.joint_proj = nn.Linear(2 * markov_rank + hidden_size, 3 * markov_rank)
@@ -215,6 +260,7 @@ class RNNMarkovHead(VanillaMarkovHead):
         first_prev_token_ids: torch.Tensor,
         hidden_states: Optional[torch.Tensor],
         temperature: float = 0.0,
+        to_target_ids: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if hidden_states is None:
             raise ValueError("rnn Markov head requires hidden_states")
@@ -246,6 +292,8 @@ class RNNMarkovHead(VanillaMarkovHead):
                 step_logits.unsqueeze(1),
                 temperature=temperature,
             ).squeeze(1)
+            if to_target_ids is not None:
+                next_token_ids = to_target_ids(next_token_ids)
             sampled_tokens.append(next_token_ids)
             prev_token_ids = next_token_ids
         return torch.stack(sampled_tokens, dim=1), torch.cat(corrected_logits, dim=1)
@@ -258,21 +306,27 @@ def build_markov_head(config, dspark_config: dict) -> Optional[nn.Module]:
     if markov_rank == 0:
         return None
 
+    # W1 is indexed by the previous real token (target vocabulary); W2 emits the
+    # draft-side bias, so it follows draft_vocab_size when the vocab is pruned.
+    draft_vocab_size = getattr(config, "draft_vocab_size", None) or config.vocab_size
     markov_head_type = str(dspark_config.get("markov_head_type", "vanilla")).lower()
     if markov_head_type == "vanilla":
         return VanillaMarkovHead(
             vocab_size=config.vocab_size,
+            draft_vocab_size=draft_vocab_size,
             markov_rank=markov_rank,
         )
     if markov_head_type == "gated":
         return GatedMarkovHead(
             vocab_size=config.vocab_size,
+            draft_vocab_size=draft_vocab_size,
             markov_rank=markov_rank,
             hidden_size=config.hidden_size,
         )
     if markov_head_type == "rnn":
         return RNNMarkovHead(
             vocab_size=config.vocab_size,
+            draft_vocab_size=draft_vocab_size,
             markov_rank=markov_rank,
             hidden_size=config.hidden_size,
         )
@@ -332,13 +386,16 @@ class DSparkDraftModel(DFlashDraftModel):
         """Generate a block with the same Markov correction used in training."""
 
         proposal_hidden = draft_hidden[:, -self.block_size + 1 :, :]
-        base_logits = target.lm_head(proposal_hidden)
+        base_logits = self.draft_logits_from_target_head(target, proposal_hidden)
         if self.markov_head is None:
-            return _sample(base_logits)
+            return self.draft_ids_to_target_ids(_sample(base_logits))
         sampled_tokens, _ = self.markov_head.sample_block_tokens(
             base_logits,
             first_prev_token_ids=block_output_ids[:, 0],
             hidden_states=proposal_hidden,
+            to_target_ids=(
+                self.draft_ids_to_target_ids if self.use_draft_vocab else None
+            ),
         )
         return sampled_tokens
 

--- a/specforge/modeling/draft/vocab_mixin.py
+++ b/specforge/modeling/draft/vocab_mixin.py
@@ -1,0 +1,252 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Target -> draft vocabulary pruning shared by draft architectures.
+
+A draft model may predict over a frequency-pruned subset of the target
+vocabulary.  Two buffers describe that subset:
+
+``t2d``  ``bool[target_vocab_size]``  -- True where a target id is kept.
+``d2t``  ``long[draft_vocab_size]``   -- offset such that ``i + d2t[i]`` is the
+                                         target id of draft id ``i``.
+
+The buffers are registered by the concrete architecture and populated later,
+once the token-frequency map for the run is known -- an EAGLE3 draft is built in
+``build_model_bundle`` but its mapping is installed further down in
+``_ensure_offline_vocab_mapping``.  Anything derived from the mapping (a
+row-sliced target head, a target->draft label lookup) must therefore be built
+lazily and re-derived when a different mapping is installed, which is what
+``vocab_mapping_version`` exists for.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+#: Label value for target tokens outside the draft vocabulary. Matches
+#: ``F.cross_entropy``'s default ``ignore_index`` and can never equal a real
+#: draft id, so an out-of-vocabulary label is both unsupervised and counted as
+#: an accuracy miss -- which is exactly what serving does with it.
+OUT_OF_DRAFT_VOCAB_LABEL = -100
+
+
+def _reject_conflicting_vocab_mapping(
+    module, state_dict, prefix, *_load_hook_args
+) -> None:
+    """Refuse to silently replace an installed mapping with a different one.
+
+    This is the resume hazard: the run resolves a mapping (from
+    ``model.vocab_mapping_path``, or derived from the offline features), and then
+    ``load_state_dict`` overwrites it with whatever the checkpoint carried. With
+    the same ``draft_vocab_size`` nothing complains, yet every row of the pruned
+    head now means a different token than the run believes. It does not crash --
+    it just trains against a quietly wrong label space.
+
+    Recording a fingerprint in the resume contract would not catch this: the
+    contract is bound in ``build_model_bundle``, which runs *before*
+    ``_ensure_offline_vocab_mapping`` installs the derived mapping, so the
+    fingerprint would describe an empty one. Comparing at load time has no such
+    ordering dependency.
+    """
+    if not module.vocab_mapping_loaded:
+        return
+    incoming = state_dict.get(prefix + "t2d")
+    if incoming is None:
+        return
+    current = module.t2d
+    incoming = incoming.to(device=current.device, dtype=current.dtype)
+    if incoming.shape == current.shape and torch.equal(incoming, current):
+        return
+    raise ValueError(
+        "the checkpoint's vocabulary mapping differs from the one this run "
+        f"resolved ({int(current.sum())} kept tokens vs "
+        f"{int(incoming.sum())} in the checkpoint, differing selections); the "
+        "pruned lm_head rows would silently change meaning. Point "
+        "model.vocab_mapping_path at the mapping this checkpoint was trained "
+        "with, or start a fresh run."
+    )
+
+
+def _invalidate_vocab_mapping_derivations(module, _incompatible_keys) -> None:
+    """Bump the mapping version and drop everything derived from the buffers.
+
+    Registered as a ``load_state_dict`` post hook and called directly by
+    :meth:`DraftVocabMappingMixin.install_vocab_mapping`, so both routes into the
+    buffers converge on one invalidation point.
+    """
+    module.vocab_mapping_version = int(getattr(module, "vocab_mapping_version", 0)) + 1
+    module._draft_vocab_index = None
+
+
+class DraftVocabMappingMixin:
+    """``t2d``/``d2t`` ownership for drafts that prune the target vocabulary.
+
+    Concrete architectures register the buffers themselves (EAGLE3 always,
+    DFlash-family only under :meth:`register_draft_vocab_buffers`); this mixin
+    owns installation, validation, and the derived lookup table.
+    """
+
+    #: Bumped whenever the buffers change so lazy consumers can invalidate.
+    vocab_mapping_version: int = 0
+
+    @property
+    def vocab_mapping_loaded(self) -> bool:
+        """Whether a usable mapping is present, derived from the buffer itself.
+
+        Deliberately not a flag set by :meth:`install_vocab_mapping`: buffers
+        also arrive through ``load_state_dict`` and ``from_pretrained``, which
+        call no method of ours.  A flag would leave a correctly reloaded
+        checkpoint reporting "not installed" and refusing to run.  The empty
+        ``t2d`` that :meth:`register_draft_vocab_buffers` starts from is the
+        unambiguous "nothing installed yet" state, since a real mapping always
+        selects exactly ``draft_vocab_size`` tokens.
+        """
+        if not getattr(self, "use_draft_vocab", False):
+            return True
+        t2d = getattr(self, "t2d", None)
+        return t2d is not None and bool(t2d.any())
+
+    def register_draft_vocab_buffers(
+        self,
+        *,
+        vocab_size: int,
+        draft_vocab_size: Optional[int],
+    ) -> None:
+        """Record the vocabulary sizes and register buffers only when pruning.
+
+        Registering unconditionally would add ``t2d``/``d2t`` to the state dict
+        of every existing full-vocabulary checkpoint, and warm start treats any
+        missing key as fatal (``training/model_loading.py``).  Keeping the
+        buffers behind ``use_draft_vocab`` leaves those checkpoints loadable
+        byte-for-byte.
+        """
+        vocab_size = int(vocab_size)
+        # Only None means "unset". Coercing with ``or`` would turn an explicit 0
+        # into the full vocabulary and make the check below unreachable, while
+        # build_model_bundle kept reading the literal 0 out of the config -- the
+        # same setting meaning two different things in two places.
+        if draft_vocab_size is None:
+            draft_vocab_size = vocab_size
+        if isinstance(draft_vocab_size, bool) or not isinstance(draft_vocab_size, int):
+            raise ValueError(
+                "draft_vocab_size must be an integer or None, got "
+                f"{draft_vocab_size!r}"
+            )
+        if draft_vocab_size <= 0:
+            raise ValueError(f"draft_vocab_size must be > 0, got {draft_vocab_size}")
+        if draft_vocab_size > vocab_size:
+            raise ValueError(
+                "draft_vocab_size must not exceed vocab_size; got "
+                f"draft_vocab_size={draft_vocab_size}, vocab_size={vocab_size}"
+            )
+        self.vocab_size = vocab_size
+        self.draft_vocab_size = draft_vocab_size
+        self.use_draft_vocab = draft_vocab_size != vocab_size
+        if self.use_draft_vocab:
+            self.register_buffer("t2d", torch.zeros(vocab_size, dtype=torch.bool))
+            self.register_buffer("d2t", torch.zeros(draft_vocab_size, dtype=torch.long))
+            # load_state_dict writes the buffers behind our back, so anything
+            # derived from them (the row-sliced head, the label lookup) has to be
+            # invalidated here or a resumed run keeps using the previous slice.
+            self.register_load_state_dict_pre_hook(_reject_conflicting_vocab_mapping)
+            self.register_load_state_dict_post_hook(
+                _invalidate_vocab_mapping_derivations
+            )
+
+    def install_vocab_mapping(self, t2d: torch.Tensor, d2t: torch.Tensor) -> None:
+        """Validate one mapping and copy it into the buffers.
+
+        Every producer of a mapping funnels through here so the ascending-ids
+        invariant (``nonzero(t2d) == d2t + arange``) is checked exactly once,
+        rather than at each call site.
+        """
+        if not hasattr(self, "t2d") or not hasattr(self, "d2t"):
+            raise ValueError(
+                "t2d/d2t buffers are not present on this draft model; it was "
+                "built without vocabulary pruning"
+            )
+        from specforge.core.compact_teacher import validate_vocab_mapping_consistency
+
+        t2d = t2d.to(dtype=self.t2d.dtype)
+        d2t = d2t.to(dtype=self.d2t.dtype)
+        if t2d.shape != self.t2d.shape:
+            raise ValueError(
+                f"t2d has shape {list(t2d.shape)}, expected {list(self.t2d.shape)}"
+            )
+        if d2t.shape != self.d2t.shape:
+            raise ValueError(
+                f"d2t has shape {list(d2t.shape)}, expected {list(self.d2t.shape)}"
+            )
+        validate_vocab_mapping_consistency(t2d, d2t)
+        self.t2d.copy_(t2d)
+        self.d2t.copy_(d2t)
+        _invalidate_vocab_mapping_derivations(self, None)
+
+    def load_vocab_mapping(self, file_path: str) -> None:
+        """Load and install the ``{"t2d", "d2t"}`` tensor file at ``file_path``."""
+        mapping = torch.load(file_path, map_location="cpu")
+        missing = [key for key in ("t2d", "d2t") if key not in mapping]
+        if missing:
+            raise ValueError(f"{file_path} is missing vocab-mapping keys {missing}")
+        self.install_vocab_mapping(mapping["t2d"], mapping["d2t"])
+
+    def draft_vocab_index(self) -> torch.Tensor:
+        """Return ``long[vocab_size]``: draft id, or the ignore label if pruned.
+
+        Cached against :attr:`vocab_mapping_version` rather than registered as a
+        buffer -- it is fully derived from ``t2d`` and must not enter the
+        checkpoint.
+        """
+        if not getattr(self, "use_draft_vocab", False):
+            raise ValueError(
+                "draft_vocab_index() is only defined when the draft prunes the "
+                "target vocabulary"
+            )
+        self.require_vocab_mapping()
+        cached = getattr(self, "_draft_vocab_index", None)
+        version = int(self.vocab_mapping_version)
+        if (
+            cached is not None
+            and cached[0] == version
+            and cached[1].device == self.t2d.device
+        ):
+            return cached[1]
+        # Built on CPU and then moved: masked assignment is a one-time setup
+        # cost, and keeping it off the accelerator avoids relying on boolean
+        # index-put support on backends such as Ascend NPU.
+        mask = self.t2d.detach().to(device="cpu", dtype=torch.bool)
+        index = torch.full(
+            (int(mask.shape[0]),),
+            OUT_OF_DRAFT_VOCAB_LABEL,
+            dtype=torch.long,
+        )
+        index[mask] = torch.arange(int(mask.sum().item()), dtype=torch.long)
+        index = index.to(device=self.t2d.device)
+        self._draft_vocab_index = (version, index)
+        return index
+
+    def require_vocab_mapping(self) -> None:
+        """Fail loudly when a pruned draft is used before its map is installed.
+
+        The zero-initialized buffers are silently wrong rather than obviously
+        wrong: an all-False ``t2d`` slices an empty head and an all-zero ``d2t``
+        maps every draft id to 0.
+        """
+        if getattr(self, "use_draft_vocab", False) and not self.vocab_mapping_loaded:
+            raise RuntimeError(
+                "this draft prunes the target vocabulary "
+                f"({getattr(self, 'draft_vocab_size', '?')} of "
+                f"{getattr(self, 'vocab_size', '?')} tokens) but no t2d/d2t "
+                "mapping has been installed; set model.vocab_mapping_path or "
+                "run a topology that derives one"
+            )
+
+
+__all__ = ["DraftVocabMappingMixin", "OUT_OF_DRAFT_VOCAB_LABEL"]

--- a/specforge/training/assembly.py
+++ b/specforge/training/assembly.py
@@ -453,9 +453,7 @@ def _install_dataset_vocab_mapping(
     # Every rank derives the same mapping and installs it directly, so training
     # does not depend on a shared cache filesystem. Rank 0 alone persists the
     # reusable cache file, avoiding concurrent torch.save writes.
-    bundle.draft_model.d2t.copy_(d2t)
-    bundle.draft_model.t2d.copy_(t2d)
-    bundle.draft_model.vocab_mapping_loaded = True
+    bundle.draft_model.install_vocab_mapping(t2d, d2t)
     distributed = (
         torch.distributed.is_available() and torch.distributed.is_initialized()
     )

--- a/tests/test_algorithms/test_builtin_providers.py
+++ b/tests/test_algorithms/test_builtin_providers.py
@@ -172,11 +172,12 @@ class BuiltinProviderContractTest(unittest.TestCase):
         )
         config = SimpleNamespace(training=training)
         draft = SimpleNamespace(
-            config=SimpleNamespace(num_hidden_layers=2),
+            config=SimpleNamespace(num_hidden_layers=2, vocab_size=128),
             layers=[object(), object()],
             norm_before_residual=True,
             target_layer_ids=[3, 7],
             pure_draft_prefix_len=2,
+            draft_vocab_size=32,
         )
         dflash_family = SimpleNamespace(
             block_size=16,

--- a/tests/test_config/test_launch_topology.py
+++ b/tests/test_config/test_launch_topology.py
@@ -54,6 +54,7 @@ EXPECTED_NPROC_PER_NODE = {
     "qwen3-8b-domino-online.yaml": 8,
     "qwen3-8b-dpace-online.yaml": 8,
     "qwen3-8b-dspark-disaggregated.yaml": 1,
+    "qwen3-8b-dspark-draftvocab32k-offline.yaml": 1,
     "qwen3-8b-eagle3-offline-disaggregated.yaml": 1,
     "qwen3-8b-eagle3-offline.yaml": 1,
     "qwen3-8b-eagle3-disaggregated.yaml": 1,
@@ -347,7 +348,7 @@ def _recipes() -> dict[str, Path]:
 class ExampleLaunchTopologyTest(unittest.TestCase):
     def test_every_recipe_has_the_explicit_golden_topology(self):
         recipes = _recipes()
-        self.assertEqual(len(EXPECTED_NPROC_PER_NODE), 65)
+        self.assertEqual(len(EXPECTED_NPROC_PER_NODE), 66)
         self.assertEqual(set(recipes), set(EXPECTED_NPROC_PER_NODE))
 
         for filename, nproc_per_node in EXPECTED_NPROC_PER_NODE.items():

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -34,8 +34,21 @@ ONLINE_DEPLOYMENT = {
 }
 
 
+#: Algorithms that accept model.vocab_mapping_path. Others now reject it rather
+#: than ignoring it, so payloads derived from MINIMAL must drop the key.
+VOCAB_MAPPING_STRATEGIES = {"eagle3", "peagle", "dspark"}
+
+
+def _payload(strategy: str | None = None, base: dict | None = None) -> dict:
+    """Copy MINIMAL, dropping the mapping path when the strategy cannot use it."""
+    payload = copy.deepcopy(base if base is not None else MINIMAL)
+    if strategy is not None and strategy not in VOCAB_MAPPING_STRATEGIES:
+        payload["model"].pop("vocab_mapping_path", None)
+    return payload
+
+
 def _online_payload(strategy: str = "eagle3") -> dict:
-    payload = copy.deepcopy(MINIMAL)
+    payload = _payload(strategy)
     payload["model"]["target_backend"] = "sglang"
     payload["data"] = {"train_data_path": "/train.jsonl"}
     payload["training"] = {"strategy": strategy, "max_steps": 1}
@@ -361,7 +374,7 @@ class ConfigSchemaTest(unittest.TestCase):
                 }
             )
         offline_dflash = Config.model_validate(
-            {**MINIMAL, "training": {"strategy": "dflash"}}
+            {**_payload("dflash"), "training": {"strategy": "dflash"}}
         )
         resolve_run(offline_dflash)
         self.assertEqual(offline_dflash.mode, "offline")

--- a/tests/test_config/test_unified_feature_reachability.py
+++ b/tests/test_config/test_unified_feature_reachability.py
@@ -146,7 +146,7 @@ class UnifiedFeatureReachabilityTest(unittest.TestCase):
             for path in EXAMPLE_CONFIG_DIR.glob("*.yaml")
             if not path.name.startswith(".")
         )
-        self.assertEqual(len(paths), 65)
+        self.assertEqual(len(paths), 66)
 
         resolved_runs = {
             path.name: resolve_run(Config.from_file(str(path))) for path in paths
@@ -223,10 +223,17 @@ class UnifiedFeatureReachabilityTest(unittest.TestCase):
 
     def test_loader_and_profiler_options_reach_the_canonical_trainer(self):
         eagle = resolve_run(Config.model_validate(OFFLINE_EAGLE3))
+        # DFlash declares no vocab-mapping capability, so it must not carry the
+        # EAGLE3 fixture's mapping path.
         dflash = resolve_run(
             Config.model_validate(
                 {
                     **OFFLINE_EAGLE3,
+                    "model": {
+                        key: value
+                        for key, value in OFFLINE_EAGLE3["model"].items()
+                        if key != "vocab_mapping_path"
+                    },
                     "training": {"strategy": "dflash"},
                 }
             )

--- a/tests/test_runtime/test_offline_vocab_mapping.py
+++ b/tests/test_runtime/test_offline_vocab_mapping.py
@@ -11,6 +11,7 @@ import torch
 
 from specforge.algorithms.builtin import builtin_algorithm_registry
 from specforge.config import Config
+from specforge.modeling.draft.vocab_mixin import DraftVocabMappingMixin
 from specforge.training.assembly import (
     _ensure_offline_vocab_mapping,
     _install_dataset_vocab_mapping,
@@ -21,18 +22,19 @@ from specforge.training.vocab_mapping import count_effective_feature_tokens
 ALGORITHM = builtin_algorithm_registry().resolve("eagle3")
 
 
-class _DraftWithMapping(torch.nn.Module):
+class _DraftWithMapping(DraftVocabMappingMixin, torch.nn.Module):
+    """Minimal draft standing in for the buffers/installation contract.
+
+    Uses the production mixin rather than re-implementing loading, so the
+    assembly path under test exercises the real installation and validation.
+    """
+
     def __init__(self, target_vocab_size=8, draft_vocab_size=4):
         super().__init__()
-        self.register_buffer("t2d", torch.zeros(target_vocab_size, dtype=torch.bool))
-        self.register_buffer("d2t", torch.zeros(draft_vocab_size, dtype=torch.long))
-        self.vocab_mapping_loaded = False
-
-    def load_vocab_mapping(self, path):
-        mapping = torch.load(path, weights_only=True)
-        self.t2d.copy_(mapping["t2d"])
-        self.d2t.copy_(mapping["d2t"])
-        self.vocab_mapping_loaded = True
+        self.register_draft_vocab_buffers(
+            vocab_size=target_vocab_size,
+            draft_vocab_size=draft_vocab_size,
+        )
 
 
 class OfflineVocabMappingTest(unittest.TestCase):

--- a/tests/test_runtime/test_package_architecture.py
+++ b/tests/test_runtime/test_package_architecture.py
@@ -716,6 +716,7 @@ class TestPackageArchitecture(unittest.TestCase):
                 "kimi-k3-dspark.json",
                 "qwen3-4b-dspark.json",
                 "qwen3-8b-dspark.json",
+                "qwen3-8b-dspark-draftvocab32k.json",
                 "qwen3.6-27b-dspark.json",
             },
         )

--- a/tests/test_utils/test_dspark_vocab_mapping.py
+++ b/tests/test_utils/test_dspark_vocab_mapping.py
@@ -1,0 +1,764 @@
+# coding=utf-8
+"""DSpark draft-vocabulary pruning: buffers, objective, and run validation.
+
+These run the real DSpark draft and online model on CPU with a tiny random
+configuration, because the parts most likely to break silently -- which factor
+of the Markov head follows which vocabulary, which id space the labels live in
+-- are invisible to shape-only checks.
+"""
+
+import unittest
+from collections import Counter
+from unittest import mock
+
+import torch
+from torch import nn
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Config
+
+from specforge.algorithms.builtin import builtin_algorithm_registry
+from specforge.algorithms.common.dflash_family_model import OnlineDSparkModel
+from specforge.algorithms.contracts import FeatureMode
+from specforge.application.planning import _prunes_vocabulary, _validate_vocab_mapping
+from specforge.config import Config
+from specforge.data.preprocessing import process_token_dict_to_mappings
+from specforge.modeling.draft.dspark import DSparkDraftModel
+from specforge.modeling.draft.vocab_mixin import OUT_OF_DRAFT_VOCAB_LABEL
+
+VOCAB_SIZE = 256
+DRAFT_VOCAB_SIZE = 64
+HIDDEN = 32
+BLOCK = 4
+SEQ = 64
+MARKOV_RANK = 8
+
+
+def _draft_config(draft_vocab_size):
+    config = Qwen3Config(
+        vocab_size=VOCAB_SIZE,
+        hidden_size=HIDDEN,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=128,
+    )
+    config.num_target_layers = 4
+    config.block_size = BLOCK
+    config.draft_vocab_size = draft_vocab_size
+    config.layer_types = ["full_attention"] * 2
+    config.dflash_config = {
+        "projector_type": "dspark",
+        "markov_rank": MARKOV_RANK,
+        "markov_head_type": "vanilla",
+        "target_layer_ids": [0, 1],
+        "mask_token_id": 3,
+        "enable_confidence_head": True,
+        "confidence_head_with_markov": True,
+    }
+    config._attn_implementation = "eager"
+    return config
+
+
+def _build(draft_vocab_size, seed=0):
+    torch.manual_seed(seed)
+    draft = DSparkDraftModel(_draft_config(draft_vocab_size))
+    lm_head = nn.Linear(HIDDEN, VOCAB_SIZE, bias=False)
+    torch.manual_seed(seed + 100)
+    nn.init.normal_(lm_head.weight, std=0.02)
+    lm_head.requires_grad_(False)
+    model = OnlineDSparkModel(
+        draft_model=draft,
+        target_lm_head=lm_head,
+        target_embed_tokens=nn.Embedding(VOCAB_SIZE, HIDDEN),
+        mask_token_id=3,
+        block_size=BLOCK,
+        attention_backend="eager",
+        num_anchors=8,
+        objective_chunk_blocks=4,
+    )
+    return draft, model
+
+
+def _inputs(seed=5):
+    torch.manual_seed(seed)
+    return {
+        "input_ids": torch.randint(0, VOCAB_SIZE, (1, SEQ)),
+        "hidden_states": torch.randn(1, SEQ, 2 * HIDDEN),
+        "loss_mask": torch.ones(1, SEQ),
+        "target_last_hidden_states": torch.randn(1, SEQ, HIDDEN),
+    }
+
+
+def _mapping(draft_vocab_size=DRAFT_VOCAB_SIZE):
+    """Frequencies whose top-K is scattered, so d2t is a non-trivial offset table.
+
+    A contiguous selection would make d2t all zeros and hide any ordering bug.
+    """
+    counts = Counter(
+        {
+            token: (VOCAB_SIZE - token if token % 2 == 0 else 1)
+            for token in range(VOCAB_SIZE)
+        }
+    )
+    d2t, t2d = process_token_dict_to_mappings(counts, draft_vocab_size, VOCAB_SIZE)
+    return t2d, d2t
+
+
+#: Names for ``_dspark_objective_chunk_terms``'s positional return, so the
+#: reference below can be compared by meaning instead of by index.
+_TERM_NAMES = (
+    "ce_num",
+    "l1_num",
+    "confidence_num",
+    "confidence_error_num",
+    "correct_num",
+    "eval_den",
+    "ce_eval_den",
+    "ce_position_num",
+    "ce_position_den",
+    "correct_position_num",
+    "position_den",
+    "teacher_agreement_num",
+    "teacher_top1_num",
+    "draft_top1_num",
+    "tau_num",
+    "tau_den",
+    "kept_mass_num",
+)
+
+
+def _chunk_term_args(model, blocks=4, seed=11):
+    """Build one chunk's worth of objective inputs, shaped as the forward does."""
+    torch.manual_seed(seed)
+    hidden = torch.randn(1, blocks, BLOCK, HIDDEN)
+    prev_token_ids = torch.randint(0, VOCAB_SIZE, (1, blocks, BLOCK))
+    target_ids = torch.randint(0, VOCAB_SIZE, (1, blocks, BLOCK))
+    # eval_mask is a per-block prefix mask in the real forward (cumprod), so
+    # reproduce that shape of truth rather than an arbitrary boolean field.
+    keep = torch.tensor([[[1, 1, 1, 1], [1, 1, 1, 0], [1, 1, 0, 0], [1, 0, 0, 0]]])
+    eval_mask = keep[:, :blocks].bool()
+    loss_weights = eval_mask.to(torch.float32)
+    aligned_target_hidden = torch.randn(1, blocks, BLOCK, HIDDEN)
+    return (
+        hidden,
+        prev_token_ids,
+        target_ids,
+        loss_weights,
+        eval_mask,
+        aligned_target_hidden,
+    )
+
+
+def _reference_dspark_chunk_terms(
+    model,
+    hidden,
+    prev_token_ids,
+    target_ids,
+    loss_weights,
+    eval_mask,
+    aligned_target_hidden,
+):
+    """The DSpark objective exactly as it stood at 7712377, before pruning.
+
+    Transcribed rather than imported on purpose: a reference that is generated
+    from the implementation cannot detect a change in the implementation. Keep
+    this function frozen -- if a deliberate change to the unpruned objective is
+    ever made, the right move is to update it in the same commit and say so,
+    not to relax the comparison.
+    """
+    batch_size, num_blocks, block_size, hidden_size = hidden.shape
+    base_logits = model.lm_head(
+        hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
+    ).reshape(batch_size, num_blocks, block_size, -1)
+    draft_logits = model.draft_model.apply_logits_head(
+        base_logits,
+        prev_token_ids=prev_token_ids,
+        hidden_states=hidden,
+    )
+    vocab_size = draft_logits.shape[-1]
+    cross_entropy = torch.nn.functional.cross_entropy(
+        draft_logits.reshape(-1, vocab_size),
+        target_ids.reshape(-1),
+        reduction="none",
+    ).reshape_as(target_ids)
+    terms = {"ce_num": (cross_entropy * loss_weights).sum()}
+
+    with torch.no_grad():
+        target_logits = model.lm_head(
+            aligned_target_hidden.reshape(
+                batch_size, num_blocks * block_size, hidden_size
+            )
+        ).reshape_as(draft_logits)
+        target_probabilities = torch.softmax(target_logits.float(), dim=-1)
+        teacher_ids = target_logits.argmax(dim=-1)
+    draft_probabilities = torch.softmax(draft_logits.float(), dim=-1)
+    l1_per_token = (draft_probabilities - target_probabilities).abs().sum(dim=-1)
+    accept_probability = (1.0 - 0.5 * l1_per_token).clamp(0.0, 1.0)
+    terms["l1_num"] = (l1_per_token * loss_weights).sum()
+
+    confidence_pred = model.draft_model.predict_confidence(
+        hidden, prev_token_ids=prev_token_ids
+    )
+    confidence_per_token = torch.nn.functional.binary_cross_entropy_with_logits(
+        confidence_pred.float(),
+        accept_probability.detach(),
+        reduction="none",
+    )
+    terms["confidence_num"] = (confidence_per_token * loss_weights).sum()
+    terms["confidence_error_num"] = (
+        (confidence_pred.float().sigmoid() - accept_probability).abs() * loss_weights
+    ).sum()
+
+    with torch.no_grad():
+        predicted_ids = draft_logits.argmax(dim=-1)
+        correct = ((predicted_ids == target_ids) & eval_mask).float()
+        terms["correct_num"] = correct.sum()
+        terms["eval_den"] = eval_mask.float().sum()
+        terms["ce_position_num"] = (cross_entropy.detach() * eval_mask).sum(dim=(0, 1))
+        terms["correct_position_num"] = correct.sum(dim=(0, 1))
+        terms["position_den"] = eval_mask.float().sum(dim=(0, 1))
+        terms["teacher_agreement_num"] = (
+            (predicted_ids == teacher_ids).float() * eval_mask
+        ).sum()
+        terms["teacher_top1_num"] = (
+            target_probabilities.max(dim=-1).values * eval_mask
+        ).sum()
+        terms["draft_top1_num"] = (
+            draft_probabilities.max(dim=-1).values * eval_mask
+        ).sum()
+        valid_blocks = eval_mask.any(dim=-1).float()
+        accepted_expectation = (accept_probability.detach() * eval_mask).cumprod(
+            dim=-1
+        ).sum(dim=-1) + 1.0
+        terms["tau_num"] = (accepted_expectation * valid_blocks).sum()
+        terms["tau_den"] = valid_blocks.sum()
+    return terms
+
+
+class DSparkDraftVocabTest(unittest.TestCase):
+    def test_full_vocab_draft_keeps_an_unchanged_state_dict(self):
+        """Existing checkpoints must stay loadable: no new keys when unpruned."""
+        full, _ = _build(VOCAB_SIZE)
+        pruned, _ = _build(DRAFT_VOCAB_SIZE)
+
+        self.assertFalse(full.use_draft_vocab)
+        self.assertNotIn("t2d", full.state_dict())
+        self.assertNotIn("d2t", full.state_dict())
+
+        self.assertTrue(pruned.use_draft_vocab)
+        self.assertIn("t2d", pruned.state_dict())
+        self.assertIn("d2t", pruned.state_dict())
+
+    def test_markov_head_conditions_on_full_vocab_and_emits_draft_vocab(self):
+        """W1 reads the previous real token; only W2 follows the pruned vocab."""
+        pruned, _ = _build(DRAFT_VOCAB_SIZE)
+        head = pruned.markov_head
+
+        self.assertEqual(tuple(head.markov_w1.weight.shape), (VOCAB_SIZE, MARKOV_RANK))
+        self.assertEqual(
+            tuple(head.markov_w2.weight.shape), (DRAFT_VOCAB_SIZE, MARKOV_RANK)
+        )
+
+    def test_forward_before_the_mapping_is_installed_raises(self):
+        """Zeroed buffers are silently wrong, so using them must be impossible."""
+        _pruned, model = _build(DRAFT_VOCAB_SIZE)
+        with self.assertRaisesRegex(RuntimeError, "no t2d/d2t"):
+            model(**_inputs())
+
+    def test_full_vocab_objective_matches_the_pre_pruning_formula(self):
+        """Pin the unpruned objective against the formula it had before pruning.
+
+        Comparing two runs of the *current* implementation would only prove
+        determinism -- a regression that moved both sides equally would still
+        pass. ``_reference_dspark_chunk_terms`` is a transcription of the
+        objective at 7712377, so it cannot drift along with the code under test.
+        """
+        _draft, model = _build(VOCAB_SIZE, seed=1)
+        args = _chunk_term_args(model)
+
+        expected = _reference_dspark_chunk_terms(model, *args)
+        # The current signature splits CE weights out of the shared weights; for
+        # a full-vocabulary run the two are the same tensor by construction.
+        hidden, prev_token_ids, target_ids, loss_weights, eval_mask, teacher = args
+        actual = dict(
+            zip(
+                _TERM_NAMES,
+                model._dspark_objective_chunk_terms(
+                    hidden,
+                    prev_token_ids,
+                    target_ids,
+                    loss_weights,
+                    loss_weights,
+                    eval_mask,
+                    teacher,
+                ),
+            )
+        )
+
+        self.assertEqual(len(actual), len(_TERM_NAMES))
+        self.assertTrue(set(expected) <= set(actual))
+        for name, want in expected.items():
+            with self.subTest(term=name):
+                # Bit-exact: the claim is that the unpruned path is the same
+                # arithmetic, not merely a close approximation of it.
+                self.assertTrue(
+                    torch.equal(actual[name], want),
+                    f"{name}: {actual[name]} != {want}",
+                )
+
+    def test_full_vocab_loss_keeps_the_single_denominator_form(self):
+        """Pin the final scalar too, not just the terms it is built from.
+
+        Pruning gives cross-entropy its own denominator. Unpruned the two
+        denominators are equal, so the split form is algebraically the same --
+        but ``x/D + y/D`` and ``(x + y)/D`` do not round the same way once a
+        decayed ``loss_weights`` makes ``D`` inexact, which is precisely the
+        configuration this checks. Existing runs must not see their loss move.
+        """
+        for gamma in (None, 3.0):
+            with self.subTest(loss_decay_gamma=gamma):
+                _draft, model = _build(VOCAB_SIZE, seed=1)
+                model.loss_decay_gamma = gamma
+                torch.manual_seed(42)
+                loss, _accuracy, _metrics = model(**_inputs())
+
+                # The metrics carry the very tensors the loss was built from, so
+                # the pre-pruning expression can be rebuilt exactly.
+                ratios = _metrics["ratio_metrics"]
+                ce_num, _ce_den = ratios["ce_loss"]
+                l1_num, loss_den = ratios["l1_loss"]
+                confidence_num, _ = ratios["confidence_loss"]
+                world_size = 1  # no process group is initialized under test
+                expected = (
+                    world_size
+                    * (
+                        model.dspark_ce_loss_alpha * ce_num
+                        + model.dspark_l1_loss_alpha * l1_num
+                        + model.dspark_confidence_head_alpha * confidence_num
+                    )
+                    / loss_den
+                )
+                self.assertTrue(torch.equal(loss, expected), f"{loss} != {expected}")
+
+    def test_full_vocab_run_emits_one_denominator_all_reduce(self):
+        """Pin the collective sequence: single-process runs cannot observe it.
+
+        Ranks must agree on the count and order of collectives. Pruning gives
+        cross-entropy its own denominator and therefore a second all_reduce; an
+        unpruned run must keep emitting exactly the one it always did, or a
+        multi-GPU resume onto this branch would desynchronize.
+        """
+        for draft_vocab_size, expected in ((VOCAB_SIZE, 1), (DRAFT_VOCAB_SIZE, 2)):
+            with self.subTest(draft_vocab_size=draft_vocab_size):
+                draft, model = _build(draft_vocab_size)
+                if draft_vocab_size != VOCAB_SIZE:
+                    draft.install_vocab_mapping(*_mapping())
+                calls = []
+                with mock.patch.multiple(
+                    "torch.distributed",
+                    is_available=lambda: True,
+                    is_initialized=lambda: True,
+                    get_world_size=lambda: 4,
+                    all_reduce=lambda tensor, **kw: calls.append(tensor),
+                ):
+                    model(**_inputs())
+                self.assertEqual(len(calls), expected)
+
+    def test_full_vocab_coverage_terms_are_degenerate(self):
+        """The two terms pruning added must be no-ops without pruning."""
+        _draft, model = _build(VOCAB_SIZE, seed=1)
+        hidden, prev_token_ids, target_ids, loss_weights, eval_mask, teacher = (
+            _chunk_term_args(model)
+        )
+
+        terms = model._dspark_objective_chunk_terms(
+            hidden,
+            prev_token_ids,
+            target_ids,
+            loss_weights,
+            loss_weights,
+            eval_mask,
+            teacher,
+        )
+        named = dict(zip(_TERM_NAMES, terms))
+        ce_eval_den = named["ce_eval_den"]
+        ce_position_den = named["ce_position_den"]
+
+        # Every label is in vocabulary, so the CE evaluation set is the full one.
+        self.assertTrue(torch.equal(ce_eval_den, eval_mask.float().sum()))
+        self.assertTrue(torch.equal(ce_position_den, eval_mask.float().sum(dim=(0, 1))))
+
+    def test_pruned_objective_trains_and_reports_coverage(self):
+        pruned, model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+
+        loss, _accuracy, metrics = model(**_inputs())
+        loss.backward()
+
+        ratios = metrics["ratio_metrics"]
+        self.assertIn("draft_vocab_coverage", ratios)
+        numerator, denominator = ratios["draft_vocab_coverage"]
+        coverage = float(numerator) / float(denominator)
+        self.assertGreater(coverage, 0.0)
+        self.assertLessEqual(coverage, 1.0)
+
+        # The pruned factor must actually receive gradient.
+        self.assertIsNotNone(pruned.markov_head.markov_w2.weight.grad)
+        self.assertGreater(float(pruned.markov_head.markov_w2.weight.grad.norm()), 0.0)
+
+    def test_cross_entropy_denominator_excludes_pruned_labels(self):
+        """ce_loss is a mean over in-vocabulary positions, not over all of them."""
+        pruned, model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+
+        _loss, _accuracy, metrics = model(**_inputs())
+        ratios = metrics["ratio_metrics"]
+        ce_denominator = float(ratios["ce_loss"][1])
+        l1_denominator = float(ratios["l1_loss"][1])
+        coverage_numerator = float(ratios["draft_vocab_coverage"][0])
+
+        self.assertLess(ce_denominator, l1_denominator)
+        self.assertAlmostEqual(ce_denominator, coverage_numerator, places=4)
+
+    def test_label_lookup_maps_kept_tokens_and_flags_pruned_ones(self):
+        pruned, _model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+
+        index = pruned.draft_vocab_index()
+        kept = torch.nonzero(t2d.bool()).flatten()
+
+        self.assertTrue(
+            torch.equal(index[kept], torch.arange(DRAFT_VOCAB_SIZE, dtype=torch.long))
+        )
+        dropped = torch.nonzero(~t2d.bool()).flatten()
+        if dropped.numel():
+            self.assertTrue(bool((index[dropped] == OUT_OF_DRAFT_VOCAB_LABEL).all()))
+
+    def test_draft_ids_round_trip_to_the_target_vocabulary(self):
+        """Generation feeds sampled ids back into W1, so they must be target ids."""
+        pruned, _model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+
+        target_ids = pruned.draft_ids_to_target_ids(torch.arange(DRAFT_VOCAB_SIZE))
+        self.assertTrue(torch.equal(target_ids, torch.nonzero(t2d.bool()).flatten()))
+        self.assertLess(int(target_ids.max()), VOCAB_SIZE)
+
+    def test_install_rejects_an_inconsistent_mapping(self):
+        pruned, _model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        with self.assertRaises(ValueError):
+            pruned.install_vocab_mapping(t2d, d2t.flip(0))
+
+    def test_reinstalling_a_mapping_invalidates_the_cached_head(self):
+        pruned, model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+        first = model._pruned_head_state()[0].clone()
+
+        other_counts = Counter({token: token + 1 for token in range(VOCAB_SIZE)})
+        other_d2t, other_t2d = process_token_dict_to_mappings(
+            other_counts, DRAFT_VOCAB_SIZE, VOCAB_SIZE
+        )
+        pruned.install_vocab_mapping(other_t2d, other_d2t)
+        second = model._pruned_head_state()[0]
+
+        self.assertFalse(torch.equal(first, second))
+
+    def test_mapping_survives_a_state_dict_round_trip(self):
+        """A reloaded pruned checkpoint must be runnable, not just byte-correct.
+
+        t2d/d2t travel in the state dict, but load_state_dict calls none of our
+        methods; if "is a mapping installed" were tracked as a flag, a correctly
+        saved checkpoint would reload and then refuse to run.
+        """
+        source, _model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        source.install_vocab_mapping(t2d, d2t)
+
+        target, target_model = _build(DRAFT_VOCAB_SIZE, seed=7)
+        self.assertFalse(target.vocab_mapping_loaded)
+        target.load_state_dict(source.state_dict())
+
+        self.assertTrue(target.vocab_mapping_loaded)
+        self.assertTrue(torch.equal(target.t2d, source.t2d))
+        self.assertTrue(torch.equal(target.d2t, source.d2t))
+        self.assertTrue(
+            torch.equal(target.draft_vocab_index(), source.draft_vocab_index())
+        )
+        target_model(**_inputs())
+
+    def test_full_vocab_logsumexp_matches_the_dense_computation(self):
+        """The chunked normalizer must equal the one-shot one, exactly enough.
+
+        It is walked in vocabulary chunks to avoid materializing [.., V]; that
+        partitioning is the only thing that could make it wrong.
+        """
+        _draft, model = _build(DRAFT_VOCAB_SIZE)
+        hidden = torch.randn(1, 12, HIDDEN)
+
+        chunked = model._full_vocab_logsumexp(hidden)
+        dense = torch.logsumexp(model.lm_head(hidden).float(), dim=-1)
+
+        self.assertEqual(chunked.shape, dense.shape)
+        self.assertTrue(torch.allclose(chunked, dense, atol=1e-6, rtol=1e-6))
+
+    def test_full_vocab_logsumexp_is_chunk_boundary_independent(self):
+        """Chunking is an implementation detail and must not change the value."""
+        import specforge.algorithms.common.dflash_family_model as module
+
+        _draft, model = _build(DRAFT_VOCAB_SIZE)
+        hidden = torch.randn(1, 8, HIDDEN)
+        original = module._TEACHER_NORMALIZER_VOCAB_CHUNK
+        values = []
+        try:
+            for chunk in (7, 64, VOCAB_SIZE, VOCAB_SIZE * 2):
+                module._TEACHER_NORMALIZER_VOCAB_CHUNK = chunk
+                values.append(model._full_vocab_logsumexp(hidden))
+        finally:
+            module._TEACHER_NORMALIZER_VOCAB_CHUNK = original
+
+        for value in values[1:]:
+            self.assertTrue(torch.allclose(values[0], value, atol=1e-6, rtol=1e-6))
+
+    def test_acceptance_uses_true_target_mass_not_the_conditional(self):
+        """The review's counterexample, made analytic.
+
+        Build a teacher that puts all its mass uniformly on four tokens, two of
+        which the draft vocabulary keeps. The reachable mass is then 1/2, and
+        acceptance can never exceed that. Renormalizing over the kept tokens --
+        what the pruned path used to do -- would report a teacher summing to 1
+        and an acceptance ceiling of 1, hiding exactly the cost of pruning.
+        """
+        pruned, model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        pruned.install_vocab_mapping(t2d, d2t)
+
+        kept = torch.nonzero(t2d, as_tuple=False).flatten().tolist()
+        dropped = [t for t in range(VOCAB_SIZE) if t not in set(kept)]
+        favoured = [kept[0], kept[1], dropped[0], dropped[1]]
+
+        # logit_v = weight[v, 0] once the teacher state is the first basis
+        # vector, so the target distribution is set directly.
+        with torch.no_grad():
+            model.lm_head.weight.fill_(0.0)
+            model.lm_head.weight[:, 0] = -50.0
+            for token in favoured:
+                model.lm_head.weight[token, 0] = 0.0
+
+        batch = _inputs()
+        teacher_state = torch.zeros(1, SEQ, HIDDEN)
+        teacher_state[:, :, 0] = 1.0
+        batch["target_last_hidden_states"] = teacher_state
+
+        _loss, _accuracy, metrics = model(**batch)
+        ratios = metrics["ratio_metrics"]
+
+        kept_mass_num, eval_den = ratios["teacher_kept_mass"]
+        kept_mass = float(kept_mass_num) / float(eval_den)
+        self.assertAlmostEqual(kept_mass, 0.5, places=3)
+
+        # kept_mass bounds each SINGLE-STEP acceptance probability, not tau.
+        # tau = 1 + sum_j prod_{k<=j} a_k, so the bound below is the loose one
+        # that follows from prod_{k<=j} a_k <= a_j <= kept_mass: an anchor token
+        # plus at most one kept_mass per suffix position.
+        tau_num, tau_den = ratios["tau_probabilistic"]
+        tau = float(tau_num) / float(tau_den)
+        self.assertLessEqual(tau, 1.0 + BLOCK * kept_mass + 1e-4)
+
+    def test_full_vocab_run_reports_no_kept_mass(self):
+        """Without pruning there is nothing to lose, so the metric is absent."""
+        _draft, model = _build(VOCAB_SIZE)
+        _loss, _accuracy, metrics = model(**_inputs())
+        self.assertNotIn("teacher_kept_mass", metrics["ratio_metrics"])
+
+    def test_loading_a_conflicting_mapping_is_rejected(self):
+        """The resume hazard: same K, different tokens, no error, wrong labels.
+
+        Nothing about the shapes disagrees, so without this check the run keeps
+        training with lm_head rows that mean different tokens than it believes.
+        """
+        resolved, _model = _build(DRAFT_VOCAB_SIZE)
+        t2d, d2t = _mapping()
+        resolved.install_vocab_mapping(t2d, d2t)
+
+        other = Counter({token: token + 1 for token in range(VOCAB_SIZE)})
+        other_d2t, other_t2d = process_token_dict_to_mappings(
+            other, DRAFT_VOCAB_SIZE, VOCAB_SIZE
+        )
+        donor, _ = _build(DRAFT_VOCAB_SIZE, seed=7)
+        donor.install_vocab_mapping(other_t2d, other_d2t)
+        self.assertEqual(int(donor.t2d.sum()), int(resolved.t2d.sum()))
+
+        with self.assertRaisesRegex(ValueError, "differs from the one this run"):
+            resolved.load_state_dict(donor.state_dict())
+
+    def test_loading_an_identical_mapping_is_allowed(self):
+        """A matching mapping is the normal resume; it must not be an error."""
+        resolved, _model = _build(DRAFT_VOCAB_SIZE)
+        donor, _ = _build(DRAFT_VOCAB_SIZE, seed=7)
+        t2d, d2t = _mapping()
+        resolved.install_vocab_mapping(t2d, d2t)
+        donor.install_vocab_mapping(t2d, d2t)
+
+        resolved.load_state_dict(donor.state_dict())
+        self.assertTrue(torch.equal(resolved.t2d, t2d))
+
+    def test_draft_vocab_size_rejects_degenerate_values(self):
+        """0 must not be coerced to "full vocabulary" behind the user's back."""
+        for bad in (0, -1, True, 2.5, VOCAB_SIZE + 1):
+            with self.subTest(draft_vocab_size=bad):
+                with self.assertRaises(ValueError):
+                    DSparkDraftModel(_draft_config(bad))
+
+        # None remains the only spelling of "unset".
+        unset = DSparkDraftModel(_draft_config(None))
+        self.assertEqual(unset.draft_vocab_size, VOCAB_SIZE)
+        self.assertFalse(unset.use_draft_vocab)
+
+
+class DSparkResumeContractTest(unittest.TestCase):
+    """The resume contract must not grow a key unpruned runs cannot supply."""
+
+    STEP = builtin_algorithm_registry().resolve("dspark").providers.step
+
+    def _contract(self, draft_vocab_size):
+        draft, model = _build(draft_vocab_size)
+        return self.STEP.resume_contract(None, draft, model)
+
+    def test_full_vocab_contract_has_no_draft_vocab_size_key(self):
+        """Trainer treats a contract key a checkpoint lacks as fatal.
+
+        Every DSpark checkpoint written before pruning existed carries no
+        dspark_draft_vocab_size, so recording it unconditionally would make all
+        of them unresumable -- for a field that, unpruned, could only ever hold
+        vocab_size.
+        """
+        self.assertNotIn("dspark_draft_vocab_size", self._contract(VOCAB_SIZE))
+
+    def test_pruned_contract_records_the_draft_vocab_size(self):
+        contract = self._contract(DRAFT_VOCAB_SIZE)
+        self.assertEqual(contract["dspark_draft_vocab_size"], DRAFT_VOCAB_SIZE)
+
+    def test_pruning_adds_exactly_one_key(self):
+        """Nothing else about the contract may shift with the feature."""
+        full = self._contract(VOCAB_SIZE)
+        pruned = self._contract(DRAFT_VOCAB_SIZE)
+        self.assertEqual(set(pruned) - set(full), {"dspark_draft_vocab_size"})
+        self.assertEqual(set(full) - set(pruned), set())
+
+
+class DSparkVocabMappingPlanningTest(unittest.TestCase):
+    """Requiring an explicit mapping must key off pruning, not capability."""
+
+    ALGORITHM = builtin_algorithm_registry().resolve("dspark")
+
+    def _config(self, draft_config, **model_overrides):
+        model = {
+            "target_model_path": "target/model",
+            "draft_model_config": draft_config,
+            "target_backend": "sglang",
+        }
+        model.update(model_overrides)
+        return Config.model_validate(
+            {
+                "model": model,
+                "data": {"train_data_path": "train.jsonl"},
+                "training": {"strategy": "dspark", "max_steps": 1},
+                "deployment": {
+                    "mode": "disaggregated",
+                    "disaggregated": {
+                        "control_dir": "/control",
+                        "backend": "mooncake",
+                        "server_urls": ["http://capture.invalid:30000"],
+                    },
+                },
+            }
+        )
+
+    def test_full_vocab_disaggregated_run_needs_no_mapping_path(self):
+        cfg = self._config("configs/qwen3-8b-dspark.json")
+        self.assertFalse(_prunes_vocabulary(cfg, self.ALGORITHM))
+        _validate_vocab_mapping(cfg, self.ALGORITHM, FeatureMode.STREAMING)
+
+    def test_unreadable_draft_config_is_unknown_not_unpruned(self):
+        """An unreadable draft config answers "unknown", never "unpruned".
+
+        Config validation must keep working without the draft config on disk, so
+        this cannot resolve it. Each rule then decides what unknown means for
+        itself: DSpark carries t2d/d2t only when it prunes, so an unproven run
+        is not held to the shared-mapping requirement, and the real resolution
+        error is reported at the model-loading boundary. EAGLE3, which always
+        carries the buffers, keeps its unconditional requirement -- covered by
+        tests/test_config/test_schema.py.
+        """
+        cfg = self._config("missing-draft-config")
+        with mock.patch(
+            "specforge.training.model_loading.draft_config_dict",
+            side_effect=OSError("draft config is unavailable"),
+        ):
+            self.assertIsNone(_prunes_vocabulary(cfg, self.ALGORITHM))
+            self.assertFalse(
+                self.ALGORITHM.spec.capabilities.keeps_vocab_buffers_when_unpruned
+            )
+            _validate_vocab_mapping(cfg, self.ALGORITHM, FeatureMode.STREAMING)
+
+    def test_unreadable_draft_config_does_not_reject_a_mapping_path(self):
+        """Only a config proven unpruned may be told to drop its mapping path.
+
+        Rejecting on "unknown" would answer an unreadable draft config with a
+        confident, wrong instruction to delete a correct setting; the real
+        resolution error is reported at the model-loading boundary instead.
+        """
+        cfg = self._config(
+            "missing-draft-config",
+            vocab_mapping_path="mapping.pt",
+        )
+        with mock.patch(
+            "specforge.training.model_loading.draft_config_dict",
+            side_effect=OSError("draft config is unavailable"),
+        ):
+            _validate_vocab_mapping(cfg, self.ALGORITHM, FeatureMode.STREAMING)
+
+    def test_pruned_disaggregated_run_requires_a_mapping_path(self):
+        cfg = self._config("configs/qwen3-8b-dspark-draftvocab32k.json")
+        self.assertTrue(_prunes_vocabulary(cfg, self.ALGORITHM))
+        with self.assertRaisesRegex(ValueError, "vocab_mapping_path"):
+            _validate_vocab_mapping(cfg, self.ALGORITHM, FeatureMode.STREAMING)
+
+    def test_mapping_path_on_a_full_vocab_run_is_rejected(self):
+        """Capability is not use: a full-vocab run has nothing to map.
+
+        Without this the path is accepted here and then fails deep in model
+        construction with an error about missing t2d/d2t buffers, which points
+        at the model instead of at the config that is actually wrong.
+        """
+        cfg = self._config(
+            "configs/qwen3-8b-dspark.json", vocab_mapping_path="mapping.pt"
+        )
+        with self.assertRaisesRegex(ValueError, "no t2d/d2t buffers"):
+            _validate_vocab_mapping(cfg, self.ALGORITHM, FeatureMode.STREAMING)
+
+    def test_mapping_path_on_an_incapable_algorithm_is_rejected(self):
+        dflash = builtin_algorithm_registry().resolve("dflash")
+        cfg = Config.model_validate(
+            {
+                "model": {
+                    "target_model_path": "target/model",
+                    "draft_model_config": "configs/qwen3-8b-dflash.json",
+                    "vocab_mapping_path": "mapping.pt",
+                },
+                "data": {"hidden_states_path": "features"},
+                "training": {"strategy": "dflash"},
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "does not support vocabulary mapping"):
+            _validate_vocab_mapping(cfg, dflash, FeatureMode.OFFLINE)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

EAGLE3 can train a draft over a subset of the target vocabulary. The DFlash family cannot — its contract rejects `model.vocab_mapping_path` outright — even though the same argument applies more strongly there: on a 27B target, DSpark's Markov head over a full vocabulary is the dominant memory term, and most of that vocabulary never appears as a supervised target in a domain corpus.

This adds pruning to the DFlash family. Set `draft_vocab_size` below `vocab_size` in the draft config and the draft predicts over the pruned vocabulary; leave it out and nothing changes.

## What's in it

- **`DraftVocabMappingMixin`** now holds the `t2d`/`d2t` contract shared by EAGLE3 and the DFlash family: registration, installation, validation, and the `load_state_dict` path. Buffers are registered **only when the run actually prunes**, so a full-vocabulary checkpoint keeps its exact state dict, and installed state is derived from the persisted buffers rather than a flag — otherwise a reloaded pruned checkpoint reports itself as uninstalled.
- **Installing a different mapping of the same size is rejected.** Identical shapes with different contents silently repoint every draft id at another token; no shape check catches it.
- **Objective.** Target ids are mapped into the draft id space; out-of-vocabulary labels leave both the numerator *and* the denominator of the cross entropy, so `alpha_ce` keeps its meaning instead of scaling with how much of the batch the vocabulary happens to cover. Acceptance uses the target's true retained probability mass rather than a distribution renormalized over the kept tokens — the renormalized form reports acceptance well above what the pruned draft can deliver.
- **Two new ratio metrics** make the ceiling visible during training: `draft_vocab_coverage` (share of supervised tokens the vocabulary can propose) and `teacher_kept_mass` (teacher belief that survives pruning).
- **The unpruned path is unchanged, deliberately down to the arithmetic.** The single-denominator expression is kept so an existing run's loss curve does not move by a few ulps for a feature it does not use, and the second all-reduce is emitted only when the run prunes, so the collective sequence of existing runs is untouched.
- **`keeps_vocab_buffers_when_unpruned`** lets validation tell the two families apart. A draft that registers the buffers unconditionally can absorb a redundant mapping; one that registers them only when pruning cannot, so that config is rejected at planning time instead of failing later inside the model. When the draft config cannot be resolved at all, `_prunes_vocabulary` reports `None` and each rule falls back to what its algorithm needs by default — config validation keeps working without the draft config on disk.

## Testing

`tests/test_utils/test_dspark_vocab_mapping.py` runs the real DSpark draft and online model on CPU with a tiny random config, because what breaks silently here — which factor of the Markov head follows which vocabulary, which id space the labels live in — is invisible to shape-only checks. It covers `t2d`/`d2t` round trips, label id spaces, coverage, an analytic acceptance counterexample, checkpoint reload, mapping-conflict rejection, and byte-for-byte equality of the unpruned loss with the pre-change expression.

Full suite run on CPU (no CUDA available on the dev box): no test fails that does not already fail on `main` at the same commit.
