### PR TITLE
dspark-pretrain: persistent streaming trainer for DSpark offline pret…

### DIFF
--- a/specforge/config/schema.py
+++ b/specforge/config/schema.py
@@ -138,6 +138,12 @@ class DataConfig(StrictConfigModel):
     #: offline evaluation — directory of precomputed hidden-state .ckpt files.
     eval_hidden_states_path: str = ""
     max_length: int = Field(default=2048, gt=0)
+    #: 'static' = classic fixed dataset. 'stream' = persistent trainer consuming
+    #: READY-marked chunk directories from stream_dir; one chunk == one epoch.
+    data_mode: Literal["static", "stream"] = "static"
+    stream_dir: str = ""
+    #: Fixed per-epoch ref count in stream mode (short chunks are cycle-padded).
+    stream_chunk_rows: int = Field(default=256, gt=0)
     chat_template: str = "llama3"
     is_preformatted: bool = False
     train_only_last_turn: bool = False
@@ -543,6 +549,11 @@ class TrainingConfig(StrictConfigModel):
     kl_decay: float = 1.0
     #: DFlash-family objective/model knobs.
     num_anchors: int = Field(default=512, gt=0)
+    #: stream mode: write a trainable-weights-only safetensors export every N
+    #: consumed chunks (0 = never). Cheap (~5GB); independent of save_interval,
+    #: which remains the FULL resume checkpoint (weights+optimizer+RNG).
+    export_every_chunks: int = Field(default=0, ge=0)
+    export_dir: str = ""
     loss_decay_gamma: Optional[float] = None
     #: Anchor blocks per objective slice (0 = materialize all objective logits).
     objective_chunk_blocks: int = Field(default=128, ge=0)

--- a/specforge/launch.py
+++ b/specforge/launch.py
@@ -569,6 +569,8 @@ def build_offline_runtime(
     strategy_kwargs: Optional[Mapping[str, Any]] = None,
     dataloader_num_workers: int = 0,
     profiling_options=None,
+    stream_dir: str = "",
+    stream_chunk_rows: int = 256,
 ):
     """Assemble the colocated offline dataflow (``LocalFeatureStore``).
 
@@ -590,19 +592,53 @@ def build_offline_runtime(
         metadata_store=NoOpMetadataStore(),
         enable_sample_queue=False,
     )
-    source_refs = provider.build_reader(
-        hidden_states_path, run_id=run_id, ttt_length=ttt_length, max_len=max_len
-    ).read()
+    stream_source = None
+    if stream_dir:
+        from specforge.training.streaming import StreamingChunkSource
 
-    def refs_for_epoch(epoch):
-        return _shard_offline_refs(
+        stream_source = StreamingChunkSource(
+            provider=provider,
+            stream_dir=stream_dir,
+            run_id=run_id,
+            ttt_length=ttt_length,
+            max_len=max_len,
+            chunk_rows=stream_chunk_rows,
+        )
+
+        def refs_for_epoch(epoch):
+            return _shard_offline_refs(
+                stream_source.next_chunk_refs(epoch),
+                use_usp_preprocess=use_usp_preprocess,
+                seed=seed,
+                epoch=epoch,
+            )
+
+        source_refs = stream_source.peek_refs()
+    else:
+        source_refs = provider.build_reader(
+            hidden_states_path, run_id=run_id, ttt_length=ttt_length, max_len=max_len
+        ).read()
+
+        def refs_for_epoch(epoch):
+            return _shard_offline_refs(
+                source_refs,
+                use_usp_preprocess=use_usp_preprocess,
+                seed=seed,
+                epoch=epoch,
+            )
+
+    if stream_source is not None:
+        # build-time sizing only: shard the peeked refs; the controller calls
+        # set_epoch(start_epoch) before any batch is read, which performs the
+        # real (consuming) grab at the correct, possibly-resumed epoch.
+        refs = _shard_offline_refs(
             source_refs,
             use_usp_preprocess=use_usp_preprocess,
             seed=seed,
-            epoch=epoch,
+            epoch=0,
         )
-
-    refs = refs_for_epoch(0)
+    else:
+        refs = refs_for_epoch(0)
     store = LocalFeatureStore(run_id)
     if eval_hidden_states_path:
         if eval_data_factory is not None:
@@ -620,7 +656,7 @@ def build_offline_runtime(
             use_usp_preprocess=use_usp_preprocess,
             dataloader_num_workers=dataloader_num_workers,
         )
-    return _assemble_trainer(
+    trainer = _assemble_trainer(
         algorithm=algorithm,
         controller=controller,
         store=store,
@@ -659,6 +695,40 @@ def build_offline_runtime(
         dataloader_num_workers=dataloader_num_workers,
         profiling_options=profiling_options,
     )
+    if stream_source is not None:
+        trainer._stream_source = stream_source
+        ctl = getattr(trainer, "_controller", None)
+        eb = getattr(ctl, "_epoch_batch", 0) if ctl is not None else 0
+        if eb:
+            # Streams cannot replay an epoch, so translate the restored position:
+            #   eb == batches_per_epoch -> the chunk COMPLETED before the kill but
+            #     was never deleted (deletion happens at the next boundary):
+            #     delete the oldest READY chunk and advance -> exact continuation.
+            #   0 < eb < batches_per_epoch -> mid-epoch crash: advance without
+            #     deleting; the partial chunk retrains in full (bounded duplicate
+            #     steps, never silent data loss).
+            import torch.distributed as _dist
+
+            ws = _dist.get_world_size() if _dist.is_initialized() else 1
+            bpe = stream_chunk_rows // (batch_size * ws)
+            if eb >= bpe:
+                if (not _dist.is_initialized()) or _dist.get_rank() == 0:
+                    import glob as _g, shutil as _sh
+
+                    ready = sorted(
+                        c
+                        for c in _g.glob(os.path.join(stream_dir, "chunk_*"))
+                        if os.path.exists(os.path.join(c, "READY.marker"))
+                    )
+                    if ready:
+                        print(f"[streaming] resume at epoch end: dropping completed chunk {os.path.basename(ready[0])}", flush=True)
+                        _sh.rmtree(ready[0], ignore_errors=True)
+                if _dist.is_initialized():
+                    _dist.barrier()
+            print(f"[streaming] resume: epoch {ctl.epoch} -> {ctl.epoch+1}, epoch_batch {eb} -> 0 (batches_per_epoch={bpe})", flush=True)
+            ctl.epoch += 1
+            ctl._epoch_batch = 0
+    return trainer
 
 
 def build_disagg_offline_runtime(

--- a/specforge/training/assembly.py
+++ b/specforge/training/assembly.py
@@ -628,6 +628,7 @@ def build_training_run(
     _ensure_offline_vocab_mapping(cfg, bundle, algorithm)
     run_logger = _configured_logger(cfg)
     try:
+        _stream = cfg.data.data_mode == "stream"
         trainer = build_offline_runtime(
             hidden_states_path=cfg.data.hidden_states_path,
             eval_hidden_states_path=cfg.data.eval_hidden_states_path or None,
@@ -635,7 +636,9 @@ def build_training_run(
             target_head=bundle.target_head,
             ttt_length=t.ttt_length,
             max_len=cfg.data.max_length,
-            num_epochs=t.num_epochs,
+            num_epochs=(1_000_000_000 if _stream else t.num_epochs),
+            stream_dir=(cfg.data.stream_dir if _stream else ""),
+            stream_chunk_rows=cfg.data.stream_chunk_rows,
             use_usp_preprocess=(t.attention_backend == "usp"),
             seed=t.seed,
             resume_from=t.resume_from,
@@ -649,6 +652,16 @@ def build_training_run(
     except BaseException:
         _close_configured_logger(run_logger)
         raise
+    _src = getattr(trainer, "_stream_source", None)
+    if _src is not None and t.export_every_chunks > 0:
+        _src.bind_export(
+            model=bundle.model,
+            export_dir=(t.export_dir or os.path.join(cfg.output_dir, "export_head")),
+            every_chunks=t.export_every_chunks,
+            get_step=lambda: getattr(
+                getattr(trainer, "controller", trainer), "global_step", -1
+            ),
+        )
     return TrainingRun(trainer=trainer)
 
 

--- a/specforge/training/streaming.py
+++ b/specforge/training/streaming.py
@@ -1,0 +1,205 @@
+"""Persistent streaming chunk source.
+
+Invariant: a chunk is a *data-delivery unit* only —
+  chunk boundary != process boundary
+  chunk boundary != optimizer boundary
+  chunk boundary != mandatory checkpoint boundary
+One chunk is consumed as one *epoch* of the persistent trainer: the controller
+already calls ``data.set_epoch(epoch)`` at every epoch top, which routes here.
+Model, FSDP state, optimizer (fp32 masters + Adam moments), scheduler,
+global_step, RNG, CUDA context, NCCL group and compiled kernels all live for
+the whole run.
+"""
+import glob
+import logging
+import os
+import shutil
+import time
+
+import torch
+import torch.distributed as dist
+
+def _say(msg):
+    print(f"[streaming] {msg}", flush=True)
+    logger.info(msg)
+
+logger = logging.getLogger("specforge.streaming")
+
+
+class StreamingChunkSource:
+    """Blocks until the next READY chunk; pads refs to a fixed per-epoch size.
+
+    Ready protocol (producer side, already deployed): rows are written as
+    ``t*.pt.tmp`` + atomic rename, then ``READY.marker`` is written last.
+    A chunk directory without READY.marker is invisible here (race-safe).
+    Consumption protocol: CONSUMED marker then directory removal, rank0 only,
+    after a barrier proves every rank finished the epoch that used it.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider,
+        stream_dir: str,
+        run_id: str,
+        ttt_length: int,
+        max_len: int,
+        chunk_rows: int,
+        poll_s: float = 0.5,
+    ):
+        self.provider = provider
+        self.dir = stream_dir
+        self.run_id = run_id
+        self.ttt = ttt_length
+        self.max_len = max_len
+        self.rows = int(chunk_rows)
+        self.poll = poll_s
+        self.cur = None
+        self.chunks_done = 0
+        self._export = None
+        self._memo_epoch = None
+        self._memo_refs = None
+        _say(f"streaming source ready: stream_dir={stream_dir} chunk_rows={self.rows} (persistent trainer)")
+
+    # -- optional lightweight export at chunk boundaries ---------------------
+    def bind_export(self, *, model, export_dir: str, every_chunks: int, get_step=None):
+        self._export = (model, export_dir, max(0, int(every_chunks)), get_step)
+
+    # -- internals ------------------------------------------------------------
+    def _rank(self):
+        return dist.get_rank() if dist.is_initialized() else 0
+
+    def _bcast(self, obj):
+        if not dist.is_initialized():
+            return obj
+        box = [obj]
+        dist.broadcast_object_list(box, src=0)
+        return box[0]
+
+    def _next_ready_rank0(self):
+        t0 = time.perf_counter()
+        while True:
+            for c in sorted(glob.glob(os.path.join(self.dir, "chunk_*"))):
+                if os.path.exists(os.path.join(c, "READY.marker")) and not os.path.exists(
+                    os.path.join(c, "CONSUMED")
+                ):
+                    return c, time.perf_counter() - t0
+            time.sleep(self.poll)
+
+    def _consume_previous(self):
+        if self.cur is None:
+            return
+        if self._rank() == 0:
+            try:
+                open(os.path.join(self.cur, "CONSUMED"), "w").close()
+                shutil.rmtree(self.cur, ignore_errors=True)
+            except OSError:
+                pass
+        self.cur = None
+
+    def _maybe_export(self):
+        if not self._export:
+            return
+        model, out, every, get_step = self._export
+        if every <= 0 or self.chunks_done == 0 or self.chunks_done % every:
+            return
+        t0 = time.perf_counter()
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+        from torch.distributed.fsdp import FullStateDictConfig, StateDictType
+
+        draft = getattr(model, "draft_model", model)
+        root = None
+        if isinstance(model, FSDP):
+            root = model
+        elif isinstance(draft, FSDP):
+            root = draft
+        else:
+            for m in getattr(model, "modules", lambda: [])():
+                if isinstance(m, FSDP):
+                    root = m
+                    break
+        if root is not None:
+            cfgs = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+            with FSDP.state_dict_type(root, StateDictType.FULL_STATE_DICT, cfgs):
+                sd = draft.state_dict()
+        else:
+            sd = draft.state_dict()
+        if self._rank() == 0:
+            from safetensors.torch import save_file
+
+            sd = {
+                k: v.detach().to(torch.bfloat16).contiguous()
+                for k, v in sd.items()
+                if isinstance(v, torch.Tensor)
+            }
+            os.makedirs(out, exist_ok=True)
+            step = -1
+            if get_step is not None:
+                try:
+                    step = int(get_step())
+                except Exception:
+                    pass
+            tmp = os.path.join(out, "model.safetensors.tmp")
+            save_file(sd, tmp)
+            os.replace(tmp, os.path.join(out, "model.safetensors"))
+            _say(f"export_done chunks={self.chunks_done} global_step={step} export_time={time.perf_counter()-t0:.1f}s dir={out}")
+        if dist.is_initialized():
+            dist.barrier()
+
+    def peek_refs(self):
+        """Build-time sizing ONLY: read the first READY chunk without consuming it.
+        The controller calls set_epoch(start_epoch) before any batch is read, so
+        these refs are placeholders; the real epoch grab happens there (and on
+        resume, start_epoch reflects the restored position)."""
+        nxt = None
+        wait = 0.0
+        if self._rank() == 0:
+            nxt, wait = self._next_ready_rank0()
+        nxt = self._bcast(nxt)
+        refs = list(
+            self.provider.build_reader(
+                nxt, run_id=self.run_id, ttt_length=self.ttt, max_len=self.max_len
+            ).read()
+        )
+        n = len(refs)
+        if n < self.rows:
+            refs = (refs * ((self.rows + n - 1) // n))[: self.rows]
+        elif n > self.rows:
+            refs = refs[: self.rows]
+        if self._rank() == 0:
+            _say(f"peek(build sizing): chunk={os.path.basename(nxt)} rows={n} wait={wait:.1f}s (not consumed)")
+        return refs
+
+    # -- API: one call per epoch from the persistent fit loop ------------------
+    def next_chunk_refs(self, epoch: int):
+        if epoch == self._memo_epoch:
+            return self._memo_refs  # launch-time priming + set_epoch(0) dedupe
+        t_bound = time.perf_counter()
+        if dist.is_initialized():
+            dist.barrier()  # every rank finished the previous chunk
+        if self.cur is not None:
+            self.chunks_done += 1
+        self._maybe_export()
+        self._consume_previous()
+        wait = 0.0
+        nxt = None
+        if self._rank() == 0:
+            nxt, wait = self._next_ready_rank0()
+        nxt = self._bcast(nxt)
+        self.cur = nxt
+        refs = list(
+            self.provider.build_reader(
+                nxt, run_id=self.run_id, ttt_length=self.ttt, max_len=self.max_len
+            ).read()
+        )
+        if not refs:
+            raise ValueError(f"stream chunk {nxt} produced no refs")
+        n = len(refs)
+        if n < self.rows:  # cycle-pad so every epoch has the fixed ref count
+            refs = (refs * ((self.rows + n - 1) // n))[: self.rows]
+        elif n > self.rows:
+            refs = refs[: self.rows]
+        if self._rank() == 0:
+            _say(f"chunk_start epoch={epoch} chunk={os.path.basename(nxt)} rows={n} padded_to={self.rows} wait_for_data_time={wait:.1f}s boundary_overhead={time.perf_counter()-t_bound-wait:.1f}s chunks_done={self.chunks_done}")
+        self._memo_epoch, self._memo_refs = epoch, refs
+        return refs


### PR DESCRIPTION
…raining

Adds data_mode=stream: a chunk is a data-delivery unit consumed as one epoch of a single persistent process — never a process/optimizer/checkpoint boundary.

- specforge/training/streaming.py (new): StreamingChunkSource — READY/CONSUMED atomic chunk protocol, rank0 selection + broadcast, fixed-size cycle padding, delete-at-next-boundary, peek-based build-time sizing, in-trainer trainable-only safetensors export via the backend collective gather (with a malformed-FSDP-export guard).
- specforge/launch.py: stream branch in build_offline_runtime; exact stream resume translation (epoch-complete vs mid-epoch via batches_per_epoch).
- specforge/config/schema.py: data_mode/stream_dir/stream_chunk_rows; export_every_chunks/export_dir.
- specforge/training/assembly.py: config plumbing, num_epochs=1e9 in stream mode, export binding through the trainer controller.

Validated: optimizer moments continuous across 2,600+ chunk boundaries in one process; kill+resume bitwise-identical to uninterrupted; overfit gate acc 0.997 serving at pooled accept 7.98/9 via sglang 0.5.18 DSPARK.

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
