### PR TITLE
add dflash2 selector metrics

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -43,15 +43,17 @@ class SelectorTerms(NamedTuple):
     correct_num: torch.Tensor
     weight_den: torch.Tensor
     covered_num: torch.Tensor
+    topk_mass_num: torch.Tensor
+    oracle_accepted_length_num: torch.Tensor
+    path_accepted_length_num: torch.Tensor
+    path_correct_num: torch.Tensor
+    path_position_den: torch.Tensor
+    block_valid_den: torch.Tensor
 
     @classmethod
     def zeros(cls, reference: torch.Tensor) -> "SelectorTerms":
         return cls(
-            reference.new_zeros(()),
-            reference.new_zeros(()),
-            reference.new_zeros(()),
-            reference.new_zeros(()),
-            reference.new_zeros(()),
+            *([reference.new_zeros(())] * len(cls._fields)),
         )
 
 
@@ -75,6 +77,12 @@ class DFlashObjectiveTerms(NamedTuple):
     selector_correct_num: torch.Tensor
     selector_weight_den: torch.Tensor
     selector_covered_num: torch.Tensor
+    selector_topk_mass_num: torch.Tensor
+    selector_oracle_accepted_length_num: torch.Tensor
+    selector_path_accepted_length_num: torch.Tensor
+    selector_path_correct_num: torch.Tensor
+    selector_path_position_den: torch.Tensor
+    selector_block_valid_den: torch.Tensor
 
 
 def compute_accept_len(
@@ -520,12 +528,84 @@ class OnlineDFlashModel(nn.Module):
             correct_num = (
                 (selected_ids == target_ids).float() * selector_loss_weights
             ).sum()
+
+            # --- Candidate-set and accepted-length telemetry -------------
+            # Draft softmax mass inside its own strict unary top-k: how much
+            # score mass a reranker can ever move as selector_top_k changes.
+            topk_mass_num = (
+                torch.exp(
+                    torch.logsumexp(unary_logits, dim=-1)
+                    - torch.logsumexp(objective_logits, dim=-1)
+                )
+                * weight_mask
+            ).sum()
+
+            # Per-block accepted-length proxies for the serving path. The
+            # verified anchor counts as one accepted token, and a block extends
+            # only while every earlier draft slot is supervised and accepted.
+            # The oracle walk credits any slot whose gold token sits in the
+            # unary top-k; the realized walk re-scores each slot with its own
+            # greedy predecessor instead of the gold one.
+            batch_size, num_blocks, block_size = target_ids.shape
+            valid_positions = weight_mask > 0.5
+            block_valid = valid_positions[:, :, 1:].any(dim=-1)
+            block_valid_den = block_valid.float().sum()
+
+            oracle_alive = torch.ones(
+                batch_size, num_blocks, dtype=torch.bool, device=hidden.device
+            )
+            oracle_accepted = torch.ones(
+                batch_size, num_blocks, dtype=torch.float32, device=hidden.device
+            )
+            path_alive = torch.ones_like(oracle_alive)
+            path_accepted = torch.ones_like(oracle_accepted)
+            realized_predecessor = target_ids[:, :, 0]
+            path_correct_num = correct_num.new_zeros(())
+            path_position_den = correct_num.new_zeros(())
+            for position in range(1, block_size):
+                oracle_alive &= (
+                    valid_positions[:, :, position]
+                    & target_is_candidate[:, :, position]
+                )
+                oracle_accepted += oracle_alive.float()
+
+                conditioned = path_alive & valid_positions[:, :, position]
+                step_logits = candidate_selector.score_candidates(
+                    candidate_ids=candidate_ids[:, :, position],
+                    unary_logits=unary_logits[:, :, position],
+                    hidden_states=hidden[:, :, position],
+                    predecessor_ids=realized_predecessor,
+                )
+                realized_predecessor = (
+                    candidate_ids[:, :, position]
+                    .gather(
+                        -1,
+                        step_logits.argmax(dim=-1, keepdim=True),
+                    )
+                    .squeeze(-1)
+                )
+                step_hit = conditioned & (
+                    realized_predecessor == target_ids[:, :, position]
+                )
+                path_correct_num += step_hit.float().sum()
+                path_position_den += conditioned.float().sum()
+                path_accepted += step_hit.float()
+                path_alive &= step_hit
+
+            oracle_accepted_length_num = (oracle_accepted * block_valid.float()).sum()
+            path_accepted_length_num = (path_accepted * block_valid.float()).sum()
         return SelectorTerms(
             ce_num=ce_num,
             probability_num=probability_num,
             correct_num=correct_num,
             weight_den=weight_den,
             covered_num=covered_num,
+            topk_mass_num=topk_mass_num,
+            oracle_accepted_length_num=oracle_accepted_length_num,
+            path_accepted_length_num=path_accepted_length_num,
+            path_correct_num=path_correct_num,
+            path_position_den=path_position_den,
+            block_valid_den=block_valid_den,
         )
 
     def _dflash_objective_chunk_terms(
@@ -616,6 +696,14 @@ class OnlineDFlashModel(nn.Module):
             selector_correct_num=selector_terms.correct_num,
             selector_weight_den=selector_terms.weight_den,
             selector_covered_num=selector_terms.covered_num,
+            selector_topk_mass_num=selector_terms.topk_mass_num,
+            selector_oracle_accepted_length_num=(
+                selector_terms.oracle_accepted_length_num
+            ),
+            selector_path_accepted_length_num=selector_terms.path_accepted_length_num,
+            selector_path_correct_num=selector_terms.path_correct_num,
+            selector_path_position_den=selector_terms.path_position_den,
+            selector_block_valid_den=selector_terms.block_valid_den,
         )
 
     def _compose_token_objective(
@@ -712,6 +800,12 @@ class OnlineDFlashModel(nn.Module):
             selector_correct_num,
             selector_weight_den,
             selector_covered_num,
+            selector_topk_mass_num,
+            selector_oracle_accepted_length_num,
+            selector_path_accepted_length_num,
+            selector_path_correct_num,
+            selector_path_position_den,
+            selector_block_valid_den,
         ) = checkpointed_chunk_reduce(
             self._dflash_objective_chunk_terms,
             hidden_4d,
@@ -769,6 +863,22 @@ class OnlineDFlashModel(nn.Module):
                     "selector_target_probability": (
                         selector_probability_num.detach(),
                         selector_covered_num.detach(),
+                    ),
+                    "unary_topk_probability_mass": (
+                        selector_topk_mass_num.detach(),
+                        accuracy_denom.detach(),
+                    ),
+                    "unary_topk_oracle_accepted_length": (
+                        selector_oracle_accepted_length_num.detach(),
+                        selector_block_valid_den.detach(),
+                    ),
+                    "selector_path_accepted_length": (
+                        selector_path_accepted_length_num.detach(),
+                        selector_block_valid_den.detach(),
+                    ),
+                    "selector_path_accuracy": (
+                        selector_path_correct_num.detach(),
+                        selector_path_position_den.detach(),
                     ),
                 }
             )

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -641,6 +641,157 @@ class CandidateSelectorTest(unittest.TestCase):
             self.assertIsNotNone(parameter.grad)
             self.assertGreater(parameter.grad.abs().sum().item(), 0.0)
 
+    def test_candidate_mass_and_accepted_length_metrics(self):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=6,
+                    vocab_size=6,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        draft = Draft()
+        # Zeroed selector factors make the selector a unary no-op, so the
+        # realized path always takes the unary top-1 candidate.
+        with torch.no_grad():
+            draft.candidate_selector.predecessor_codebook.zero_()
+            draft.candidate_selector.successor_codebook.zero_()
+            draft.candidate_selector.hidden_projection.weight.zero_()
+        model = OnlineDFlashModel(
+            draft_model=draft,
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(6, 6),
+            mask_token_id=5,
+            block_size=3,
+            attention_backend="eager",
+            selector_loss_alpha=1.0,
+        )
+        # Two blocks of three slots; slot 0 is the unsupervised anchor.
+        # Block 0: slot 1 covers the gold token at rank 1 (realized path
+        # misses), slot 2 has it at rank 0. Block 1: slot 1 misses the top-k
+        # entirely (oracle path dies at once), slot 2 covers at rank 0.
+        hidden = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 2.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 3.0, 0.0],
+                    ],
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 2.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 0.0, 3.0],
+                    ],
+                ]
+            ]
+        )
+        target_ids = torch.tensor([[[4, 2, 4], [4, 1, 5]]])
+        weights = torch.tensor([[[0.0, 1.0, 1.0], [0.0, 1.0, 1.0]]])
+        predecessors = torch.tensor([[[4, 4, 2], [4, 4, 1]]])
+
+        terms = model._dflash_objective_chunk_terms(
+            hidden,
+            target_ids,
+            weights,
+            predecessors,
+        )
+
+        def topk_mass(slot_logits):
+            return torch.exp(
+                slot_logits.topk(2).values.logsumexp(dim=-1)
+                - slot_logits.logsumexp(dim=-1)
+            )
+
+        # Every supervised slot except block-1 slot 1 covers its gold token.
+        self.assertEqual(terms.selector_covered_num.item(), 3.0)
+
+        expected_mass = (
+            topk_mass(hidden[0, 0, 1])
+            + topk_mass(hidden[0, 0, 2])
+            + topk_mass(hidden[0, 1, 1])
+            + topk_mass(hidden[0, 1, 2])
+        )
+        torch.testing.assert_close(terms.selector_topk_mass_num, expected_mass)
+
+        # Oracle: block 0 accepts anchor + slots 1-2, block 1 stops at the
+        # anchor because slot 1 is outside the unary top-k.
+        self.assertEqual(terms.selector_oracle_accepted_length_num.item(), 4.0)
+        # Realized path: both blocks miss at slot 1 (rank-1 / uncovered gold),
+        # so each accepts only the anchor.
+        self.assertEqual(terms.selector_path_accepted_length_num.item(), 2.0)
+        self.assertEqual(terms.selector_path_correct_num.item(), 0.0)
+        self.assertEqual(terms.selector_path_position_den.item(), 2.0)
+        self.assertEqual(terms.selector_block_valid_den.item(), 2.0)
+
+    def test_forward_reports_candidate_path_ratio_metrics(self):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=4,
+                    vocab_size=4,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        draft = Draft()
+        with torch.no_grad():
+            draft.candidate_selector.predecessor_codebook.zero_()
+            draft.candidate_selector.successor_codebook.zero_()
+            draft.candidate_selector.hidden_projection.weight.zero_()
+        model = OnlineDFlashModel(
+            draft_model=draft,
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(4, 4),
+            mask_token_id=3,
+            block_size=2,
+            attention_backend="eager",
+            selector_loss_alpha=1.0,
+        )
+        output_hidden = torch.tensor([[[0.0, 0.0, 0.0, 0.0], [0.0, 3.0, 2.0, 1.0]]])
+        model._forward_draft_blocks = lambda **_kwargs: (
+            torch.tensor([[0]]),
+            torch.tensor([[True]]),
+            output_hidden,
+        )
+
+        _loss, _accuracy, metrics = model(
+            input_ids=torch.tensor([[0, 2]]),
+            hidden_states=torch.zeros(1, 2, 4),
+            loss_mask=torch.ones(1, 2),
+        )
+
+        ratio_metrics = metrics["ratio_metrics"]
+        for name in (
+            "unary_topk_probability_mass",
+            "unary_topk_oracle_accepted_length",
+            "selector_path_accepted_length",
+            "selector_path_accuracy",
+        ):
+            self.assertIn(name, ratio_metrics)
+
+        # Slot 1 covers the gold token at rank 1: the oracle block accepts
+        # anchor + 1, but the realized path takes the unary top-1 and misses.
+        oracle_num, oracle_den = ratio_metrics["unary_topk_oracle_accepted_length"]
+        torch.testing.assert_close(oracle_num / oracle_den, torch.tensor(2.0))
+        path_num, path_den = ratio_metrics["selector_path_accepted_length"]
+        torch.testing.assert_close(path_num / path_den, torch.tensor(1.0))
+        correct_num, position_den = ratio_metrics["selector_path_accuracy"]
+        torch.testing.assert_close(correct_num / position_den, torch.tensor(0.0))
+
     def test_zero_effective_selector_alpha_keeps_selector_in_autograd_graph(self):
         class Draft(nn.Module):
             def __init__(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Follow-up to #772 (DFlash2). The DFlash2 selector currently reports only `selector_loss` / `selector_accuracy` / `selector_coverage` / `selector_target_probability`, which is not enough to answer the two questions that come up when tuning the selector:

- How much score mass can reranking ever move - i.e., is `selector_top_k` too small, or already wasteful?
- How much accepted length could a perfect reranker buy, and how much does the realized greedy path actually buy today?

This PR ports the three validation signals that the merged DFlash2 implementation in vllm-project/speculators reports (`unary_candidate_target_mass_at_k`, `unary_top_k_oracle_accepted_length`, and the realized greedy self-conditioned path), adapted to SpecForge's hard-target online pipeline. Since SpecForge captures hidden states only, the teacher-side soft "target mass" becomes the draft's own softmax mass on the same strict unary top-k candidate set.

## Modifications

`specforge/algorithms/common/dflash_family_model.py`:

- `SelectorTerms` / `DFlashObjectiveTerms` gain six additive telemetry fields (top-k mass, oracle/path accepted lengths, path accuracy, and their block/position denominators), preserving the flat tensor-only NamedTuple contract of `checkpointed_chunk_reduce`.
- Inside the existing `no_grad` block of `_selector_chunk_terms`, the new metrics are computed:
  - `unary_topk_probability_mass` - the draft's softmax mass inside its own strict unary top-k, via two `logsumexp` reductions (no extra full-vocab materialization);
  - `unary_topk_oracle_accepted_length` - per-block accepted length under a perfect reranker: every supervised slot whose gold token sits in the unary top-k is credited. The verified anchor counts as one accepted token, and a block extends only while every earlier slot is supervised and covered;
  - `selector_path_accepted_length` / `selector_path_accuracy` - the realized greedy candidate path: each slot is re-scored with its own selected predecessor (starting from the verified anchor) instead of the gold one, mirroring the serving walk; per-position accuracy is conditioned on the earlier path being correct.
- `forward` exposes the four new metrics through the existing `ratio_metrics` (numerator, denominator) contract under the same `_selector_objective_enabled` gate, so they chunk-reduce and all-reduce exactly like the current selector metrics (zero denominators are clamped by the consumer).
- Loss terms, gradients, and checkpoint contents are unchanged; drafts without a candidate selector pay nothing.

`tests/test_modeling/test_dflash2.py`:

- `test_candidate_mass_and_accepted_length_metrics`: a two-block fixture with hand-computed mass, oracle, and realized-path values (rank-1 coverage vs. realized top-1 miss vs. uncovered slot).
- `test_forward_reports_candidate_path_ratio_metrics`: forward-level check that the four new ratio metrics are reported with the expected values.

## Related Issues

- Follow-up to #772 (merged).

## Accuracy Test

- `tests.test_modeling.test_dflash2`: 23 passed (21 existing + 2 new).
- Regression: `tests.test_utils.test_dflash_losses`, `tests.test_modeling.test_draft_registry`, `tests.test_algorithms.test_builtin_providers` all pass.
- No model-side numerics change: loss terms are untouched; all additions are `no_grad` telemetry.

## Benchmark & Profiling

No throughput impact by design. The metrics run under `no_grad` inside the existing chunk pass; the realized path adds `block_size - 1` small codebook-lookup/einsum scorings per chunk (vs. one full-vocab `lm_head` projection already there), and the mass metric avoids any full-vocab softmax materialization via two `logsumexp` reductions.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit). (`ruff check` clean; new test code mirrors the file's existing formatting.)
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci). (Inline comments document the metric semantics; no user-facing surface changes.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html). (N/A - telemetry only.)
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.