### PR TITLE
fix(domino): normalize training loss by the global token count

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -1034,6 +1034,13 @@ class OnlineDominoModel(OnlineDFlashModel):
             "lambda_base": float(lambda_base),
             "accuracy_denom": accuracy_denom.detach(),
         }
+        # Hand the trainer raw numerator/denominator so gradients are
+        # normalized by the globally reduced token count instead of a
+        # mean of per-rank ratios.
+        metrics["loss_terms"] = (
+            (1.0 - lambda_base) * final_num + lambda_base * base_num,
+            loss_den.detach(),
+        )
 
         return loss, accuracy, metrics
 

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -705,7 +705,11 @@ class DominoTrainStrategy(DraftTrainStrategy):
             "lambda_base",
             float(lambda_base),
         )
-        return StepOutput(loss=loss, metrics=metrics)
+        return StepOutput(
+            loss=loss,
+            metrics=metrics,
+            loss_terms=model_metrics.get("loss_terms"),
+        )
 
     def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
         # Everything trainable lives under draft_model.; the target

--- a/tests/test_modeling/test_domino_model.py
+++ b/tests/test_modeling/test_domino_model.py
@@ -110,6 +110,67 @@ class TestDominoDraftModel(unittest.TestCase):
                 0.0,
             )
 
+    def test_loss_terms_carry_blended_numerator_and_token_count(self):
+        from specforge.algorithms.common.dflash_family_model import OnlineDominoModel
+
+        torch.manual_seed(11)
+        hidden_size, vocab_size, block_size = 4, 7, 4
+        draft = _bare_domino(
+            hidden_size=hidden_size,
+            gru_hidden_size=3,
+            embedding_size=2,
+            vocab_size=vocab_size,
+            block_size=block_size,
+        )
+        model = OnlineDominoModel(
+            draft_model=draft,
+            target_lm_head=nn.Linear(hidden_size, vocab_size, bias=False),
+            target_embed_tokens=nn.Embedding(vocab_size, hidden_size),
+            mask_token_id=0,
+            block_size=block_size,
+            attention_backend="sdpa",
+            num_anchors=1,
+            shift_label=False,
+        )
+        fixed_hidden = torch.randn(1, block_size, hidden_size)
+
+        def fixed_draft_blocks(
+            self,
+            input_ids,
+            hidden_states,
+            loss_mask,
+            max_valid_anchors=None,
+        ):
+            del hidden_states, loss_mask, max_valid_anchors
+            return (
+                torch.zeros(1, 1, dtype=torch.long, device=input_ids.device),
+                torch.ones(1, 1, dtype=torch.bool, device=input_ids.device),
+                fixed_hidden.to(input_ids.device),
+            )
+
+        model._forward_draft_blocks = MethodType(fixed_draft_blocks, model)
+        for lambda_base in (0.0, 0.4):
+            with self.subTest(lambda_base=lambda_base):
+                loss, _accuracy, metrics = model(
+                    input_ids=torch.tensor([[1, 2, 3, 4]]),
+                    hidden_states=torch.zeros(1, block_size, hidden_size),
+                    loss_mask=torch.ones(1, block_size),
+                    lambda_base=lambda_base,
+                )
+                numerator, denominator = metrics["loss_terms"]
+                self.assertEqual(numerator.numel(), 1)
+                self.assertEqual(denominator.numel(), 1)
+                self.assertTrue(numerator.requires_grad)
+                self.assertFalse(denominator.requires_grad)
+                self.assertGreater(denominator.item(), 0.0)
+                self.assertTrue(
+                    torch.isclose(
+                        numerator / denominator,
+                        loss.detach(),
+                        atol=1e-5,
+                    )
+                )
+
     def test_chunked_objective_matches_full_loss_metrics_and_gradients(self):
         from specforge.algorithms.common.dflash_family_model import OnlineDominoModel
 


### PR DESCRIPTION
## Motivation

`OnlineDominoModel` normalizes the loss by the rank-local token count, so under DDP/FSDP the averaged gradient is a mean of per-rank ratios instead of the global token-weighted objective. When ranks hold uneven numbers of supervised tokens, tokens on low-count ranks are over-weighted. DFlash/DSpark/MTP already avoid this via `loss_terms`; Domino was the remaining one.

## Modifications

- `OnlineDominoModel` returns `loss_terms` so the trainer normalizes by the globally reduced token count, same as the DFlash path.
- `DominoTrainStrategy` forwards `loss_terms`.
- Unit test for the numerator/denominator contract.

Single-rank behavior is unchanged. `train/loss` telemetry switches to the global ratio; `final_loss`/`base_loss` stay rank-local averages.

## Accuracy Test

`tests/test_modeling/test_domino_model.py` + domino parity/launch suites pass on CPU.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-ci).
- [ ] Update documentation / docstrings / example tutorials as needed.
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed.
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.