### PR TITLE
fix dflash mask device

### DIFF
--- a/tests/test_utils/test_dflash_mask.py
+++ b/tests/test_utils/test_dflash_mask.py
@@ -12,6 +12,7 @@ from specforge.algorithms.common.dflash_family_model import (
     create_dflash_block_mask,
     create_dflash_sdpa_mask,
 )
+from specforge.utils import get_device_type
 
 
 def _reference_dflash_mask(
@@ -79,7 +80,7 @@ class TestDFlashMask(unittest.TestCase):
 
     def setUp(self):
         torch.manual_seed(42)
-        self.device = torch.device("cuda")
+        self.device = torch.device(get_device_type())
 
     def _compare_masks(
         self,


### PR DESCRIPTION
## Motivation

The DFlash mask tests hardcode `torch.device("cuda")`, so the whole file fails on hosts without a GPU (34 failed, 3 passed on CPU). The mask logic under test is pure tensor ops with no CUDA dependency.

## Modifications

`setUp` uses `get_device_type()` (cuda > npu > cpu) instead of the hardcoded cuda device. No test logic changed.

## Accuracy Test

`tests/test_utils/test_dflash_mask.py`: 23 passed, 23 subtests passed on CPU (previously 34 failed, 3 passed).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.