### PR TITLE
docs: fix stale --tp flag in regenerate_train_data SGLang example

### DIFF
--- a/scripts/regenerate_train_data.py
+++ b/scripts/regenerate_train_data.py
@@ -8,7 +8,7 @@ Usage:
 python3 -m sglang.launch_server \
 	--model Qwen/Qwen3.5-35B-A3B \
 	--mem-fraction-static 0.7 \
-	--tp 1 \
+	--tp-size 1 \
 	--trust-remote-code \
     --cuda-graph-max-bs 128 \
 	--host 0.0.0.0 \


### PR DESCRIPTION
## Summary
Replace invalid `--tp` with `--tp-size` in the `sglang.launch_server` usage docstring in `scripts/regenerate_train_data.py`.

SGLang `0.5.18` `ServerArgs` exposes `--tp-size` (alias `--tensor-parallel-size`), not `--tp`.

## How verified
Against upstream `sgl-project/SpecForge` main SHA `bc5d8451aa5e7d30aa971dba93d1b7d0c61b83c1` and SGLang `v0.5.18` `ServerArgs`:

- `tp_size` CLI flag: `--tp-size` with alias `--tensor-parallel-size` only (no `--tp`)
- SpecForge pin: `sglang==0.5.18` in `pyproject.toml`

**Before**
```bash
python3 -m sglang.launch_server \
  ...
  --tp 1 \
  ...
```

**After**
```bash
python3 -m sglang.launch_server \
  ...
  --tp-size 1 \
  ...
```