### PR TITLE
docs: add MTP attention backends to customization table

### DIFF
--- a/docs/advanced_features/customization.md
+++ b/docs/advanced_features/customization.md
@@ -58,6 +58,7 @@ strategy-specific set:
 | EAGLE3 | `sdpa`, `flex_attention`, `fa`, offline `usp` |
 | P-EAGLE | `flex_attention` |
 | DFlash, DFlash2, Domino, DSpark | `eager`, `sdpa`, `flex_attention` |
+| MTP | `eager`, `sdpa` |
 
 ## Target models
 


### PR DESCRIPTION
## Summary
- Add the missing **MTP** row to the strategy-specific attention-backend table in `docs/advanced_features/customization.md`.
- Documented values match the MTP algorithm provider (`eager`, `sdpa`) and the training guide.

## Repro
1. Open `docs/advanced_features/customization.md` on `main`: the attention-backend table lists EAGLE3, P-EAGLE, and DFlash-family only.
2. Compare with `docs/basic_usage/training.md` (MTP accepts `eager` or `sdpa`) and `specforge/algorithms/mtp/providers.py` (`attention_backends={"eager", "sdpa"}`).
3. The customization table previously omitted MTP despite MTP being a supported strategy (e.g. `examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml`).

## Test plan
- [ ] Confirm the new table row renders correctly in the docs site / markdown preview
- [ ] Spot-check against `training.md` MTP backend wording