### PR TITLE
docs: clarify MTP needs merge_mtp_to_base (not shared export)

### DIFF
--- a/docs/get_started/about.md
+++ b/docs/get_started/about.md
@@ -16,5 +16,7 @@ As SpecForge is built by the SGLang team, draft models trained with SpecForge
 can be exported for [SGLang](https://github.com/sgl-project/sglang) serving.
 Runtime checkpoints retain training state, so materialize a serving directory
 with the shared `specforge export` command. SGLang and Hugging Face export
-targets use the same checkpoint surface; there are no method-specific
-conversion scripts.
+targets use the same checkpoint surface for most methods. MTP is the
+exception: merge the trained head back into the target with
+`scripts/merge_mtp_to_base.py` rather than `specforge export` alone (see
+[Export a trained draft](../basic_usage/training.md#export-a-trained-draft)).


### PR DESCRIPTION
## What drifted

`docs/get_started/about.md` (SGLang-ready) claimed that SGLang/HF export targets share one checkpoint surface and that **there are no method-specific conversion scripts**.

## Truth

Most methods do share `specforge export`, but **MTP does not**: serving requires merging the trained MTP head back into the target via `scripts/merge_mtp_to_base.py` (thin wrapper around `specforge.export.mtp.merge_mtp_into_base`). That path is already documented under [Export a trained draft](https://github.com/sgl-project/SpecForge/blob/main/docs/basic_usage/training.md#export-a-trained-draft) in `docs/basic_usage/training.md`.

## Fix

Smallest wording change in `about.md`: keep the shared-export story for other methods, and note MTP’s `merge_mtp_to_base.py` exception with a pointer to the training Export section.

## Local repro

```bash
# Stale claim still on default branch before this PR:
curl -sL https://raw.githubusercontent.com/sgl-project/SpecForge/main/docs/get_started/about.md | rg -n "method-specific|conversion scripts|merge_mtp"

# MTP merge script exists and points at the package helper:
curl -sL https://raw.githubusercontent.com/sgl-project/SpecForge/main/scripts/merge_mtp_to_base.py | rg -n "merge_mtp_into_base|merge_mtp_to_base"

# Export docs already describe the MTP merge path:
curl -sL https://raw.githubusercontent.com/sgl-project/SpecForge/main/docs/basic_usage/training.md | rg -n "merge_mtp_to_base|MTP is deployed"
```

## Related

- `scripts/merge_mtp_to_base.py`
- `docs/basic_usage/training.md` → Export a trained draft