### PR TITLE
MoE FFN skeleton for DFlash-family drafters (contracts, config, seams)

### DIFF
--- a/docs/advanced_features/customization.md
+++ b/docs/advanced_features/customization.md
@@ -128,6 +128,38 @@ drafts currently implements the GQA/MHA layout only, so plan benchmarks
 accordingly. DFlash2 otherwise follows the same mode selection; its convolution
 and selector do not change the attention projection contract.
 
+## MoE FFN for DFlash-family drafts
+
+Any DFlash-family draft (DFlash, DFlash2, DSpark) swaps its dense MLP for a
+sparse MoE FFN when the draft JSON sets `n_routed_experts > 0`. The MoE is one
+configurable layer (`specforge/modeling/draft/moe/`, see its `DESIGN.md`):
+a `moe_preset` names a target family's routing recipe, and the architecture
+keys use the target checkpoints' native HF names so they can be copied from
+the target's `config.json`:
+
+```json
+{
+  "moe_preset": "<target family>",
+  "n_routed_experts": 64,
+  "num_experts_per_tok": 6,
+  "moe_intermediate_size": 2048,
+  "n_shared_experts": 1,
+  "dflash_config": {"moe_bias_update_rate": 0.001, "moe_dispatch": "grouped_mm"}
+}
+```
+
+Top-level keys override the preset (for ablations: `scoring_func`,
+`norm_topk_prob`, `routed_scaling_factor`, `balance`, `shared_expert_gate`,
+`swiglu_limit`, ...). Training-only knobs live under `dflash_config` with an
+`moe_` prefix and never change the checkpoint. Checkpoints, warm starts and
+exports keep the official per-expert naming (`experts.{i}.w{1,2,3}.weight`),
+so an exported drafter loads into SGLang unchanged. Dense drafts are
+unaffected: with no `n_routed_experts` the kernel provider's MLP is used as-is.
+
+A new target family is a preset registration plus whichever components it
+needs (score function, balance controller, experts backend, shared expert);
+each registers by name from its own module.
+
 ## Draft architectures
 
 Draft classes register through `@register_draft`. The key defaults to the

--- a/specforge/export/checkpoint_io.py
+++ b/specforge/export/checkpoint_io.py
@@ -159,7 +159,12 @@ def materialize_draft(
 
     draft_config = AutoDraftModelConfig.from_file(draft_config_path)
     model = AutoDraftModel.from_config(draft_config, torch_dtype=torch.bfloat16)
-    missing, unexpected = model.load_state_dict(state["draft_state_dict"], strict=False)
+    from specforge.modeling.draft.moe import from_checkpoint_state_dict
+
+    # Files use the official naming; modules may use a native MoE layout.
+    missing, unexpected = model.load_state_dict(
+        from_checkpoint_state_dict(state["draft_state_dict"]), strict=False
+    )
     if unexpected:
         raise ValueError(
             f"checkpoint carries weights the {type(model).__name__} architecture "

--- a/specforge/export/to_hf.py
+++ b/specforge/export/to_hf.py
@@ -31,6 +31,7 @@ from specforge.export.checkpoint_io import (
     materialize_draft,
     resolve_training_state,
 )
+from specforge.modeling.draft.moe import to_checkpoint_state_dict
 
 
 def _load_embedding_tensor(source: str, key: str) -> torch.Tensor:
@@ -87,7 +88,7 @@ def export_to_hf(
     model = materialize_draft(
         state, draft_config_path, vocab_mapping_path=vocab_mapping_path
     )
-    full_state = dict(model.state_dict())
+    full_state = dict(to_checkpoint_state_dict(model.state_dict()))
     owns_embedding = hasattr(model, "embed_tokens")
     if owns_embedding and "embed_tokens.weight" not in state["draft_state_dict"]:
         if not embedding_source:

--- a/specforge/export/to_sglang.py
+++ b/specforge/export/to_sglang.py
@@ -28,6 +28,7 @@ from specforge.export.checkpoint_io import (
     materialize_draft,
     resolve_training_state,
 )
+from specforge.modeling.draft.moe import to_checkpoint_state_dict
 
 #: per-architecture trainer-key -> serving-key renames ({} = identity).
 WEIGHT_MAPS: Dict[str, Dict[str, str]] = {
@@ -82,7 +83,11 @@ def export_to_sglang(
         weight_map = WEIGHT_MAPS.get(type(model).__name__, {})
     # the model's state dict includes any refreshed t2d/d2t buffers; drop the
     # embeddings exactly as the trainer-side checkpoint filter does.
-    full = {k: v for k, v in model.state_dict().items() if "embed" not in k.lower()}
+    full = {
+        k: v
+        for k, v in to_checkpoint_state_dict(model.state_dict()).items()
+        if "embed" not in k.lower()
+    }
     model.save_pretrained(output_dir, state_dict=_serving_state(full, weight_map))
     apply_legacy_rope_scaling(output_dir)
     return output_dir

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -21,6 +21,7 @@ from transformers.models.qwen3.modeling_qwen3 import (
 from typing_extensions import Tuple, Unpack
 
 from .dflash_kernels import DEFAULT_DFLASH_KERNELS, DFlashKernels
+from .moe import MoELayer, apply_pending_balance_updates, build_ffn
 from .flex_attention_backend import flex_attention_backend
 from .registry import register_draft
 
@@ -558,7 +559,9 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
             layer_idx=layer_idx,
             kernels=kernels,
         )
-        self.mlp = kernels.make_mlp(config)
+        # Dense MLP from the kernel provider, or an MoELayer when the draft
+        # JSON sets n_routed_experts > 0 (see modeling/draft/moe).
+        self.mlp = build_ffn(config, dense=kernels.make_mlp)
         self.input_layernorm = kernels.make_rms_norm(
             config.hidden_size, config.rms_norm_eps
         )
@@ -733,6 +736,14 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
 
         return self.decoder_layer_class(config, layer_idx, kernels)
 
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, MoELayer):
+            # MoE components hold bare Parameters (gate weight, stacked
+            # experts) that the inherited Qwen3 init never visits.
+            module.reset_parameters(std=self.config.initializer_range)
+            return
+        super()._init_weights(module)
+
     def _init_draft_head(self, config, dflash_config: dict) -> None:
         del config, dflash_config
 
@@ -796,6 +807,11 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         **kwargs,
     ) -> CausalLMOutputWithPast:
         hidden_states = noise_embedding
+        if self.training:
+            # Consume the PREVIOUS forward's routing statistics before any
+            # routing this step, outside every activation-checkpoint region
+            # (see modeling/draft/moe/balance.py for why the timing matters).
+            apply_pending_balance_updates(self)
         target_hidden = self.hidden_norm(self.fc(target_hidden))
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
         for layer_type, layer in zip(self.layer_types, self.layers):

--- a/specforge/modeling/draft/moe/DESIGN.md
+++ b/specforge/modeling/draft/moe/DESIGN.md
@@ -1,0 +1,101 @@
+# MoE FFN Design (`specforge.modeling.draft.moe`)
+
+Design note for the sparse-MoE FFN that any DFlash-family draft (DFlash,
+DFlash2, DSpark) can opt into. The training plane's picture is in
+[`../../../training/DESIGN.md`](../../../training/DESIGN.md).
+
+## Responsibility
+
+Owns the FFN of a decoder layer when the draft JSON sets
+`n_routed_experts > 0`, and nothing else: attention, heads, losses and the
+trainer loop are unchanged. The package is **one configurable layer**, not one
+block per target family. This is the Megatron-Core split (one `MoELayer`,
+router/balancing/experts/dispatcher/shared-expert as orthogonal components
+picked by config), chosen over the transformers pattern of a copied
+`XxxSparseMoeBlock` per model because the family differences are a handful of
+small functions while the expensive parts are shared:
+
+| differs per target family        | shared by every family                    |
+| -------------------------------- | ----------------------------------------- |
+| score function (softmax, sigmoid, sqrtsoftplus) | token dispatch (sorted segments, grouped GEMM) |
+| balancing policy (aux loss, aux-loss-free bias, none) | deferred balance-update timing vs activation checkpointing |
+| combine-weight renorm and scale  | FSDP-friendly stacked expert layout       |
+| shared-expert gate (none, sigmoid) | checkpoint naming boundary               |
+| SwiGLU clamp                     | load metrics, warm-start plans            |
+
+## Why match the target's MoE
+
+The drafter's MoE should be the *target's* MoE, expressed as a preset:
+
+- **Warm start.** Same expert shape means the draft experts can be seeded from
+  a subset of the target's, which a dense drafter cannot do.
+- **Serving.** The drafter runs inside SGLang's draft model; matching the
+  target's routing reuses its fused MoE kernels and weight naming.
+- **Latency.** At small batch, top-k of narrow experts reads about the same
+  bytes as the dense MLP, so MoE buys parameters at roughly constant step
+  cost. That is the hypothesis the dense-vs-MoE ablation tests.
+
+## Layout
+
+```
+config.py      MoEConfig + preset registry. Architecture keys use the target
+               checkpoints' native HF names at the draft JSON top level;
+               training-only knobs live under dflash_config as moe_*.
+router.py      Router contract (x -> RoutingResult) + score-function registry.
+balance.py     BalanceController contract; owns selection-bias buffers, stashes
+               counts in forward, applies updates from the model forward.
+experts.py     RoutedExperts contract (weights + dispatch), MoEConfig.dispatch knob.
+shared.py      SharedExpert contract, gate variant via MoEConfig.shared_expert_gate.
+layer.py       MoELayer = gate + experts + shared_experts; build_ffn() is the
+               dense/MoE switch used by the DFlash decoder layer.
+hooks.py       apply_pending_balance_updates / collect_moe_aux_loss /
+               collect_moe_metrics over any module tree.
+state_dict.py  to/from_checkpoint_state_dict: module layout <-> official names.
+init.py        WarmStartPlan: which target experts seed which draft experts.
+```
+
+Implementations (a target-family preset, its score function, controller,
+experts backend, shared expert, converter) live in their own module and
+register into these registries at import time. This package holds contracts
+and composition only.
+
+## Contracts that matter
+
+**Attribute names are the checkpoint contract.** `MoELayer` exposes `gate`,
+`experts`, `shared_experts` (the DeepSeek-family names SGLang loads). A
+component whose native parameter layout differs from the official file naming
+registers a `state_dict` converter pair; both directions are idempotent and
+no-ops on dense models.
+
+**Naming is converted at the boundary, not in `state_dict()`.** FSDP's
+full-state-dict hooks index the gathered dict by the module's own parameter
+FQNs, so a rename inside `state_dict()` breaks under `use_orig_params`. Every
+file read/write goes through `to_checkpoint_state_dict` /
+`from_checkpoint_state_dict`: `FSDPTrainingBackend` save/load, warm start,
+`materialize_draft`, and the HF and SGLang exporters.
+
+**Balance updates are deferred.** `BalanceController.observe` only stashes
+(overwrite, never accumulate) so an activation-checkpoint recompute leaves
+identical state. `apply_pending_update` runs from the *model* forward before
+any routing, outside checkpoint regions, and may run collectives. Mutating
+selection state inside a layer forward would make the recompute route
+differently and raise `CheckpointError`.
+
+**Metrics ride the existing scalar channel.** `collect_moe_metrics` yields
+`moe/load_max_ratio`, `moe/load_min_ratio`, `moe/experts_unused_frac` plus
+controller metrics; the DFlash/DSpark strategies add them to `StepOutput.metrics`,
+and the trainer DP-averages and logs them like any other scalar.
+
+**Aux losses are collected, not yet consumed.** `collect_moe_aux_loss` sums
+scaled layer losses; wiring it into an objective is done with the first preset
+whose balancing policy emits one (aux-loss-free policies do not).
+
+## Extension points
+
+- New target family: `register_moe_preset("<family>", scoring_func=..., ...)`
+  plus any missing component registrations. The draft JSON then sets
+  `moe_preset` and the per-run sizes.
+- New dispatch: a `RoutedExperts` subclass under `register_experts_backend`,
+  or a new `MoEConfig.dispatch` value handled inside an existing backend.
+- Ablation knobs: any `ARCHITECTURE_KEYS` entry at the draft JSON top level
+  overrides its preset default; `dflash_config.moe_*` overrides training knobs.

--- a/specforge/modeling/draft/moe/__init__.py
+++ b/specforge/modeling/draft/moe/__init__.py
@@ -1,0 +1,121 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Sparse MoE FFN for DFlash-family drafts.
+
+One configurable layer, not one block per target family. A draft JSON selects a
+``moe_preset`` (the routing recipe of a target family) and may override any
+architecture knob for ablations; the expensive parts (dispatch, checkpoint
+naming, FSDP layout, deferred balance updates) are shared. See ``DESIGN.md``.
+
+Modules:
+
+- :mod:`.config`      ``MoEConfig`` + the preset registry; resolves a draft JSON
+- :mod:`.router`      ``Router`` contract (scores -> top-k) + score functions
+- :mod:`.balance`     ``BalanceController`` contract: balancing as a policy
+- :mod:`.experts`     ``RoutedExperts`` contract: expert weights + dispatch
+- :mod:`.shared`      ``SharedExpert`` contract
+- :mod:`.layer`       ``MoELayer`` composition; ``build_ffn`` is the dense/MoE switch
+- :mod:`.hooks`       model-level plumbing: balance updates, aux loss, metrics
+- :mod:`.state_dict`  module layout <-> official checkpoint naming boundary
+- :mod:`.init`        warm-start plans from a target model's experts
+
+Implementations register into the registries from their own modules; this
+package defines contracts and holds no routing math itself.
+"""
+
+from .balance import (
+    BALANCE_CONTROLLERS,
+    BalanceController,
+    build_balance_controller,
+    register_balance_controller,
+)
+from .config import (
+    MOE_PRESETS,
+    MoEConfig,
+    available_moe_presets,
+    is_moe_config,
+    register_moe_preset,
+    resolve_moe_config,
+)
+from .experts import (
+    EXPERTS_BACKENDS,
+    RoutedExperts,
+    build_routed_experts,
+    register_experts_backend,
+)
+from .hooks import (
+    apply_pending_balance_updates,
+    collect_moe_aux_loss,
+    collect_moe_metrics,
+    iter_moe_layers,
+)
+from .init import WarmStartPlan, plan_warm_start, select_target_experts
+from .layer import MoELayer, build_ffn
+from .router import (
+    ROUTERS,
+    SCORE_FUNCTIONS,
+    Router,
+    RoutingResult,
+    build_router,
+    get_score_function,
+    register_router,
+    register_score_function,
+)
+from .shared import (
+    SHARED_EXPERTS,
+    SharedExpert,
+    build_shared_expert,
+    register_shared_expert,
+)
+from .state_dict import (
+    from_checkpoint_state_dict,
+    register_state_dict_converter,
+    to_checkpoint_state_dict,
+)
+
+__all__ = [
+    "BALANCE_CONTROLLERS",
+    "BalanceController",
+    "EXPERTS_BACKENDS",
+    "MOE_PRESETS",
+    "MoEConfig",
+    "MoELayer",
+    "ROUTERS",
+    "RoutedExperts",
+    "Router",
+    "RoutingResult",
+    "SCORE_FUNCTIONS",
+    "SHARED_EXPERTS",
+    "SharedExpert",
+    "WarmStartPlan",
+    "apply_pending_balance_updates",
+    "available_moe_presets",
+    "build_balance_controller",
+    "build_ffn",
+    "build_routed_experts",
+    "build_router",
+    "build_shared_expert",
+    "collect_moe_aux_loss",
+    "collect_moe_metrics",
+    "from_checkpoint_state_dict",
+    "get_score_function",
+    "is_moe_config",
+    "iter_moe_layers",
+    "plan_warm_start",
+    "register_balance_controller",
+    "register_experts_backend",
+    "register_moe_preset",
+    "register_router",
+    "register_score_function",
+    "register_shared_expert",
+    "register_state_dict_converter",
+    "resolve_moe_config",
+    "select_target_experts",
+    "to_checkpoint_state_dict",
+]

--- a/specforge/modeling/draft/moe/_registry.py
+++ b/specforge/modeling/draft/moe/_registry.py
@@ -1,0 +1,49 @@
+# coding=utf-8
+"""Tiny named-registry helper shared by the MoE component registries."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class Registry(Generic[T]):
+    """Name -> implementation map with a decorator form and helpful errors."""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self._items: Dict[str, T] = {}
+
+    def register(self, name: str, item: Optional[T] = None) -> Callable[[T], T] | T:
+        def _register(obj: T) -> T:
+            if name in self._items and self._items[name] is not obj:
+                raise ValueError(f"{self.kind} {name!r} is already registered")
+            self._items[name] = obj
+            return obj
+
+        return _register if item is None else _register(item)
+
+    def unregister(self, name: str) -> None:
+        self._items.pop(name, None)
+
+    def get(self, name: str) -> T:
+        try:
+            return self._items[name]
+        except KeyError:
+            available = ", ".join(sorted(self._items)) or "<none registered>"
+            raise KeyError(
+                f"unknown {self.kind} {name!r}; available: {available}"
+            ) from None
+
+    def names(self) -> list[str]:
+        return sorted(self._items)
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._items
+
+    def __getitem__(self, name: str) -> T:
+        return self.get(name)
+
+    def __len__(self) -> int:
+        return len(self._items)

--- a/specforge/modeling/draft/moe/balance.py
+++ b/specforge/modeling/draft/moe/balance.py
@@ -1,0 +1,71 @@
+# coding=utf-8
+"""Load balancing as a swappable policy.
+
+The controller sees routing outcomes and may (a) shift scores used for expert
+*selection* (never the combine weights), (b) emit an auxiliary loss, and (c)
+report load metrics. It is an ``nn.Module`` so implementations can own
+buffers that travel with the checkpoint (e.g. a selection bias).
+
+Two timing rules every implementation must respect:
+
+- :meth:`observe` is called from the layer forward and must only *stash*
+  (overwrite, never accumulate): an activation-checkpoint recompute re-runs the
+  forward and must leave identical state behind.
+- :meth:`apply_pending_update` is called by the *model* before the next
+  forward, outside any checkpoint region, and may mutate selection state and
+  run collectives. Mutating selection state inside the forward would make the
+  recompute route differently and break checkpointing.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Type, Union
+
+import torch
+from torch import nn
+
+from ._registry import Registry
+from .config import MoEConfig
+
+MetricValue = Union[torch.Tensor, float]
+
+
+class BalanceController(nn.Module):
+    """No balancing (registered as ``"none"``); the base for real policies."""
+
+    def __init__(self, cfg: MoEConfig, n_experts: int) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.n_experts = n_experts
+
+    def adjust_selection_scores(self, scores: torch.Tensor) -> torch.Tensor:
+        """Scores used to pick experts; combine weights still use the raw ones."""
+        return scores
+
+    def observe(self, counts: torch.Tensor) -> None:
+        """Stash this forward's per-expert token counts (training only)."""
+
+    def apply_pending_update(self) -> None:
+        """Consume the stash; called by the model outside checkpoint regions."""
+
+    def aux_loss(self) -> Optional[torch.Tensor]:
+        """Scaled auxiliary loss for the last forward, or ``None``."""
+        return None
+
+    def metrics(self) -> Dict[str, MetricValue]:
+        """Scalar diagnostics (rank-local; the trainer DP-averages them)."""
+        return {}
+
+
+BALANCE_CONTROLLERS: Registry[Type[BalanceController]] = Registry(
+    "MoE balance controller"
+)
+BALANCE_CONTROLLERS.register("none", BalanceController)
+
+
+def register_balance_controller(name: str):
+    return BALANCE_CONTROLLERS.register(name)
+
+
+def build_balance_controller(cfg: MoEConfig, n_experts: int) -> BalanceController:
+    return BALANCE_CONTROLLERS.get(cfg.balance)(cfg, n_experts)

--- a/specforge/modeling/draft/moe/balance.py
+++ b/specforge/modeling/draft/moe/balance.py
@@ -10,7 +10,8 @@ Two timing rules every implementation must respect:
 
 - :meth:`observe` is called from the layer forward and must only *stash*
   (overwrite, never accumulate): an activation-checkpoint recompute re-runs the
-  forward and must leave identical state behind.
+  forward and must leave identical state behind. An auxiliary loss built here
+  is consumed by the trainer right after the same forward.
 - :meth:`apply_pending_update` is called by the *model* before the next
   forward, outside any checkpoint region, and may mutate selection state and
   run collectives. Mutating selection state inside the forward would make the
@@ -19,13 +20,16 @@ Two timing rules every implementation must respect:
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Type, Union
+from typing import TYPE_CHECKING, Dict, Optional, Type, Union
 
 import torch
 from torch import nn
 
 from ._registry import Registry
 from .config import MoEConfig
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle with router.py
+    from .router import RoutingResult
 
 MetricValue = Union[torch.Tensor, float]
 
@@ -42,8 +46,12 @@ class BalanceController(nn.Module):
         """Scores used to pick experts; combine weights still use the raw ones."""
         return scores
 
-    def observe(self, counts: torch.Tensor) -> None:
-        """Stash this forward's per-expert token counts (training only)."""
+    def observe(self, routing: "RoutingResult") -> None:
+        """Stash this forward's routing outcome (training only).
+
+        ``routing.counts`` feeds load statistics; ``routing.scores`` (when the
+        router provides it) lets a policy build a differentiable auxiliary
+        loss to return from :meth:`aux_loss` for the same forward."""
 
     def apply_pending_update(self) -> None:
         """Consume the stash; called by the model outside checkpoint regions."""

--- a/specforge/modeling/draft/moe/config.py
+++ b/specforge/modeling/draft/moe/config.py
@@ -1,0 +1,208 @@
+# coding=utf-8
+"""MoE architecture config: the knobs a draft JSON can set, and their presets.
+
+Two kinds of keys, deliberately kept apart:
+
+- **Architecture keys** live at the top level of the draft JSON under the
+  target checkpoints' native HF names (``n_routed_experts``,
+  ``moe_intermediate_size``, ``scoring_func``, ...). They determine which
+  weights a checkpoint carries and how serving must route, so a draft JSON can
+  be assembled by copying them from the target's ``config.json``. A
+  ``moe_preset`` supplies the defaults for one target family; explicit keys
+  override the preset for ablations.
+- **Training-only keys** live under ``dflash_config`` with an ``moe_`` prefix
+  (``moe_bias_update_rate``, ``moe_aux_loss_coeff``, ``moe_dispatch``). They
+  never change the checkpoint and are invisible to serving.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Dict, Mapping, Optional
+
+from ._registry import Registry
+
+_MISSING = object()
+
+#: Draft-JSON top-level keys that describe the MoE architecture.
+ARCHITECTURE_KEYS = (
+    "n_routed_experts",
+    "num_experts_per_tok",
+    "moe_intermediate_size",
+    "n_shared_experts",
+    "shared_expert_intermediate_size",
+    "scoring_func",
+    "norm_topk_prob",
+    "routed_scaling_factor",
+    "n_group",
+    "topk_group",
+    "swiglu_limit",
+    "router",
+    "balance",
+    "shared_expert",
+    "shared_expert_gate",
+    "experts_backend",
+)
+
+#: ``dflash_config`` keys (training-only) -> MoEConfig field.
+TRAINING_KEYS = {
+    "moe_bias_update_rate": "bias_update_rate",
+    "moe_aux_loss_coeff": "aux_loss_coeff",
+    "moe_dispatch": "dispatch",
+}
+
+
+@dataclass(frozen=True)
+class MoEConfig:
+    """Resolved MoE configuration for one draft model (all layers share it)."""
+
+    preset: str
+    n_routed_experts: int
+    num_experts_per_tok: int
+    moe_intermediate_size: int
+    n_shared_experts: int = 1
+    shared_expert_intermediate_size: Optional[int] = None
+    # Routing recipe. ``scoring_func`` names a registered score function;
+    # ``router``/``balance`` name registered component implementations.
+    scoring_func: str = "softmax"
+    norm_topk_prob: bool = True
+    routed_scaling_factor: float = 1.0
+    n_group: int = 1
+    topk_group: int = 1
+    router: str = "topk"
+    balance: str = "none"
+    # Expert MLPs.
+    swiglu_limit: float = 0.0
+    experts_backend: str = "grouped"
+    shared_expert: str = "swiglu"
+    shared_expert_gate: str = "none"
+    # Training-only (never part of the checkpoint).
+    bias_update_rate: float = 0.0
+    aux_loss_coeff: float = 0.0
+    dispatch: str = "sorted_loop"
+
+    def __post_init__(self) -> None:
+        if self.n_routed_experts <= 0:
+            raise ValueError("n_routed_experts must be positive for an MoE FFN")
+        if not 0 < self.num_experts_per_tok <= self.n_routed_experts:
+            raise ValueError(
+                "num_experts_per_tok must be in [1, n_routed_experts], got "
+                f"{self.num_experts_per_tok} with {self.n_routed_experts} experts"
+            )
+        if self.moe_intermediate_size <= 0:
+            raise ValueError("moe_intermediate_size must be positive")
+        if self.n_shared_experts not in (0, 1):
+            raise ValueError(
+                "n_shared_experts must be 0 or 1 (one shared expert of "
+                "shared_expert_intermediate_size width), got "
+                f"{self.n_shared_experts}"
+            )
+        if self.shared_expert_intermediate_size is None:
+            object.__setattr__(
+                self, "shared_expert_intermediate_size", self.moe_intermediate_size
+            )
+        if self.shared_expert_intermediate_size <= 0:
+            raise ValueError("shared_expert_intermediate_size must be positive")
+        if self.n_group <= 0 or self.n_routed_experts % self.n_group:
+            raise ValueError(
+                f"n_group={self.n_group} must divide n_routed_experts="
+                f"{self.n_routed_experts}"
+            )
+        if not 0 < self.topk_group <= self.n_group:
+            raise ValueError(
+                f"topk_group={self.topk_group} must be in [1, n_group={self.n_group}]"
+            )
+        if self.swiglu_limit < 0:
+            raise ValueError("swiglu_limit must be >= 0 (0 disables the clamp)")
+        if self.bias_update_rate < 0 or self.aux_loss_coeff < 0:
+            raise ValueError("bias_update_rate and aux_loss_coeff must be >= 0")
+
+    @property
+    def group_limited(self) -> bool:
+        """Whether routing restricts top-k to ``topk_group`` of ``n_group``."""
+        return self.topk_group < self.n_group
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+#: preset name -> architecture defaults (a subset of ARCHITECTURE_KEYS).
+MOE_PRESETS: Registry[Dict[str, Any]] = Registry("MoE preset")
+
+_FIELD_NAMES = {f.name for f in fields(MoEConfig)}
+
+
+def register_moe_preset(name: str, **defaults: Any) -> Dict[str, Any]:
+    """Register the architecture defaults of one target family.
+
+    A preset may set any ``MoEConfig`` field except the training-only ones and
+    the per-run sizes (``n_routed_experts``, ``num_experts_per_tok``,
+    ``moe_intermediate_size``), which the draft JSON must state explicitly.
+    """
+    forbidden = set(TRAINING_KEYS.values()) | {
+        "preset",
+        "n_routed_experts",
+        "num_experts_per_tok",
+        "moe_intermediate_size",
+    }
+    bad = sorted(set(defaults) - _FIELD_NAMES)
+    if bad:
+        raise ValueError(f"preset {name!r} sets unknown MoEConfig fields: {bad}")
+    bad = sorted(set(defaults) & forbidden)
+    if bad:
+        raise ValueError(f"preset {name!r} may not set per-run/training fields: {bad}")
+    MOE_PRESETS.register(name, dict(defaults))
+    return defaults
+
+
+def available_moe_presets() -> list[str]:
+    return MOE_PRESETS.names()
+
+
+def _get(config: Any, key: str, default: Any = _MISSING) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(key, default)
+    return getattr(config, key, default)
+
+
+def is_moe_config(config: Any) -> bool:
+    """True when a draft config asks for an MoE FFN (``n_routed_experts > 0``)."""
+    value = _get(config, "n_routed_experts", 0)
+    return int(value or 0) > 0
+
+
+def resolve_moe_config(config: Any) -> Optional[MoEConfig]:
+    """Resolve a draft config (HF ``PretrainedConfig`` or dict) to ``MoEConfig``.
+
+    Returns ``None`` for dense drafts. For MoE drafts, ``moe_preset`` is
+    required: it names the target family's routing recipe and is the only way
+    the architecture keys get validated defaults.
+    """
+    if not is_moe_config(config):
+        return None
+    preset = _get(config, "moe_preset", None)
+    if not preset:
+        raise ValueError(
+            "n_routed_experts > 0 requires moe_preset in the draft config; "
+            f"available presets: {available_moe_presets() or '<none registered>'}"
+        )
+    values: Dict[str, Any] = dict(MOE_PRESETS.get(preset))
+    for key in ARCHITECTURE_KEYS:
+        explicit = _get(config, key, _MISSING)
+        if explicit is not _MISSING and explicit is not None:
+            values[key] = explicit
+    dflash_config = _get(config, "dflash_config", None) or {}
+    unknown = sorted(
+        key
+        for key in dflash_config
+        if key.startswith("moe_") and key not in TRAINING_KEYS
+    )
+    if unknown:
+        raise ValueError(
+            f"unknown MoE training keys in dflash_config: {unknown}; "
+            f"known: {sorted(TRAINING_KEYS)}"
+        )
+    for json_key, field_name in TRAINING_KEYS.items():
+        if json_key in dflash_config:
+            values[field_name] = dflash_config[json_key]
+    return MoEConfig(preset=preset, **values)

--- a/specforge/modeling/draft/moe/experts.py
+++ b/specforge/modeling/draft/moe/experts.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Routed experts contract: the expert weights and how tokens reach them.
+
+An implementation owns the parameters of all ``n_routed_experts`` experts and
+turns a :class:`RoutingResult` into the combined routed output. Weight layout
+is the implementation's choice (per-expert modules, stacked ``[E, out, in]``
+tensors, ...); it must register a :mod:`.state_dict` converter if its native
+layout differs from the official checkpoint naming
+(``experts.{i}.w{1,2,3}.weight``). ``MoEConfig.dispatch`` is the
+implementation's execution knob (e.g. sorted-segment loop vs grouped GEMM).
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Type
+
+import torch
+from torch import nn
+
+from ._registry import Registry
+from .config import MoEConfig
+from .router import RoutingResult
+
+
+class RoutedExperts(nn.Module, abc.ABC):
+    def __init__(self, cfg: MoEConfig, hidden_size: int) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.hidden_size = hidden_size
+        self.n_experts = cfg.n_routed_experts
+        self.intermediate_size = cfg.moe_intermediate_size
+
+    @abc.abstractmethod
+    def forward(self, x: torch.Tensor, routing: RoutingResult) -> torch.Tensor:
+        """``x`` is ``[T, hidden]``; return the combined routed output ``[T, hidden]``
+        in ``x.dtype``."""
+
+    @abc.abstractmethod
+    def reset_parameters(self, std: float) -> None:
+        """Initialize expert weights with the draft's ``initializer_range`` so an
+        MoE FFN starts from the same distribution as the dense MLP it replaces."""
+
+
+EXPERTS_BACKENDS: Registry[Type[RoutedExperts]] = Registry("MoE experts backend")
+
+
+def register_experts_backend(name: str):
+    return EXPERTS_BACKENDS.register(name)
+
+
+def build_routed_experts(cfg: MoEConfig, hidden_size: int) -> RoutedExperts:
+    return EXPERTS_BACKENDS.get(cfg.experts_backend)(cfg, hidden_size)

--- a/specforge/modeling/draft/moe/hooks.py
+++ b/specforge/modeling/draft/moe/hooks.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+"""Model-level plumbing for MoE layers.
+
+A draft model with MoE FFNs needs three things from its trainer loop, all
+expressed here as functions over any ``nn.Module`` tree so DFlash, DFlash2 and
+DSpark share them:
+
+- :func:`apply_pending_balance_updates` at the top of the model forward (in
+  training), outside activation-checkpoint regions;
+- :func:`collect_moe_aux_loss` to add to the objective when a balance policy
+  emits one;
+- :func:`collect_moe_metrics` for per-step diagnostics (``moe/...``).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterator, Optional
+
+import torch
+from torch import nn
+
+from .balance import MetricValue
+from .layer import MoELayer
+
+
+def iter_moe_layers(module: nn.Module) -> Iterator[MoELayer]:
+    for sub in module.modules():
+        if isinstance(sub, MoELayer):
+            yield sub
+
+
+def apply_pending_balance_updates(module: nn.Module) -> None:
+    for layer in iter_moe_layers(module):
+        layer.apply_pending_balance_update()
+
+
+def collect_moe_aux_loss(module: nn.Module) -> Optional[torch.Tensor]:
+    """Sum of the layers' (already scaled) auxiliary losses, or ``None``."""
+    total: Optional[torch.Tensor] = None
+    for layer in iter_moe_layers(module):
+        loss = layer.aux_loss()
+        if loss is None:
+            continue
+        total = loss if total is None else total + loss
+    return total
+
+
+def collect_moe_metrics(
+    module: nn.Module, prefix: str = "moe/"
+) -> Dict[str, MetricValue]:
+    """Layer-averaged scalar diagnostics; ``{}`` for dense models."""
+    sums: Dict[str, MetricValue] = {}
+    n = 0
+    for layer in iter_moe_layers(module):
+        n += 1
+        for key, value in layer.metrics().items():
+            sums[key] = value if key not in sums else sums[key] + value
+    if n == 0:
+        return {}
+    return {
+        f"{prefix}{key}": (value / n if isinstance(value, torch.Tensor) else value / n)
+        for key, value in sums.items()
+    }

--- a/specforge/modeling/draft/moe/init.py
+++ b/specforge/modeling/draft/moe/init.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+"""Warm-start plans: which target experts seed which draft experts.
+
+A drafter whose MoE matches the target's expert shape can inherit expert
+weights instead of training them from scratch. This module holds the
+implementation-independent part: choosing the mapping. Applying a plan needs
+the target checkpoint's (possibly quantized) weights and the experts backend's
+native layout, and is provided alongside each target-family preset.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from .config import MoEConfig
+
+
+@dataclass(frozen=True)
+class WarmStartPlan:
+    """``target_expert_ids[i]`` is the target expert that seeds draft expert ``i``."""
+
+    target_expert_ids: Tuple[int, ...]
+    copy_shared_expert: bool = True
+    copy_gate_rows: bool = True
+
+    @property
+    def n_draft_experts(self) -> int:
+        return len(self.target_expert_ids)
+
+
+def select_target_experts(
+    n_target: int, n_draft: int, strategy: str = "strided"
+) -> Tuple[int, ...]:
+    """Pick ``n_draft`` distinct target experts.
+
+    ``"strided"`` spreads picks evenly over the target's expert ids (the
+    default: no assumption about which experts matter for the draft's data);
+    ``"first"`` takes the leading ids.
+    """
+    if n_draft <= 0 or n_target <= 0:
+        raise ValueError("expert counts must be positive")
+    if n_draft > n_target:
+        raise ValueError(
+            f"cannot seed {n_draft} draft experts from {n_target} target experts"
+        )
+    if strategy == "first":
+        return tuple(range(n_draft))
+    if strategy == "strided":
+        return tuple((i * n_target) // n_draft for i in range(n_draft))
+    raise ValueError(f"unknown warm-start selection strategy {strategy!r}")
+
+
+def plan_warm_start(
+    cfg: MoEConfig, n_target_experts: int, strategy: str = "strided"
+) -> WarmStartPlan:
+    return WarmStartPlan(
+        target_expert_ids=select_target_experts(
+            n_target_experts, cfg.n_routed_experts, strategy
+        ),
+        copy_shared_expert=bool(cfg.n_shared_experts),
+    )

--- a/specforge/modeling/draft/moe/layer.py
+++ b/specforge/modeling/draft/moe/layer.py
@@ -46,7 +46,7 @@ class MoELayer(nn.Module):
         routing: RoutingResult = self.gate(x)
         if self.training:
             self.last_counts = routing.counts.detach()
-            self.balance.observe(routing.counts)
+            self.balance.observe(routing)
         y = self.experts(x, routing)
         if self.shared_experts is not None:
             y = y + self.shared_experts(x)

--- a/specforge/modeling/draft/moe/layer.py
+++ b/specforge/modeling/draft/moe/layer.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+"""``MoELayer``: the FFN that composes router, experts and shared expert.
+
+Attribute names follow the official DeepSeek-style checkpoint layout
+(``gate``, ``experts``, ``shared_experts``) so that per-implementation
+converters only need to handle their own internals.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional
+
+import torch
+from torch import nn
+
+from .balance import MetricValue, build_balance_controller
+from .config import MoEConfig, resolve_moe_config
+from .experts import build_routed_experts
+from .router import RoutingResult, build_router
+from .shared import build_shared_expert
+
+
+class MoELayer(nn.Module):
+    """Routed FFN: ``y = experts(x, gate(x)) + shared_experts(x)``."""
+
+    def __init__(self, cfg: MoEConfig, hidden_size: int) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.hidden_size = hidden_size
+        balance = build_balance_controller(cfg, cfg.n_routed_experts)
+        self.gate = build_router(cfg, hidden_size, balance)
+        self.experts = build_routed_experts(cfg, hidden_size)
+        self.shared_experts: Optional[nn.Module] = (
+            build_shared_expert(cfg, hidden_size) if cfg.n_shared_experts else None
+        )
+        # Detached per-expert counts of the last training forward, for metrics.
+        self.last_counts: Optional[torch.Tensor] = None
+
+    @property
+    def balance(self):
+        return self.gate.balance
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        x = x.reshape(-1, self.hidden_size)
+        routing: RoutingResult = self.gate(x)
+        if self.training:
+            self.last_counts = routing.counts.detach()
+            self.balance.observe(routing.counts)
+        y = self.experts(x, routing)
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+        return y.view(shape)
+
+    # -- model-level hooks (see hooks.py) ---------------------------------
+    def apply_pending_balance_update(self) -> None:
+        self.balance.apply_pending_update()
+
+    def aux_loss(self) -> Optional[torch.Tensor]:
+        return self.balance.aux_loss()
+
+    def metrics(self) -> Dict[str, MetricValue]:
+        out: Dict[str, MetricValue] = {}
+        counts = self.last_counts
+        if counts is not None and counts.numel():
+            load = counts.float()
+            mean = load.mean().clamp_min(1e-9)
+            out["load_max_ratio"] = load.max() / mean
+            out["load_min_ratio"] = load.min() / mean
+            out["experts_unused_frac"] = (load == 0).float().mean()
+        out.update(self.balance.metrics())
+        return out
+
+    def reset_parameters(self, std: float) -> None:
+        """Initialize bare Parameters the HF ``_init_weights`` pass cannot see."""
+        self.gate.reset_parameters(std)
+        self.experts.reset_parameters(std)
+        if self.shared_experts is not None:
+            self.shared_experts.reset_parameters(std)
+
+
+def build_ffn(config, dense: Callable[[object], nn.Module]) -> nn.Module:
+    """The dense/MoE switch for a decoder layer's FFN.
+
+    ``config`` is the draft's HF config; ``dense`` builds the dense MLP (the
+    kernel provider's factory) and is used verbatim when the config is dense,
+    so dense drafts are byte-for-byte unaffected by this package.
+    """
+    moe_cfg = resolve_moe_config(config)
+    if moe_cfg is None:
+        return dense(config)
+    return MoELayer(moe_cfg, int(config.hidden_size))

--- a/specforge/modeling/draft/moe/router.py
+++ b/specforge/modeling/draft/moe/router.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+"""Router contract: hidden states -> per-token expert choices + combine weights.
+
+A router owns the gate projection and composes a :class:`BalanceController`
+(``self.balance``) that may shift scores for *selection only*. Concrete routers
+register by name (``MoEConfig.router``); score functions register separately
+(``MoEConfig.scoring_func``) so one top-k router serves softmax, sigmoid and
+sqrtsoftplus families.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+from typing import Callable, Type
+
+import torch
+from torch import nn
+
+from ._registry import Registry
+from .balance import BalanceController
+from .config import MoEConfig
+
+
+@dataclass
+class RoutingResult:
+    """Routing decision for a flat batch of ``T`` tokens.
+
+    ``weights`` are the final combine weights (normalized and scaled as the
+    recipe dictates) in fp32; ``indices`` the chosen experts; ``counts`` the
+    per-expert token counts on device (no host sync), which dispatch and
+    balancing both consume.
+    """
+
+    weights: torch.Tensor  # [T, k] fp32
+    indices: torch.Tensor  # [T, k] long
+    counts: torch.Tensor  # [E] long
+
+    @property
+    def topk(self) -> int:
+        return int(self.indices.shape[-1])
+
+
+#: name -> f(logits [T, E] fp32) -> scores [T, E] fp32
+SCORE_FUNCTIONS: Registry[Callable[[torch.Tensor], torch.Tensor]] = Registry(
+    "MoE score function"
+)
+
+
+def register_score_function(name: str):
+    return SCORE_FUNCTIONS.register(name)
+
+
+def get_score_function(name: str) -> Callable[[torch.Tensor], torch.Tensor]:
+    return SCORE_FUNCTIONS.get(name)
+
+
+class Router(nn.Module, abc.ABC):
+    """Base router. Subclasses implement :meth:`forward` and :meth:`reset_parameters`."""
+
+    def __init__(
+        self, cfg: MoEConfig, hidden_size: int, balance: BalanceController
+    ) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.hidden_size = hidden_size
+        self.n_experts = cfg.n_routed_experts
+        self.topk = cfg.num_experts_per_tok
+        self.balance = balance
+
+    @abc.abstractmethod
+    def forward(self, x: torch.Tensor) -> RoutingResult:
+        """Route a flat ``[T, hidden]`` batch."""
+
+    @abc.abstractmethod
+    def reset_parameters(self, std: float) -> None:
+        """Initialize the gate weights (called from the model's ``_init_weights``)."""
+
+
+ROUTERS: Registry[Type[Router]] = Registry("MoE router")
+
+
+def register_router(name: str):
+    return ROUTERS.register(name)
+
+
+def build_router(
+    cfg: MoEConfig, hidden_size: int, balance: BalanceController
+) -> Router:
+    return ROUTERS.get(cfg.router)(cfg, hidden_size, balance)

--- a/specforge/modeling/draft/moe/router.py
+++ b/specforge/modeling/draft/moe/router.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Callable, Type
+from typing import Callable, Optional, Type
 
 import torch
 from torch import nn
@@ -29,12 +29,15 @@ class RoutingResult:
     ``weights`` are the final combine weights (normalized and scaled as the
     recipe dictates) in fp32; ``indices`` the chosen experts; ``counts`` the
     per-expert token counts on device (no host sync), which dispatch and
-    balancing both consume.
+    balancing both consume. ``scores`` are the full pre-selection affinities
+    (differentiable, fp32) for balance policies that need a gradient signal,
+    e.g. an auxiliary balance loss; routers may leave it ``None``.
     """
 
     weights: torch.Tensor  # [T, k] fp32
     indices: torch.Tensor  # [T, k] long
     counts: torch.Tensor  # [E] long
+    scores: Optional[torch.Tensor] = None  # [T, E] fp32, differentiable
 
     @property
     def topk(self) -> int:

--- a/specforge/modeling/draft/moe/shared.py
+++ b/specforge/modeling/draft/moe/shared.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+"""Shared expert contract: an always-on FFN added to the routed output.
+
+Families differ in the gate on it (DeepSeek: none; Qwen: a per-token sigmoid
+gate), which is ``MoEConfig.shared_expert_gate``, and in its width
+(``shared_expert_intermediate_size``). Implementations register by name
+(``MoEConfig.shared_expert``). Checkpoint naming follows the official
+``shared_experts.w{1,2,3}.weight`` layout unless a converter says otherwise.
+"""
+
+from __future__ import annotations
+
+import abc
+from typing import Type
+
+import torch
+from torch import nn
+
+from ._registry import Registry
+from .config import MoEConfig
+
+
+class SharedExpert(nn.Module, abc.ABC):
+    def __init__(self, cfg: MoEConfig, hidden_size: int) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.hidden_size = hidden_size
+        self.intermediate_size = cfg.shared_expert_intermediate_size
+
+    @abc.abstractmethod
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """``x`` is ``[T, hidden]``; return ``[T, hidden]`` in ``x.dtype``."""
+
+    def reset_parameters(self, std: float) -> None:
+        """Hook for bare Parameters; ``nn.Linear`` children are covered by HF init."""
+
+
+SHARED_EXPERTS: Registry[Type[SharedExpert]] = Registry("MoE shared expert")
+
+
+def register_shared_expert(name: str):
+    return SHARED_EXPERTS.register(name)
+
+
+def build_shared_expert(cfg: MoEConfig, hidden_size: int) -> SharedExpert:
+    return SHARED_EXPERTS.get(cfg.shared_expert)(cfg, hidden_size)

--- a/specforge/modeling/draft/moe/state_dict.py
+++ b/specforge/modeling/draft/moe/state_dict.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+"""Checkpoint-naming boundary for MoE modules.
+
+Checkpoint FILES (trainer checkpoints, warm-start sources, exports) use the
+official per-expert naming so SGLang and HF loaders read them unchanged.
+Modules may use a different native layout (e.g. stacked ``[E, out, in]``
+expert tensors, which FSDP ``use_orig_params`` and grouped GEMMs want).
+
+FSDP's full-state-dict hooks index the gathered dict by the module's own
+parameter FQNs, so the rename cannot live inside ``state_dict()``; it lives at
+the save/load boundary instead. Every place that reads a model's state for a
+file, or loads a file into a model, goes through :func:`to_checkpoint_state_dict`
+/ :func:`from_checkpoint_state_dict`: the training backend, warm start, and
+the HF/SGLang exporters. Implementations with a native layout register a
+converter pair; both directions must be no-ops on dicts already in the other
+form, and on dense models.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Tuple
+
+Converter = Callable[[Dict[str, object]], Dict[str, object]]
+
+_CONVERTERS: List[Tuple[str, Converter, Converter]] = []
+
+
+def register_state_dict_converter(
+    name: str, *, to_checkpoint: Converter, from_checkpoint: Converter
+) -> None:
+    for existing, _, _ in _CONVERTERS:
+        if existing == name:
+            raise ValueError(f"state-dict converter {name!r} is already registered")
+    _CONVERTERS.append((name, to_checkpoint, from_checkpoint))
+
+
+def unregister_state_dict_converter(name: str) -> None:
+    _CONVERTERS[:] = [entry for entry in _CONVERTERS if entry[0] != name]
+
+
+def registered_state_dict_converters() -> List[str]:
+    return [name for name, _, _ in _CONVERTERS]
+
+
+def to_checkpoint_state_dict(state: Dict[str, object]) -> Dict[str, object]:
+    """Module-native naming -> official checkpoint naming (identity for dense)."""
+    for _, to_checkpoint, _ in _CONVERTERS:
+        state = to_checkpoint(state)
+    return state
+
+
+def from_checkpoint_state_dict(state: Dict[str, object]) -> Dict[str, object]:
+    """Official checkpoint naming -> module-native naming (identity for dense)."""
+    for _, _, from_checkpoint in reversed(_CONVERTERS):
+        state = from_checkpoint(state)
+    return state

--- a/specforge/training/backend.py
+++ b/specforge/training/backend.py
@@ -373,22 +373,30 @@ class FSDPTrainingBackend(TrainingBackend):
         )
 
     def _module_state_dict(self) -> dict:
+        # Checkpoint FILES use the official parameter naming; modules may use
+        # a different native layout (MoE experts). Convert at this boundary:
+        # FSDP's full-state-dict hooks need the module's own FQNs.
+        from specforge.modeling.draft.moe import to_checkpoint_state_dict
+
         if self._wrapper_kind == "ddp":
             if dist.is_initialized() and dist.get_rank() != 0:
                 return {}
-            return self.module.module.state_dict()
+            return to_checkpoint_state_dict(self.module.module.state_dict())
         if self._wrapper_kind != "fsdp":
-            return self.module.state_dict()
+            return to_checkpoint_state_dict(self.module.state_dict())
         from torch.distributed.fsdp import FullStateDictConfig
 
         # gather to rank0 CPU only — materializing the full model on every
         # rank's GPU is wasted memory when only rank0 writes it.
         cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
         with self._full_state_ctx(cfg):
-            return self.module.state_dict()
+            return to_checkpoint_state_dict(self.module.state_dict())
 
     def _load_module_state_dict(self, model_state: dict) -> None:
+        from specforge.modeling.draft.moe import from_checkpoint_state_dict
+
         # every rank loads the full state dict read from the shared file.
+        model_state = from_checkpoint_state_dict(model_state)
         if self._wrapper_kind == "ddp":
             self.module.module.load_state_dict(model_state)
             return

--- a/specforge/training/model_loading.py
+++ b/specforge/training/model_loading.py
@@ -426,7 +426,10 @@ def warm_start_draft_model(
     if not state:
         raise ValueError(f"warm-start checkpoint {source!r} contains no draft weights")
     try:
-        result = model.load_state_dict(state, strict=False)
+        # Files use the official naming; modules may use a native MoE layout.
+        from specforge.modeling.draft.moe import from_checkpoint_state_dict
+
+        result = model.load_state_dict(from_checkpoint_state_dict(state), strict=False)
     except RuntimeError as exc:
         raise ValueError(
             f"warm-start checkpoint {source!r} has incompatible draft tensor "

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -52,6 +52,16 @@ class StepContext:
     total_steps: Optional[int] = None
 
 
+def _moe_metrics(model_wrapper: nn.Module) -> Dict[str, Any]:
+    """``moe/...`` load diagnostics of the wrapped draft; ``{}`` for dense drafts."""
+    from specforge.modeling.draft.moe import collect_moe_metrics
+
+    draft_model = getattr(model_wrapper, "draft_model", None)
+    if draft_model is None:
+        return {}
+    return collect_moe_metrics(draft_model)
+
+
 def linear_lambda_base(
     global_step: int,
     total_steps: int,
@@ -511,6 +521,7 @@ class DFlashTrainStrategy(DraftTrainStrategy):
             metrics["accuracy_denom"] = model_metrics["accuracy_denom"]
         if "selector_loss_alpha" in model_metrics:
             metrics["selector_loss_alpha"] = model_metrics["selector_loss_alpha"]
+        metrics.update(_moe_metrics(self.dflash_model))
         return StepOutput(
             loss=loss,
             metrics=metrics,
@@ -577,6 +588,7 @@ class DSparkTrainStrategy(DraftTrainStrategy):
         ):
             if name in model_metrics:
                 metrics[name] = model_metrics[name]
+        metrics.update(_moe_metrics(self.dspark_model))
         return StepOutput(
             loss=loss,
             metrics=metrics,

--- a/tests/test_modeling/test_moe.py
+++ b/tests/test_modeling/test_moe.py
@@ -1,0 +1,464 @@
+# coding=utf-8
+"""MoE FFN skeleton: config resolution, component contracts, composition, and
+the model/trainer/checkpoint seams — exercised with stub components so the
+contracts are pinned independently of any target-family implementation."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+from transformers.models.qwen3.modeling_qwen3 import Qwen3MLP
+
+from specforge.modeling.draft.dflash import DFlashDraftModel
+from specforge.modeling.draft.moe import (
+    BALANCE_CONTROLLERS,
+    EXPERTS_BACKENDS,
+    MOE_PRESETS,
+    ROUTERS,
+    SCORE_FUNCTIONS,
+    SHARED_EXPERTS,
+    BalanceController,
+    MoEConfig,
+    MoELayer,
+    RoutedExperts,
+    Router,
+    RoutingResult,
+    SharedExpert,
+    apply_pending_balance_updates,
+    build_ffn,
+    collect_moe_aux_loss,
+    collect_moe_metrics,
+    from_checkpoint_state_dict,
+    iter_moe_layers,
+    plan_warm_start,
+    register_balance_controller,
+    register_experts_backend,
+    register_moe_preset,
+    register_router,
+    register_score_function,
+    register_shared_expert,
+    register_state_dict_converter,
+    resolve_moe_config,
+    select_target_experts,
+    to_checkpoint_state_dict,
+)
+from specforge.modeling.draft.moe.state_dict import unregister_state_dict_converter
+from specforge.training.strategies.base import _moe_metrics
+
+PRESET = "_test_family"
+
+
+# --- stub components: a minimal but real top-k reference for the contracts ---
+
+
+class _StubBalance(BalanceController):
+    def __init__(self, cfg, n_experts):
+        super().__init__(cfg, n_experts)
+        self.register_buffer("bias", torch.zeros(n_experts))
+        self.observed = []
+        self.applied = 0
+
+    def adjust_selection_scores(self, scores):
+        return scores + self.bias
+
+    def observe(self, counts):
+        self.observed.append(counts.detach().clone())
+
+    def apply_pending_update(self):
+        self.applied += 1
+
+    def aux_loss(self):
+        if self.cfg.aux_loss_coeff <= 0:
+            return None
+        return torch.tensor(self.cfg.aux_loss_coeff)
+
+    def metrics(self):
+        return {"stub_metric": 1.0}
+
+
+class _StubRouter(Router):
+    def __init__(self, cfg, hidden_size, balance):
+        super().__init__(cfg, hidden_size, balance)
+        self.weight = nn.Parameter(torch.empty(self.n_experts, hidden_size))
+        self.score_fn = SCORE_FUNCTIONS.get(cfg.scoring_func)
+
+    def reset_parameters(self, std):
+        nn.init.normal_(self.weight, std=std)
+
+    def forward(self, x):
+        scores = self.score_fn(x.float() @ self.weight.float().t())
+        indices = self.balance.adjust_selection_scores(scores).topk(self.topk).indices
+        weights = scores.gather(1, indices)
+        if self.cfg.norm_topk_prob:
+            weights = weights / weights.sum(-1, keepdim=True)
+        weights = weights * self.cfg.routed_scaling_factor
+        counts = torch.zeros(
+            self.n_experts, dtype=torch.long, device=x.device
+        ).scatter_add_(0, indices.flatten(), torch.ones_like(indices.flatten()))
+        return RoutingResult(weights=weights, indices=indices, counts=counts)
+
+
+class _StubExperts(RoutedExperts):
+    def __init__(self, cfg, hidden_size):
+        super().__init__(cfg, hidden_size)
+        self.w = nn.Parameter(torch.empty(self.n_experts, hidden_size, hidden_size))
+
+    def reset_parameters(self, std):
+        nn.init.normal_(self.w, std=std)
+
+    def forward(self, x, routing):
+        # dense gather: fine for tiny tests, pins the [T, k] -> [T, H] contract
+        per_choice = torch.einsum(
+            "td,tkdo->tko", x.float(), self.w[routing.indices].float()
+        )
+        return (routing.weights.unsqueeze(-1) * per_choice).sum(1).to(x.dtype)
+
+
+class _StubShared(SharedExpert):
+    def __init__(self, cfg, hidden_size):
+        super().__init__(cfg, hidden_size)
+        self.proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+def setUpModule():
+    register_score_function("_test_softplus")(torch.nn.functional.softplus)
+    register_router("_test_router")(_StubRouter)
+    register_balance_controller("_test_balance")(_StubBalance)
+    register_experts_backend("_test_experts")(_StubExperts)
+    register_shared_expert("_test_shared")(_StubShared)
+    register_moe_preset(
+        PRESET,
+        scoring_func="_test_softplus",
+        router="_test_router",
+        balance="_test_balance",
+        experts_backend="_test_experts",
+        shared_expert="_test_shared",
+        routed_scaling_factor=1.5,
+    )
+
+
+def tearDownModule():
+    SCORE_FUNCTIONS.unregister("_test_softplus")
+    ROUTERS.unregister("_test_router")
+    BALANCE_CONTROLLERS.unregister("_test_balance")
+    EXPERTS_BACKENDS.unregister("_test_experts")
+    SHARED_EXPERTS.unregister("_test_shared")
+    MOE_PRESETS.unregister(PRESET)
+
+
+def _moe_json(**overrides):
+    payload = dict(
+        hidden_size=16,
+        moe_preset=PRESET,
+        n_routed_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        dflash_config={},
+    )
+    payload.update(overrides)
+    return payload
+
+
+def _dflash_config(moe=True, **overrides):
+    fields = dict(
+        architectures=["DFlashDraftModel"],
+        block_size=2,
+        hidden_size=16,
+        intermediate_size=32,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_hidden_layers=2,
+        num_target_layers=6,
+        head_dim=8,
+        max_position_embeddings=64,
+        vocab_size=32,
+        layer_types=["full_attention", "full_attention"],
+        dflash_config={"attention_mode": "gqa"},
+    )
+    if moe:
+        fields.update(_moe_json(hidden_size=16))
+        fields["dflash_config"] = {
+            "attention_mode": "gqa",
+            "moe_bias_update_rate": 0.005,
+        }
+    fields.update(overrides)
+    config = Qwen3Config(**fields)
+    config._attn_implementation = "sdpa"
+    return config
+
+
+class TestMoEConfig(unittest.TestCase):
+    def test_dense_config_resolves_to_none(self):
+        self.assertIsNone(resolve_moe_config({"hidden_size": 16}))
+        self.assertIsNone(resolve_moe_config(SimpleNamespace(n_routed_experts=0)))
+
+    def test_preset_is_required_for_moe(self):
+        with self.assertRaisesRegex(ValueError, "moe_preset"):
+            resolve_moe_config(_moe_json(moe_preset=None))
+        with self.assertRaisesRegex(KeyError, "available"):
+            resolve_moe_config(_moe_json(moe_preset="no-such-family"))
+
+    def test_preset_defaults_and_explicit_overrides(self):
+        cfg = resolve_moe_config(_moe_json())
+        self.assertEqual(cfg.preset, PRESET)
+        self.assertEqual(cfg.scoring_func, "_test_softplus")
+        self.assertEqual(cfg.routed_scaling_factor, 1.5)
+        self.assertEqual(
+            cfg.shared_expert_intermediate_size, 8
+        )  # defaults to moe width
+        cfg = resolve_moe_config(
+            _moe_json(routed_scaling_factor=2.0, shared_expert_intermediate_size=4)
+        )
+        self.assertEqual(cfg.routed_scaling_factor, 2.0)
+        self.assertEqual(cfg.shared_expert_intermediate_size, 4)
+        # Works on attribute-style configs (HF PretrainedConfig) as well.
+        self.assertEqual(resolve_moe_config(_dflash_config()).n_routed_experts, 8)
+
+    def test_training_knobs_come_from_dflash_config(self):
+        cfg = resolve_moe_config(
+            _moe_json(
+                dflash_config={
+                    "moe_bias_update_rate": 0.01,
+                    "moe_dispatch": "grouped_mm",
+                }
+            )
+        )
+        self.assertEqual(cfg.bias_update_rate, 0.01)
+        self.assertEqual(cfg.dispatch, "grouped_mm")
+        with self.assertRaisesRegex(ValueError, "unknown MoE training keys"):
+            resolve_moe_config(_moe_json(dflash_config={"moe_bias_udpate_rate": 1}))
+
+    def test_validation(self):
+        with self.assertRaisesRegex(ValueError, "num_experts_per_tok"):
+            resolve_moe_config(_moe_json(num_experts_per_tok=9))
+        with self.assertRaisesRegex(ValueError, "n_shared_experts"):
+            resolve_moe_config(_moe_json(n_shared_experts=2))
+        with self.assertRaisesRegex(ValueError, "n_group"):
+            resolve_moe_config(_moe_json(n_group=3))
+        cfg = resolve_moe_config(_moe_json(n_group=4, topk_group=2))
+        self.assertTrue(cfg.group_limited)
+        self.assertFalse(resolve_moe_config(_moe_json()).group_limited)
+
+    def test_presets_cannot_set_per_run_or_training_fields(self):
+        with self.assertRaisesRegex(ValueError, "per-run/training"):
+            register_moe_preset("_bad", n_routed_experts=4)
+        with self.assertRaisesRegex(ValueError, "unknown MoEConfig fields"):
+            register_moe_preset("_bad", nonsense=1)
+        self.assertNotIn("_bad", MOE_PRESETS)
+
+    def test_registry_errors_name_the_kind_and_choices(self):
+        with self.assertRaisesRegex(KeyError, "MoE router.*available"):
+            ROUTERS.get("missing")
+        with self.assertRaisesRegex(ValueError, "already registered"):
+            register_router("_test_router")(_StubRouter.__mro__[1])
+        self.assertIn("none", BALANCE_CONTROLLERS)
+
+
+class TestMoELayerComposition(unittest.TestCase):
+    def _layer(self, **overrides):
+        torch.manual_seed(0)
+        cfg = resolve_moe_config(_moe_json(**overrides))
+        layer = MoELayer(cfg, 16)
+        layer.reset_parameters(std=0.02)
+        return layer
+
+    def test_dense_config_uses_the_dense_factory_verbatim(self):
+        sentinel = nn.Identity()
+        self.assertIs(
+            build_ffn(SimpleNamespace(hidden_size=16), lambda c: sentinel), sentinel
+        )
+
+    def test_moe_config_builds_official_attribute_layout(self):
+        layer = build_ffn(SimpleNamespace(**_moe_json()), lambda c: nn.Identity())
+        self.assertIsInstance(layer, MoELayer)
+        names = {name for name, _ in layer.named_children()}
+        self.assertEqual(names, {"gate", "experts", "shared_experts"})
+        self.assertIsInstance(layer.gate.balance, _StubBalance)
+        self.assertIs(layer.balance, layer.gate.balance)
+
+    def test_forward_preserves_shape_and_adds_shared_expert(self):
+        layer = self._layer()
+        x = torch.randn(2, 3, 16)
+        y = layer(x)
+        self.assertEqual(y.shape, x.shape)
+        routed_only = self._layer(n_shared_experts=0)
+        self.assertIsNone(routed_only.shared_experts)
+        routed_only.load_state_dict(
+            {k: v for k, v in layer.state_dict().items() if "shared" not in k}
+        )
+        shared = layer.shared_experts(x.reshape(-1, 16)).view_as(x)
+        self.assertTrue(torch.allclose(y, routed_only(x) + shared, atol=1e-5))
+
+    def test_training_observes_counts_and_eval_does_not(self):
+        layer = self._layer().train()
+        x = torch.randn(5, 16)
+        layer(x)
+        self.assertEqual(len(layer.balance.observed), 1)
+        self.assertEqual(int(layer.balance.observed[0].sum()), 5 * 2)
+        self.assertTrue(torch.equal(layer.last_counts, layer.balance.observed[0]))
+        layer.eval()
+        layer(x)
+        self.assertEqual(len(layer.balance.observed), 1)
+
+    def test_model_hooks_delegate_to_the_controller(self):
+        layer = self._layer(dflash_config={"moe_aux_loss_coeff": 0.25}).train()
+        layer(torch.randn(4, 16))
+        layer.apply_pending_balance_update()
+        self.assertEqual(layer.balance.applied, 1)
+        self.assertAlmostEqual(float(layer.aux_loss()), 0.25)
+        metrics = layer.metrics()
+        self.assertEqual(
+            set(metrics),
+            {"load_max_ratio", "load_min_ratio", "experts_unused_frac", "stub_metric"},
+        )
+        self.assertGreaterEqual(float(metrics["load_max_ratio"]), 1.0)
+        self.assertLessEqual(float(metrics["load_min_ratio"]), 1.0)
+
+    def test_selection_bias_changes_choice_not_weights(self):
+        layer = self._layer().eval()
+        x = torch.randn(1, 16)
+        before = layer.gate(x)
+        layer.balance.bias[:] = -1e3
+        favored = int((before.indices[0, 0] + 1) % 8)
+        layer.balance.bias[favored] = 0.0
+        after = layer.gate(x)
+        self.assertIn(favored, after.indices[0].tolist())
+        # combine weights come from raw scores: still normalized and scaled
+        self.assertAlmostEqual(float(after.weights.detach().sum()), 1.5, places=5)
+
+
+class TestHooks(unittest.TestCase):
+    def _tree(self, **overrides):
+        cfg = resolve_moe_config(_moe_json(**overrides))
+        a, b = MoELayer(cfg, 16), MoELayer(cfg, 16)
+        for layer in (a, b):
+            layer.reset_parameters(std=0.02)
+        return nn.Sequential(nn.Linear(16, 16), a, nn.Linear(16, 16), b), (a, b)
+
+    def test_iteration_updates_and_aggregation(self):
+        tree, (a, b) = self._tree(dflash_config={"moe_aux_loss_coeff": 0.5})
+        self.assertEqual(list(iter_moe_layers(tree)), [a, b])
+        tree.train()(torch.randn(3, 16))
+        apply_pending_balance_updates(tree)
+        self.assertEqual((a.balance.applied, b.balance.applied), (1, 1))
+        self.assertAlmostEqual(float(collect_moe_aux_loss(tree)), 1.0)
+        metrics = collect_moe_metrics(tree)
+        self.assertTrue(all(key.startswith("moe/") for key in metrics))
+        self.assertAlmostEqual(float(metrics["moe/stub_metric"]), 1.0)
+
+    def test_dense_trees_are_inert(self):
+        dense = nn.Sequential(nn.Linear(16, 16))
+        apply_pending_balance_updates(dense)
+        self.assertIsNone(collect_moe_aux_loss(dense))
+        self.assertEqual(collect_moe_metrics(dense), {})
+        self.assertEqual(_moe_metrics(SimpleNamespace()), {})
+
+    def test_strategy_metrics_read_the_wrapped_draft(self):
+        tree, _ = self._tree()
+        tree.train()(torch.randn(3, 16))
+        metrics = _moe_metrics(SimpleNamespace(draft_model=tree))
+        self.assertIn("moe/load_max_ratio", metrics)
+
+
+class TestStateDictBoundary(unittest.TestCase):
+    def test_dense_state_passes_through_unchanged(self):
+        state = {"a": torch.zeros(1), "layers.0.mlp.gate_proj.weight": torch.ones(1)}
+        for convert in (to_checkpoint_state_dict, from_checkpoint_state_dict):
+            out = convert(dict(state))
+            self.assertEqual(set(out), set(state))
+            for key in state:
+                self.assertIs(out[key], state[key])
+
+    def test_registered_converters_apply_in_both_directions(self):
+        def to_ckpt(state):
+            return {k.replace("native.", "official."): v for k, v in state.items()}
+
+        def from_ckpt(state):
+            return {k.replace("official.", "native."): v for k, v in state.items()}
+
+        register_state_dict_converter(
+            "_test", to_checkpoint=to_ckpt, from_checkpoint=from_ckpt
+        )
+        try:
+            with self.assertRaisesRegex(ValueError, "already registered"):
+                register_state_dict_converter(
+                    "_test", to_checkpoint=to_ckpt, from_checkpoint=from_ckpt
+                )
+            official = to_checkpoint_state_dict({"native.w": 1, "other": 2})
+            self.assertEqual(official, {"official.w": 1, "other": 2})
+            self.assertEqual(
+                from_checkpoint_state_dict(official), {"native.w": 1, "other": 2}
+            )
+        finally:
+            unregister_state_dict_converter("_test")
+        self.assertEqual(to_checkpoint_state_dict({"native.w": 1}), {"native.w": 1})
+
+
+class TestWarmStartPlan(unittest.TestCase):
+    def test_selection_strategies(self):
+        self.assertEqual(select_target_experts(256, 4), (0, 64, 128, 192))
+        self.assertEqual(select_target_experts(8, 3, "strided"), (0, 2, 5))
+        self.assertEqual(select_target_experts(8, 3, "first"), (0, 1, 2))
+        self.assertEqual(len(set(select_target_experts(256, 64))), 64)
+        with self.assertRaises(ValueError):
+            select_target_experts(4, 8)
+        with self.assertRaises(ValueError):
+            select_target_experts(8, 2, "random")
+
+    def test_plan_follows_the_moe_config(self):
+        cfg = resolve_moe_config(_moe_json(n_shared_experts=0))
+        plan = plan_warm_start(cfg, n_target_experts=64)
+        self.assertEqual(plan.n_draft_experts, 8)
+        self.assertFalse(plan.copy_shared_expert)
+        self.assertTrue(plan.copy_gate_rows)
+
+
+class TestDFlashWiring(unittest.TestCase):
+    def _forward(self, model):
+        return model(
+            position_ids=torch.arange(6).unsqueeze(0),
+            noise_embedding=torch.randn(1, 2, 16),
+            target_hidden=torch.randn(1, 4, 2 * 16),
+        )
+
+    def test_dense_draft_is_unchanged(self):
+        model = DFlashDraftModel(_dflash_config(moe=False))
+        for layer in model.layers:
+            self.assertIsInstance(layer.mlp, Qwen3MLP)
+        self.assertEqual(list(iter_moe_layers(model)), [])
+
+    def test_moe_draft_layers_init_and_apply_balance_updates(self):
+        model = DFlashDraftModel(_dflash_config())
+        layers = list(iter_moe_layers(model))
+        self.assertEqual(len(layers), 2)
+        for layer in layers:
+            self.assertIs(layer, [m for m in model.layers if m.mlp is layer][0].mlp)
+            self.assertEqual(layer.cfg.bias_update_rate, 0.005)
+            # _init_weights reached the bare Parameters (no uninitialized memory)
+            self.assertTrue(torch.isfinite(layer.gate.weight).all())
+            self.assertGreater(float(layer.gate.weight.abs().sum()), 0.0)
+            self.assertTrue(torch.isfinite(layer.experts.w).all())
+        model.train()
+        self._forward(model)
+        self._forward(model)
+        self.assertEqual([layer.balance.applied for layer in layers], [2, 2])
+        self.assertEqual([len(layer.balance.observed) for layer in layers], [2, 2])
+        model.eval()
+        self._forward(model)
+        self.assertEqual([layer.balance.applied for layer in layers], [2, 2])
+
+    def test_state_dict_names_follow_the_official_layout(self):
+        model = DFlashDraftModel(_dflash_config())
+        keys = set(model.state_dict())
+        self.assertIn("layers.0.mlp.gate.weight", keys)
+        self.assertIn("layers.0.mlp.shared_experts.proj.weight", keys)
+        self.assertTrue(any(k.startswith("layers.0.mlp.experts.") for k in keys))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_modeling/test_moe.py
+++ b/tests/test_modeling/test_moe.py
@@ -63,8 +63,9 @@ class _StubBalance(BalanceController):
     def adjust_selection_scores(self, scores):
         return scores + self.bias
 
-    def observe(self, counts):
-        self.observed.append(counts.detach().clone())
+    def observe(self, routing):
+        self.observed.append(routing.counts.detach().clone())
+        self.saw_scores = routing.scores is not None
 
     def apply_pending_update(self):
         self.applied += 1
@@ -97,7 +98,9 @@ class _StubRouter(Router):
         counts = torch.zeros(
             self.n_experts, dtype=torch.long, device=x.device
         ).scatter_add_(0, indices.flatten(), torch.ones_like(indices.flatten()))
-        return RoutingResult(weights=weights, indices=indices, counts=counts)
+        return RoutingResult(
+            weights=weights, indices=indices, counts=counts, scores=scores
+        )
 
 
 class _StubExperts(RoutedExperts):
@@ -301,6 +304,7 @@ class TestMoELayerComposition(unittest.TestCase):
         self.assertEqual(len(layer.balance.observed), 1)
         self.assertEqual(int(layer.balance.observed[0].sum()), 5 * 2)
         self.assertTrue(torch.equal(layer.last_counts, layer.balance.observed[0]))
+        self.assertTrue(layer.balance.saw_scores)
         layer.eval()
         layer(x)
         self.assertEqual(len(layer.balance.observed), 1)


### PR DESCRIPTION
Stacked on #798 (`kan/pr2-dsv4-dspark`); retarget as the stack merges. First of two: this PR lays out the MoE FFN package (modules, contracts, config, and every trainer/checkpoint seam) with **no routing math**; the follow-up adds the DeepSeek-V4 implementation and the DSV4-Flash ablation arm. Together they supersede #799.

## Design

One configurable MoE layer with swappable components, not one block per target family (the Megatron-Core split; see `specforge/modeling/draft/moe/DESIGN.md`). Family differences are a handful of small functions (score function, balancing policy, renorm/scale, shared-expert gate, activation clamp); the expensive parts (dispatch, checkpoint naming, FSDP layout, deferred balance-update timing) are shared.

```
specforge/modeling/draft/moe/
  config.py      MoEConfig + moe_preset registry; resolve_moe_config(draft_config)
  router.py      Router contract (x -> RoutingResult) + score-function registry
  balance.py     BalanceController contract (selection shift / observe / deferred apply / aux loss / metrics)
  experts.py     RoutedExperts contract (weights + dispatch)
  shared.py      SharedExpert contract
  layer.py       MoELayer = gate + experts + shared_experts; build_ffn() is the dense/MoE switch
  hooks.py       apply_pending_balance_updates / collect_moe_aux_loss / collect_moe_metrics
  state_dict.py  to/from_checkpoint_state_dict: module layout <-> official file naming
  init.py        WarmStartPlan / select_target_experts
```

**Config contract.** Architecture keys use the target checkpoints' native HF names at the draft-JSON top level (`n_routed_experts`, `num_experts_per_tok`, `moe_intermediate_size`, `scoring_func`, `routed_scaling_factor`, ...) so a draft JSON can copy them from the target's `config.json`; `moe_preset` supplies a family's defaults and any explicit key overrides it for ablations. Training-only knobs live under `dflash_config` as `moe_*` and never touch the checkpoint.

**Seams wired here** (so the implementation PR is components only):
- `Qwen3DFlashDecoderLayer` builds its FFN through `build_ffn(config, dense=kernels.make_mlp)`: dense drafts get the kernel provider's MLP verbatim (DFlash, DFlash2 and DSpark all inherit).
- `DFlashDraftModel._init_weights` reaches MoE bare Parameters; the model forward applies pending balance updates in training, outside activation-checkpoint regions.
- DFlash/DSpark strategies add `moe/*` load metrics to `StepOutput.metrics` (DP-averaged and logged like any scalar).
- Checkpoint-naming boundary applied in `FSDPTrainingBackend` save/load, warm start, `materialize_draft`, and both exporters. FSDP's full-state-dict hooks index by the module's own FQNs, so the rename cannot live inside `state_dict()`.

## Tests
`tests/test_modeling/test_moe.py` pins the contracts with stub components: config resolution/validation/presets, registries, `MoELayer` composition (shape, shared-expert add, train-only observe, hook delegation, selection bias affects choice not weights), hooks over module trees, the state-dict boundary, warm-start plans, and DFlash wiring (dense unchanged; MoE layers initialized; balance updates applied per training forward). Existing modeling/training/export/loading suites pass unchanged.

## Not in this PR
Any preset, score function, controller, experts backend or shared expert. Aux-loss consumption in an objective (collected, not yet wired; the first preset with an aux-loss policy adds it).
