### PR TITLE
docs: add MTP to Supported Methods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ There are no method-specific Python training entry points.
 | **[DFlash2](https://inco.ai/blog/dflash2/)** | DFlash with grouped dynamic convolution and top-k path selection | [Online managed-local](./examples/configs/online/disaggregated/managed-local/qwen3.6-27b-dflash2-disaggregated.yaml) | [D-PACE](https://arxiv.org/abs/2605.18810)|
 | **[Domino](https://arxiv.org/html/2605.29707v1)** | DFlash with GRU logit correction | [Online external](./examples/configs/online/disaggregated/external/qwen3-8b-domino-online.yaml) / [Offline colocated](./examples/configs/offline/colocated/qwen3-8b-domino-offline.yaml) / [Online managed-local](./examples/configs/online/disaggregated/managed-local/qwen3-8b-domino-multiserver-disaggregated.yaml) | — |
 | **[DSpark](https://arxiv.org/abs/2607.05147)** | Confidence-Scheduled Semi-Autoregressive Generation | [Online external](./examples/configs/online/disaggregated/external/qwen3-4b-dspark-disaggregated.yaml) / [Offline colocated](./examples/configs/offline/colocated/qwen3-4b-dspark-offline.yaml) | — |
+| MTP | Native Multi-Token Prediction draft head (e.g. Qwen3.5) | Online managed-local (Ascend) | — |
 
 See the [training guide](./docs/basic_usage/training.md) for the supported
 method/topology matrix and the


### PR DESCRIPTION
## Summary

Root `README.md` **Supported Methods** lists EAGLE3 / P-EAGLE / EAGLE3.1 / DFlash / DFlash2 / Domino / DSpark but omits **MTP**, which is already registered and documented elsewhere.

This PR adds an MTP row to the Supported Methods table so the README matches the rest of the tree.

## Repro (verified on `main` @ `bc5d8451`)

```bash
# Methods named in README Supported Methods table
rg -n '^\| \*\*' README.md

# MTP is registered as a builtin algorithm
rg -n 'mtp' specforge/algorithms/builtin.py

# MTP appears in the training method matrix
rg -n 'MTP' docs/basic_usage/training.md

# Example Ascend managed-local config exists
ls examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml
```

Observed: README Supported Methods has no MTP row; `builtin.py`, `training.md`, and the managed-local NPU config all include MTP.

## Change

Add:

`| MTP | Native Multi-Token Prediction draft head (e.g. Qwen3.5) | Online managed-local (Ascend) | — |`

## Test plan

- [ ] Confirm Supported Methods table columns still align (Method / Description / Example config / Optimization)
- [ ] Confirm the new MTP row matches existing MTP docs and the managed-local Ascend example path
- [ ] Spot-check markdown render of the table on GitHub