### PR TITLE
feat: add structured DFlash2 training metrics

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -224,17 +224,22 @@ anchor is omitted), so each position renders as one dashboard group:
 - `hard_label/*`: unary top-1 accuracy, top-K recall and probability mass,
   gold-token probability, selector loss, selector conditional accuracy (uniform
   over covered slots, so comparable across loss types), and the realized greedy
-  serving path's per-slot accuracy. Two aggregate-only per-block accepted-length
-  proxies count the anchor plus the leading run of supervised slots that are
-  covered by the unary top-K (`unary_topK_oracle_accepted_length`) or matched by
-  the serving path (`selector_serving_accepted_length`).
+  serving path's per-slot accuracy. Three aggregate-only per-block
+  accepted-length proxies apply `1 + sum_k prod_{j<=k} a_j` over the supervised
+  slots with `a_j` being coverage by the unary top-K
+  (`unary_topK_oracle_accepted_length`), a serving-path hit
+  (`selector_serving_accepted_length`), or the gold-token probability
+  (`expected_accepted_length`, the smooth D-PACE surrogate). All three are
+  teacher-forced on the real prefix and anchor.
 - `position_<k>/objective/loss_weight_share`: the fraction of the effective
   objective weight each block position receives under the configured
   fixed-decay or D-PACE weighting.
 - `train/objective/lk_kl_weight`: the CE weight of the `lambda` LK objective.
 - `teacher/*` (online capture only): full-vocabulary expected acceptance, unary
   top-1 agreement, unary top-K teacher mass, and serving-path agreement against
-  the frozen target head.
+  the frozen target head, plus the aggregate `expected_accepted_length` that
+  chains the per-slot expected acceptance, the sampling-regime counterpart of
+  the hard-label surrogate.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -215,15 +215,24 @@ from updating the unary logits and draft hidden states. The selector parameters
 still train, and the primary DFlash/D-PACE/LK objective keeps its normal draft
 gradient path. The option defaults to `false`, preserving coupled training.
 
-External tracking reports aggregate and per-block-position DFlash2 diagnostics.
-The `train/dflash2/hard_label/*` family separates unary top-1 accuracy,
-unary top-K recall and probability, selector loss, conditional selector
-accuracy, and strict-serving selector accuracy. Online runs additionally report
-`train/dflash2/teacher/*` top-1 agreement, unary top-K teacher mass, expected
-acceptance, and strict-serving selector agreement. Per-position keys end in
-`position_1` through `position_<block_size-1>`; the verified position-zero
-anchor is omitted. Full-vocabulary alignment telemetry is computed only for
-optimizer steps that reach `training.log_interval`.
+External tracking reports DFlash2 diagnostics on optimizer steps that reach
+`training.log_interval`, as aggregates plus `position_1` through
+`position_<block_size-1>` breakdowns (the verified anchor is omitted):
+
+- `train/dflash2/hard_label/*`: unary top-1 accuracy, top-K recall and
+  probability mass, gold-token probability, selector loss, selector conditional
+  accuracy (uniform over covered slots, so comparable across loss types), and
+  the realized greedy serving path's per-slot accuracy. Two per-block
+  accepted-length proxies count the anchor plus the leading run of supervised
+  slots that are covered by the unary top-K (`unary_topK_oracle_accepted_length`)
+  or matched by the serving path (`selector_serving_accepted_length`).
+- `train/dflash2/objective/loss_weight_share/position_*`: the fraction of the
+  effective objective weight each block position receives under the configured
+  fixed-decay or D-PACE weighting.
+- `train/objective/lk_kl_weight`: the CE weight of the `lambda` LK objective.
+- `train/dflash2/teacher/*` (online capture only): full-vocabulary expected
+  acceptance, unary top-1 agreement, unary top-K teacher mass, and serving-path
+  agreement against the frozen target head.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -183,7 +183,10 @@ The `eager`, `sdpa`, and `flex_attention` backends support both layouts.
 DFlash2 is a draft-architecture variant of DFlash, not a separate capture
 strategy. Keep `training.strategy: dflash` and select it with a draft config
 whose architecture is `DFlash2DraftModel`. The target server still captures
-the same selected hidden states with `--spec-capture-method dflash`.
+the same selected hidden states with `--spec-capture-method dflash`. Online
+capture also retains the target's final hidden state for teacher-alignment
+telemetry; existing offline DFlash datasets remain compatible and omit only
+the teacher-only metrics.
 
 The DFlash2 config additionally defines `conv_kernel_size` and
 `conv_group_size` for the local convolution, plus `selector_rank` and
@@ -211,6 +214,16 @@ Set `training.dflash2_selector_stop_gradient: true` to keep the selector CE
 from updating the unary logits and draft hidden states. The selector parameters
 still train, and the primary DFlash/D-PACE/LK objective keeps its normal draft
 gradient path. The option defaults to `false`, preserving coupled training.
+
+External tracking reports aggregate and per-block-position DFlash2 diagnostics.
+The `train/dflash2/hard_label/*` family separates unary top-1 accuracy,
+unary top-K recall and probability, selector loss, conditional selector
+accuracy, and strict-serving selector accuracy. Online runs additionally report
+`train/dflash2/teacher/*` top-1 agreement, unary top-K teacher mass, expected
+acceptance, and strict-serving selector agreement. Per-position keys end in
+`position_1` through `position_<block_size-1>`; the verified position-zero
+anchor is omitted. Full-vocabulary alignment telemetry is computed only for
+optimizer steps that reach `training.log_interval`.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and
@@ -447,8 +460,11 @@ tracking:
 Accepted values are `none`, `wandb`, `tensorboard`, `swanlab`, and `mlflow`.
 W&B, SwanLab, and MLflow have matching project/run fields in the typed schema;
 TensorBoard writes beneath `output_dir/runs`, and SwanLab writes beneath
-`output_dir/swanlog`. Trainer and evaluator metrics use `train/*` and `eval/*`
-names consistently.
+`output_dir/swanlog`. Optimization and evaluator metrics use `train/*` and
+`eval/*`; throughput and timing counters use the top-level `perf/*` namespace.
+Historical `ploss*`, `acceptance_rate*`, and `target_probability` names remain
+available alongside explicit `kl_loss*` or `lk_loss*`, `ce_loss`, and
+`expected_acceptance*` names.
 
 ## CUDA, ROCm, and Ascend NPU
 

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -216,23 +216,25 @@ still train, and the primary DFlash/D-PACE/LK objective keeps its normal draft
 gradient path. The option defaults to `false`, preserving coupled training.
 
 External tracking reports DFlash2 diagnostics on optimizer steps that reach
-`training.log_interval`, as aggregates plus `position_1` through
-`position_<block_size-1>` breakdowns (the verified anchor is omitted):
+`training.log_interval`. Aggregates live under `train/dflash2/*`; the same
+families are broken down per predicted block position under their own
+`position_1/*` through `position_<block_size-1>/*` sections (the verified
+anchor is omitted), so each position renders as one dashboard group:
 
-- `train/dflash2/hard_label/*`: unary top-1 accuracy, top-K recall and
-  probability mass, gold-token probability, selector loss, selector conditional
-  accuracy (uniform over covered slots, so comparable across loss types), and
-  the realized greedy serving path's per-slot accuracy. Two per-block
-  accepted-length proxies count the anchor plus the leading run of supervised
-  slots that are covered by the unary top-K (`unary_topK_oracle_accepted_length`)
-  or matched by the serving path (`selector_serving_accepted_length`).
-- `train/dflash2/objective/loss_weight_share/position_*`: the fraction of the
-  effective objective weight each block position receives under the configured
+- `hard_label/*`: unary top-1 accuracy, top-K recall and probability mass,
+  gold-token probability, selector loss, selector conditional accuracy (uniform
+  over covered slots, so comparable across loss types), and the realized greedy
+  serving path's per-slot accuracy. Two aggregate-only per-block accepted-length
+  proxies count the anchor plus the leading run of supervised slots that are
+  covered by the unary top-K (`unary_topK_oracle_accepted_length`) or matched by
+  the serving path (`selector_serving_accepted_length`).
+- `position_<k>/objective/loss_weight_share`: the fraction of the effective
+  objective weight each block position receives under the configured
   fixed-decay or D-PACE weighting.
 - `train/objective/lk_kl_weight`: the CE weight of the `lambda` LK objective.
-- `train/dflash2/teacher/*` (online capture only): full-vocabulary expected
-  acceptance, unary top-1 agreement, unary top-K teacher mass, and serving-path
-  agreement against the frozen target head.
+- `teacher/*` (online capture only): full-vocabulary expected acceptance, unary
+  top-1 agreement, unary top-K teacher mass, and serving-path agreement against
+  the frozen target head.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and

--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -215,31 +215,37 @@ from updating the unary logits and draft hidden states. The selector parameters
 still train, and the primary DFlash/D-PACE/LK objective keeps its normal draft
 gradient path. The option defaults to `false`, preserving coupled training.
 
-External tracking reports DFlash2 diagnostics on optimizer steps that reach
-`training.log_interval`. Aggregates live under `train/dflash2/*`; the same
-families are broken down per predicted block position under their own
-`position_1/*` through `position_<block_size-1>/*` sections (the verified
-anchor is omitted), so each position renders as one dashboard group:
+External tracking reports DFlash-family diagnostics on optimizer steps that
+reach `training.log_interval`. Aggregates live under `train/dflash/*` for every
+DFlash-family draft and under `train/dflash2/selector/*` for drafts with a
+candidate selector. The same families are broken down per predicted block
+position under their own `position_1/*` through `position_<block_size-1>/*`
+sections (the verified anchor is omitted), so each position renders as one
+dashboard group:
 
-- `hard_label/*`: unary top-1 accuracy, top-K recall and probability mass,
-  gold-token probability, selector loss, selector conditional accuracy (uniform
-  over covered slots, so comparable across loss types), and the realized greedy
-  serving path's per-slot accuracy. Three aggregate-only per-block
-  accepted-length proxies apply `1 + sum_k prod_{j<=k} a_j` over the supervised
-  slots with `a_j` being coverage by the unary top-K
-  (`unary_topK_oracle_accepted_length`), a serving-path hit
-  (`selector_serving_accepted_length`), or the gold-token probability
-  (`expected_accepted_length`, the smooth D-PACE surrogate). All three are
-  teacher-forced on the real prefix and anchor.
+- `dflash/hard_label/*`: unary top-1 accuracy, top-K recall and probability
+  mass, and gold-token probability. K is the selector's `selector_top_k` when
+  present, otherwise the model's `metric_top_k` (default 16). Two aggregate-only
+  per-block accepted-length proxies apply `1 + sum_k prod_{j<=k} a_j` over the
+  supervised slots with `a_j` being coverage by the unary top-K
+  (`unary_topK_oracle_accepted_length`) or the gold-token probability
+  (`expected_accepted_length`, the smooth D-PACE surrogate).
 - `position_<k>/objective/loss_weight_share`: the fraction of the effective
   objective weight each block position receives under the configured
   fixed-decay or D-PACE weighting.
 - `train/objective/lk_kl_weight`: the CE weight of the `lambda` LK objective.
-- `teacher/*` (online capture only): full-vocabulary expected acceptance, unary
-  top-1 agreement, unary top-K teacher mass, and serving-path agreement against
-  the frozen target head, plus the aggregate `expected_accepted_length` that
-  chains the per-slot expected acceptance, the sampling-regime counterpart of
-  the hard-label surrogate.
+- `dflash/teacher/*` (online capture only): full-vocabulary expected
+  acceptance, unary top-1 agreement, and unary top-K teacher mass against the
+  frozen target head, plus the aggregate `expected_accepted_length` that chains
+  the per-slot expected acceptance, the sampling-regime counterpart of the
+  hard-label surrogate.
+- `dflash2/selector/*` (DFlash2 only): selector loss, conditional accuracy
+  (uniform over covered slots, so comparable across loss types), the realized
+  greedy serving path's per-slot accuracy, its per-block
+  `serving_accepted_length`, and, with online capture, its agreement with the
+  target argmax (`teacher_serving_agreement`).
+
+All accepted-length proxies are teacher-forced on the real prefix and anchor.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and

--- a/specforge/algorithms/common/collation.py
+++ b/specforge/algorithms/common/collation.py
@@ -26,8 +26,13 @@ def pad_and_concatenate_features(
     *,
     sequence_axes: Mapping[str, int],
     required_keys: Sequence[str],
+    optional_keys: Sequence[str] = (),
 ):
-    """Zero-pad configured tensor axes to the longest input sequence."""
+    """Zero-pad configured tensor axes to the longest input sequence.
+
+    ``optional_keys`` are collated when every sample carries them and omitted
+    when none does; a batch that mixes both raises.
+    """
 
     if not features:
         raise ValueError("cannot collate an empty feature batch")
@@ -40,12 +45,22 @@ def pad_and_concatenate_features(
     ]
     if missing:
         raise KeyError(f"feature batch is missing required keys: {missing}")
+    keys = list(required)
+    for key in optional_keys:
+        present = [key in feature for feature in features]
+        if all(present):
+            keys.append(key)
+        elif any(present):
+            raise KeyError(
+                f"optional feature {key!r} must be present in every sample or "
+                "omitted from every sample"
+            )
     max_length = max(int(feature["input_ids"].shape[-1]) for feature in features)
 
     import torch
 
     batch = {}
-    for key in required:
+    for key in keys:
         axis = sequence_axes[key]
         padded = []
         for feature in features:

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -77,6 +77,23 @@ class DFlashObjectiveTerms(NamedTuple):
     selector_covered_num: torch.Tensor
 
 
+class DFlashMetricTerms(NamedTuple):
+    """Additive per-position DFlash2 diagnostics for one metric chunk."""
+
+    hard_label_probability_num: torch.Tensor
+    unary_correct_num: torch.Tensor
+    position_den: torch.Tensor
+    unary_topk_recall_num: torch.Tensor
+    selector_ce_num: torch.Tensor
+    selector_weight_den: torch.Tensor
+    selector_conditional_correct_num: torch.Tensor
+    selector_serving_correct_num: torch.Tensor
+    teacher_expected_acceptance_num: torch.Tensor
+    teacher_unary_top1_agreement_num: torch.Tensor
+    teacher_unary_topk_mass_num: torch.Tensor
+    teacher_selector_serving_agreement_num: torch.Tensor
+
+
 def compute_accept_len(
     pred_ids_4d: torch.Tensor,
     target_ids_4d: torch.Tensor,
@@ -381,6 +398,56 @@ class OnlineDFlashModel(nn.Module):
             return suffix / prefix.clamp_min(torch.finfo(prefix.dtype).tiny)
         raise ValueError(f"unknown D-PACE loss_type {loss_type!r}")
 
+    def _aligned_target_hidden(
+        self,
+        target_last_hidden_states: torch.Tensor,
+        safe_label_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        """Gather the frozen target state that predicts each hard label."""
+
+        target_pred_indices = (safe_label_indices - 1).clamp(min=0)
+        batch_size = target_last_hidden_states.shape[0]
+        hidden_size = target_last_hidden_states.shape[-1]
+        gather_indices = target_pred_indices.reshape(batch_size, -1, 1).expand(
+            -1, -1, hidden_size
+        )
+        return torch.gather(
+            target_last_hidden_states,
+            1,
+            gather_indices,
+        ).reshape(*safe_label_indices.shape, hidden_size)
+
+    @staticmethod
+    def _add_position_ratios(
+        metrics: Dict[str, Tuple[torch.Tensor, torch.Tensor]],
+        name: str,
+        numerators: torch.Tensor,
+        denominators: torch.Tensor,
+    ) -> None:
+        """Add one explicitly named ratio per predicted block position."""
+
+        for position in range(1, numerators.numel()):
+            metrics[f"{name}/position_{position}"] = (
+                numerators[position].detach(),
+                denominators[position].detach(),
+            )
+
+    @classmethod
+    def _add_ratio_family(
+        cls,
+        metrics: Dict[str, Tuple[torch.Tensor, torch.Tensor]],
+        name: str,
+        numerators: torch.Tensor,
+        denominators: torch.Tensor,
+    ) -> None:
+        """Add the aggregate and each predicted-position ratio."""
+
+        metrics[name] = (
+            numerators.sum().detach(),
+            denominators.sum().detach(),
+        )
+        cls._add_position_ratios(metrics, name, numerators, denominators)
+
     def _forward_draft_blocks(
         self,
         input_ids: torch.Tensor,
@@ -626,6 +693,169 @@ class OnlineDFlashModel(nn.Module):
             selector_covered_num=selector_terms.covered_num,
         )
 
+    @torch.no_grad()
+    def _dflash2_metric_chunk_terms(
+        self,
+        hidden: torch.Tensor,
+        target_ids: torch.Tensor,
+        weight_mask: torch.Tensor,
+        predecessor_ids: torch.Tensor,
+        aligned_target_hidden: Optional[torch.Tensor] = None,
+    ) -> DFlashMetricTerms:
+        """Return additive serving and teacher diagnostics for one block chunk."""
+
+        batch_size, num_blocks, block_size, hidden_size = hidden.shape
+        candidate_selector = self.draft_model.candidate_selector
+        logits = self.lm_head(
+            hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
+        ).reshape(batch_size, num_blocks, block_size, -1)
+        objective_logits = self.draft_model.transform_unary_logits(logits)
+        probabilities = torch.softmax(objective_logits.float(), dim=-1)
+        hard_label_probability = probabilities.gather(
+            -1, target_ids.unsqueeze(-1)
+        ).squeeze(-1)
+        predicted_ids = objective_logits.argmax(dim=-1)
+        unary_topk, candidate_ids = objective_logits.topk(
+            candidate_selector.top_k,
+            dim=-1,
+        )
+        target_matches = candidate_ids.eq(target_ids.unsqueeze(-1))
+        target_is_candidate = target_matches.any(dim=-1)
+
+        loss_weights = weight_mask
+        if self.loss_type == "dflash":
+            if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
+                positions = torch.arange(block_size, device=hidden.device).view(
+                    1, 1, -1
+                )
+                decay_weights = torch.exp(
+                    -(positions - 1).clamp(min=0).float() / self.loss_decay_gamma
+                )
+                loss_weights = loss_weights * decay_weights
+        else:
+            dpace_weights = self._dpace_weight(
+                hard_label_probability,
+                weight_mask,
+                weight_mask > 0,
+                self.loss_type,
+            )
+            loss_weights = weight_mask * dpace_weights
+
+        target_candidate_index = target_matches.long().argmax(dim=-1)
+        selector_logits = candidate_selector.score_candidates(
+            candidate_ids=candidate_ids,
+            unary_logits=unary_topk,
+            hidden_states=hidden,
+            predecessor_ids=predecessor_ids,
+        )
+        selector_ce = F.cross_entropy(
+            selector_logits.float().reshape(-1, selector_logits.shape[-1]),
+            target_candidate_index.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        selector_loss_weights = loss_weights * target_is_candidate.float()
+        selector_teacher_forced_ids = candidate_ids.gather(
+            -1,
+            selector_logits.argmax(dim=-1, keepdim=True),
+        ).squeeze(-1)
+
+        position_den = weight_mask.sum(dim=(0, 1))
+        selector_serving_correct_num = position_den.new_zeros(block_size)
+        teacher_selector_serving_agreement_num = position_den.new_zeros(block_size)
+        teacher_expected_acceptance_num = position_den.new_zeros(block_size)
+        teacher_unary_top1_agreement_num = position_den.new_zeros(block_size)
+        teacher_unary_topk_mass_num = position_den.new_zeros(block_size)
+        teacher_probabilities = None
+        teacher_ids = None
+        if aligned_target_hidden is not None:
+            teacher_logits = self.lm_head(
+                aligned_target_hidden.reshape(
+                    batch_size,
+                    num_blocks * block_size,
+                    hidden_size,
+                )
+            ).reshape_as(objective_logits)
+            teacher_probabilities = torch.softmax(teacher_logits.float(), dim=-1)
+            teacher_ids = teacher_logits.argmax(dim=-1)
+            expected_acceptance = (
+                1.0 - 0.5 * (probabilities - teacher_probabilities).abs().sum(dim=-1)
+            ).clamp(0.0, 1.0)
+            teacher_expected_acceptance_num = (expected_acceptance * weight_mask).sum(
+                dim=(0, 1)
+            )
+            teacher_unary_top1_agreement_num = (
+                (predicted_ids == teacher_ids).float() * weight_mask
+            ).sum(dim=(0, 1))
+            teacher_unary_topk_mass_num = (
+                teacher_probabilities.gather(-1, candidate_ids).sum(dim=-1)
+                * weight_mask
+            ).sum(dim=(0, 1))
+
+        if block_size > 1:
+            serving_ids = candidate_selector.greedy_path(
+                candidate_ids=candidate_ids[:, :, 1:].reshape(
+                    batch_size * num_blocks,
+                    block_size - 1,
+                    candidate_selector.top_k,
+                ),
+                unary_logits=unary_topk[:, :, 1:].reshape(
+                    batch_size * num_blocks,
+                    block_size - 1,
+                    candidate_selector.top_k,
+                ),
+                hidden_states=hidden[:, :, 1:].reshape(
+                    batch_size * num_blocks,
+                    block_size - 1,
+                    hidden_size,
+                ),
+                anchor_token_ids=target_ids[:, :, 0].reshape(-1),
+            ).reshape(batch_size, num_blocks, block_size - 1)
+            selector_serving_correct_num = torch.cat(
+                (
+                    position_den.new_zeros(1),
+                    (
+                        (serving_ids == target_ids[:, :, 1:]).float()
+                        * weight_mask[:, :, 1:]
+                    ).sum(dim=(0, 1)),
+                )
+            )
+            if teacher_ids is not None:
+                teacher_selector_serving_agreement_num = torch.cat(
+                    (
+                        position_den.new_zeros(1),
+                        (
+                            (serving_ids == teacher_ids[:, :, 1:]).float()
+                            * weight_mask[:, :, 1:]
+                        ).sum(dim=(0, 1)),
+                    )
+                )
+
+        return DFlashMetricTerms(
+            hard_label_probability_num=(hard_label_probability * weight_mask).sum(
+                dim=(0, 1)
+            ),
+            unary_correct_num=((predicted_ids == target_ids).float() * weight_mask).sum(
+                dim=(0, 1)
+            ),
+            position_den=position_den,
+            unary_topk_recall_num=(target_is_candidate.float() * weight_mask).sum(
+                dim=(0, 1)
+            ),
+            selector_ce_num=(selector_ce * selector_loss_weights).sum(dim=(0, 1)),
+            selector_weight_den=selector_loss_weights.sum(dim=(0, 1)),
+            selector_conditional_correct_num=(
+                (selector_teacher_forced_ids == target_ids).float()
+                * selector_loss_weights
+            ).sum(dim=(0, 1)),
+            selector_serving_correct_num=selector_serving_correct_num,
+            teacher_expected_acceptance_num=teacher_expected_acceptance_num,
+            teacher_unary_top1_agreement_num=(teacher_unary_top1_agreement_num),
+            teacher_unary_topk_mass_num=teacher_unary_topk_mass_num,
+            teacher_selector_serving_agreement_num=(
+                teacher_selector_serving_agreement_num
+            ),
+        )
+
     def _compose_token_objective(
         self,
         ce_num: torch.Tensor,
@@ -651,8 +881,10 @@ class OnlineDFlashModel(nn.Module):
         input_ids: torch.Tensor,
         hidden_states: torch.Tensor,
         loss_mask: torch.Tensor,
+        target_last_hidden_states: Optional[torch.Tensor] = None,
         max_valid_anchors: Optional[int] = None,
         selector_loss_alpha: Optional[float] = None,
+        collect_detailed_metrics: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, object]]:
         """Parallel block-wise training forward pass; returns
         (loss, accuracy, metrics) — same shape as Domino's forward."""
@@ -708,6 +940,16 @@ class OnlineDFlashModel(nn.Module):
             self.block_size,
             -1,
         )
+        aligned_target_hidden = (
+            self._aligned_target_hidden(
+                target_last_hidden_states,
+                safe_label_indices,
+            )
+            if target_last_hidden_states is not None
+            and collect_detailed_metrics
+            and getattr(self.draft_model, "candidate_selector", None) is not None
+            else None
+        )
         (
             ce_loss_num,
             tv_loss_num,
@@ -729,12 +971,13 @@ class OnlineDFlashModel(nn.Module):
             chunk_size=self.objective_chunk_blocks,
             dim=1,
         )
-        loss_num = self._compose_token_objective(
+        token_loss_num = self._compose_token_objective(
             ce_loss_num,
             tv_loss_num,
             target_probability_num,
             accuracy_denom,
         )
+        loss_num = token_loss_num
         effective_selector_alpha = (
             self.selector_loss_alpha
             if selector_loss_alpha is None
@@ -758,7 +1001,94 @@ class OnlineDFlashModel(nn.Module):
                 target_probability_num.detach(),
                 accuracy_denom.detach(),
             ),
+            "expected_acceptance": (
+                target_probability_num.detach(),
+                accuracy_denom.detach(),
+            ),
+            "lk_loss" if self.lk_loss_type is not None else "ce_loss": (
+                token_loss_num.detach(),
+                loss_denominator.detach(),
+            ),
         }
+        candidate_selector = getattr(self.draft_model, "candidate_selector", None)
+        if candidate_selector is not None and collect_detailed_metrics:
+            (
+                hard_label_probability_position_num,
+                unary_correct_position_num,
+                position_den,
+                unary_topk_recall_position_num,
+                selector_ce_position_num,
+                selector_weight_position_den,
+                selector_correct_position_num,
+                selector_serving_correct_position_num,
+                teacher_expected_acceptance_position_num,
+                teacher_unary_top1_agreement_position_num,
+                teacher_unary_topk_mass_position_num,
+                teacher_selector_serving_agreement_position_num,
+            ) = checkpointed_chunk_reduce(
+                self._dflash2_metric_chunk_terms,
+                hidden_4d.detach(),
+                target_ids,
+                weight_mask,
+                predecessor_ids,
+                aligned_target_hidden,
+                chunk_size=self.objective_chunk_blocks,
+                dim=1,
+            )
+            top_k = candidate_selector.top_k
+            for name, numerators in (
+                (
+                    "dflash2/hard_label/unary_top1_accuracy",
+                    unary_correct_position_num,
+                ),
+                (
+                    "dflash2/hard_label/unary_probability",
+                    hard_label_probability_position_num,
+                ),
+                (
+                    "dflash2/hard_label/expected_acceptance",
+                    hard_label_probability_position_num,
+                ),
+                (
+                    f"dflash2/hard_label/unary_top{top_k}_recall",
+                    unary_topk_recall_position_num,
+                ),
+                (
+                    "dflash2/hard_label/selector_serving_accuracy",
+                    selector_serving_correct_position_num,
+                ),
+            ):
+                self._add_ratio_family(
+                    ratio_metrics,
+                    name,
+                    numerators,
+                    position_den,
+                )
+            if aligned_target_hidden is not None:
+                for name, numerators in (
+                    (
+                        "dflash2/teacher/expected_acceptance",
+                        teacher_expected_acceptance_position_num,
+                    ),
+                    (
+                        "dflash2/teacher/unary_top1_agreement",
+                        teacher_unary_top1_agreement_position_num,
+                    ),
+                    (
+                        f"dflash2/teacher/unary_top{top_k}_mass",
+                        teacher_unary_topk_mass_position_num,
+                    ),
+                    (
+                        "dflash2/teacher/selector_serving_agreement",
+                        teacher_selector_serving_agreement_position_num,
+                    ),
+                ):
+                    self._add_ratio_family(
+                        ratio_metrics,
+                        name,
+                        numerators,
+                        position_den,
+                    )
         if has_selector_objective:
             ratio_metrics.update(
                 {
@@ -778,8 +1108,29 @@ class OnlineDFlashModel(nn.Module):
                         selector_probability_num.detach(),
                         selector_covered_num.detach(),
                     ),
+                    "dflash2/hard_label/selector_loss": (
+                        selector_loss_num.detach(),
+                        selector_weight_den.detach(),
+                    ),
+                    "dflash2/hard_label/selector_conditional_accuracy": (
+                        selector_correct_num.detach(),
+                        selector_weight_den.detach(),
+                    ),
                 }
             )
+            if collect_detailed_metrics:
+                self._add_position_ratios(
+                    ratio_metrics,
+                    "dflash2/hard_label/selector_loss",
+                    selector_ce_position_num,
+                    selector_weight_position_den,
+                )
+                self._add_position_ratios(
+                    ratio_metrics,
+                    "dflash2/hard_label/selector_conditional_accuracy",
+                    selector_correct_position_num,
+                    selector_weight_position_den,
+                )
         metrics: Dict[str, object] = {
             "accuracy_denom": accuracy_denom.detach(),
             "ratio_metrics": ratio_metrics,

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -104,6 +104,55 @@ class DFlashMetricTerms(NamedTuple):
     serving_accepted_length_num: torch.Tensor
 
 
+class _DFlashUnaryDiagnostics(NamedTuple):
+    """Full-vocabulary unary outputs reused by all DFlash2 diagnostics."""
+
+    probabilities: torch.Tensor
+    hard_label_probability: torch.Tensor
+    predicted_ids: torch.Tensor
+    topk_logits: torch.Tensor
+    candidate_ids: torch.Tensor
+    target_is_candidate: torch.Tensor
+    target_candidate_index: torch.Tensor
+
+
+class _DFlashSelectorDiagnostics(NamedTuple):
+    """Teacher-forced selector outputs and their effective metric masks."""
+
+    cross_entropy: torch.Tensor
+    loss_weights: torch.Tensor
+    selected_ids: torch.Tensor
+    covered_mask: torch.Tensor
+
+
+class _DFlashServingDiagnostics(NamedTuple):
+    """Greedy serving path plus additive per-block acceptance statistics."""
+
+    selected_ids: torch.Tensor
+    correct_num: torch.Tensor
+    block_den: torch.Tensor
+    oracle_accepted_length_num: torch.Tensor
+    accepted_length_num: torch.Tensor
+
+
+class _DFlashTeacherTerms(NamedTuple):
+    """Additive target-distribution diagnostics for one metric chunk."""
+
+    expected_acceptance_num: torch.Tensor
+    unary_top1_agreement_num: torch.Tensor
+    unary_topk_mass_num: torch.Tensor
+    selector_serving_agreement_num: torch.Tensor
+
+    @classmethod
+    def zeros(cls, position_den: torch.Tensor) -> "_DFlashTeacherTerms":
+        return cls(
+            position_den.new_zeros(position_den.shape),
+            position_den.new_zeros(position_den.shape),
+            position_den.new_zeros(position_den.shape),
+            position_den.new_zeros(position_den.shape),
+        )
+
+
 def compute_accept_len(
     pred_ids_4d: torch.Tensor,
     target_ids_4d: torch.Tensor,
@@ -714,8 +763,58 @@ class OnlineDFlashModel(nn.Module):
     ) -> DFlashMetricTerms:
         """Return additive serving and teacher diagnostics for one block chunk."""
 
-        batch_size, num_blocks, block_size, hidden_size = hidden.shape
         candidate_selector = self.draft_model.candidate_selector
+        unary = self._dflash2_unary_diagnostics(
+            hidden,
+            target_ids,
+        )
+        loss_weights = self._dflash2_metric_loss_weights(
+            unary.hard_label_probability,
+            weight_mask,
+        )
+        selector = self._dflash2_selector_diagnostics(
+            candidate_selector=candidate_selector,
+            unary=unary,
+            hidden=hidden,
+            predecessor_ids=predecessor_ids,
+            loss_weights=loss_weights,
+            weight_mask=weight_mask,
+        )
+        position_den = weight_mask.sum(dim=(0, 1))
+        serving = self._dflash2_serving_diagnostics(
+            candidate_selector=candidate_selector,
+            unary=unary,
+            hidden=hidden,
+            target_ids=target_ids,
+            weight_mask=weight_mask,
+            position_den=position_den,
+        )
+        teacher = self._dflash2_teacher_terms(
+            unary=unary,
+            serving_ids=serving.selected_ids,
+            aligned_target_hidden=aligned_target_hidden,
+            weight_mask=weight_mask,
+            position_den=position_den,
+        )
+        return self._reduce_dflash2_metric_terms(
+            unary=unary,
+            selector=selector,
+            serving=serving,
+            teacher=teacher,
+            target_ids=target_ids,
+            weight_mask=weight_mask,
+            loss_weights=loss_weights,
+            position_den=position_den,
+        )
+
+    def _dflash2_unary_diagnostics(
+        self,
+        hidden: torch.Tensor,
+        target_ids: torch.Tensor,
+    ) -> _DFlashUnaryDiagnostics:
+        """Project draft states once and derive the strict unary top-k view."""
+
+        batch_size, num_blocks, block_size, hidden_size = hidden.shape
         logits = self.lm_head(
             hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
         ).reshape(batch_size, num_blocks, block_size, -1)
@@ -724,166 +823,243 @@ class OnlineDFlashModel(nn.Module):
         hard_label_probability = probabilities.gather(
             -1, target_ids.unsqueeze(-1)
         ).squeeze(-1)
-        predicted_ids = objective_logits.argmax(dim=-1)
-        unary_topk, candidate_ids = objective_logits.topk(
-            candidate_selector.top_k,
+        topk_logits, candidate_ids = objective_logits.topk(
+            self.draft_model.candidate_selector.top_k,
             dim=-1,
         )
         target_matches = candidate_ids.eq(target_ids.unsqueeze(-1))
-        target_is_candidate = target_matches.any(dim=-1)
-
-        loss_weights = weight_mask
-        if self.loss_type == "dflash":
-            if self.loss_decay_gamma is not None and self.loss_decay_gamma > 0:
-                positions = torch.arange(block_size, device=hidden.device).view(
-                    1, 1, -1
-                )
-                decay_weights = torch.exp(
-                    -(positions - 1).clamp(min=0).float() / self.loss_decay_gamma
-                )
-                loss_weights = loss_weights * decay_weights
-        else:
-            dpace_weights = self._dpace_weight(
-                hard_label_probability,
-                weight_mask,
-                weight_mask > 0,
-                self.loss_type,
-            )
-            loss_weights = weight_mask * dpace_weights
-
-        target_candidate_index = target_matches.long().argmax(dim=-1)
-        selector_logits = candidate_selector.score_candidates(
+        return _DFlashUnaryDiagnostics(
+            probabilities=probabilities,
+            hard_label_probability=hard_label_probability,
+            predicted_ids=objective_logits.argmax(dim=-1),
+            topk_logits=topk_logits,
             candidate_ids=candidate_ids,
-            unary_logits=unary_topk,
+            target_is_candidate=target_matches.any(dim=-1),
+            target_candidate_index=target_matches.long().argmax(dim=-1),
+        )
+
+    def _dflash2_metric_loss_weights(
+        self,
+        hard_label_probability: torch.Tensor,
+        weight_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Reconstruct effective objective weights for position-share metrics."""
+
+        if self.loss_type == "dflash":
+            if self.loss_decay_gamma is None or self.loss_decay_gamma <= 0:
+                return weight_mask
+            positions = torch.arange(
+                weight_mask.shape[-1],
+                device=weight_mask.device,
+            ).view(1, 1, -1)
+            decay_weights = torch.exp(
+                -(positions - 1).clamp(min=0).float() / self.loss_decay_gamma
+            )
+            return weight_mask * decay_weights
+
+        dpace_weights = self._dpace_weight(
+            hard_label_probability,
+            weight_mask,
+            weight_mask > 0,
+            self.loss_type,
+        )
+        return weight_mask * dpace_weights
+
+    @staticmethod
+    def _dflash2_selector_diagnostics(
+        *,
+        candidate_selector: nn.Module,
+        unary: _DFlashUnaryDiagnostics,
+        hidden: torch.Tensor,
+        predecessor_ids: torch.Tensor,
+        loss_weights: torch.Tensor,
+        weight_mask: torch.Tensor,
+    ) -> _DFlashSelectorDiagnostics:
+        """Evaluate the selector with ground-truth predecessor tokens."""
+
+        selector_logits = candidate_selector.score_candidates(
+            candidate_ids=unary.candidate_ids,
+            unary_logits=unary.topk_logits,
             hidden_states=hidden,
             predecessor_ids=predecessor_ids,
         )
         selector_ce = F.cross_entropy(
             selector_logits.float().reshape(-1, selector_logits.shape[-1]),
-            target_candidate_index.reshape(-1),
+            unary.target_candidate_index.reshape(-1),
             reduction="none",
-        ).reshape_as(target_ids)
-        selector_loss_weights = loss_weights * target_is_candidate.float()
-        selector_teacher_forced_ids = candidate_ids.gather(
-            -1,
-            selector_logits.argmax(dim=-1, keepdim=True),
-        ).squeeze(-1)
+        ).reshape_as(unary.target_candidate_index)
+        target_is_candidate = unary.target_is_candidate.float()
+        return _DFlashSelectorDiagnostics(
+            cross_entropy=selector_ce,
+            loss_weights=loss_weights * target_is_candidate,
+            selected_ids=unary.candidate_ids.gather(
+                -1,
+                selector_logits.argmax(dim=-1, keepdim=True),
+            ).squeeze(-1),
+            covered_mask=weight_mask * target_is_candidate,
+        )
 
-        covered_mask = weight_mask * target_is_candidate.float()
-        position_den = weight_mask.sum(dim=(0, 1))
-        selector_serving_correct_num = position_den.new_zeros(block_size)
-        block_den = position_den.new_zeros(())
-        oracle_accepted_length_num = position_den.new_zeros(())
-        serving_accepted_length_num = position_den.new_zeros(())
-        teacher_selector_serving_agreement_num = position_den.new_zeros(block_size)
-        teacher_expected_acceptance_num = position_den.new_zeros(block_size)
-        teacher_unary_top1_agreement_num = position_den.new_zeros(block_size)
-        teacher_unary_topk_mass_num = position_den.new_zeros(block_size)
-        teacher_probabilities = None
-        teacher_ids = None
-        if aligned_target_hidden is not None:
-            teacher_logits = self.lm_head(
-                aligned_target_hidden.reshape(
-                    batch_size,
-                    num_blocks * block_size,
-                    hidden_size,
-                )
-            ).reshape_as(objective_logits)
-            teacher_probabilities = torch.softmax(teacher_logits.float(), dim=-1)
-            teacher_ids = teacher_logits.argmax(dim=-1)
-            expected_acceptance = (
-                1.0 - 0.5 * (probabilities - teacher_probabilities).abs().sum(dim=-1)
-            ).clamp(0.0, 1.0)
-            teacher_expected_acceptance_num = (expected_acceptance * weight_mask).sum(
-                dim=(0, 1)
+    @staticmethod
+    def _dflash2_serving_diagnostics(
+        *,
+        candidate_selector: nn.Module,
+        unary: _DFlashUnaryDiagnostics,
+        hidden: torch.Tensor,
+        target_ids: torch.Tensor,
+        weight_mask: torch.Tensor,
+        position_den: torch.Tensor,
+    ) -> _DFlashServingDiagnostics:
+        """Walk the greedy selector path and reduce prefix-acceptance metrics."""
+
+        batch_size, num_blocks, block_size, hidden_size = hidden.shape
+        if block_size <= 1:
+            zero = position_den.new_zeros(())
+            return _DFlashServingDiagnostics(
+                selected_ids=target_ids.new_empty(batch_size, num_blocks, 0),
+                correct_num=position_den.new_zeros(position_den.shape),
+                block_den=zero,
+                oracle_accepted_length_num=zero.clone(),
+                accepted_length_num=zero.clone(),
             )
-            teacher_unary_top1_agreement_num = (
-                (predicted_ids == teacher_ids).float() * weight_mask
-            ).sum(dim=(0, 1))
-            teacher_unary_topk_mass_num = (
-                teacher_probabilities.gather(-1, candidate_ids).sum(dim=-1)
-                * weight_mask
-            ).sum(dim=(0, 1))
 
+        serving_ids = candidate_selector.greedy_path(
+            candidate_ids=unary.candidate_ids[:, :, 1:].reshape(
+                batch_size * num_blocks,
+                block_size - 1,
+                candidate_selector.top_k,
+            ),
+            unary_logits=unary.topk_logits[:, :, 1:].reshape(
+                batch_size * num_blocks,
+                block_size - 1,
+                candidate_selector.top_k,
+            ),
+            hidden_states=hidden[:, :, 1:].reshape(
+                batch_size * num_blocks,
+                block_size - 1,
+                hidden_size,
+            ),
+            anchor_token_ids=target_ids[:, :, 0].reshape(-1),
+        ).reshape(batch_size, num_blocks, block_size - 1)
+        serving_hit = serving_ids == target_ids[:, :, 1:]
+        correct_num = torch.cat(
+            (
+                position_den.new_zeros(1),
+                (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
+            )
+        )
+
+        # A block accepts its anchor, then only its leading run of supervised hits.
+        supervised = weight_mask[:, :, 1:] > 0.5
+        block_valid = supervised.any(dim=-1).float()
+        oracle_alive = supervised & unary.target_is_candidate[:, :, 1:]
+        serving_alive = supervised & serving_hit
+        return _DFlashServingDiagnostics(
+            selected_ids=serving_ids,
+            correct_num=correct_num,
+            block_den=block_valid.sum(),
+            oracle_accepted_length_num=(
+                (1.0 + oracle_alive.float().cumprod(dim=-1).sum(dim=-1)) * block_valid
+            ).sum(),
+            accepted_length_num=(
+                (1.0 + serving_alive.float().cumprod(dim=-1).sum(dim=-1)) * block_valid
+            ).sum(),
+        )
+
+    def _dflash2_teacher_terms(
+        self,
+        *,
+        unary: _DFlashUnaryDiagnostics,
+        serving_ids: torch.Tensor,
+        aligned_target_hidden: Optional[torch.Tensor],
+        weight_mask: torch.Tensor,
+        position_den: torch.Tensor,
+    ) -> _DFlashTeacherTerms:
+        """Compare unary and serving predictions with the frozen target head."""
+
+        if aligned_target_hidden is None:
+            return _DFlashTeacherTerms.zeros(position_den)
+
+        batch_size, num_blocks, block_size, hidden_size = aligned_target_hidden.shape
+        teacher_logits = self.lm_head(
+            aligned_target_hidden.reshape(
+                batch_size,
+                num_blocks * block_size,
+                hidden_size,
+            )
+        ).reshape_as(unary.probabilities)
+        teacher_probabilities = torch.softmax(teacher_logits.float(), dim=-1)
+        teacher_ids = teacher_logits.argmax(dim=-1)
+        expected_acceptance = (
+            1.0 - 0.5 * (unary.probabilities - teacher_probabilities).abs().sum(dim=-1)
+        ).clamp(0.0, 1.0)
+
+        selector_serving_agreement_num = position_den.new_zeros(position_den.shape)
         if block_size > 1:
-            serving_ids = candidate_selector.greedy_path(
-                candidate_ids=candidate_ids[:, :, 1:].reshape(
-                    batch_size * num_blocks,
-                    block_size - 1,
-                    candidate_selector.top_k,
-                ),
-                unary_logits=unary_topk[:, :, 1:].reshape(
-                    batch_size * num_blocks,
-                    block_size - 1,
-                    candidate_selector.top_k,
-                ),
-                hidden_states=hidden[:, :, 1:].reshape(
-                    batch_size * num_blocks,
-                    block_size - 1,
-                    hidden_size,
-                ),
-                anchor_token_ids=target_ids[:, :, 0].reshape(-1),
-            ).reshape(batch_size, num_blocks, block_size - 1)
-            serving_hit = serving_ids == target_ids[:, :, 1:]
-            selector_serving_correct_num = torch.cat(
+            selector_serving_agreement_num = torch.cat(
                 (
                     position_den.new_zeros(1),
-                    (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
+                    (
+                        (serving_ids == teacher_ids[:, :, 1:]).float()
+                        * weight_mask[:, :, 1:]
+                    ).sum(dim=(0, 1)),
                 )
             )
-            # Accepted length per block: the anchor counts as one token and a
-            # block extends while every earlier slot is supervised and accepted.
-            supervised = weight_mask[:, :, 1:] > 0.5
-            block_valid = supervised.any(dim=-1).float()
-            block_den = block_valid.sum()
-            oracle_alive = (supervised & target_is_candidate[:, :, 1:]).float()
-            serving_alive = (supervised & serving_hit).float()
-            oracle_accepted_length_num = (
-                (1.0 + oracle_alive.cumprod(dim=-1).sum(dim=-1)) * block_valid
-            ).sum()
-            serving_accepted_length_num = (
-                (1.0 + serving_alive.cumprod(dim=-1).sum(dim=-1)) * block_valid
-            ).sum()
-            if teacher_ids is not None:
-                teacher_selector_serving_agreement_num = torch.cat(
-                    (
-                        position_den.new_zeros(1),
-                        (
-                            (serving_ids == teacher_ids[:, :, 1:]).float()
-                            * weight_mask[:, :, 1:]
-                        ).sum(dim=(0, 1)),
-                    )
-                )
+        return _DFlashTeacherTerms(
+            expected_acceptance_num=(expected_acceptance * weight_mask).sum(dim=(0, 1)),
+            unary_top1_agreement_num=(
+                (unary.predicted_ids == teacher_ids).float() * weight_mask
+            ).sum(dim=(0, 1)),
+            unary_topk_mass_num=(
+                teacher_probabilities.gather(-1, unary.candidate_ids).sum(dim=-1)
+                * weight_mask
+            ).sum(dim=(0, 1)),
+            selector_serving_agreement_num=selector_serving_agreement_num,
+        )
+
+    @staticmethod
+    def _reduce_dflash2_metric_terms(
+        *,
+        unary: _DFlashUnaryDiagnostics,
+        selector: _DFlashSelectorDiagnostics,
+        serving: _DFlashServingDiagnostics,
+        teacher: _DFlashTeacherTerms,
+        target_ids: torch.Tensor,
+        weight_mask: torch.Tensor,
+        loss_weights: torch.Tensor,
+        position_den: torch.Tensor,
+    ) -> DFlashMetricTerms:
+        """Reduce per-token diagnostics into the flat chunk-reducer contract."""
 
         return DFlashMetricTerms(
-            hard_label_probability_num=(hard_label_probability * weight_mask).sum(
+            hard_label_probability_num=(unary.hard_label_probability * weight_mask).sum(
                 dim=(0, 1)
             ),
-            unary_correct_num=((predicted_ids == target_ids).float() * weight_mask).sum(
-                dim=(0, 1)
-            ),
+            unary_correct_num=(
+                (unary.predicted_ids == target_ids).float() * weight_mask
+            ).sum(dim=(0, 1)),
             position_den=position_den,
-            unary_topk_recall_num=covered_mask.sum(dim=(0, 1)),
+            unary_topk_recall_num=selector.covered_mask.sum(dim=(0, 1)),
             unary_topk_mass_num=(
-                probabilities.gather(-1, candidate_ids).sum(dim=-1) * weight_mask
+                unary.probabilities.gather(-1, unary.candidate_ids).sum(dim=-1)
+                * weight_mask
             ).sum(dim=(0, 1)),
-            selector_ce_num=(selector_ce * selector_loss_weights).sum(dim=(0, 1)),
-            selector_weight_den=selector_loss_weights.sum(dim=(0, 1)),
-            selector_conditional_correct_num=(
-                (selector_teacher_forced_ids == target_ids).float() * covered_mask
-            ).sum(dim=(0, 1)),
-            selector_covered_den=covered_mask.sum(dim=(0, 1)),
-            selector_serving_correct_num=selector_serving_correct_num,
-            loss_weight_num=loss_weights.sum(dim=(0, 1)),
-            teacher_expected_acceptance_num=teacher_expected_acceptance_num,
-            teacher_unary_top1_agreement_num=teacher_unary_top1_agreement_num,
-            teacher_unary_topk_mass_num=teacher_unary_topk_mass_num,
-            teacher_selector_serving_agreement_num=(
-                teacher_selector_serving_agreement_num
+            selector_ce_num=(selector.cross_entropy * selector.loss_weights).sum(
+                dim=(0, 1)
             ),
-            block_den=block_den,
-            oracle_accepted_length_num=oracle_accepted_length_num,
-            serving_accepted_length_num=serving_accepted_length_num,
+            selector_weight_den=selector.loss_weights.sum(dim=(0, 1)),
+            selector_conditional_correct_num=(
+                (selector.selected_ids == target_ids).float() * selector.covered_mask
+            ).sum(dim=(0, 1)),
+            selector_covered_den=selector.covered_mask.sum(dim=(0, 1)),
+            selector_serving_correct_num=serving.correct_num,
+            loss_weight_num=loss_weights.sum(dim=(0, 1)),
+            teacher_expected_acceptance_num=teacher.expected_acceptance_num,
+            teacher_unary_top1_agreement_num=teacher.unary_top1_agreement_num,
+            teacher_unary_topk_mass_num=teacher.unary_topk_mass_num,
+            teacher_selector_serving_agreement_num=teacher.selector_serving_agreement_num,
+            block_den=serving.block_den,
+            oracle_accepted_length_num=serving.oracle_accepted_length_num,
+            serving_accepted_length_num=serving.accepted_length_num,
         )
 
     def _lk_kl_weight(

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -143,9 +143,9 @@ class _DFlashSelectorDiagnostics(NamedTuple):
 
 
 class _DFlashServingDiagnostics(NamedTuple):
-    """Greedy serving path plus additive per-block acceptance statistics."""
+    """Per-block acceptance chains plus the greedy selector path when present."""
 
-    selected_ids: torch.Tensor
+    selected_ids: Optional[torch.Tensor]
     correct_num: torch.Tensor
     block_den: torch.Tensor
     oracle_accepted_length_num: torch.Tensor
@@ -312,8 +312,11 @@ class OnlineDFlashModel(nn.Module):
         lk_loss_type: Optional[str] = None,
         kl_scale: float = 1.0,
         kl_decay: float = 1.0,
+        metric_top_k: int = 16,
     ):
         super().__init__()
+        if metric_top_k <= 0:
+            raise ValueError(f"metric_top_k must be > 0, got {metric_top_k}")
         if loss_type not in _VALID_LOSS_TYPES:
             raise ValueError(
                 f"loss_type={loss_type!r}; must be one of {sorted(_VALID_LOSS_TYPES)}"
@@ -351,6 +354,8 @@ class OnlineDFlashModel(nn.Module):
         self.lk_loss_type = lk_loss_type
         self.kl_scale = float(kl_scale)
         self.kl_decay = float(kl_decay)
+        # Candidate-set width for top-K diagnostics on drafts without a selector.
+        self.metric_top_k = int(metric_top_k)
 
         candidate_selector = getattr(self.draft_model, "candidate_selector", None)
         self._selector_objective_enabled = (
@@ -505,11 +510,12 @@ class OnlineDFlashModel(nn.Module):
     ) -> None:
         """Add one ratio per predicted block position.
 
-        Per-position keys live under their own ``position_<k>/`` tracker
-        section so each block position renders as one dashboard group.
+        Per-position keys drop the algorithm prefix and live under their own
+        ``position_<k>/`` tracker section so each block position renders as one
+        dashboard group.
         """
 
-        family = name.removeprefix("dflash2/")
+        family = name.split("/", 1)[1]
         for position in range(1, numerators.numel()):
             metrics[f"position_{position}/{family}"] = (
                 numerators[position].detach(),
@@ -778,7 +784,22 @@ class OnlineDFlashModel(nn.Module):
         )
 
     @torch.no_grad()
-    def _dflash2_metric_chunk_terms(
+    def _metric_top_k(self) -> int:
+        """Candidate-set width: the selector's top-k, else ``metric_top_k``.
+
+        Never wider than the vocabulary, so tiny test vocabularies stay valid.
+        """
+
+        candidate_selector = getattr(self.draft_model, "candidate_selector", None)
+        top_k = (
+            int(candidate_selector.top_k)
+            if candidate_selector is not None
+            else self.metric_top_k
+        )
+        vocab_size = getattr(self.embed_tokens, "num_embeddings", None)
+        return top_k if vocab_size is None else min(top_k, int(vocab_size))
+
+    def _dflash_metric_chunk_terms(
         self,
         hidden: torch.Tensor,
         target_ids: torch.Tensor,
@@ -786,27 +807,35 @@ class OnlineDFlashModel(nn.Module):
         predecessor_ids: torch.Tensor,
         aligned_target_hidden: Optional[torch.Tensor] = None,
     ) -> DFlashMetricTerms:
-        """Return additive serving and teacher diagnostics for one block chunk."""
+        """Return additive unary, selector, and teacher diagnostics for one chunk.
 
-        candidate_selector = self.draft_model.candidate_selector
-        unary = self._dflash2_unary_diagnostics(
+        The unary, objective-weight, and teacher families apply to every
+        DFlash-family draft; the selector and serving-path families are only
+        computed when the draft carries a DFlash2 candidate selector.
+        """
+
+        candidate_selector = getattr(self.draft_model, "candidate_selector", None)
+        unary = self._dflash_unary_diagnostics(
             hidden,
             target_ids,
+            top_k=self._metric_top_k(),
         )
-        loss_weights = self._dflash2_metric_loss_weights(
+        loss_weights = self._dflash_metric_loss_weights(
             unary.hard_label_probability,
             weight_mask,
         )
-        selector = self._dflash2_selector_diagnostics(
-            candidate_selector=candidate_selector,
-            unary=unary,
-            hidden=hidden,
-            predecessor_ids=predecessor_ids,
-            loss_weights=loss_weights,
-            weight_mask=weight_mask,
-        )
+        selector = None
+        if candidate_selector is not None:
+            selector = self._dflash2_selector_diagnostics(
+                candidate_selector=candidate_selector,
+                unary=unary,
+                hidden=hidden,
+                predecessor_ids=predecessor_ids,
+                loss_weights=loss_weights,
+                weight_mask=weight_mask,
+            )
         position_den = weight_mask.sum(dim=(0, 1))
-        serving = self._dflash2_serving_diagnostics(
+        serving = self._dflash_serving_diagnostics(
             candidate_selector=candidate_selector,
             unary=unary,
             hidden=hidden,
@@ -814,14 +843,14 @@ class OnlineDFlashModel(nn.Module):
             weight_mask=weight_mask,
             position_den=position_den,
         )
-        teacher = self._dflash2_teacher_terms(
+        teacher = self._dflash_teacher_terms(
             unary=unary,
             serving_ids=serving.selected_ids,
             aligned_target_hidden=aligned_target_hidden,
             weight_mask=weight_mask,
             position_den=position_den,
         )
-        return self._reduce_dflash2_metric_terms(
+        return self._reduce_dflash_metric_terms(
             unary=unary,
             selector=selector,
             serving=serving,
@@ -832,10 +861,12 @@ class OnlineDFlashModel(nn.Module):
             position_den=position_den,
         )
 
-    def _dflash2_unary_diagnostics(
+    def _dflash_unary_diagnostics(
         self,
         hidden: torch.Tensor,
         target_ids: torch.Tensor,
+        *,
+        top_k: int,
     ) -> _DFlashUnaryDiagnostics:
         """Project draft states once and derive the strict unary top-k view."""
 
@@ -843,13 +874,14 @@ class OnlineDFlashModel(nn.Module):
         logits = self.lm_head(
             hidden.reshape(batch_size, num_blocks * block_size, hidden_size)
         ).reshape(batch_size, num_blocks, block_size, -1)
-        objective_logits = self.draft_model.transform_unary_logits(logits)
+        transform = getattr(self.draft_model, "transform_unary_logits", None)
+        objective_logits = logits if transform is None else transform(logits)
         probabilities = torch.softmax(objective_logits.float(), dim=-1)
         hard_label_probability = probabilities.gather(
             -1, target_ids.unsqueeze(-1)
         ).squeeze(-1)
         topk_logits, candidate_ids = objective_logits.topk(
-            self.draft_model.candidate_selector.top_k,
+            min(top_k, objective_logits.shape[-1]),
             dim=-1,
         )
         target_matches = candidate_ids.eq(target_ids.unsqueeze(-1))
@@ -863,7 +895,7 @@ class OnlineDFlashModel(nn.Module):
             target_candidate_index=target_matches.long().argmax(dim=-1),
         )
 
-    def _dflash2_metric_loss_weights(
+    def _dflash_metric_loss_weights(
         self,
         hard_label_probability: torch.Tensor,
         weight_mask: torch.Tensor,
@@ -925,27 +957,48 @@ class OnlineDFlashModel(nn.Module):
         )
 
     @staticmethod
-    def _dflash2_serving_diagnostics(
+    def _dflash_serving_diagnostics(
         *,
-        candidate_selector: nn.Module,
+        candidate_selector: Optional[nn.Module],
         unary: _DFlashUnaryDiagnostics,
         hidden: torch.Tensor,
         target_ids: torch.Tensor,
         weight_mask: torch.Tensor,
         position_den: torch.Tensor,
     ) -> _DFlashServingDiagnostics:
-        """Walk the greedy selector path and reduce prefix-acceptance metrics."""
+        """Reduce per-block acceptance chains; walk the selector path if any."""
 
         batch_size, num_blocks, block_size, hidden_size = hidden.shape
+        zero = position_den.new_zeros(())
         if block_size <= 1:
-            zero = position_den.new_zeros(())
             return _DFlashServingDiagnostics(
-                selected_ids=target_ids.new_empty(batch_size, num_blocks, 0),
+                selected_ids=None,
                 correct_num=position_den.new_zeros(position_den.shape),
                 block_den=zero,
                 oracle_accepted_length_num=zero.clone(),
                 accepted_length_num=zero.clone(),
                 expected_accepted_length_num=zero.clone(),
+            )
+
+        # A block accepts its anchor, then only its leading run of supervised
+        # slots: covered (oracle), hit by the serving path (realized), or, for
+        # the smooth D-PACE surrogate, weighted by the gold-token probability.
+        supervised = weight_mask[:, :, 1:] > 0.5
+        block_valid = supervised.any(dim=-1).float()
+        oracle_accepted_length_num = _expected_accepted_length_num(
+            unary.target_is_candidate[:, :, 1:], supervised, block_valid
+        )
+        expected_accepted_length_num = _expected_accepted_length_num(
+            unary.hard_label_probability[:, :, 1:], supervised, block_valid
+        )
+        if candidate_selector is None:
+            return _DFlashServingDiagnostics(
+                selected_ids=None,
+                correct_num=position_den.new_zeros(position_den.shape),
+                block_den=block_valid.sum(),
+                oracle_accepted_length_num=oracle_accepted_length_num,
+                accepted_length_num=zero,
+                expected_accepted_length_num=expected_accepted_length_num,
             )
 
         serving_ids = candidate_selector.greedy_path(
@@ -967,38 +1020,27 @@ class OnlineDFlashModel(nn.Module):
             anchor_token_ids=target_ids[:, :, 0].reshape(-1),
         ).reshape(batch_size, num_blocks, block_size - 1)
         serving_hit = serving_ids == target_ids[:, :, 1:]
-        correct_num = torch.cat(
-            (
-                position_den.new_zeros(1),
-                (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
-            )
-        )
-
-        # A block accepts its anchor, then only its leading run of supervised
-        # slots: covered (oracle), hit by the serving path (realized), or, for
-        # the smooth D-PACE surrogate, weighted by the gold-token probability.
-        supervised = weight_mask[:, :, 1:] > 0.5
-        block_valid = supervised.any(dim=-1).float()
         return _DFlashServingDiagnostics(
             selected_ids=serving_ids,
-            correct_num=correct_num,
-            block_den=block_valid.sum(),
-            oracle_accepted_length_num=_expected_accepted_length_num(
-                unary.target_is_candidate[:, :, 1:], supervised, block_valid
+            correct_num=torch.cat(
+                (
+                    position_den.new_zeros(1),
+                    (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
+                )
             ),
+            block_den=block_valid.sum(),
+            oracle_accepted_length_num=oracle_accepted_length_num,
             accepted_length_num=_expected_accepted_length_num(
                 serving_hit, supervised, block_valid
             ),
-            expected_accepted_length_num=_expected_accepted_length_num(
-                unary.hard_label_probability[:, :, 1:], supervised, block_valid
-            ),
+            expected_accepted_length_num=expected_accepted_length_num,
         )
 
-    def _dflash2_teacher_terms(
+    def _dflash_teacher_terms(
         self,
         *,
         unary: _DFlashUnaryDiagnostics,
-        serving_ids: torch.Tensor,
+        serving_ids: Optional[torch.Tensor],
         aligned_target_hidden: Optional[torch.Tensor],
         weight_mask: torch.Tensor,
         position_den: torch.Tensor,
@@ -1025,15 +1067,16 @@ class OnlineDFlashModel(nn.Module):
         selector_serving_agreement_num = position_den.new_zeros(position_den.shape)
         expected_accepted_length_num = position_den.new_zeros(())
         if block_size > 1:
-            selector_serving_agreement_num = torch.cat(
-                (
-                    position_den.new_zeros(1),
+            if serving_ids is not None:
+                selector_serving_agreement_num = torch.cat(
                     (
-                        (serving_ids == teacher_ids[:, :, 1:]).float()
-                        * weight_mask[:, :, 1:]
-                    ).sum(dim=(0, 1)),
+                        position_den.new_zeros(1),
+                        (
+                            (serving_ids == teacher_ids[:, :, 1:]).float()
+                            * weight_mask[:, :, 1:]
+                        ).sum(dim=(0, 1)),
+                    )
                 )
-            )
             supervised = weight_mask[:, :, 1:] > 0.5
             expected_accepted_length_num = _expected_accepted_length_num(
                 expected_acceptance[:, :, 1:],
@@ -1054,10 +1097,10 @@ class OnlineDFlashModel(nn.Module):
         )
 
     @staticmethod
-    def _reduce_dflash2_metric_terms(
+    def _reduce_dflash_metric_terms(
         *,
         unary: _DFlashUnaryDiagnostics,
-        selector: _DFlashSelectorDiagnostics,
+        selector: Optional[_DFlashSelectorDiagnostics],
         serving: _DFlashServingDiagnostics,
         teacher: _DFlashTeacherTerms,
         target_ids: torch.Tensor,
@@ -1067,6 +1110,20 @@ class OnlineDFlashModel(nn.Module):
     ) -> DFlashMetricTerms:
         """Reduce per-token diagnostics into the flat chunk-reducer contract."""
 
+        covered_mask = weight_mask * unary.target_is_candidate.float()
+        position_zeros = position_den.new_zeros(position_den.shape)
+        if selector is None:
+            selector_ce_num = position_zeros
+            selector_weight_den = position_zeros
+            selector_conditional_correct_num = position_zeros
+        else:
+            selector_ce_num = (selector.cross_entropy * selector.loss_weights).sum(
+                dim=(0, 1)
+            )
+            selector_weight_den = selector.loss_weights.sum(dim=(0, 1))
+            selector_conditional_correct_num = (
+                (selector.selected_ids == target_ids).float() * selector.covered_mask
+            ).sum(dim=(0, 1))
         return DFlashMetricTerms(
             hard_label_probability_num=(unary.hard_label_probability * weight_mask).sum(
                 dim=(0, 1)
@@ -1075,19 +1132,15 @@ class OnlineDFlashModel(nn.Module):
                 (unary.predicted_ids == target_ids).float() * weight_mask
             ).sum(dim=(0, 1)),
             position_den=position_den,
-            unary_topk_recall_num=selector.covered_mask.sum(dim=(0, 1)),
+            unary_topk_recall_num=covered_mask.sum(dim=(0, 1)),
             unary_topk_mass_num=(
                 unary.probabilities.gather(-1, unary.candidate_ids).sum(dim=-1)
                 * weight_mask
             ).sum(dim=(0, 1)),
-            selector_ce_num=(selector.cross_entropy * selector.loss_weights).sum(
-                dim=(0, 1)
-            ),
-            selector_weight_den=selector.loss_weights.sum(dim=(0, 1)),
-            selector_conditional_correct_num=(
-                (selector.selected_ids == target_ids).float() * selector.covered_mask
-            ).sum(dim=(0, 1)),
-            selector_covered_den=selector.covered_mask.sum(dim=(0, 1)),
+            selector_ce_num=selector_ce_num,
+            selector_weight_den=selector_weight_den,
+            selector_conditional_correct_num=selector_conditional_correct_num,
+            selector_covered_den=covered_mask.sum(dim=(0, 1)),
             selector_serving_correct_num=serving.correct_num,
             loss_weight_num=loss_weights.sum(dim=(0, 1)),
             teacher_expected_acceptance_num=teacher.expected_acceptance_num,
@@ -1201,9 +1254,7 @@ class OnlineDFlashModel(nn.Module):
                 target_last_hidden_states,
                 safe_label_indices,
             )
-            if target_last_hidden_states is not None
-            and collect_detailed_metrics
-            and getattr(self.draft_model, "candidate_selector", None) is not None
+            if target_last_hidden_states is not None and collect_detailed_metrics
             else None
         )
         (
@@ -1273,7 +1324,7 @@ class OnlineDFlashModel(nn.Module):
                 accuracy_denom.detach(),
             )
         candidate_selector = getattr(self.draft_model, "candidate_selector", None)
-        if candidate_selector is not None and collect_detailed_metrics:
+        if collect_detailed_metrics:
             (
                 hard_label_probability_position_num,
                 unary_correct_position_num,
@@ -1296,7 +1347,7 @@ class OnlineDFlashModel(nn.Module):
                 expected_accepted_length_num,
                 teacher_expected_accepted_length_num,
             ) = checkpointed_chunk_reduce(
-                self._dflash2_metric_chunk_terms,
+                self._dflash_metric_chunk_terms,
                 hidden_4d.detach(),
                 target_ids,
                 weight_mask,
@@ -1305,31 +1356,27 @@ class OnlineDFlashModel(nn.Module):
                 chunk_size=self.objective_chunk_blocks,
                 dim=1,
             )
-            top_k = candidate_selector.top_k
+            top_k = self._metric_top_k()
             for name, numerators in (
                 (
-                    "dflash2/hard_label/unary_top1_accuracy",
+                    "dflash/hard_label/unary_top1_accuracy",
                     unary_correct_position_num,
                 ),
                 (
-                    "dflash2/hard_label/unary_probability",
+                    "dflash/hard_label/unary_probability",
                     hard_label_probability_position_num,
                 ),
                 (
-                    "dflash2/hard_label/expected_acceptance",
+                    "dflash/hard_label/expected_acceptance",
                     hard_label_probability_position_num,
                 ),
                 (
-                    f"dflash2/hard_label/unary_top{top_k}_recall",
+                    f"dflash/hard_label/unary_top{top_k}_recall",
                     unary_topk_recall_position_num,
                 ),
                 (
-                    f"dflash2/hard_label/unary_top{top_k}_mass",
+                    f"dflash/hard_label/unary_top{top_k}_mass",
                     unary_topk_mass_position_num,
-                ),
-                (
-                    "dflash2/hard_label/selector_serving_accuracy",
-                    selector_serving_correct_position_num,
                 ),
             ):
                 self._add_ratio_family(
@@ -1338,56 +1385,66 @@ class OnlineDFlashModel(nn.Module):
                     numerators,
                     position_den,
                 )
-            self._add_ratio_family(
-                ratio_metrics,
-                "dflash2/hard_label/selector_conditional_accuracy",
-                selector_correct_position_num,
-                selector_covered_position_den,
-            )
             self._add_position_ratios(
                 ratio_metrics,
-                "dflash2/objective/loss_weight_share",
+                "dflash/objective/loss_weight_share",
                 loss_weight_position_num,
                 loss_weight_position_num.sum().expand_as(loss_weight_position_num),
             )
             ratio_metrics[
-                f"dflash2/hard_label/unary_top{top_k}_oracle_accepted_length"
+                f"dflash/hard_label/unary_top{top_k}_oracle_accepted_length"
             ] = (oracle_accepted_length_num.detach(), block_den.detach())
-            ratio_metrics["dflash2/hard_label/selector_serving_accepted_length"] = (
-                serving_accepted_length_num.detach(),
-                block_den.detach(),
-            )
-            ratio_metrics["dflash2/hard_label/expected_accepted_length"] = (
+            ratio_metrics["dflash/hard_label/expected_accepted_length"] = (
                 expected_accepted_length_num.detach(),
                 block_den.detach(),
             )
             if aligned_target_hidden is not None:
-                ratio_metrics["dflash2/teacher/expected_accepted_length"] = (
+                ratio_metrics["dflash/teacher/expected_accepted_length"] = (
                     teacher_expected_accepted_length_num.detach(),
                     block_den.detach(),
                 )
                 for name, numerators in (
                     (
-                        "dflash2/teacher/expected_acceptance",
+                        "dflash/teacher/expected_acceptance",
                         teacher_expected_acceptance_position_num,
                     ),
                     (
-                        "dflash2/teacher/unary_top1_agreement",
+                        "dflash/teacher/unary_top1_agreement",
                         teacher_unary_top1_agreement_position_num,
                     ),
                     (
-                        f"dflash2/teacher/unary_top{top_k}_mass",
+                        f"dflash/teacher/unary_top{top_k}_mass",
                         teacher_unary_topk_mass_position_num,
-                    ),
-                    (
-                        "dflash2/teacher/selector_serving_agreement",
-                        teacher_selector_serving_agreement_position_num,
                     ),
                 ):
                     self._add_ratio_family(
                         ratio_metrics,
                         name,
                         numerators,
+                        position_den,
+                    )
+            if candidate_selector is not None:
+                self._add_ratio_family(
+                    ratio_metrics,
+                    "dflash2/selector/serving_accuracy",
+                    selector_serving_correct_position_num,
+                    position_den,
+                )
+                self._add_ratio_family(
+                    ratio_metrics,
+                    "dflash2/selector/conditional_accuracy",
+                    selector_correct_position_num,
+                    selector_covered_position_den,
+                )
+                ratio_metrics["dflash2/selector/serving_accepted_length"] = (
+                    serving_accepted_length_num.detach(),
+                    block_den.detach(),
+                )
+                if aligned_target_hidden is not None:
+                    self._add_ratio_family(
+                        ratio_metrics,
+                        "dflash2/selector/teacher_serving_agreement",
+                        teacher_selector_serving_agreement_position_num,
                         position_den,
                     )
         if has_selector_objective:
@@ -1409,7 +1466,7 @@ class OnlineDFlashModel(nn.Module):
                         selector_probability_num.detach(),
                         selector_covered_num.detach(),
                     ),
-                    "dflash2/hard_label/selector_loss": (
+                    "dflash2/selector/loss": (
                         selector_loss_num.detach(),
                         selector_weight_den.detach(),
                     ),
@@ -1418,7 +1475,7 @@ class OnlineDFlashModel(nn.Module):
             if collect_detailed_metrics:
                 self._add_position_ratios(
                     ratio_metrics,
-                    "dflash2/hard_label/selector_loss",
+                    "dflash2/selector/loss",
                     selector_ce_position_num,
                     selector_weight_position_den,
                 )

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -102,6 +102,23 @@ class DFlashMetricTerms(NamedTuple):
     block_den: torch.Tensor
     oracle_accepted_length_num: torch.Tensor
     serving_accepted_length_num: torch.Tensor
+    expected_accepted_length_num: torch.Tensor
+    teacher_expected_accepted_length_num: torch.Tensor
+
+
+def _expected_accepted_length_num(
+    acceptance: torch.Tensor,
+    supervised: torch.Tensor,
+    block_valid: torch.Tensor,
+) -> torch.Tensor:
+    """Sum ``1 + sum_k prod_{j<=k} a_j`` over valid blocks.
+
+    ``acceptance`` holds the per-slot acceptance event or probability for the
+    predicted slots; the chain stops at the first unsupervised slot.
+    """
+
+    alive = acceptance.float() * supervised.float()
+    return ((1.0 + alive.cumprod(dim=-1).sum(dim=-1)) * block_valid).sum()
 
 
 class _DFlashUnaryDiagnostics(NamedTuple):
@@ -133,6 +150,7 @@ class _DFlashServingDiagnostics(NamedTuple):
     block_den: torch.Tensor
     oracle_accepted_length_num: torch.Tensor
     accepted_length_num: torch.Tensor
+    expected_accepted_length_num: torch.Tensor
 
 
 class _DFlashTeacherTerms(NamedTuple):
@@ -142,6 +160,7 @@ class _DFlashTeacherTerms(NamedTuple):
     unary_top1_agreement_num: torch.Tensor
     unary_topk_mass_num: torch.Tensor
     selector_serving_agreement_num: torch.Tensor
+    expected_accepted_length_num: torch.Tensor
 
     @classmethod
     def zeros(cls, position_den: torch.Tensor) -> "_DFlashTeacherTerms":
@@ -150,6 +169,7 @@ class _DFlashTeacherTerms(NamedTuple):
             position_den.new_zeros(position_den.shape),
             position_den.new_zeros(position_den.shape),
             position_den.new_zeros(position_den.shape),
+            position_den.new_zeros(()),
         )
 
 
@@ -925,6 +945,7 @@ class OnlineDFlashModel(nn.Module):
                 block_den=zero,
                 oracle_accepted_length_num=zero.clone(),
                 accepted_length_num=zero.clone(),
+                expected_accepted_length_num=zero.clone(),
             )
 
         serving_ids = candidate_selector.greedy_path(
@@ -953,21 +974,24 @@ class OnlineDFlashModel(nn.Module):
             )
         )
 
-        # A block accepts its anchor, then only its leading run of supervised hits.
+        # A block accepts its anchor, then only its leading run of supervised
+        # slots: covered (oracle), hit by the serving path (realized), or, for
+        # the smooth D-PACE surrogate, weighted by the gold-token probability.
         supervised = weight_mask[:, :, 1:] > 0.5
         block_valid = supervised.any(dim=-1).float()
-        oracle_alive = supervised & unary.target_is_candidate[:, :, 1:]
-        serving_alive = supervised & serving_hit
         return _DFlashServingDiagnostics(
             selected_ids=serving_ids,
             correct_num=correct_num,
             block_den=block_valid.sum(),
-            oracle_accepted_length_num=(
-                (1.0 + oracle_alive.float().cumprod(dim=-1).sum(dim=-1)) * block_valid
-            ).sum(),
-            accepted_length_num=(
-                (1.0 + serving_alive.float().cumprod(dim=-1).sum(dim=-1)) * block_valid
-            ).sum(),
+            oracle_accepted_length_num=_expected_accepted_length_num(
+                unary.target_is_candidate[:, :, 1:], supervised, block_valid
+            ),
+            accepted_length_num=_expected_accepted_length_num(
+                serving_hit, supervised, block_valid
+            ),
+            expected_accepted_length_num=_expected_accepted_length_num(
+                unary.hard_label_probability[:, :, 1:], supervised, block_valid
+            ),
         )
 
     def _dflash2_teacher_terms(
@@ -999,6 +1023,7 @@ class OnlineDFlashModel(nn.Module):
         ).clamp(0.0, 1.0)
 
         selector_serving_agreement_num = position_den.new_zeros(position_den.shape)
+        expected_accepted_length_num = position_den.new_zeros(())
         if block_size > 1:
             selector_serving_agreement_num = torch.cat(
                 (
@@ -1008,6 +1033,12 @@ class OnlineDFlashModel(nn.Module):
                         * weight_mask[:, :, 1:]
                     ).sum(dim=(0, 1)),
                 )
+            )
+            supervised = weight_mask[:, :, 1:] > 0.5
+            expected_accepted_length_num = _expected_accepted_length_num(
+                expected_acceptance[:, :, 1:],
+                supervised,
+                supervised.any(dim=-1).float(),
             )
         return _DFlashTeacherTerms(
             expected_acceptance_num=(expected_acceptance * weight_mask).sum(dim=(0, 1)),
@@ -1019,6 +1050,7 @@ class OnlineDFlashModel(nn.Module):
                 * weight_mask
             ).sum(dim=(0, 1)),
             selector_serving_agreement_num=selector_serving_agreement_num,
+            expected_accepted_length_num=expected_accepted_length_num,
         )
 
     @staticmethod
@@ -1065,6 +1097,8 @@ class OnlineDFlashModel(nn.Module):
             block_den=serving.block_den,
             oracle_accepted_length_num=serving.oracle_accepted_length_num,
             serving_accepted_length_num=serving.accepted_length_num,
+            expected_accepted_length_num=serving.expected_accepted_length_num,
+            teacher_expected_accepted_length_num=teacher.expected_accepted_length_num,
         )
 
     def _lk_kl_weight(
@@ -1259,6 +1293,8 @@ class OnlineDFlashModel(nn.Module):
                 block_den,
                 oracle_accepted_length_num,
                 serving_accepted_length_num,
+                expected_accepted_length_num,
+                teacher_expected_accepted_length_num,
             ) = checkpointed_chunk_reduce(
                 self._dflash2_metric_chunk_terms,
                 hidden_4d.detach(),
@@ -1321,7 +1357,15 @@ class OnlineDFlashModel(nn.Module):
                 serving_accepted_length_num.detach(),
                 block_den.detach(),
             )
+            ratio_metrics["dflash2/hard_label/expected_accepted_length"] = (
+                expected_accepted_length_num.detach(),
+                block_den.detach(),
+            )
             if aligned_target_hidden is not None:
+                ratio_metrics["dflash2/teacher/expected_accepted_length"] = (
+                    teacher_expected_accepted_length_num.detach(),
+                    block_den.detach(),
+                )
                 for name, numerators in (
                     (
                         "dflash2/teacher/expected_acceptance",

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -78,20 +78,30 @@ class DFlashObjectiveTerms(NamedTuple):
 
 
 class DFlashMetricTerms(NamedTuple):
-    """Additive per-position DFlash2 diagnostics for one metric chunk."""
+    """Additive DFlash2 diagnostics for one metric chunk.
+
+    Per-position fields hold one entry per block position; the accepted-length
+    fields and ``block_den`` are per-block scalars.
+    """
 
     hard_label_probability_num: torch.Tensor
     unary_correct_num: torch.Tensor
     position_den: torch.Tensor
     unary_topk_recall_num: torch.Tensor
+    unary_topk_mass_num: torch.Tensor
     selector_ce_num: torch.Tensor
     selector_weight_den: torch.Tensor
     selector_conditional_correct_num: torch.Tensor
+    selector_covered_den: torch.Tensor
     selector_serving_correct_num: torch.Tensor
+    loss_weight_num: torch.Tensor
     teacher_expected_acceptance_num: torch.Tensor
     teacher_unary_top1_agreement_num: torch.Tensor
     teacher_unary_topk_mass_num: torch.Tensor
     teacher_selector_serving_agreement_num: torch.Tensor
+    block_den: torch.Tensor
+    oracle_accepted_length_num: torch.Tensor
+    serving_accepted_length_num: torch.Tensor
 
 
 def compute_accept_len(
@@ -759,8 +769,12 @@ class OnlineDFlashModel(nn.Module):
             selector_logits.argmax(dim=-1, keepdim=True),
         ).squeeze(-1)
 
+        covered_mask = weight_mask * target_is_candidate.float()
         position_den = weight_mask.sum(dim=(0, 1))
         selector_serving_correct_num = position_den.new_zeros(block_size)
+        block_den = position_den.new_zeros(())
+        oracle_accepted_length_num = position_den.new_zeros(())
+        serving_accepted_length_num = position_den.new_zeros(())
         teacher_selector_serving_agreement_num = position_den.new_zeros(block_size)
         teacher_expected_acceptance_num = position_den.new_zeros(block_size)
         teacher_unary_top1_agreement_num = position_den.new_zeros(block_size)
@@ -810,15 +824,26 @@ class OnlineDFlashModel(nn.Module):
                 ),
                 anchor_token_ids=target_ids[:, :, 0].reshape(-1),
             ).reshape(batch_size, num_blocks, block_size - 1)
+            serving_hit = serving_ids == target_ids[:, :, 1:]
             selector_serving_correct_num = torch.cat(
                 (
                     position_den.new_zeros(1),
-                    (
-                        (serving_ids == target_ids[:, :, 1:]).float()
-                        * weight_mask[:, :, 1:]
-                    ).sum(dim=(0, 1)),
+                    (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
                 )
             )
+            # Accepted length per block: the anchor counts as one token and a
+            # block extends while every earlier slot is supervised and accepted.
+            supervised = weight_mask[:, :, 1:] > 0.5
+            block_valid = supervised.any(dim=-1).float()
+            block_den = block_valid.sum()
+            oracle_alive = (supervised & target_is_candidate[:, :, 1:]).float()
+            serving_alive = (supervised & serving_hit).float()
+            oracle_accepted_length_num = (
+                (1.0 + oracle_alive.cumprod(dim=-1).sum(dim=-1)) * block_valid
+            ).sum()
+            serving_accepted_length_num = (
+                (1.0 + serving_alive.cumprod(dim=-1).sum(dim=-1)) * block_valid
+            ).sum()
             if teacher_ids is not None:
                 teacher_selector_serving_agreement_num = torch.cat(
                     (
@@ -838,23 +863,40 @@ class OnlineDFlashModel(nn.Module):
                 dim=(0, 1)
             ),
             position_den=position_den,
-            unary_topk_recall_num=(target_is_candidate.float() * weight_mask).sum(
-                dim=(0, 1)
-            ),
+            unary_topk_recall_num=covered_mask.sum(dim=(0, 1)),
+            unary_topk_mass_num=(
+                probabilities.gather(-1, candidate_ids).sum(dim=-1) * weight_mask
+            ).sum(dim=(0, 1)),
             selector_ce_num=(selector_ce * selector_loss_weights).sum(dim=(0, 1)),
             selector_weight_den=selector_loss_weights.sum(dim=(0, 1)),
             selector_conditional_correct_num=(
-                (selector_teacher_forced_ids == target_ids).float()
-                * selector_loss_weights
+                (selector_teacher_forced_ids == target_ids).float() * covered_mask
             ).sum(dim=(0, 1)),
+            selector_covered_den=covered_mask.sum(dim=(0, 1)),
             selector_serving_correct_num=selector_serving_correct_num,
+            loss_weight_num=loss_weights.sum(dim=(0, 1)),
             teacher_expected_acceptance_num=teacher_expected_acceptance_num,
-            teacher_unary_top1_agreement_num=(teacher_unary_top1_agreement_num),
+            teacher_unary_top1_agreement_num=teacher_unary_top1_agreement_num,
             teacher_unary_topk_mass_num=teacher_unary_topk_mass_num,
             teacher_selector_serving_agreement_num=(
                 teacher_selector_serving_agreement_num
             ),
+            block_den=block_den,
+            oracle_accepted_length_num=oracle_accepted_length_num,
+            serving_accepted_length_num=serving_accepted_length_num,
         )
+
+    def _lk_kl_weight(
+        self,
+        probability_num: torch.Tensor,
+        probability_den: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        """Return the LK-lambda CE weight, or ``None`` for other objectives."""
+
+        if self.lk_loss_type != "lambda":
+            return None
+        acceptance = probability_num / probability_den.clamp_min(1.0)
+        return self.kl_scale * torch.exp(-self.kl_decay * acceptance.detach())
 
     def _compose_token_objective(
         self,
@@ -871,8 +913,7 @@ class OnlineDFlashModel(nn.Module):
         if self.lk_loss_type == "tv":
             return tv_num
         if self.lk_loss_type == "lambda":
-            acceptance = probability_num / probability_den.clamp_min(1.0)
-            kl_weight = self.kl_scale * torch.exp(-self.kl_decay * acceptance.detach())
+            kl_weight = self._lk_kl_weight(probability_num, probability_den)
             return kl_weight * ce_num + (1.0 - kl_weight) * tv_num
         raise ValueError(f"unknown lk_loss_type {self.lk_loss_type!r}")
 
@@ -1010,6 +1051,12 @@ class OnlineDFlashModel(nn.Module):
                 loss_denominator.detach(),
             ),
         }
+        lk_kl_weight = self._lk_kl_weight(target_probability_num, accuracy_denom)
+        if lk_kl_weight is not None:
+            ratio_metrics["objective/lk_kl_weight"] = (
+                (lk_kl_weight * accuracy_denom).detach(),
+                accuracy_denom.detach(),
+            )
         candidate_selector = getattr(self.draft_model, "candidate_selector", None)
         if candidate_selector is not None and collect_detailed_metrics:
             (
@@ -1017,14 +1064,20 @@ class OnlineDFlashModel(nn.Module):
                 unary_correct_position_num,
                 position_den,
                 unary_topk_recall_position_num,
+                unary_topk_mass_position_num,
                 selector_ce_position_num,
                 selector_weight_position_den,
                 selector_correct_position_num,
+                selector_covered_position_den,
                 selector_serving_correct_position_num,
+                loss_weight_position_num,
                 teacher_expected_acceptance_position_num,
                 teacher_unary_top1_agreement_position_num,
                 teacher_unary_topk_mass_position_num,
                 teacher_selector_serving_agreement_position_num,
+                block_den,
+                oracle_accepted_length_num,
+                serving_accepted_length_num,
             ) = checkpointed_chunk_reduce(
                 self._dflash2_metric_chunk_terms,
                 hidden_4d.detach(),
@@ -1054,6 +1107,10 @@ class OnlineDFlashModel(nn.Module):
                     unary_topk_recall_position_num,
                 ),
                 (
+                    f"dflash2/hard_label/unary_top{top_k}_mass",
+                    unary_topk_mass_position_num,
+                ),
+                (
                     "dflash2/hard_label/selector_serving_accuracy",
                     selector_serving_correct_position_num,
                 ),
@@ -1064,6 +1121,25 @@ class OnlineDFlashModel(nn.Module):
                     numerators,
                     position_den,
                 )
+            self._add_ratio_family(
+                ratio_metrics,
+                "dflash2/hard_label/selector_conditional_accuracy",
+                selector_correct_position_num,
+                selector_covered_position_den,
+            )
+            self._add_position_ratios(
+                ratio_metrics,
+                "dflash2/objective/loss_weight_share",
+                loss_weight_position_num,
+                loss_weight_position_num.sum().expand_as(loss_weight_position_num),
+            )
+            ratio_metrics[
+                f"dflash2/hard_label/unary_top{top_k}_oracle_accepted_length"
+            ] = (oracle_accepted_length_num.detach(), block_den.detach())
+            ratio_metrics["dflash2/hard_label/selector_serving_accepted_length"] = (
+                serving_accepted_length_num.detach(),
+                block_den.detach(),
+            )
             if aligned_target_hidden is not None:
                 for name, numerators in (
                     (
@@ -1112,10 +1188,6 @@ class OnlineDFlashModel(nn.Module):
                         selector_loss_num.detach(),
                         selector_weight_den.detach(),
                     ),
-                    "dflash2/hard_label/selector_conditional_accuracy": (
-                        selector_correct_num.detach(),
-                        selector_weight_den.detach(),
-                    ),
                 }
             )
             if collect_detailed_metrics:
@@ -1123,12 +1195,6 @@ class OnlineDFlashModel(nn.Module):
                     ratio_metrics,
                     "dflash2/hard_label/selector_loss",
                     selector_ce_position_num,
-                    selector_weight_position_den,
-                )
-                self._add_position_ratios(
-                    ratio_metrics,
-                    "dflash2/hard_label/selector_conditional_accuracy",
-                    selector_correct_position_num,
                     selector_weight_position_den,
                 )
         metrics: Dict[str, object] = {

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -483,10 +483,15 @@ class OnlineDFlashModel(nn.Module):
         numerators: torch.Tensor,
         denominators: torch.Tensor,
     ) -> None:
-        """Add one explicitly named ratio per predicted block position."""
+        """Add one ratio per predicted block position.
 
+        Per-position keys live under their own ``position_<k>/`` tracker
+        section so each block position renders as one dashboard group.
+        """
+
+        family = name.removeprefix("dflash2/")
         for position in range(1, numerators.numel()):
-            metrics[f"{name}/position_{position}"] = (
+            metrics[f"position_{position}/{family}"] = (
                 numerators[position].detach(),
                 denominators[position].detach(),
             )

--- a/specforge/algorithms/common/hidden_states_data.py
+++ b/specforge/algorithms/common/hidden_states_data.py
@@ -153,52 +153,35 @@ def build_dspark_offline_normalizer(max_len, **_topology):
     return partial(normalize_dspark_offline_sample, max_len=max_len)
 
 
-def build_collator():
+def _padded_collator(required_keys, optional_keys=()):
+    """Build a collator that zero-pads every listed key along the sequence axis."""
+
+    sequence_axes = {key: 1 for key in (*required_keys, *optional_keys)}
+
     def collate(features):
-        required_keys = ["input_ids", "loss_mask", "hidden_states"]
-        teacher_feature_presence = [
-            "target_last_hidden_states" in feature for feature in features
-        ]
-        if any(teacher_feature_presence) and not all(teacher_feature_presence):
-            raise KeyError(
-                "target_last_hidden_states must be present in every DFlash sample "
-                "or omitted from every sample"
-            )
-        if all(teacher_feature_presence):
-            required_keys.append("target_last_hidden_states")
         return pad_and_concatenate_features(
             features,
-            sequence_axes={
-                "input_ids": 1,
-                "loss_mask": 1,
-                "hidden_states": 1,
-                "target_last_hidden_states": 1,
-            },
+            sequence_axes=sequence_axes,
             required_keys=required_keys,
+            optional_keys=optional_keys,
         )
 
     return collate
+
+
+def build_collator():
+    # The target's final hidden state rides along when the capture layout
+    # carries it; offline v1 DFlash and Domino batches omit it.
+    return _padded_collator(
+        ("input_ids", "loss_mask", "hidden_states"),
+        optional_keys=("target_last_hidden_states",),
+    )
 
 
 def build_dspark_collator():
-    def collate(features):
-        return pad_and_concatenate_features(
-            features,
-            sequence_axes={
-                "input_ids": 1,
-                "loss_mask": 1,
-                "hidden_states": 1,
-                "target_last_hidden_states": 1,
-            },
-            required_keys=(
-                "input_ids",
-                "loss_mask",
-                "hidden_states",
-                "target_last_hidden_states",
-            ),
-        )
-
-    return collate
+    return _padded_collator(
+        ("input_ids", "loss_mask", "hidden_states", "target_last_hidden_states")
+    )
 
 
 def normalize_mtp_offline_sample(raw, max_len: int):
@@ -262,22 +245,7 @@ def build_mtp_offline_normalizer(max_len, **_topology):
 
 
 def build_mtp_collator():
-    def collate(features):
-        return pad_and_concatenate_features(
-            features,
-            sequence_axes={
-                "input_ids": 1,
-                "loss_mask": 1,
-                "target_last_hidden_states": 1,
-            },
-            required_keys=(
-                "input_ids",
-                "loss_mask",
-                "target_last_hidden_states",
-            ),
-        )
-
-    return collate
+    return _padded_collator(("input_ids", "loss_mask", "target_last_hidden_states"))
 
 
 __all__ = [

--- a/specforge/algorithms/common/hidden_states_data.py
+++ b/specforge/algorithms/common/hidden_states_data.py
@@ -155,14 +155,26 @@ def build_dspark_offline_normalizer(max_len, **_topology):
 
 def build_collator():
     def collate(features):
+        required_keys = ["input_ids", "loss_mask", "hidden_states"]
+        teacher_feature_presence = [
+            "target_last_hidden_states" in feature for feature in features
+        ]
+        if any(teacher_feature_presence) and not all(teacher_feature_presence):
+            raise KeyError(
+                "target_last_hidden_states must be present in every DFlash sample "
+                "or omitted from every sample"
+            )
+        if all(teacher_feature_presence):
+            required_keys.append("target_last_hidden_states")
         return pad_and_concatenate_features(
             features,
             sequence_axes={
                 "input_ids": 1,
                 "loss_mask": 1,
                 "hidden_states": 1,
+                "target_last_hidden_states": 1,
             },
-            required_keys=("input_ids", "loss_mask", "hidden_states"),
+            required_keys=required_keys,
         )
 
     return collate

--- a/specforge/algorithms/dflash/providers.py
+++ b/specforge/algorithms/dflash/providers.py
@@ -249,7 +249,7 @@ def algorithm_providers() -> AlgorithmProviders:
                 target_representation=None,
                 layout=ServerCaptureLayout(
                     aux_feature="hidden_states",
-                    last_hidden_feature=None,
+                    last_hidden_feature="target_last_hidden_states",
                     passthrough=(
                         ("input_ids", "input_ids", ()),
                         ("loss_mask", "loss_mask", ()),

--- a/specforge/eval/evaluator.py
+++ b/specforge/eval/evaluator.py
@@ -151,6 +151,7 @@ class Evaluator:
             if ar_w > 0:
                 for i, v in enumerate((pp[2] / ar_w).tolist()):
                     metrics[f"eval/acceptance_rate_{i}"] = v
+                    metrics[f"eval/expected_acceptance_{i}"] = v
             if pl_w > 0:
                 for i, v in enumerate((pp[3] / pl_w).tolist()):
                     metrics[f"eval/ploss_{i}"] = v

--- a/specforge/training/controller.py
+++ b/specforge/training/controller.py
@@ -272,6 +272,7 @@ def _reduce_eagle3_metrics(
     process_group: Any,
     ploss_decay: float,
     reduce: bool,
+    objective_metric_name: Optional[str] = None,
 ) -> Optional[Dict[str, torch.Tensor]]:
     """Reduce EAGLE3's per-position training telemetry as numerators/counts.
 
@@ -355,6 +356,8 @@ def _reduce_eagle3_metrics(
     for index in range(length):
         result[f"acc_{index}"] = reduced_acc[index]
         result[f"ploss_{index}"] = reduced_ploss[index]
+        if objective_metric_name is not None:
+            result[f"{objective_metric_name}_{index}"] = reduced_ploss[index]
 
     result["acc"] = packed[0].sum().div(packed[1].sum().clamp_min(1e-6))
     weights = torch.tensor(
@@ -363,12 +366,16 @@ def _reduce_eagle3_metrics(
         device=reduced_ploss.device,
     )
     result["loss"] = (reduced_ploss * weights).sum()
+    if objective_metric_name is not None:
+        result[objective_metric_name] = result["loss"]
 
     if acceptance_rates is not None:
         reduced_acceptance = packed[4] / packed[5].clamp_min(1e-6)
         for index in range(length):
             result[f"acceptance_rate_{index}"] = reduced_acceptance[index]
+            result[f"expected_acceptance_{index}"] = reduced_acceptance[index]
         result["acceptance_rate"] = reduced_acceptance.mean()
+        result["expected_acceptance"] = result["acceptance_rate"]
     return result
 
 
@@ -481,12 +488,22 @@ class TrainerCore:
         )
         parallel_config = getattr(self.backend, "parallel_config", None)
         process_group = getattr(parallel_config, "fsdp_process_group", None)
+        eagle3_model = getattr(self.strategy, "eagle3_model", None)
+        if eagle3_model is not None and not hasattr(eagle3_model, "lk_loss_type"):
+            eagle3_model = getattr(eagle3_model, "module", eagle3_model)
+        objective_metric_name = (
+            "lk_loss"
+            if eagle3_model is not None
+            and getattr(eagle3_model, "lk_loss_type", None) is not None
+            else "kl_loss"
+        )
         structured = _reduce_eagle3_metrics(
             out.metrics,
             device=metric_device,
             process_group=process_group,
             ploss_decay=float(getattr(self.strategy, "ploss_decay", 1.0)),
             reduce=stepped,
+            objective_metric_name=objective_metric_name,
         )
         # Structured EAGLE3 metrics are already globally reduced.  Remaining
         # scalar diagnostics are DP-averaged in a single collective at optimizer
@@ -743,7 +760,12 @@ class TrainerController:
                 result = self.core.train_step(
                     batch,
                     ctx=StepContext(
-                        global_step=self.global_step, total_steps=self.total_steps
+                        global_step=self.global_step,
+                        total_steps=self.total_steps,
+                        collect_detailed_metrics=(
+                            self.logger is not None
+                            and (self.global_step + 1) % max(1, self.log_interval) == 0
+                        ),
                     ),
                 )
                 perf_train_compute_s += time.perf_counter() - train_compute_started

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -44,9 +44,9 @@ class StepOutput:
 
 @dataclass(frozen=True)
 class StepContext:
-    """Training-schedule state passed into ``forward_loss`` for objectives that
-    depend on where in training we are (e.g. Domino's decaying ``lambda_base``);
-    ``collect_detailed_metrics`` gates expensive diagnostics to log windows."""
+    """Training-schedule state passed into ``forward_loss``.
+
+    ``collect_detailed_metrics`` gates expensive diagnostics to log steps."""
 
     global_step: int = 0
     total_steps: Optional[int] = None

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -46,10 +46,11 @@ class StepOutput:
 class StepContext:
     """Training-schedule state passed into ``forward_loss`` for objectives that
     depend on where in training we are (e.g. Domino's decaying ``lambda_base``);
-    most strategies ignore it."""
+    ``collect_detailed_metrics`` gates expensive diagnostics to log windows."""
 
     global_step: int = 0
     total_steps: Optional[int] = None
+    collect_detailed_metrics: bool = True
 
 
 def linear_lambda_base(
@@ -499,13 +500,24 @@ class DFlashTrainStrategy(DraftTrainStrategy):
         device = self._device()
         selector_loss_alpha = self._selector_loss_alpha(ctx)
         max_valid_anchors = _cpu_max_valid_anchors(t["loss_mask"])
-        loss, accuracy, model_metrics = self.dflash_model(
-            input_ids=t["input_ids"].to(device, non_blocking=True),
-            hidden_states=t["hidden_states"].to(device, non_blocking=True),
-            loss_mask=t["loss_mask"].to(device, non_blocking=True),
-            max_valid_anchors=max_valid_anchors,
-            selector_loss_alpha=selector_loss_alpha,
+        collect_detailed_metrics = (
+            ctx.collect_detailed_metrics if ctx is not None else True
         )
+        model_inputs = {
+            "input_ids": t["input_ids"].to(device, non_blocking=True),
+            "hidden_states": t["hidden_states"].to(device, non_blocking=True),
+            "loss_mask": t["loss_mask"].to(device, non_blocking=True),
+            "max_valid_anchors": max_valid_anchors,
+            "selector_loss_alpha": selector_loss_alpha,
+        }
+        if ctx is not None:
+            model_inputs["collect_detailed_metrics"] = collect_detailed_metrics
+        target_last_hidden_states = t.get("target_last_hidden_states")
+        if target_last_hidden_states is not None and collect_detailed_metrics:
+            model_inputs["target_last_hidden_states"] = target_last_hidden_states.to(
+                device, non_blocking=True
+            )
+        loss, accuracy, model_metrics = self.dflash_model(**model_inputs)
         metrics = {"accuracy": accuracy.detach()}
         if "accuracy_denom" in model_metrics:
             metrics["accuracy_denom"] = model_metrics["accuracy_denom"]

--- a/specforge/training/tracking.py
+++ b/specforge/training/tracking.py
@@ -54,13 +54,8 @@ def scalar_metrics(metrics: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def training_metric_names(metrics: Mapping[str, float]) -> Dict[str, float]:
-    """Place metrics in their stable external-tracker namespaces.
-
-    Evaluation and performance counters already carry explicit namespaces.
-    Strategy results are plain names because the console logger is
-    intentionally backend-neutral; add ``train/`` only to those metrics at the
-    external-tracker boundary.
-    """
+    """Prefix plain strategy metrics with ``train/``; ``eval/`` and ``perf/``
+    keys already carry their namespace."""
     return {
         key if key.startswith(("train/", "eval/", "perf/")) else f"train/{key}": value
         for key, value in metrics.items()

--- a/specforge/training/tracking.py
+++ b/specforge/training/tracking.py
@@ -54,14 +54,15 @@ def scalar_metrics(metrics: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def training_metric_names(metrics: Mapping[str, float]) -> Dict[str, float]:
-    """Preserve the historical ``train/*`` tracker namespace.
+    """Place metrics in their stable external-tracker namespaces.
 
-    Evaluation already reports ``eval/*`` keys.  Strategy results are plain
-    names because the console logger is intentionally backend-neutral; add the
-    training namespace only at the external-tracker boundary.
+    Evaluation and performance counters already carry explicit namespaces.
+    Strategy results are plain names because the console logger is
+    intentionally backend-neutral; add ``train/`` only to those metrics at the
+    external-tracker boundary.
     """
     return {
-        key if key.startswith(("train/", "eval/")) else f"train/{key}": value
+        key if key.startswith(("train/", "eval/", "perf/")) else f"train/{key}": value
         for key, value in metrics.items()
     }
 

--- a/specforge/training/tracking.py
+++ b/specforge/training/tracking.py
@@ -54,10 +54,14 @@ def scalar_metrics(metrics: Mapping[str, Any]) -> Dict[str, float]:
 
 
 def training_metric_names(metrics: Mapping[str, float]) -> Dict[str, float]:
-    """Prefix plain strategy metrics with ``train/``; ``eval/`` and ``perf/``
-    keys already carry their namespace."""
+    """Prefix plain strategy metrics with ``train/``; ``eval/``, ``perf/`` and
+    per-position ``position_<k>/`` keys already carry their section."""
     return {
-        key if key.startswith(("train/", "eval/", "perf/")) else f"train/{key}": value
+        (
+            key
+            if key.startswith(("train/", "eval/", "perf/", "position_"))
+            else f"train/{key}"
+        ): value
         for key, value in metrics.items()
     }
 

--- a/tests/test_algorithms/test_builtin_parity.py
+++ b/tests/test_algorithms/test_builtin_parity.py
@@ -87,7 +87,7 @@ class BuiltinProviderParityTest(unittest.TestCase):
         expected = {
             "dflash": (
                 "hidden_states",
-                None,
+                "target_last_hidden_states",
                 (("input_ids", "input_ids", ()), ("loss_mask", "loss_mask", ())),
                 None,
             ),
@@ -214,6 +214,38 @@ class BuiltinProviderParityTest(unittest.TestCase):
                 self.assertTrue(
                     torch.all(batch["target_last_hidden_states"][0, 2:] == 0)
                 )
+
+    def test_dflash_collator_preserves_optional_teacher_hidden_states(self):
+        short = {
+            "input_ids": torch.tensor([[1, 2]]),
+            "loss_mask": torch.ones(1, 2, dtype=torch.long),
+            "hidden_states": torch.ones(1, 2, 4),
+            "target_last_hidden_states": torch.ones(1, 2, 3),
+        }
+        long = {
+            "input_ids": torch.tensor([[1, 2, 3]]),
+            "loss_mask": torch.ones(1, 3, dtype=torch.long),
+            "hidden_states": torch.ones(1, 3, 4),
+            "target_last_hidden_states": torch.ones(1, 3, 3),
+        }
+        collate = (
+            self.registry.resolve("dflash")
+            .providers.server_streaming_for("text")
+            .build_collator()
+        )
+
+        batch = collate([short, long])
+
+        self.assertEqual((2, 3, 3), tuple(batch["target_last_hidden_states"].shape))
+        self.assertTrue(torch.all(batch["target_last_hidden_states"][0, 2:] == 0))
+
+        without_teacher = {
+            key: value
+            for key, value in short.items()
+            if key != "target_last_hidden_states"
+        }
+        with self.assertRaisesRegex(KeyError, "target_last_hidden_states"):
+            collate([without_teacher, long])
 
     def test_dspark_offline_contract_and_normalizer_preserve_target_hidden(self):
         registration = self.registry.resolve("dspark")

--- a/tests/test_algorithms/test_collation.py
+++ b/tests/test_algorithms/test_collation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from specforge.algorithms.common.collation import pad_and_concatenate_features
+
+
+def _sample(length, *, with_teacher):
+    feature = {
+        "input_ids": torch.arange(length).unsqueeze(0),
+        "loss_mask": torch.ones(1, length, dtype=torch.long),
+        "hidden_states": torch.ones(1, length, 4),
+    }
+    if with_teacher:
+        feature["target_last_hidden_states"] = torch.full((1, length, 3), 2.0)
+    return feature
+
+
+class PadAndConcatenateFeaturesTest(unittest.TestCase):
+    REQUIRED = ("input_ids", "loss_mask", "hidden_states")
+    OPTIONAL = ("target_last_hidden_states",)
+
+    def _collate(self, features):
+        return pad_and_concatenate_features(
+            features,
+            sequence_axes={key: 1 for key in (*self.REQUIRED, *self.OPTIONAL)},
+            required_keys=self.REQUIRED,
+            optional_keys=self.OPTIONAL,
+        )
+
+    def test_optional_key_is_padded_when_every_sample_has_it(self):
+        batch = self._collate(
+            [_sample(2, with_teacher=True), _sample(3, with_teacher=True)]
+        )
+
+        teacher = batch["target_last_hidden_states"]
+        self.assertEqual((2, 3, 3), tuple(teacher.shape))
+        self.assertTrue(torch.all(teacher[0, :2] == 2.0))
+        self.assertTrue(torch.all(teacher[0, 2:] == 0.0))
+
+    def test_optional_key_is_omitted_when_no_sample_has_it(self):
+        batch = self._collate(
+            [_sample(2, with_teacher=False), _sample(3, with_teacher=False)]
+        )
+
+        self.assertEqual(set(self.REQUIRED), set(batch))
+
+    def test_mixed_optional_presence_is_rejected(self):
+        with self.assertRaisesRegex(KeyError, "target_last_hidden_states"):
+            self._collate(
+                [_sample(2, with_teacher=True), _sample(3, with_teacher=False)]
+            )
+
+    def test_missing_required_key_is_still_rejected(self):
+        broken = _sample(2, with_teacher=True)
+        del broken["hidden_states"]
+
+        with self.assertRaisesRegex(KeyError, "hidden_states"):
+            self._collate([broken])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -397,41 +397,39 @@ class CandidateSelectorTest(unittest.TestCase):
         expected_keys = {
             "lk_loss",
             "expected_acceptance",
-            "dflash2/hard_label/unary_top1_accuracy/position_1",
-            "dflash2/hard_label/unary_top1_accuracy/position_2",
-            "dflash2/hard_label/unary_top2_recall/position_1",
-            "dflash2/hard_label/unary_top2_recall/position_2",
-            "dflash2/hard_label/selector_loss/position_1",
-            "dflash2/hard_label/unary_top2_mass/position_1",
+            "dflash2/hard_label/unary_top1_accuracy",
             "dflash2/hard_label/selector_conditional_accuracy",
-            "dflash2/hard_label/selector_conditional_accuracy/position_2",
             "dflash2/hard_label/unary_top2_oracle_accepted_length",
             "dflash2/hard_label/selector_serving_accepted_length",
-            "dflash2/objective/loss_weight_share/position_1",
-            "dflash2/teacher/expected_acceptance/position_1",
-            "dflash2/teacher/expected_acceptance/position_2",
-            "dflash2/teacher/unary_top1_agreement/position_1",
-            "dflash2/teacher/unary_top2_mass/position_2",
-            "dflash2/teacher/selector_serving_agreement/position_2",
+            "position_1/hard_label/unary_top1_accuracy",
+            "position_2/hard_label/unary_top1_accuracy",
+            "position_1/hard_label/unary_top2_recall",
+            "position_2/hard_label/unary_top2_recall",
+            "position_1/hard_label/selector_loss",
+            "position_1/hard_label/unary_top2_mass",
+            "position_2/hard_label/selector_conditional_accuracy",
+            "position_1/objective/loss_weight_share",
+            "position_1/teacher/expected_acceptance",
+            "position_2/teacher/expected_acceptance",
+            "position_1/teacher/unary_top1_agreement",
+            "position_2/teacher/unary_top2_mass",
+            "position_2/teacher/selector_serving_agreement",
         }
         self.assertTrue(expected_keys.issubset(ratios))
-        self.assertFalse(any(key.endswith("position_0") for key in ratios))
+        self.assertFalse(any(key.startswith("position_0/") for key in ratios))
+        self.assertFalse(any("/position_" in key for key in ratios))
         self.assertNotIn("objective/lk_kl_weight", ratios)
 
         def ratio(name):
             numerator, denominator = ratios[name]
             return float(numerator / denominator)
 
-        self.assertEqual(
-            ratio("dflash2/hard_label/unary_top1_accuracy/position_1"), 1.0
-        )
-        self.assertEqual(
-            ratio("dflash2/hard_label/unary_top1_accuracy/position_2"), 0.0
-        )
-        self.assertEqual(ratio("dflash2/hard_label/unary_top2_recall/position_1"), 1.0)
-        self.assertEqual(ratio("dflash2/hard_label/unary_top2_recall/position_2"), 0.0)
-        self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_1"), 1.0)
-        self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_2"), 0.0)
+        self.assertEqual(ratio("position_1/hard_label/unary_top1_accuracy"), 1.0)
+        self.assertEqual(ratio("position_2/hard_label/unary_top1_accuracy"), 0.0)
+        self.assertEqual(ratio("position_1/hard_label/unary_top2_recall"), 1.0)
+        self.assertEqual(ratio("position_2/hard_label/unary_top2_recall"), 0.0)
+        self.assertEqual(ratio("position_1/teacher/unary_top1_agreement"), 1.0)
+        self.assertEqual(ratio("position_2/teacher/unary_top1_agreement"), 0.0)
         # Position 1 is covered and served correctly, position 2 is uncovered:
         # both accepted-length walks credit the anchor plus one slot.
         self.assertEqual(
@@ -441,8 +439,8 @@ class CandidateSelectorTest(unittest.TestCase):
             ratio("dflash2/hard_label/selector_serving_accepted_length"), 2.0
         )
         # Uniform dflash weights split the objective evenly over both slots.
-        self.assertEqual(ratio("dflash2/objective/loss_weight_share/position_1"), 0.5)
-        self.assertEqual(ratio("dflash2/objective/loss_weight_share/position_2"), 0.5)
+        self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
+        self.assertEqual(ratio("position_2/objective/loss_weight_share"), 0.5)
 
     def test_metric_chunk_reports_accepted_lengths_and_unweighted_selector_terms(
         self,

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -397,23 +397,23 @@ class CandidateSelectorTest(unittest.TestCase):
         expected_keys = {
             "lk_loss",
             "expected_acceptance",
-            "dflash2/hard_label/unary_top1_accuracy",
-            "dflash2/hard_label/selector_conditional_accuracy",
-            "dflash2/hard_label/unary_top2_oracle_accepted_length",
-            "dflash2/hard_label/selector_serving_accepted_length",
+            "dflash/hard_label/unary_top1_accuracy",
+            "dflash/hard_label/unary_top2_oracle_accepted_length",
+            "dflash2/selector/conditional_accuracy",
+            "dflash2/selector/serving_accepted_length",
             "position_1/hard_label/unary_top1_accuracy",
             "position_2/hard_label/unary_top1_accuracy",
             "position_1/hard_label/unary_top2_recall",
             "position_2/hard_label/unary_top2_recall",
-            "position_1/hard_label/selector_loss",
             "position_1/hard_label/unary_top2_mass",
-            "position_2/hard_label/selector_conditional_accuracy",
+            "position_1/selector/loss",
+            "position_2/selector/conditional_accuracy",
+            "position_2/selector/teacher_serving_agreement",
             "position_1/objective/loss_weight_share",
             "position_1/teacher/expected_acceptance",
             "position_2/teacher/expected_acceptance",
             "position_1/teacher/unary_top1_agreement",
             "position_2/teacher/unary_top2_mass",
-            "position_2/teacher/selector_serving_agreement",
         }
         self.assertTrue(expected_keys.issubset(ratios))
         self.assertFalse(any(key.startswith("position_0/") for key in ratios))
@@ -433,11 +433,9 @@ class CandidateSelectorTest(unittest.TestCase):
         # Position 1 is covered and served correctly, position 2 is uncovered:
         # both accepted-length walks credit the anchor plus one slot.
         self.assertEqual(
-            ratio("dflash2/hard_label/unary_top2_oracle_accepted_length"), 2.0
+            ratio("dflash/hard_label/unary_top2_oracle_accepted_length"), 2.0
         )
-        self.assertEqual(
-            ratio("dflash2/hard_label/selector_serving_accepted_length"), 2.0
-        )
+        self.assertEqual(ratio("dflash2/selector/serving_accepted_length"), 2.0)
         # Uniform dflash weights split the objective evenly over both slots.
         self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
         self.assertEqual(ratio("position_2/objective/loss_weight_share"), 0.5)
@@ -449,7 +447,7 @@ class CandidateSelectorTest(unittest.TestCase):
             -1, torch.tensor([[1], [3]])
         ).squeeze(-1)
         self.assertAlmostEqual(
-            ratio("dflash2/hard_label/expected_accepted_length"),
+            ratio("dflash/hard_label/expected_accepted_length"),
             float(1.0 + gold_probability.cumprod(dim=-1).sum()),
             places=5,
         )
@@ -457,9 +455,68 @@ class CandidateSelectorTest(unittest.TestCase):
             draft_probabilities - teacher_probabilities
         ).abs().sum(dim=-1)
         self.assertAlmostEqual(
-            ratio("dflash2/teacher/expected_accepted_length"),
+            ratio("dflash/teacher/expected_accepted_length"),
             float(1.0 + acceptance.cumprod(dim=-1).sum()),
             places=5,
+        )
+
+    def test_plain_dflash_draft_reports_family_metrics_without_selector_keys(self):
+        # A DFlash draft has neither a candidate selector nor a unary transform.
+        model = OnlineDFlashModel(
+            draft_model=nn.Module(),
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(4, 4),
+            mask_token_id=3,
+            block_size=3,
+            attention_backend="eager",
+            metric_top_k=2,
+        )
+        output_hidden = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 4.0, 1.0, 0.0],
+                    [0.0, 3.0, 4.0, 2.0],
+                ]
+            ]
+        )
+        target_hidden = torch.tensor(
+            [[[0.0, 5.0, 0.0, 0.0], [0.0, 0.0, 0.0, 5.0], [0.0, 0.0, 0.0, 0.0]]]
+        )
+        model._forward_draft_blocks = lambda **_kwargs: (
+            torch.tensor([[0]]),
+            torch.tensor([[True]]),
+            output_hidden,
+        )
+
+        _loss, _accuracy, metrics = model(
+            input_ids=torch.tensor([[0, 1, 3]]),
+            hidden_states=torch.zeros(1, 3, 4),
+            loss_mask=torch.ones(1, 3),
+            target_last_hidden_states=target_hidden,
+        )
+
+        ratios = metrics["ratio_metrics"]
+
+        def ratio(name):
+            numerator, denominator = ratios[name]
+            return float(numerator / denominator)
+
+        self.assertIn("ce_loss", ratios)
+        self.assertEqual(ratio("dflash/hard_label/unary_top1_accuracy"), 0.5)
+        self.assertEqual(ratio("position_1/hard_label/unary_top1_accuracy"), 1.0)
+        self.assertEqual(ratio("position_2/hard_label/unary_top2_recall"), 0.0)
+        self.assertEqual(
+            ratio("dflash/hard_label/unary_top2_oracle_accepted_length"), 2.0
+        )
+        self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
+        self.assertEqual(ratio("position_1/teacher/unary_top1_agreement"), 1.0)
+        self.assertIn("dflash/teacher/expected_accepted_length", ratios)
+        self.assertFalse(
+            any(
+                key.startswith("dflash2/") or "/selector/" in key or "selector_" in key
+                for key in ratios
+            )
         )
 
     def test_metric_chunk_reports_accepted_lengths_and_unweighted_selector_terms(
@@ -517,7 +574,7 @@ class CandidateSelectorTest(unittest.TestCase):
         weights = torch.tensor([[[0.0, 1.0, 1.0], [0.0, 1.0, 1.0]]])
         predecessors = torch.tensor([[[4, 4, 2], [4, 4, 1]]])
 
-        terms = model._dflash2_metric_chunk_terms(
+        terms = model._dflash_metric_chunk_terms(
             hidden, target_ids, weights, predecessors
         )
 
@@ -653,10 +710,10 @@ class CandidateSelectorTest(unittest.TestCase):
             any(
                 name.startswith(
                     (
-                        "dflash2/teacher/",
-                        "dflash2/hard_label/unary_",
-                        "dflash2/hard_label/expected_acceptance",
-                        "dflash2/hard_label/selector_serving_",
+                        "dflash/",
+                        "position_",
+                        "dflash2/selector/serving_",
+                        "dflash2/selector/conditional_",
                     )
                 )
                 for name in metrics["ratio_metrics"]

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -402,6 +402,12 @@ class CandidateSelectorTest(unittest.TestCase):
             "dflash2/hard_label/unary_top2_recall/position_1",
             "dflash2/hard_label/unary_top2_recall/position_2",
             "dflash2/hard_label/selector_loss/position_1",
+            "dflash2/hard_label/unary_top2_mass/position_1",
+            "dflash2/hard_label/selector_conditional_accuracy",
+            "dflash2/hard_label/selector_conditional_accuracy/position_2",
+            "dflash2/hard_label/unary_top2_oracle_accepted_length",
+            "dflash2/hard_label/selector_serving_accepted_length",
+            "dflash2/objective/loss_weight_share/position_1",
             "dflash2/teacher/expected_acceptance/position_1",
             "dflash2/teacher/expected_acceptance/position_2",
             "dflash2/teacher/unary_top1_agreement/position_1",
@@ -410,6 +416,7 @@ class CandidateSelectorTest(unittest.TestCase):
         }
         self.assertTrue(expected_keys.issubset(ratios))
         self.assertFalse(any(key.endswith("position_0") for key in ratios))
+        self.assertNotIn("objective/lk_kl_weight", ratios)
 
         def ratio(name):
             numerator, denominator = ratios[name]
@@ -425,6 +432,149 @@ class CandidateSelectorTest(unittest.TestCase):
         self.assertEqual(ratio("dflash2/hard_label/unary_top2_recall/position_2"), 0.0)
         self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_1"), 1.0)
         self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_2"), 0.0)
+        # Position 1 is covered and served correctly, position 2 is uncovered:
+        # both accepted-length walks credit the anchor plus one slot.
+        self.assertEqual(
+            ratio("dflash2/hard_label/unary_top2_oracle_accepted_length"), 2.0
+        )
+        self.assertEqual(
+            ratio("dflash2/hard_label/selector_serving_accepted_length"), 2.0
+        )
+        # Uniform dflash weights split the objective evenly over both slots.
+        self.assertEqual(ratio("dflash2/objective/loss_weight_share/position_1"), 0.5)
+        self.assertEqual(ratio("dflash2/objective/loss_weight_share/position_2"), 0.5)
+
+    def test_metric_chunk_reports_accepted_lengths_and_unweighted_selector_terms(
+        self,
+    ):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=6,
+                    vocab_size=6,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        draft = Draft()
+        # A zeroed selector always picks the unary top-1 candidate.
+        with torch.no_grad():
+            draft.candidate_selector.predecessor_codebook.zero_()
+            draft.candidate_selector.successor_codebook.zero_()
+            draft.candidate_selector.hidden_projection.weight.zero_()
+        model = OnlineDFlashModel(
+            draft_model=draft,
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(6, 6),
+            mask_token_id=5,
+            block_size=3,
+            attention_backend="eager",
+            loss_type="dpace",
+        )
+        # Block 0: slot 1 covers gold at rank 1 (serving misses), slot 2 at
+        # rank 0. Block 1: slot 1 misses the top-2 entirely, slot 2 at rank 0.
+        hidden = torch.tensor(
+            [
+                [
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 2.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 3.0, 0.0],
+                    ],
+                    [
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 2.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0, 0.0, 3.0],
+                    ],
+                ]
+            ]
+        )
+        target_ids = torch.tensor([[[4, 2, 4], [4, 1, 5]]])
+        weights = torch.tensor([[[0.0, 1.0, 1.0], [0.0, 1.0, 1.0]]])
+        predecessors = torch.tensor([[[4, 4, 2], [4, 4, 1]]])
+
+        terms = model._dflash2_metric_chunk_terms(
+            hidden, target_ids, weights, predecessors
+        )
+
+        self.assertEqual(terms.block_den.item(), 2.0)
+        # Oracle: anchor + 2 slots in block 0, anchor only in block 1.
+        self.assertEqual(terms.oracle_accepted_length_num.item(), 4.0)
+        # Serving path misses slot 1 in both blocks, so each accepts the anchor.
+        self.assertEqual(terms.serving_accepted_length_num.item(), 2.0)
+        torch.testing.assert_close(
+            terms.selector_covered_den, torch.tensor([0.0, 1.0, 2.0])
+        )
+        torch.testing.assert_close(
+            terms.selector_conditional_correct_num, torch.tensor([0.0, 0.0, 2.0])
+        )
+        expected_mass = torch.stack(
+            [
+                torch.softmax(hidden[0, :, position], dim=-1)
+                .topk(2, dim=-1)
+                .values.sum()
+                for position in range(3)
+            ]
+        ) * torch.tensor([0.0, 1.0, 1.0])
+        torch.testing.assert_close(terms.unary_topk_mass_num, expected_mass)
+        self.assertEqual(terms.loss_weight_num[0].item(), 0.0)
+        self.assertGreater(
+            terms.loss_weight_num[1].item(), terms.loss_weight_num[2].item()
+        )
+
+    def test_lambda_objective_reports_its_kl_weight(self):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=4,
+                    vocab_size=4,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        model = OnlineDFlashModel(
+            draft_model=Draft(),
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(4, 4),
+            mask_token_id=3,
+            block_size=2,
+            attention_backend="eager",
+            lk_loss_type="lambda",
+            kl_scale=1.0,
+            kl_decay=3.0,
+        )
+        model._forward_draft_blocks = lambda **_kwargs: (
+            torch.tensor([[0]]),
+            torch.tensor([[True]]),
+            torch.tensor([[[0.0, 0.0, 0.0, 0.0], [0.0, 2.0, 1.0, 0.0]]]),
+        )
+
+        _loss, _accuracy, metrics = model(
+            input_ids=torch.tensor([[0, 1]]),
+            hidden_states=torch.zeros(1, 2, 4),
+            loss_mask=torch.ones(1, 2),
+            collect_detailed_metrics=False,
+        )
+
+        ratios = metrics["ratio_metrics"]
+        probability_num, probability_den = ratios["target_probability"]
+        weight_num, weight_den = ratios["objective/lk_kl_weight"]
+        torch.testing.assert_close(
+            weight_num / weight_den,
+            torch.exp(-3.0 * probability_num / probability_den),
+        )
 
     def test_detailed_metrics_can_be_disabled_between_log_steps(self):
         class Draft(nn.Module):

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -527,6 +527,13 @@ class CandidateSelectorTest(unittest.TestCase):
         self.assertGreater(
             terms.loss_weight_num[1].item(), terms.loss_weight_num[2].item()
         )
+        for teacher_term in (
+            terms.teacher_expected_acceptance_num,
+            terms.teacher_unary_top1_agreement_num,
+            terms.teacher_unary_topk_mass_num,
+            terms.teacher_selector_serving_agreement_num,
+        ):
+            torch.testing.assert_close(teacher_term, torch.zeros(3))
 
     def test_lambda_objective_reports_its_kl_weight(self):
         class Draft(nn.Module):

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -441,6 +441,26 @@ class CandidateSelectorTest(unittest.TestCase):
         # Uniform dflash weights split the objective evenly over both slots.
         self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
         self.assertEqual(ratio("position_2/objective/loss_weight_share"), 0.5)
+        # Expected accepted lengths chain the per-slot probabilities of the two
+        # predicted slots; the teacher rows are aligned to label index - 1.
+        draft_probabilities = torch.softmax(output_hidden[0, 1:], dim=-1)
+        teacher_probabilities = torch.softmax(target_hidden[0, :2], dim=-1)
+        gold_probability = draft_probabilities.gather(
+            -1, torch.tensor([[1], [3]])
+        ).squeeze(-1)
+        self.assertAlmostEqual(
+            ratio("dflash2/hard_label/expected_accepted_length"),
+            float(1.0 + gold_probability.cumprod(dim=-1).sum()),
+            places=5,
+        )
+        acceptance = 1.0 - 0.5 * (
+            draft_probabilities - teacher_probabilities
+        ).abs().sum(dim=-1)
+        self.assertAlmostEqual(
+            ratio("dflash2/teacher/expected_accepted_length"),
+            float(1.0 + acceptance.cumprod(dim=-1).sum()),
+            places=5,
+        )
 
     def test_metric_chunk_reports_accepted_lengths_and_unweighted_selector_terms(
         self,
@@ -521,6 +541,17 @@ class CandidateSelectorTest(unittest.TestCase):
             ]
         ) * torch.tensor([0.0, 1.0, 1.0])
         torch.testing.assert_close(terms.unary_topk_mass_num, expected_mass)
+        # Smooth surrogate: 1 + q1 + q1*q2 per block with q = gold probability.
+        gold_probability = (
+            torch.softmax(hidden[0], dim=-1)
+            .gather(-1, target_ids[0].unsqueeze(-1))
+            .squeeze(-1)
+        )
+        torch.testing.assert_close(
+            terms.expected_accepted_length_num,
+            (1.0 + gold_probability[:, 1:].cumprod(dim=-1).sum(dim=-1)).sum(),
+        )
+        self.assertEqual(terms.teacher_expected_accepted_length_num.item(), 0.0)
         self.assertEqual(terms.loss_weight_num[0].item(), 0.0)
         self.assertGreater(
             terms.loss_weight_num[1].item(), terms.loss_weight_num[2].item()

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -332,6 +332,151 @@ class CandidateSelectorTest(unittest.TestCase):
         )
         torch.testing.assert_close(terms.ce_loss_num, expected)
 
+    def test_reports_per_position_hard_label_and_teacher_metrics(self):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=4,
+                    vocab_size=4,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        draft = Draft()
+        with torch.no_grad():
+            draft.candidate_selector.predecessor_codebook.zero_()
+            draft.candidate_selector.successor_codebook.zero_()
+            draft.candidate_selector.hidden_projection.weight.zero_()
+        model = OnlineDFlashModel(
+            draft_model=draft,
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(4, 4),
+            mask_token_id=3,
+            block_size=3,
+            attention_backend="eager",
+            lk_loss_type="alpha",
+        )
+        output_hidden = torch.tensor(
+            [
+                [
+                    [0.0, 0.0, 0.0, 0.0],
+                    [0.0, 4.0, 1.0, 0.0],
+                    [0.0, 3.0, 4.0, 2.0],
+                ]
+            ]
+        )
+        target_hidden = torch.tensor(
+            [
+                [
+                    [0.0, 5.0, 0.0, 0.0],
+                    [0.0, 0.0, 0.0, 5.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ]
+            ]
+        )
+        model._forward_draft_blocks = lambda **_kwargs: (
+            torch.tensor([[0]]),
+            torch.tensor([[True]]),
+            output_hidden,
+        )
+
+        _loss, _accuracy, metrics = model(
+            input_ids=torch.tensor([[0, 1, 3]]),
+            hidden_states=torch.zeros(1, 3, 4),
+            loss_mask=torch.ones(1, 3),
+            target_last_hidden_states=target_hidden,
+        )
+
+        ratios = metrics["ratio_metrics"]
+        expected_keys = {
+            "lk_loss",
+            "expected_acceptance",
+            "dflash2/hard_label/unary_top1_accuracy/position_1",
+            "dflash2/hard_label/unary_top1_accuracy/position_2",
+            "dflash2/hard_label/unary_top2_recall/position_1",
+            "dflash2/hard_label/unary_top2_recall/position_2",
+            "dflash2/hard_label/selector_loss/position_1",
+            "dflash2/teacher/expected_acceptance/position_1",
+            "dflash2/teacher/expected_acceptance/position_2",
+            "dflash2/teacher/unary_top1_agreement/position_1",
+            "dflash2/teacher/unary_top2_mass/position_2",
+            "dflash2/teacher/selector_serving_agreement/position_2",
+        }
+        self.assertTrue(expected_keys.issubset(ratios))
+        self.assertFalse(any(key.endswith("position_0") for key in ratios))
+
+        def ratio(name):
+            numerator, denominator = ratios[name]
+            return float(numerator / denominator)
+
+        self.assertEqual(
+            ratio("dflash2/hard_label/unary_top1_accuracy/position_1"), 1.0
+        )
+        self.assertEqual(
+            ratio("dflash2/hard_label/unary_top1_accuracy/position_2"), 0.0
+        )
+        self.assertEqual(ratio("dflash2/hard_label/unary_top2_recall/position_1"), 1.0)
+        self.assertEqual(ratio("dflash2/hard_label/unary_top2_recall/position_2"), 0.0)
+        self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_1"), 1.0)
+        self.assertEqual(ratio("dflash2/teacher/unary_top1_agreement/position_2"), 0.0)
+
+    def test_detailed_metrics_can_be_disabled_between_log_steps(self):
+        class Draft(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.candidate_selector = CandidateSelector(
+                    hidden_size=4,
+                    vocab_size=4,
+                    state_rank=2,
+                    top_k=2,
+                    initializer_range=0.02,
+                )
+
+            @staticmethod
+            def transform_unary_logits(logits):
+                return logits.float()
+
+        model = OnlineDFlashModel(
+            draft_model=Draft(),
+            target_lm_head=nn.Identity(),
+            target_embed_tokens=nn.Embedding(4, 4),
+            mask_token_id=3,
+            block_size=2,
+            attention_backend="eager",
+        )
+        model._forward_draft_blocks = lambda **_kwargs: (
+            torch.tensor([[0]]),
+            torch.tensor([[True]]),
+            torch.tensor([[[0.0, 0.0, 0.0, 0.0], [0.0, 2.0, 1.0, 0.0]]]),
+        )
+
+        _loss, _accuracy, metrics = model(
+            input_ids=torch.tensor([[0, 1]]),
+            hidden_states=torch.zeros(1, 2, 4),
+            loss_mask=torch.ones(1, 2),
+            collect_detailed_metrics=False,
+        )
+
+        self.assertFalse(
+            any(
+                name.startswith(
+                    (
+                        "dflash2/teacher/",
+                        "dflash2/hard_label/unary_",
+                        "dflash2/hard_label/expected_acceptance",
+                        "dflash2/hard_label/selector_serving_",
+                    )
+                )
+                for name in metrics["ratio_metrics"]
+            )
+        )
+
     def test_zero_configured_selector_alpha_freezes_selector_parameters(self):
         class Draft(nn.Module):
             def __init__(self):

--- a/tests/test_runtime/test_evaluator_aggregation.py
+++ b/tests/test_runtime/test_evaluator_aggregation.py
@@ -227,10 +227,13 @@ class TestEvaluatorAggregation(unittest.TestCase):
         )
         self.assertAlmostEqual(m["eval/acceptance_rate_0"], 0.72, places=6)
         self.assertAlmostEqual(m["eval/acceptance_rate_1"], 0.52, places=6)
+        self.assertAlmostEqual(m["eval/expected_acceptance_0"], 0.72, places=6)
+        self.assertAlmostEqual(m["eval/expected_acceptance_1"], 0.52, places=6)
         self.assertAlmostEqual(m["eval/ploss_0"], 1.4, places=6)
         self.assertAlmostEqual(m["eval/ploss_1"], 2.4, places=6)
         m2 = self._run([_step_output(1.0, corrects=[1], denoms=[2])])
         self.assertNotIn("eval/acceptance_rate_0", m2)
+        self.assertNotIn("eval/expected_acceptance_0", m2)
         self.assertNotIn("eval/ploss_0", m2)
 
 

--- a/tests/test_runtime/test_seam_fixes.py
+++ b/tests/test_runtime/test_seam_fixes.py
@@ -20,7 +20,7 @@ from specforge.training.backend import (
     TrainingBackend,
 )
 from specforge.training.controller import TrainerController, TrainerCore
-from specforge.training.strategies.base import DFlashTrainStrategy
+from specforge.training.strategies.base import DFlashTrainStrategy, StepContext
 
 
 def _ref(i):
@@ -152,6 +152,7 @@ class _FakeDFlashModel(nn.Module):
         self.w = nn.Parameter(torch.ones(1))
         self.max_valid_anchors = None
         self.received_selector_loss_alpha = None
+        self.target_last_hidden_states = None
 
     def forward(
         self,
@@ -160,10 +161,13 @@ class _FakeDFlashModel(nn.Module):
         loss_mask,
         max_valid_anchors=None,
         selector_loss_alpha=None,
+        target_last_hidden_states=None,
+        collect_detailed_metrics=True,
     ):
         # mirrors OnlineDFlashModel's (loss, accuracy, metrics) contract
         self.max_valid_anchors = max_valid_anchors
         self.received_selector_loss_alpha = selector_loss_alpha
+        self.target_last_hidden_states = target_last_hidden_states
         loss = (self.w * hidden_states.float().sum()).abs()
         acc = torch.tensor(0.5)
         return loss, acc, {"accuracy_denom": loss_mask.sum()}
@@ -194,6 +198,32 @@ class TestDFlashSharesLifecycle(unittest.TestCase):
         out = strat.forward_loss(batch)
         self.assertAlmostEqual(float(out.metrics["accuracy"]), 0.5)
         self.assertEqual(float(out.metrics["accuracy_denom"]), 4.0)
+
+    def test_dflash_strategy_forwards_teacher_hidden_only_for_detailed_metrics(self):
+        model = _FakeDFlashModel()
+        strategy = DFlashTrainStrategy(model)
+        teacher_hidden = torch.randn(1, 4, 8)
+        batch = TrainBatch(
+            sample_ids=["s0"],
+            strategy="dflash",
+            tensors={
+                "input_ids": torch.zeros(1, 4, dtype=torch.long),
+                "hidden_states": torch.randn(1, 4, 8),
+                "target_last_hidden_states": teacher_hidden,
+                "loss_mask": torch.ones(1, 4, dtype=torch.long),
+            },
+            metadata={},
+        )
+
+        strategy.forward_loss(batch)
+        self.assertIs(model.target_last_hidden_states, teacher_hidden)
+
+        model.target_last_hidden_states = None
+        strategy.forward_loss(
+            batch,
+            ctx=StepContext(collect_detailed_metrics=False),
+        )
+        self.assertIsNone(model.target_last_hidden_states)
 
     def test_dflash_validate_batch_rejects_missing(self):
         strat = DFlashTrainStrategy(_FakeDFlashModel())

--- a/tests/test_runtime/test_server_capture.py
+++ b/tests/test_runtime/test_server_capture.py
@@ -418,13 +418,19 @@ class TestServerCaptureAdapter(unittest.TestCase):
         # consume-once: released samples are physically freed
         self.assertFalse(any(backend._d))
 
-    def test_dflash_schema_names_and_no_target(self):
+    def test_dflash_schema_includes_teacher_hidden_for_metrics(self):
         backend, server, store, adapter = _mk(algorithm="dflash")
         refs = adapter.produce_refs([_task(0, 5)], capture=_dflash_contract())
         (ref,) = refs
         self.assertIsInstance(ref, SampleRef)
         self.assertEqual(
-            sorted(ref.feature_specs), ["hidden_states", "input_ids", "loss_mask"]
+            sorted(ref.feature_specs),
+            [
+                "hidden_states",
+                "input_ids",
+                "loss_mask",
+                "target_last_hidden_states",
+            ],
         )
         self.assertEqual(
             ref.feature_specs["hidden_states"].shape,
@@ -433,6 +439,7 @@ class TestServerCaptureAdapter(unittest.TestCase):
         self.assertEqual(ref.feature_specs["loss_mask"].shape, (1, 5))
         out, _ = store.get(ref)
         self.assertEqual(out["input_ids"].tolist(), [list(range(1, 6))])
+        self.assertEqual(out["target_last_hidden_states"].shape, (1, 5, HIDDEN))
 
     def test_dspark_schema_includes_target_last_hidden(self):
         backend, server, store, adapter = _mk(algorithm="dspark")

--- a/tests/test_runtime/test_server_capture_gate.py
+++ b/tests/test_runtime/test_server_capture_gate.py
@@ -417,8 +417,17 @@ class TestServerCaptureGate(unittest.TestCase):
         (ref,) = adapter.produce_refs(self._tasks(rows), capture=contract)
         self.assertIsInstance(ref, SampleRef, f"expected a ref, got: {ref}")
         out, handle = store.get(ref)
-        self.assertEqual(sorted(out), ["hidden_states", "input_ids", "loss_mask"])
+        self.assertEqual(
+            sorted(out),
+            [
+                "hidden_states",
+                "input_ids",
+                "loss_mask",
+                "target_last_hidden_states",
+            ],
+        )
         self.assertEqual(out["hidden_states"].shape, (1, 5, len(AUX_LAYER_IDS) * H))
+        self.assertEqual(out["target_last_hidden_states"].shape, (1, 5, H))
         aux_ref, _ = self._hf_reference(rows)
         torch.testing.assert_close(
             out["hidden_states"].float(), aux_ref[0].float(), rtol=TOL, atol=TOL

--- a/tests/test_runtime/test_tracking_logger.py
+++ b/tests/test_runtime/test_tracking_logger.py
@@ -135,12 +135,14 @@ class TrackingLoggerTest(unittest.TestCase):
                     "loss": 1.0,
                     "eval/loss": 2.0,
                     "perf/optimizer_step_time_s": 3.0,
+                    "position_1/hard_label/unary_top1_accuracy": 0.5,
                 }
             ),
             {
                 "train/loss": 1.0,
                 "eval/loss": 2.0,
                 "perf/optimizer_step_time_s": 3.0,
+                "position_1/hard_label/unary_top1_accuracy": 0.5,
             },
         )
 

--- a/tests/test_runtime/test_tracking_logger.py
+++ b/tests/test_runtime/test_tracking_logger.py
@@ -128,10 +128,20 @@ class TrackingLoggerTest(unittest.TestCase):
         self.assertEqual(tracker.logged, [({"train/loss": 1.5}, 7)])
         console.assert_called_once_with({"train/loss": 1.5}, 7)
 
-    def test_training_namespace_keeps_eval_metrics_unchanged(self):
+    def test_training_namespace_keeps_explicit_namespaces_unchanged(self):
         self.assertEqual(
-            training_metric_names({"loss": 1.0, "eval/loss": 2.0}),
-            {"train/loss": 1.0, "eval/loss": 2.0},
+            training_metric_names(
+                {
+                    "loss": 1.0,
+                    "eval/loss": 2.0,
+                    "perf/optimizer_step_time_s": 3.0,
+                }
+            ),
+            {
+                "train/loss": 1.0,
+                "eval/loss": 2.0,
+                "perf/optimizer_step_time_s": 3.0,
+            },
         )
 
     def test_close_is_idempotent_and_logging_after_close_fails(self):

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 import torch
@@ -41,6 +42,7 @@ class FakeStrategy(DraftTrainStrategy):
     def __init__(self):
         self.model = TinyModel()
         self.last_ctx = None
+        self.contexts = []
 
     def trainable_module(self):
         return self.model
@@ -48,6 +50,7 @@ class FakeStrategy(DraftTrainStrategy):
     def forward_loss(self, batch: TrainBatch, ctx=None) -> StepOutput:
         self.validate_batch(batch)
         self.last_ctx = ctx  # capture what fit() threads in (StepContext regression)
+        self.contexts.append(ctx)
         loss = (self.model.w * batch.tensors["x"].sum()).abs()
         return StepOutput(loss=loss, metrics={"accuracy": torch.tensor(0.5)})
 
@@ -410,13 +413,36 @@ class TestTrainerCore(unittest.TestCase):
         self.assertAlmostEqual(result.metrics["acc"], 4 / 6)
         self.assertAlmostEqual(result.metrics["ploss_0"], 2.0)
         self.assertAlmostEqual(result.metrics["ploss_1"], 4.0)
+        self.assertAlmostEqual(result.metrics["kl_loss_0"], 2.0)
+        self.assertAlmostEqual(result.metrics["kl_loss_1"], 4.0)
+        self.assertAlmostEqual(result.metrics["kl_loss"], 4.0)
         self.assertAlmostEqual(result.metrics["loss"], 4.0)
         self.assertAlmostEqual(result.metrics["acceptance_rate_0"], 0.25)
         self.assertAlmostEqual(result.metrics["acceptance_rate_1"], 0.75)
         self.assertAlmostEqual(result.metrics["acceptance_rate"], 0.5)
+        self.assertAlmostEqual(result.metrics["expected_acceptance_0"], 0.25)
+        self.assertAlmostEqual(result.metrics["expected_acceptance_1"], 0.75)
+        self.assertAlmostEqual(result.metrics["expected_acceptance"], 0.5)
         self.assertNotIn("acces", result.metrics)
         self.assertNotIn("acceptance_rates", result.metrics)
         self.assertNotIn("plosses", result.metrics)
+
+    def test_eagle_lk_objective_is_named_explicitly(self):
+        strategy = FakeStrategy()
+        strategy.ploss_decay = 0.5
+        strategy.eagle3_model = SimpleNamespace(lk_loss_type="alpha")
+        core = TrainerCore(
+            strategy,
+            FakeBackend(strategy.model),
+            accumulation_steps=1,
+        )
+
+        result = core._result(self._eagle_output(), grad_norm=None, stepped=False)
+
+        self.assertAlmostEqual(result.metrics["lk_loss_0"], 2.0)
+        self.assertAlmostEqual(result.metrics["lk_loss_1"], 4.0)
+        self.assertAlmostEqual(result.metrics["lk_loss"], 4.0)
+        self.assertNotIn("kl_loss", result.metrics)
 
     def test_eagle_metrics_sum_counts_across_data_parallel_ranks(self):
         strat = FakeStrategy()
@@ -511,6 +537,10 @@ class TestTrainerController(unittest.TestCase):
             self.assertGreaterEqual(metrics[name], 0.0)
         self.assertGreater(metrics["perf/optimizer_steps_per_hour"], 0.0)
         self.assertGreater(metrics["perf/global_samples_per_second"], 0.0)
+        self.assertEqual(
+            [ctx.collect_detailed_metrics for ctx in strat.contexts],
+            [False, True],
+        )
 
     def test_progress_bar_tracks_optimizer_steps_on_rank_zero(self):
         strat = FakeStrategy()


### PR DESCRIPTION
## Summary

- keep throughput and timing telemetry under `perf/*` instead of rewriting it as `train/perf/*`
- expose explicit `lk_loss`/`kl_loss` and `expected_acceptance` aliases in the main training/evaluation paths
- add aggregate and per-position hard-label metrics for every DFlash-family draft (unary top-1, unary top-k recall and probability mass, target probability/expected acceptance) under `train/dflash/*`, plus DFlash2-only selector metrics (loss, conditional accuracy, serving-path accuracy) under `train/dflash2/selector/*`
- add two per-block accepted-length proxies ported from #788: the unary top-k oracle walk and the realized greedy serving-path walk
- add two smooth expected-accepted-length proxies over the same per-block chain `1 + sum_k prod_{j<=k} a_j`: the gold-token probability (`dflash2/hard_label/expected_accepted_length`, the D-PACE surrogate) and the full-vocabulary expected acceptance against the target head (`dflash2/teacher/expected_accepted_length`, the sampling-regime counterpart)
- add loss-composition telemetry: the per-position share of effective objective weight (`position_<k>/objective/loss_weight_share`) and the LK-lambda CE weight (`train/objective/lk_kl_weight`)
- add online teacher-alignment metrics for expected acceptance, unary top-1 agreement, unary top-k probability mass, and selector serving-path agreement
- carry the optional target final hidden state through online capture/collation while preserving offline-v1 compatibility
- give `pad_and_concatenate_features` an `optional_keys` contract (present in every sample or none, mixed batches rejected) and collapse the DFlash/DSpark/MTP collators into one factory over it
- gate the full-vocabulary teacher/selector diagnostic pass to W&B logging steps and compute it chunked under `no_grad`

This complements the metric cleanup started in #797 and gives the DFlash2 dashboard a stable `perf/*`, `train/*`, `train/objective/*`, `train/dflash/{hard_label,teacher}/*`, `train/dflash2/selector/*`, and `position_<k>/{hard_label,objective,teacher,selector}/*` hierarchy.

## Credits

The accepted-length and candidate-mass metrics are ported from #788 by @curnane-lab, credited as co-author on the porting commit. This PR supersedes #788 for those metrics; the realized path is computed from the shared `greedy_path` walk instead of a separate scoring loop.

## Behavior notes

- Per-position families start at predicted position 1; the non-predicted anchor position is omitted. They are keyed `position_<k>/<family>/<metric>` so W&B renders one section per block position; aggregates stay under `train/dflash/*` and `train/dflash2/selector/*`.
- Top-K diagnostics use the selector's `selector_top_k` when present, else the model's `metric_top_k` (default 16, clamped to the vocabulary), so plain DFlash drafts get the same unary recall, mass, and oracle accepted-length readouts.
- Accepted-length proxies count the verified anchor as one token and extend a block only while every earlier slot is supervised and accepted; the denominator is the number of blocks with at least one supervised slot. The expected variants chain per-slot probabilities per block rather than multiplying per-position means, and all of them are teacher-forced on the real prefix and anchor.
- `selector_conditional_accuracy` is uniform over covered slots and therefore comparable between `dflash` and D-PACE runs. The historical `selector_accuracy` and `selector_loss` remain weighted by the effective objective weights.
- `objective/lk_kl_weight` is reduced as a token-weighted mean of the per-micro-batch CE weight.
- Teacher metrics are available for online capture data and are omitted when offline data does not contain target final hidden states.
- Ratio metrics are reduced by numerator/denominator across data-parallel ranks before logging.

## Validation

- `139 passed, 30 subtests passed` in the focused CPU suite (`tests/test_modeling/test_dflash2.py`, `tests/test_runtime/test_tracking_logger.py`, `tests/test_utils/test_dflash_losses.py`, `tests/test_runtime/test_trainer.py`, `tests/test_algorithms/test_builtin_parity.py`, `tests/test_runtime/test_seam_fixes.py`, `tests/test_runtime/test_evaluator_aggregation.py`)
- multi-process evaluator reduction test passed
- `black --check` passed for all changed Python files
- `git diff --check` passed
- the SGLang-backed server capture gate was not run locally because SGLang is not installed; its capture schema assertions were updated and the non-gate capture tests pass

## Follow-ups (not in this PR)

- Online runs still cannot run a held-out evaluation (`data.eval_data_path` is rejected for online mode and `eval_hidden_states_path` is offline-only), so every metric here is a training-set metric on the current micro-batch.
- W&B run config records the draft config path but not its content, and custom launch scripts should pass the git commit to the tracker.
