### PR TITLE
docs: drop stale DTA references

### DIFF
--- a/docs/basic_usage/data_preparation.md
+++ b/docs/basic_usage/data_preparation.md
@@ -314,9 +314,7 @@ uses the intended `target_layer_ids`. Its convolution, selector, and selector
 loss schedule are draft/trainer concerns and do not add tensors to the offline
 record.
 
-D-PACE uses `training.strategy: dflash` and the DFlash feature schema. DTA also
-uses `--strategy dflash`, but feature preparation must receive its DTA draft
-config so the captured layer contract matches the training run.
+D-PACE uses `training.strategy: dflash` and the DFlash feature schema.
 
 For preformatted input, add `--is-preformatted` to the same command and keep
 `--chat-template` aligned with the template already applied to the text:

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -564,6 +564,3 @@ Migration notes:
 - The old Qwen3.5-35B offline shell had its training command commented out. The
   YAML records that intended offline trainer configuration after feature
   preparation.
-- Qwen3-8B DTA still shares the DFlash trainer, as before. Its specialized
-  behavior is encoded by the draft JSON (`training_mode: vp_drafter`); there is
-  no second DTA training entry.


### PR DESCRIPTION
## Summary
- Remove orphaned **DTA** guidance from `docs/basic_usage/data_preparation.md` (kept the valid D-PACE note).
- Remove the migration note claiming a Qwen3-8B DTA draft JSON with `training_mode: vp_drafter` from `examples/configs/README.md`.

Verified on `main`: builtin algorithms are eagle3/peagle/dflash/domino/dspark/mtp; draft registry has no DTA; no `vp_drafter` / `training_mode` in any `configs/*.json`.

## Test plan
- [ ] Confirm rendered docs no longer mention DTA / vp_drafter
- [ ] Confirm D-PACE sentence remains in data preparation