### PR TITLE
fix(patch): repair spec-capture-ascend-mount.patch hunk headers

### DIFF
--- a/docs/basic_usage/Ascend/ascend_npu.md
+++ b/docs/basic_usage/Ascend/ascend_npu.md
@@ -23,6 +23,42 @@ python -m pip install -e . --no-deps
 torch/sglang. If a later step reports a missing lightweight dependency, install
 just that package, also with `--no-deps`.
 
+### Install Mooncake (Ascend)
+
+Online runs move features through Mooncake; the launcher checks for the
+`mooncake_master` binary and the `mooncake` Python package at startup. The
+fastest path is the official NPU wheel:
+
+```bash
+pip install mooncake-transfer-engine-npu
+```
+
+If the wheel does not cover your platform, build from source instead (see the
+[vLLM-Ascend Mooncake guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/features/pd_colocated_mooncake_multi_instance.html)
+for the full walkthrough):
+
+```bash
+git clone -b v0.3.9 --depth 1 https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+git submodule update --init --recursive
+apt-get install -y mpich libmpich-dev
+bash dependencies.sh -y
+mkdir build && cd build
+cmake .. -DUSE_ASCEND_DIRECT=ON   # mandatory on Ascend
+make -j && make install
+```
+
+Either way, verify both pieces before continuing:
+
+```bash
+mooncake_master --help >/dev/null && echo mooncake_master ok
+python -c "from mooncake.store import MooncakeDistributedStore; print('mooncake.store ok')"
+```
+
+If the capture server later dies with "no `allocate_and_mount_segment`", the
+Mooncake build is too old for the companion patch below — upgrade or rebuild
+it first.
+
 ### Apply the SGLang capture patches (online runs only)
 
 Online capture needs two patches on top of the installed SGLang, applied **in
@@ -35,7 +71,7 @@ bash scripts/apply_sglang_spec_capture_patch.sh
 # Ascend companion patch: skip the wildcard segment mount that Ascend
 # Mooncake rejects, and mount the feature segment with location="cpu"
 SGLANG_DIR=$(python -c "import sglang, os; print(os.path.dirname(os.path.dirname(sglang.__file__)))")
-cd "$SGLANG_DIR" && git apply /path/to/SpecForge/patches/sglang/v0.5.14/spec-capture-ascend-mount.patch
+cd "$SGLANG_DIR" && git apply -p2 /path/to/SpecForge/patches/sglang/v0.5.14/spec-capture-ascend-mount.patch
 ```
 
 Skip both for offline training, which reads features from disk. The companion

--- a/patches/sglang/v0.5.14/spec-capture-ascend-mount.patch
+++ b/patches/sglang/v0.5.14/spec-capture-ascend-mount.patch
@@ -1,8 +1,8 @@
 diff --git a/python/sglang/srt/spec_capture_sink.py b/python/sglang/srt/spec_capture_sink.py
-index 4955e11..902f0b1 100644
+index d54b920..f831b03 100644
 --- a/python/sglang/srt/spec_capture_sink.py
 +++ b/python/sglang/srt/spec_capture_sink.py
-@@ -81,18 +81,31 @@ class SpecCaptureSink:
+@@ -87,18 +87,28 @@ class SpecCaptureSink:
              from mooncake.store import MooncakeDistributedStore, ReplicateConfig
  
              store = MooncakeDistributedStore()
@@ -38,7 +38,7 @@ index 4955e11..902f0b1 100644
                  rdma_devices=os.environ.get("MOONCAKE_RDMA_DEVICES", ""),
                  master_server_addr=os.environ.get(
                      "MOONCAKE_MASTER_SERVER_ADDR", "localhost:50051"
-@@ -100,12 +113,34 @@ class SpecCaptureSink:
+@@ -106,6 +116,25 @@ class SpecCaptureSink:
              )
              if rc is not None and int(rc) != 0:
                  raise RuntimeError(f"spec-capture mooncake setup failed (status {rc})")
@@ -64,13 +64,3 @@ index 4955e11..902f0b1 100644
              # Hard-pin every object: SpecForge (not Mooncake's LRU) is the
              # lifetime authority — a committed feature must never be evicted
              # before the trainer consumes it.
-             cfg = ReplicateConfig()
-             cfg.replica_num = 1
--            cfg.with_hard_pin = True
-+            # Older Mooncake builds expose no with_hard_pin field; objects
-+            # then follow the store's default pin behavior until remove().
-+            if hasattr(cfg, "with_hard_pin"):
-+                cfg.with_hard_pin = True
-             self._put_config = cfg
-             self._store = store
-             logger.info("spec-capture mooncake sink connected")


### PR DESCRIPTION
## Motivation

The companion patch merged by #722 (`patches/sglang/v0.5.14/spec-capture-ascend-mount.patch`) does not apply. Its first hunk header declares 31 new-side lines while the body carries only 28 - a pre-merge edit shortened a comment from 5 lines to 2 without updating the header - so every fresh Ascend setup from `main` aborts with:

```
error: corrupt patch at line 41
```

Separately, a8c09931 ("feat: enhance spec_capture_sink with dynamic pinning configuration", merged into `main` via #698 nine hours after #722) moved the `with_hard_pin` guard into the base patch, leaving this patch's second hunk context stale (`patch does not apply` even once the header is fixed).

Two gaps in the Ascend docs then made fresh setups fail even with a valid patch: the documented `git apply` command lacks `-p2` (it fails with `No such file or directory` against an installed SGLang), and the doc never explains how to install Mooncake on Ascend in the first place.

## Modifications

Regenerate the patch against the current `v0.5.14` base - the Ascend behavior itself is unchanged:

- Hunk 1 header corrected: `@@ -81,18 +81,31 @@` -> `@@ -87,18 +87,28 @@` (line numbers re-based, new-side count fixed).
- Hunk 2 reduced to a pure mount-block insertion (`@@ -106,6 +116,25 @@`); the old pin-guard exchange is dropped because the base patch now ships `with_hard_pin`/`with_soft_pin` handling itself.
- Blob `index` line updated to the current base.

`docs/basic_usage/Ascend/ascend_npu.md` (+37/-1):

- Add the missing Mooncake installation section (NPU wheel first, source build with `-DUSE_ASCEND_DIRECT=ON` as fallback), with verification commands for both `mooncake_master` and `mooncake.store`.
- Fix the companion-patch apply command: `git apply` needs `-p2` against an installed SGLang.

## Related Issues

- Repairs the patch introduced by #722.

## Validation

`git apply --check` before / after:

| Base | Before | After |
|---|---|---|
| current `main` (395-line sink) | `corrupt patch at line 41` (exit 128) | ✅ applies |
| #722 merge-time (389-line sink) | `corrupt patch at line 41` (exit 128) | ✅ applies |

The patched sink compiles, the Ascend mount logic (`allocate_and_mount_segment` with `location="cpu"`) lands intact, and the base's `with_hard_pin`/`with_soft_pin` fallback is preserved. CUDA hosts are unaffected: the Ascend path activates only when `ASCEND_RT_VISIBLE_DEVICES` is set, otherwise the `setup()` arguments are identical to the base.

The `-p2` fix mirrors `scripts/apply_sglang_spec_capture_patch.sh`, which already strips the `python/` prefix for installed SGLang trees (same `dirname(dirname(sglang.__file__))` root): without `-p2` the companion patch fails with `No such file or directory`; with it, both install layouts (site-packages and editable source) apply.

## Accuracy Test

N/A - file repair only; no runtime code changed.

## Benchmark & Profiling

N/A.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution.html#code-formatting-with-pre-commit). (`.patch` files are excluded from whitespace hooks by repo config; verified the file applies cleanly.)
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci). (N/A - no code change.)
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci). (`ascend_npu.md` gains the Mooncake install section and the corrected `-p2` apply command.)
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sgl.ai/references/accuracy_evaluation.html). (N/A.)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting in merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Feel free to join our Slack channel at [https://sgl-fru7574.slack.com/archives/C09784E3EN6](https://sgl-fru7574.slack.com/archives/C09784E3EN6) to discuss your PR.