### PR TITLE
docs: say examples support offline evaluation only

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,7 +51,7 @@ guide](../docs/basic_usage/disaggregated_training.md).
 
 Offline feature training supports EAGLE3, DFlash, Domino, and DSpark, including
 local and disaggregated consumers. Optional config sections provide
-online/offline evaluation with `<run_id>-best` selection, compact teacher
+offline evaluation with `<run_id>-best` selection, compact teacher
 projection for offline text EAGLE3, and W&B, TensorBoard, SwanLab, or MLflow
 tracking. See the [training guide](../docs/basic_usage/training.md) for the full
 capability matrix, ROCm installation, and Ascend NPU/HCCL launch example.


### PR DESCRIPTION
## Summary
`examples/README.md` said optional config sections provide **online/offline** evaluation with `<run_id>-best` selection. Online evaluation is unsupported: the same README already says so, `specforge/config/schema.py` rejects `data.eval_data_path`, and both `examples/configs/README.md` and `docs/basic_usage/training.md` document eval as offline-only.

One-line wording fix: **online/offline** → **offline**.

## Repro
```bash
gh api repos/sgl-project/SpecForge/contents/examples/README.md \
  -H 'Accept: application/vnd.github.raw' | rg -n 'online/offline evaluation|Online evaluation is also unsupported'

gh api repos/sgl-project/SpecForge/contents/specforge/config/schema.py \
  -H 'Accept: application/vnd.github.raw' | nl -ba | sed -n '139,142p;773,787p'
```

## Test plan
- [x] Confirmed schema raises on `eval_data_path` and requires offline mode for `eval_hidden_states_path`
- [x] Aligned the examples README sentence with configs README + training.md
- [x] Single-file wording change only
