### PR TITLE
Drafter eval tooling: AIME25 benchmark, jsonl accept probe, template override

### DIFF
--- a/benchmarks/benchmarker/__init__.py
+++ b/benchmarks/benchmarker/__init__.py
@@ -1,4 +1,4 @@
-from .aime import AIMEBenchmarker
+from .aime import AIME25Benchmarker, AIMEBenchmarker
 from .ceval import CEvalBenchmarker
 from .financeqa import FinanceQABenchmarker
 from .gpqa import GPQABenchmarker
@@ -16,6 +16,7 @@ from .simpleqa import SimpleQABenchmarker
 __all__ = [
     "BENCHMARKS",
     "AIMEBenchmarker",
+    "AIME25Benchmarker",
     "CEvalBenchmarker",
     "GSM8KBenchmarker",
     "HumanEvalBenchmarker",

--- a/benchmarks/benchmarker/aime.py
+++ b/benchmarks/benchmarker/aime.py
@@ -131,3 +131,36 @@ class AIMEBenchmarker(Benchmarker):
     def get_max_new_tokens(self) -> int:
         """AIME problems require more tokens."""
         return 32768
+
+
+@BENCHMARKS.register("aime25")
+class AIME25Benchmarker(AIMEBenchmarker):
+    """AIME 2025 benchmark (30 problems, AIME I + II)."""
+
+    _DATASET_CANDIDATES = ("math-ai/aime25", "yentinglin/aime_2025")
+
+    def load_data(self) -> Tuple[List[Dict[str, Any]], List[Optional[str]]]:
+        dataset = None
+        errors = []
+        for name in self._DATASET_CANDIDATES:
+            try:
+                loaded = load_dataset(name)
+                dataset = loaded[list(loaded.keys())[0]]
+                break
+            except Exception as exc:  # noqa: BLE001 - fall through to next source
+                errors.append(f"{name}: {exc}")
+        if dataset is None:
+            raise RuntimeError(
+                "could not load an AIME 2025 dataset; tried "
+                + "; ".join(errors)
+            )
+        questions = []
+        labels = []
+        for idx, q in enumerate(dataset):
+            if self.num_samples is not None and idx >= self.num_samples:
+                break
+            problem = q.get("problem") or q.get("Problem")
+            answer = q.get("answer", q.get("Answer"))
+            questions.append({"question": problem})
+            labels.append(str(answer).strip() if answer is not None else None)
+        return questions, labels

--- a/scripts/analyze_tune_run.py
+++ b/scripts/analyze_tune_run.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Summarize a disaggregated tuning run: trainer step timing vs producer rate.
+
+Usage: python3 scripts/analyze_tune_run.py outputs/<run>/logs/train.log
+"""
+import re
+import sys
+
+
+def main(path: str) -> None:
+    step_time, data_wait, compute = [], [], []
+    published = []  # (epoch_seconds, produced_total, worker)
+    backpressure = 0
+    for line in open(path, errors="replace"):
+        m = re.search(r"perf/optimizer_step_time_s['\"]?[:=]\s*([0-9.]+)", line)
+        if m:
+            step_time.append(float(m.group(1)))
+        m = re.search(r"perf/data_wait_time_s['\"]?[:=]\s*([0-9.]+)", line)
+        if m:
+            data_wait.append(float(m.group(1)))
+        m = re.search(r"perf/train_compute_time_s['\"]?[:=]\s*([0-9.]+)", line)
+        if m:
+            compute.append(float(m.group(1)))
+        if "backpressure wait" in line:
+            backpressure += 1
+        m = re.search(
+            r"published refs worker=(\S+) batch=\d+ produced=(\d+).*elapsed=([0-9.]+)",
+            line,
+        )
+        if m:
+            published.append((m.group(1), int(m.group(2)), float(m.group(3))))
+
+    def stats(name, xs):
+        if not xs:
+            print(f"{name}: none")
+            return
+        xs2 = xs[max(0, len(xs) // 3):]  # drop warmup third
+        print(
+            f"{name}: n={len(xs)} last={xs[-1]:.2f}s "
+            f"steady-mean={sum(xs2)/len(xs2):.2f}s min={min(xs):.2f} max={max(xs):.2f}"
+        )
+
+    stats("optimizer_step_time", step_time)
+    stats("data_wait_time", data_wait)
+    stats("train_compute_time", compute)
+    print(f"producer backpressure-wait log lines: {backpressure}")
+    per_worker = {}
+    for w, produced, elapsed in published:
+        per_worker[w] = (produced, elapsed)
+    total = sum(p for p, _ in per_worker.values())
+    if per_worker:
+        rates = {w: p / e for w, (p, e) in per_worker.items() if e > 0}
+        agg = sum(rates.values())
+        print(f"produced total={total} samples, aggregate rate={agg*60:.1f} samples/min")
+        for w in sorted(per_worker):
+            p, e = per_worker[w]
+            print(f"  worker {w}: produced={p} over {e:.0f}s -> {p/e*60:.2f}/min")
+    if step_time and data_wait:
+        sw = step_time[max(0, len(step_time) // 3):]
+        dw = data_wait[max(0, len(data_wait) // 3):]
+        ratio = (sum(dw) / len(dw)) / max(sum(sw) / len(sw), 1e-9)
+        verdict = (
+            "PRODUCER-BOUND (trainer starved)" if ratio > 0.15
+            else "TRAINER-BOUND (producers keep up)"
+        )
+        print(f"steady data_wait/step_time = {ratio:.1%} -> {verdict}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/scripts/bench_accept_jsonl.py
+++ b/scripts/bench_accept_jsonl.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Accept-length probe over a preformatted-prompt jsonl against a running
+sglang DSPARK server.
+
+Rows must carry the full rendered prompt in a ``text`` field (e.g. the
+0813-traffic test set produced by transform_traffic_recordings.py); prompts
+are sent raw to ``/generate`` — no chat template. Reports the average
+speculative acceptance length from ``meta_info``.
+
+    python3 scripts/bench_accept_jsonl.py \
+        --jsonl cache/dataset/dsv4_flash_0813_32k_test.jsonl \
+        --base-url http://127.0.0.1:31000 --num-prompts 64 --output-json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def send(base_url: str, prompt: str, max_new_tokens: int, timeout: int):
+    import requests
+
+    response = requests.post(
+        base_url.rstrip("/") + "/generate",
+        json={
+            "text": prompt,
+            "sampling_params": {
+                "temperature": 0.0,
+                "max_new_tokens": max_new_tokens,
+            },
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload[0] if isinstance(payload, list) else payload
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--jsonl", required=True)
+    parser.add_argument("--base-url", default="http://127.0.0.1:31000")
+    parser.add_argument("--num-prompts", type=int, default=64)
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--max-new-tokens", type=int, default=512)
+    parser.add_argument("--max-prompt-chars", type=int, default=None,
+                        help="skip rows with longer rendered prompts")
+    parser.add_argument("--timeout-seconds", type=int, default=3600)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-json", default=None)
+    args = parser.parse_args()
+
+    rows = []
+    with open(args.jsonl, encoding="utf-8") as stream:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            text = row.get("text")
+            if not text:
+                continue
+            if args.max_prompt_chars and len(text) > args.max_prompt_chars:
+                continue
+            rows.append(text)
+    if not rows:
+        raise SystemExit("no usable rows (need a non-empty 'text' field)")
+    random.Random(args.seed).shuffle(rows)
+    rows = rows[: args.num_prompts]
+    print(f"probing {len(rows)} prompts from {args.jsonl}")
+
+    results = []
+    errors = 0
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = [
+            pool.submit(send, args.base_url, text, args.max_new_tokens,
+                        args.timeout_seconds)
+            for text in rows
+        ]
+        for future in as_completed(futures):
+            try:
+                payload = future.result()
+            except Exception as exc:  # noqa: BLE001
+                errors += 1
+                print(f"  request failed: {exc}")
+                continue
+            meta = payload.get("meta_info", {})
+            accept = meta.get("spec_accept_length")
+            verify = meta.get("spec_verify_ct")
+            tokens = meta.get("completion_tokens")
+            if accept is not None:
+                results.append(
+                    {"accept": accept, "verify": verify, "tokens": tokens}
+                )
+    if not results:
+        raise SystemExit(f"no successful spec responses ({errors} errors)")
+
+    total_tokens = sum(r["tokens"] or 0 for r in results)
+    total_verify = sum(r["verify"] or 0 for r in results)
+    per_request = sum(r["accept"] for r in results) / len(results)
+    token_weighted = (total_tokens / total_verify) if total_verify else None
+    print(f"completed: {len(results)}  errors: {errors}")
+    print(f"average acceptance length (per-request mean): {per_request:.3f}")
+    if token_weighted is not None:
+        print(f"average acceptance length (token-weighted): {token_weighted:.3f}")
+    summary = {
+        "jsonl": args.jsonl,
+        "num_completed": len(results),
+        "num_errors": errors,
+        "average_acceptance_length": per_request,
+        "token_weighted_acceptance_length": token_weighted,
+        "max_new_tokens": args.max_new_tokens,
+    }
+    if args.output_json:
+        with open(args.output_json, "w", encoding="utf-8") as stream:
+            json.dump(summary, stream, indent=2)
+        print(f"wrote {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/specforge/benchmarks/sglang.py
+++ b/specforge/benchmarks/sglang.py
@@ -91,12 +91,35 @@ def _load_prompts(name: str, max_samples: Optional[int]) -> list[list[str]]:
     return prompts
 
 
-def _apply_chat_template(tokenizer, messages, enable_thinking: bool) -> str:
+def _resolve_chat_template_override(name: Optional[str]) -> Optional[str]:
+    """Jinja template from SpecForge's registry, for tokenizers that ship no
+    chat_template of their own (e.g. DeepSeek-V4 keeps it in encoding/)."""
+    if not name:
+        return None
+    from specforge.data.template import TEMPLATE_REGISTRY
+
+    template = TEMPLATE_REGISTRY.get(name)
+    jinja = getattr(template, "jinja_chat_template", None)
+    if not jinja:
+        raise ValueError(
+            f"chat template {name!r} does not define jinja_chat_template"
+        )
+    return jinja
+
+
+def _apply_chat_template(
+    tokenizer,
+    messages,
+    enable_thinking: bool,
+    chat_template: Optional[str] = None,
+) -> str:
     kwargs = {
         "tokenize": False,
         "add_generation_prompt": True,
         "enable_thinking": enable_thinking,
     }
+    if chat_template is not None:
+        kwargs["chat_template"] = chat_template
     try:
         return tokenizer.apply_chat_template(messages, **kwargs)
     except TypeError:
@@ -138,6 +161,9 @@ def _run_sglang(args) -> BenchmarkResult:
         trust_remote_code=args.trust_remote_code,
     )
     dataset = _load_prompts(args.dataset, args.max_samples)
+    chat_template = _resolve_chat_template_override(
+        getattr(args, "chat_template", None)
+    )
     prompt_count = args.num_prompts
     warmup_count = args.concurrency
     prompts = [
@@ -145,6 +171,7 @@ def _run_sglang(args) -> BenchmarkResult:
             tokenizer,
             [{"role": "user", "content": dataset[index % len(dataset)][0]}],
             args.enable_thinking,
+            chat_template=chat_template,
         )
         for index in range(prompt_count + warmup_count)
     ]

--- a/specforge/cli.py
+++ b/specforge/cli.py
@@ -235,6 +235,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     benchmark.add_argument("--timeout-seconds", type=int, default=3600)
     benchmark.add_argument("--enable-thinking", action="store_true")
     benchmark.add_argument("--trust-remote-code", action="store_true")
+    benchmark.add_argument(
+        "--chat-template",
+        default=None,
+        help="SpecForge template registry name (e.g. deepseek-v4) applied "
+        "when the tokenizer ships no chat_template of its own",
+    )
     benchmark.add_argument("--output-json")
     args = parser.parse_args(argv)
 


### PR DESCRIPTION
Stacked on #800 (retarget as the stack merges). Code-wise this only needs #798's `jinja_chat_template`.

- **AIME25 accept-length benchmark plugin** (`benchmarks/benchmarker/aime.py`), exported alongside the existing benchmarkers.
- **`specforge benchmark --chat-template`**: apply a SpecForge template-registry entry (e.g. `deepseek-v4`) when the tokenizer ships no `chat_template` of its own — required to benchmark DeepSeek-V4 targets.
- **`scripts/bench_accept_jsonl.py`**: accept-length probe over a preformatted JSONL corpus (e.g. the held-out slice of recorded production traffic) against a running SGLang server — measures drafter acceptance on real traffic rather than academic sets.
- **`scripts/analyze_tune_run.py`**: summarize step-time/accept metrics from a tuning run's logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)