### PR TITLE
docs: fix --is-performatted typo in prepare_hidden_states Usage

### DIFF
--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -37,7 +37,7 @@ torchrun --nproc_per_node=2 \
     --num-samples 10000 \
     --strategy dspark \
     --draft-model-config configs/qwen3-8b-dspark.json \
-    --is-performatted
+    --is-preformatted
 """
 
 import argparse


### PR DESCRIPTION
## Summary
Fix a one-character typo in the module Usage docstring of `scripts/prepare_hidden_states.py`: `--is-performatted` → `--is-preformatted`.

The argparse flag is already `--is-preformatted`, and the prose line in the same docstring (`add --is-preformatted`) plus `docs/basic_usage/data_preparation.md` already use the correct spelling. Only the example command line had the typo.

## Repro
```bash
# on main (bc5d8451)
rg -n 'is-performatted|is-preformatted' scripts/prepare_hidden_states.py
# Usage example shows --is-performatted (typo)
# argparse defines --is-preformatted; prose already says --is-preformatted
```

## Test plan
- [x] Confirmed single-line docstring change only
- [x] Verified argparse / docs already correct; no behavioral change
