### PR TITLE
refactor: extract packed capture_rows from the offline SGLang backend

### DIFF
--- a/specforge/offline_capture/sglang.py
+++ b/specforge/offline_capture/sglang.py
@@ -83,6 +83,10 @@ class OfflineSGLangCapture:
             loss_mask=torch.cat([row[2] for row in data], dim=0),
         )
 
+    def capture_rows(self, input_ids: List[List[int]]):
+        """Capture variable-length rows without padding target compute."""
+        return self._backend.capture_rows(input_ids)
+
 
 def load_offline_capture(
     pretrained_model_name_or_path: str,

--- a/specforge/offline_capture/sglang_backend/capture.py
+++ b/specforge/offline_capture/sglang_backend/capture.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import logging
 from array import array
 from typing import List, Optional
 
@@ -32,6 +33,17 @@ from specforge.distributed import get_tp_group
 
 from .model_runner import SGLangRunner
 from .utils import wrap_offline_eagle3_logits_processors
+
+logger = logging.getLogger(__name__)
+
+# SGLang capture hooks tried in order for each capture method. K3-class targets
+# expose a native DSpark hook; dense targets serve the same auxiliary
+# hidden-state layout through the DFlash hook, so DSpark falls back to it.
+_CAPTURE_LAYER_HOOKS = {
+    "eagle3": ("set_eagle3_layers_to_capture",),
+    "dflash": ("set_dflash_layers_to_capture",),
+    "dspark": ("set_dspark_layers_to_capture", "set_dflash_layers_to_capture"),
+}
 
 
 class OfflineSGLangCaptureBackend:
@@ -128,23 +140,29 @@ class OfflineSGLangCaptureBackend:
     ) -> None:
         """Set auxiliary layers through the strategy's SGLang capture API."""
 
-        setter_name = {
-            "eagle3": "set_eagle3_layers_to_capture",
-            "dflash": "set_dflash_layers_to_capture",
-            "dspark": "set_dspark_layers_to_capture",
-        }.get(capture_method)
-        if setter_name is None:
+        setter_names = _CAPTURE_LAYER_HOOKS.get(capture_method)
+        if setter_names is None:
             raise ValueError(
                 "offline SGLang capture method must be 'eagle3', 'dflash', or "
                 "'dspark', "
                 f"got {capture_method!r}"
             )
-        setter = getattr(self.model_runner.model, setter_name, None)
-        if not callable(setter):
-            raise RuntimeError(
-                f"target model does not expose SGLang capture hook {setter_name!r}"
-            )
-        setter(layer_ids)
+        for setter_name in setter_names:
+            setter = getattr(self.model_runner.model, setter_name, None)
+            if not callable(setter):
+                continue
+            if setter_name != setter_names[0]:
+                logger.info(
+                    "capture method %r resolved through compatibility hook %s",
+                    capture_method,
+                    setter_name,
+                )
+            setter(layer_ids)
+            return
+        raise RuntimeError(
+            "target model does not expose a compatible SGLang capture hook; "
+            f"tried {setter_names!r}"
+        )
 
     def _maybe_prepare_mlp_sync_batch(self, batch: ScheduleBatch) -> None:
         if require_mlp_sync(self.model_runner.server_args):
@@ -204,29 +222,25 @@ class OfflineSGLangCaptureBackend:
         self.model_runner.token_to_kv_pool_allocator.clear()
 
     @torch.no_grad()
-    def capture_eagle3(
-        self,
-        *,
-        input_ids: torch.Tensor,
-        attention_mask: torch.Tensor,
-        loss_mask: torch.Tensor,
-    ):
-        """Capture per-request auxiliary and final hidden states without logits."""
+    def capture_rows(self, input_ids: list[list[int]]):
+        """Capture variable-length request rows in one packed prefill.
 
+        Returns ``(aux_rows, last_rows)``: per-row auxiliary and final hidden
+        states split from the packed forward, so callers never build padded
+        tensors. The KV/request pools are cleared after every call.
+        """
+
+        if not input_ids:
+            return (), ()
+        if any(not row for row in input_ids):
+            raise ValueError("SGLang capture rows must contain at least one token")
         sampling_params = SamplingParams(temperature=0, max_new_tokens=1, top_k=1)
         reqs: list[Req] = []
-        data = []
-        input_rows = torch.split(input_ids, 1, dim=0)
-        attention_rows = torch.split(attention_mask, 1, dim=0)
-        loss_rows = torch.split(loss_mask, 1, dim=0)
-
-        for idx, (input_row, attention_row, loss_row) in enumerate(
-            zip(input_rows, attention_rows, loss_rows)
-        ):
+        for idx, input_row in enumerate(input_ids):
             req = Req(
                 rid=str(idx),
                 origin_input_text="",
-                origin_input_ids=input_row.view(-1).tolist(),
+                origin_input_ids=list(input_row),
                 sampling_params=sampling_params,
             )
             req.full_untruncated_fill_ids = array("q", req.origin_input_ids)
@@ -235,7 +249,6 @@ class OfflineSGLangCaptureBackend:
             )
             req.logprob_start_len = len(req.origin_input_ids) - 1
             reqs.append(req)
-            data.append((input_row, attention_row, loss_row))
 
         input_lens = [len(req.origin_input_ids) for req in reqs]
         try:
@@ -244,14 +257,38 @@ class OfflineSGLangCaptureBackend:
             last_hidden_states = getattr(output, "last_hidden_states", None)
             if aux_hidden_states is None or last_hidden_states is None:
                 raise RuntimeError(
-                    "SGLang did not return the hidden states required for "
-                    "offline feature preparation"
+                    "SGLang did not return the hidden states required for capture"
                 )
             aux_rows = torch.split(aux_hidden_states, input_lens, dim=0)
             last_rows = torch.split(last_hidden_states, input_lens, dim=0)
         finally:
             self._clear_pools()
+        return aux_rows, last_rows
 
+    @torch.no_grad()
+    def capture_eagle3(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        loss_mask: torch.Tensor,
+    ):
+        """Capture per-request auxiliary and final hidden states without logits.
+
+        Padded rows are captured as given (padding positions included), which
+        keeps offline feature preparation byte-identical.
+        """
+
+        data = list(
+            zip(
+                torch.split(input_ids, 1, dim=0),
+                torch.split(attention_mask, 1, dim=0),
+                torch.split(loss_mask, 1, dim=0),
+            )
+        )
+        aux_rows, last_rows = self.capture_rows(
+            [input_row.view(-1).tolist() for input_row, _, _ in data]
+        )
         return data, aux_rows, last_rows
 
     def capture(

--- a/tests/test_runtime/test_sglang_0518_compat.py
+++ b/tests/test_runtime/test_sglang_0518_compat.py
@@ -17,7 +17,7 @@ class SGLang0518CompatibilityTest(unittest.TestCase):
         tree = ast.parse(
             textwrap.dedent(
                 inspect.getsource(
-                    sglang_capture.OfflineSGLangCaptureBackend.capture_eagle3
+                    sglang_capture.OfflineSGLangCaptureBackend.capture_rows
                 )
             )
         )

--- a/tests/test_runtime/test_sglang_capture_hooks.py
+++ b/tests/test_runtime/test_sglang_capture_hooks.py
@@ -1,0 +1,49 @@
+"""Capture-layer hook resolution on the offline SGLang backend.
+
+Runs where sglang is installed (CI); the backend module imports sglang.
+"""
+
+import types
+import unittest
+from unittest import mock
+
+from specforge.offline_capture.sglang_backend.capture import OfflineSGLangCaptureBackend
+
+
+def _backend_with(model):
+    backend = object.__new__(OfflineSGLangCaptureBackend)
+    backend.model_runner = types.SimpleNamespace(model=model)
+    return backend
+
+
+class CaptureLayerHookTest(unittest.TestCase):
+    def test_dspark_prefers_its_native_capture_hook(self):
+        model = mock.Mock(
+            spec=["set_dspark_layers_to_capture", "set_dflash_layers_to_capture"]
+        )
+
+        _backend_with(model).set_capture_layers([1, 9, 17], capture_method="dspark")
+
+        model.set_dspark_layers_to_capture.assert_called_once_with([1, 9, 17])
+        model.set_dflash_layers_to_capture.assert_not_called()
+
+    def test_dspark_falls_back_to_the_dense_dflash_hook(self):
+        model = mock.Mock(spec=["set_dflash_layers_to_capture"])
+
+        _backend_with(model).set_capture_layers([1, 9, 17], capture_method="dspark")
+
+        model.set_dflash_layers_to_capture.assert_called_once_with([1, 9, 17])
+
+    def test_missing_capture_hooks_fail_with_the_tried_names(self):
+        model = mock.Mock(spec=[])
+
+        with self.assertRaisesRegex(RuntimeError, "set_dspark_layers_to_capture"):
+            _backend_with(model).set_capture_layers([1], capture_method="dspark")
+
+    def test_unknown_capture_method_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "capture method"):
+            _backend_with(mock.Mock()).set_capture_layers([1], capture_method="mtp")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Stack 3/5 replacing draft #766. This PR is the capture-engine primitive the colocated runtime builds on: a packed variable-length capture API on the offline SGLang backend, plus DSpark capture-hook compatibility for dense targets.

## Modifications

- Extract `capture_rows(input_ids: list[list[int]]) -> (aux_rows, last_rows)` from `capture_eagle3` on `OfflineSGLangCaptureBackend` and expose it on `OfflineSGLangCapture`. One packed prefill captures variable-length rows without building padded tensors. `capture_eagle3` delegates to it and keeps its exact request construction (`set_extend_range`, sglang 0.5.18), outputs, and pool clearing, so offline feature preparation stays byte-identical (unlike #766, no attention-mask trimming is bundled in).
- DSpark capture-layer setup falls back from the native `set_dspark_layers_to_capture` hook to the dense DFlash hook and logs the resolved hook. In stock SGLang only `deepseek_v4` exposes the DSpark hook; dense targets such as Qwen3 serve the same auxiliary-hidden-state layout through `set_dflash_layers_to_capture` and previously failed outright. The hook table is one module constant (`_CAPTURE_LAYER_HOOKS`).

## Related Issues

Splits #766. Stack: #781 teardown-abort ← #782 rank0-tracker ← **#3 (this)** ← #783 colocated-core ← #784 hybrid-shard.

## Accuracy Test

- New `tests/test_runtime/test_sglang_capture_hooks.py`: hook preference, DFlash fallback, missing hooks, unknown method. Runs where sglang is installed (CI), like the existing sglang compat tests.
- `test_sglang_0518_compat.py` now inspects `capture_rows` for the request-construction contract.
- Behavior-preserving refactor for the existing offline path; exercised end to end by the colocated run reported in #783 (to be re-run on 0.5.18 after this rebase, see there).

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit (`black --check` and `isort --check-only`).
- [x] Add unit tests.
- [x] Update documentation as needed (none needed — internal API).
