### PR TITLE
docs: add --no-deps to ROCm install in training.md

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -453,11 +453,12 @@ names consistently.
 ## CUDA, ROCm, and Ascend NPU
 
 CUDA and ROCm runs use the same YAML and entry point. For ROCm, install the
-checked-in environment before installing SpecForge:
+checked-in environment before installing SpecForge without dependencies
+so pip does not pull CUDA wheels over the ROCm stack:
 
 ```bash
 python -m pip install -r requirements-rocm.txt
-python -m pip install -e .
+python -m pip install -e . --no-deps
 ```
 
 Use a model/backend combination supported by that PyTorch ROCm environment;


### PR DESCRIPTION
## Summary
ROCm install in `docs/basic_usage/training.md` used a bare `pip install -e .` after `requirements-rocm.txt`. `pyproject.toml` pins CUDA-default `torch==2.13.0` and `sglang==0.5.18`, so that full resolve can overwrite a working ROCm stack.

`docs/get_started/installation.md` and `docs/basic_usage/AMD/amd_rocm.md` already require `--no-deps`. This matches them.

## Local repro
```bash
# stale command in training.md
python -m pip install -r requirements-rocm.txt
python -m pip install -e .
# pip can re-resolve pyproject and pull CUDA torch/sglang

# required command (installation.md / amd_rocm.md)
python -m pip install -e . --no-deps
```

On `main` (`2fc9930`), training.md L460 is `python -m pip install -e .` with no `--no-deps`.

## Test plan
- [x] Diff is training.md only
- [x] ROCm block now uses `python -m pip install -e . --no-deps`
- [x] CUDA/Ascend instructions unchanged