### PR TITLE
docs: fix stale --tp flag in gates SGLang example

### DIFF
--- a/scripts/gates/README.md
+++ b/scripts/gates/README.md
@@ -36,7 +36,7 @@ Launch the sglang server:
 python3 -m sglang.launch_server \
   --model Qwen/Qwen3.6-27B \
   --mem-fraction-static 0.7 \
-  --tp 1 \
+  --tp-size 1 \
   --host 0.0.0.0 \
   --port 30000 \
   --dtype bfloat16 \


### PR DESCRIPTION
## Summary
Replace invalid `--tp` with `--tp-size` in the Stage 1 `sglang.launch_server` example in `scripts/gates/README.md`.

SGLang `0.5.18` `ServerArgs` exposes `--tp-size` (alias `--tensor-parallel-size`), not `--tp`. The same README already uses `--tp-size` in the Stage 3 serving example.

## How verified
Against upstream `sgl-project/SpecForge` main SHA `bc5d8451aa5e7d30aa971dba93d1b7d0c61b83c1` and SGLang `v0.5.18` `ServerArgs`:

- `tp_size` CLI flag: `--tp-size` with alias `--tensor-parallel-size` only (no `--tp`)
- SpecForge pin: `sglang==0.5.18` in `pyproject.toml`
- Same file Stage 3 example already uses `--tp-size 1`

**Before**
```bash
python3 -m sglang.launch_server \
  ...
  --tp 1 \
  ...
```

**After**
```bash
python3 -m sglang.launch_server \
  ...
  --tp-size 1 \
  ...
```