### PR TITLE
docs: fix --tp to --tp-size in specbundle SGLang flags

### DIFF
--- a/docs/community_resources/specbundle.md
+++ b/docs/community_resources/specbundle.md
@@ -23,7 +23,7 @@ We evaluate the performance of SpecBundle draft models on various benchmarks, pl
 
 ## Usage
 
-You can use the following command to launch the SGLang server with SpecBundle models. Please add `--tp`, `--ep` and `--mem-fraction-static` arguments when you encounter memory issues.
+You can use the following command to launch the SGLang server with SpecBundle models. Please add `--tp-size`, `--ep` and `--mem-fraction-static` arguments when you encounter memory issues.
 
 ```bash
 python3 -m sglang.launch_server \


### PR DESCRIPTION
## Summary
In `docs/community_resources/specbundle.md` Usage prose, replace the stale SGLang flag `--tp` with `--tp-size`. Leave `--ep` and `--mem-fraction-static` unchanged.

## Repro
Upstream docs currently say:

> Please add `--tp`, `--ep` and `--mem-fraction-static` arguments when you encounter memory issues.

Against current SGLang `ServerArgs`:

- `tp_size` → CLI `--tp-size` (aliases: `--tensor-parallel-size`). There is no bare `--tp`.
- `ep_size` → `--ep-size` with alias `--ep` (kept as written).
- `mem_fraction_static` → `--mem-fraction-static` (kept as written).

```bash
python3 -c "from sglang.srt.server_args import ServerArgs; import dataclasses; f=[x for x in dataclasses.fields(ServerArgs) if x.name=='tp_size'][0]; print(f.name, f.type)"
# or:
python3 -m sglang.launch_server -h | grep -E -- '--tp-size|--tp[^-]|--ep |--mem-fraction-static'
```

`--tp` alone is rejected / not registered; `--tp-size` is the correct flag.

## Test plan
- [x] Confirmed prose-only one-line change in `specbundle.md`
- [x] Distinct from open docs PRs #796 / #802 / #803 (different file/path)
- [ ] Docs render / review