### PR TITLE
[patch] support applying SGLang patch inside a git repo

### DIFF
--- a/scripts/apply_sglang_spec_capture_patch.sh
+++ b/scripts/apply_sglang_spec_capture_patch.sh
@@ -75,20 +75,31 @@ if ! command -v git > /dev/null; then
     exit 1
 fi
 
+# git apply must treat $SGL_PARENT as a plain directory. When site-packages
+# lives inside a git checkout (a repo-local .venv is the documented install,
+# and a source tree is itself a repository) git resolves patch paths against
+# that repository's top level and silently SKIPS every file outside the
+# current subdirectory, exiting 0 without touching anything. Stop repository
+# discovery at $SGL_PARENT so paths always resolve relative to it.
+git_apply() {
+    GIT_CEILING_DIRECTORIES="$(dirname "$SGL_PARENT")" \
+        git -C "$SGL_PARENT" apply "$@"
+}
+
 check_apply() {
-    git -C "$SGL_PARENT" apply --check -p2 "$1" 2> /dev/null
+    git_apply --check -p2 "$1" 2> /dev/null
 }
 
 check_reverse() {
-    git -C "$SGL_PARENT" apply --reverse --check -p2 "$1" 2> /dev/null
+    git_apply --reverse --check -p2 "$1" 2> /dev/null
 }
 
 apply_exact() {
-    git -C "$SGL_PARENT" apply -p2 "$1"
+    git_apply -p2 "$1"
 }
 
 reverse_exact() {
-    git -C "$SGL_PARENT" apply --reverse -p2 "$1"
+    git_apply --reverse -p2 "$1"
 }
 
 fail_unknown_state() {

--- a/tests/test_scripts/test_apply_sglang_spec_capture_patch.py
+++ b/tests/test_scripts/test_apply_sglang_spec_capture_patch.py
@@ -66,6 +66,32 @@ class ApplySglangSpecCapturePatchTest(unittest.TestCase):
         self.record.write_text(old_patch, encoding="utf-8")
         return old_patch
 
+    def test_patches_site_packages_nested_inside_a_git_repository(self) -> None:
+        # A repo-local .venv is the documented install layout. git apply run
+        # from a subdirectory of a repository resolves paths against the repo
+        # top level and silently skips everything else, so the unfixed script
+        # reported success while leaving sglang untouched.
+        subprocess.run(
+            ["git", "init", "-q", self.temp_dir.name], check=True, capture_output=True
+        )
+        self.example.write_text("new base\n", encoding="utf-8")
+
+        result = self.run_script()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("applied at", result.stdout)
+        self.assertEqual(self.example.read_text(encoding="utf-8"), "new patched\n")
+        self.assertEqual(self.sink.read_text(encoding="utf-8"), "new sink\n")
+
+        again = self.run_script()
+        self.assertEqual(again.returncode, 0, again.stderr)
+        self.assertIn("already applied", again.stdout)
+
+        reversed_ = self.run_script("--reverse")
+        self.assertEqual(reversed_.returncode, 0, reversed_.stderr)
+        self.assertEqual(self.example.read_text(encoding="utf-8"), "new base\n")
+        self.assertFalse(self.sink.exists())
+
     def test_recovers_files_left_by_pip_upgrade_and_is_idempotent(self) -> None:
         self.seed_cached_upgrade()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

`scripts/apply_sglang_spec_capture_patch.sh` silently does nothing when the installed SGLang lives inside a git checkout. It runs git apply from the site-packages directory. If that directory is nested in a repository, git resolves patch paths against the repository top level and skips every file outside the current subdirectory, then exits 0. 

This happens if the user's env is inside specforge repo, e.g. users can call `uv venv -p 3.12` in specforge repo and keep the virtual env there. 


## Modifications

<!-- Describe the changes made in this PR. -->

 - Route all git apply calls in the script through one helper that sets GIT_CEILING_DIRECTORIES to the parent of the SGLang root. This stops repository discovery, so git treats site-packages as a plain directory and patch paths resolve correctly.
  - Add a regression test that places the fake site-packages inside a fresh git repository and checks that the patch applies, that a second run is idempotent, and that --reverse restores the original files. The test fails on the old script and passes on the new one.


## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
