### PR TITLE
docs: say examples support offline evaluation only

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,7 @@ guide](../docs/basic_usage/disaggregated_training.md).
 
 Offline feature training supports EAGLE3, DFlash, Domino, and DSpark, including
 local and disaggregated consumers. Optional config sections provide
-online/offline evaluation with `<run_id>-best` selection, compact teacher
+offline evaluation with `<run_id>-best` selection, compact teacher
 projection for offline text EAGLE3, and W&B, TensorBoard, SwanLab, or MLflow
 tracking. See the [training guide](../docs/basic_usage/training.md) for the full
 capability matrix, ROCm installation, and Ascend NPU/HCCL launch example.


### PR DESCRIPTION
## Motivation

`examples/README.md` on `main` contradicts itself about online evaluation.

Same file, same page:

1. Supported-looking claim (now fixed):
   > Optional config sections provide **online/offline evaluation** with `<run_id>-best` selection

2. Contradictory claim (left as-is; matches code):
   > Online evaluation is also unsupported.

Code on `main` (`specforge/config/schema.py`) rejects online eval:

```python
if self.data.eval_data_path:
    raise ValueError(
        "data.eval_data_path is unsupported; online evaluation is not "
        "supported by the server-only capture path"
    )
...
if self.data.eval_hidden_states_path and mode != "offline":
    raise ValueError(
        "data.eval_hidden_states_path requires an offline training data source"
    )
```

Tests: `test_online_evaluation_is_explicitly_unsupported` and
`test_offline_eval_source_requires_offline_training` in
`tests/test_config/test_schema.py`.

## Modifications

One wording change in `examples/README.md`: `online/offline evaluation` → `offline evaluation`.

The earlier "Online evaluation is also unsupported." sentence is unchanged.

## Related Issues

N/A

## Accuracy Test

N/A (docs only)

## Benchmark & Profiling

N/A (docs only)

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [ ] Add unit tests as outlined in the Running Unit Tests.
- [x] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel to discuss your PR.
