### PR TITLE
docs: qualify configs README for unsupported VLM draft JSONs

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -1,7 +1,9 @@
 # Unified training recipe catalog
 
 Every draft model JSON under `configs/` has at least one typed YAML recipe in
-this catalog. Choose a recipe by answering three separate questions:
+this catalog, except future/unsupported VLM draft configs
+(`qwen2-5-vl-7b-eagle3.json` and `qwen2.5-vl-32b-eagle3.json`; see the VLM note
+below). Choose a recipe by answering three separate questions:
 
 1. **When are target features produced?** `online` captures them during the
    run; `offline` reads feature files prepared earlier.


### PR DESCRIPTION
## Summary
- Qualify the `examples/configs/README.md` catalog opener: not every `configs/*.json` has a typed YAML recipe.
- Call out the two intentional exceptions `qwen2-5-vl-7b-eagle3.json` and `qwen2.5-vl-32b-eagle3.json`, matching `test_only_future_vlm_draft_configs_lack_a_unified_recipe` and the existing VLM unsupported note later in the same README.

## Test plan
- [ ] Diff is limited to `examples/configs/README.md`
- [ ] Opener no longer contradicts the VLM unsupported note / wiring test allowlist
- [ ] Existing docs CI / lint passes