### PR TITLE
docs: add --no-deps to ROCm install in training.md

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -457,7 +457,7 @@ checked-in environment before installing SpecForge:
 
 ```bash
 python -m pip install -r requirements-rocm.txt
-python -m pip install -e .
+python -m pip install -e . --no-deps
 ```
 
 Use a model/backend combination supported by that PyTorch ROCm environment;


### PR DESCRIPTION
## Summary
Align the ROCm install snippet in `docs/basic_usage/training.md` with the other ROCm docs (`docs/get_started/installation.md`, `docs/basic_usage/AMD/amd_rocm.md`) by using `pip install -e . --no-deps` after `requirements-rocm.txt`.

`pyproject.toml` pins CUDA-default torch/sglang, so a bare editable install can replace a ROCm stack.

## How verified
Verified against upstream `sgl-project/SpecForge` main SHA `2fc993077c3c53df14ebdd5d414c854864476af8`.

**Before** (`docs/basic_usage/training.md` ROCm snippet):
```bash
python -m pip install -r requirements-rocm.txt
python -m pip install -e .
```

**After**:
```bash
python -m pip install -r requirements-rocm.txt
python -m pip install -e . --no-deps
```

**Matching `--no-deps` in other ROCm docs** (same SHA):
- `docs/get_started/installation.md`: `python -m pip install -e . --no-deps`
- `docs/basic_usage/AMD/amd_rocm.md`: `python -m pip install -e . --no-deps` (notes `--no-deps` is mandatory so CUDA wheels do not clobber ROCm torch/sglang)

**`pyproject.toml` pins** (same SHA):
- `torch==2.13.0`
- `sglang==0.5.18`