### PR TITLE
feat(core): add fused loss kernels

### DIFF
--- a/specforge/core/fused_loss.py
+++ b/specforge/core/fused_loss.py
@@ -1,0 +1,642 @@
+"""
+This file incorporates code from vllm-project/speculators licensed under
+the Apache License, Version 2.0. See the original repository at
+https://github.com/vllm-project/speculators (file: src/speculators/losses/fused.py
+and losses/eager.py), derived in turn from specforge/core/loss.py
+(Unsloth / Liger-Kernel lineage).
+Changes for SpecForge: lazy Triton import so the module loads on hosts
+without Triton; eager reference co-located in the same module.
+
+Upstream kernel documentation (speculators losses/fused.py):
+
+One kernel pair serves every fused loss: forward streams the selected
+reduction from online-softmax statistics; backward recomputes probabilities
+from five saved scalars per row and applies the closed-form gradient. No
+``[T, V]`` intermediate is ever materialized or saved -- the memory win over
+the eager losses. ``OP`` picks the reduction at Triton specialization time;
+``nla`` and ``lk_hybrid`` are ``[1, T]`` torch compositions of the primitives
+instead of kernel branches.
+
+Per-row gradients (dp = softmax(logits), draft; tp = softmax(targets),
+treated as constant), L the row loss:
+
+    kl_div  dp - tp
+    rkl     dp * (log dp - log tp - L)
+    jsd     0.5 * dp * (log(dp / mix) - KL(dp || mix)),  mix = (dp + tp) / 2
+    ce      dp - onehot(argmax tp)
+    tv      -dp * (1[dp <= tp] - s_s),  s_s = sum of dp where dp <= tp
+"""
+
+# Triton kernels idiomatically use uppercase constexpr/dim names (B, T, V,
+# BLOCK_SIZE) and inline block-size tuning thresholds; exempt this file from the
+# pep8-naming and magic-value lints rather than fight those conventions.
+# ruff: noqa: N803, N806, PLR2004
+
+from __future__ import annotations
+
+import torch
+
+__all__ = [
+    # Fused Triton losses (require Triton plus a CUDA or Ascend NPU accelerator)
+    "fused_kl_div_loss",
+    "fused_reverse_kl_div_loss",
+    "fused_js_div_loss",
+    "fused_ce_loss",
+    "fused_tv_loss",
+    "fused_nla_loss",
+    "fused_lk_hybrid_loss",
+    # Eager reference/fallback implementations (pure PyTorch, CPU-safe)
+    "kl_div_loss",
+    "reverse_kl_div_loss",
+    "js_div_loss",
+    "ce_loss",
+    "tv_loss",
+    "neg_log_acceptance_loss",
+    "lk_hybrid_loss",
+]
+
+MAX_FUSED_SIZE = 131072
+# Ascend NPU's Unified Buffer (~192 KB) cannot fit the double-row load these
+# kernels perform (logits + targets per block) beyond 4096 elements per block;
+# triton-ascend raises "ub overflow" at BLOCK_SIZE >= 8192. CE is single-row
+# but shares the same cap so all _FusedLoss OPs use one path.
+MAX_FUSED_SIZE_NPU = 4096
+
+# tl.constexpr instances: Triton kernels may only read globals wrapped this way.
+# Plain values live at module scope so importing never needs Triton;
+# _require_triton() re-wraps them as tl.constexpr before the first launch.
+_LOG2 = 0.6931471805599453
+
+# Reduction selector, baked into the kernel at specialization time. Pass
+# ``.value`` (a plain int) across the autograd boundary -- Dynamo cannot
+# represent a constexpr object as an autograd.Function argument and would
+# graph-break; the ``OP: tl.constexpr`` parameter re-wraps it in the kernel.
+_OP_KL = 0
+_OP_RKL = 1
+_OP_JSD = 2
+_OP_CE = 3
+_OP_TV = 4
+
+# stats [_N_STATS, n_rows]: [0]/[1] draft row max / sum-exp, [2]/[3] same for
+# targets (unused by ce), [4] per-OP -- kl_div/rkl: row loss L | jsd:
+# KL(dp||mix) | tv: s_s | ce: argmax as float32 (exact: vocab < 2**24).
+_N_STATS = 5
+
+_NLA_EPS = 1e-5
+
+_TRITON_READY = False
+
+
+def _next_power_of_2(n):
+    """Pure-Python twin of ``triton.next_power_of_2``.
+
+    ``_calculate_settings`` must stay Triton-free so the device-cap logic (and
+    its unit tests) runs on hosts without Triton.
+    """
+    return 1 << (n - 1).bit_length() if n > 1 else 1
+
+
+def _calculate_settings(n, device):
+    max_size = MAX_FUSED_SIZE_NPU if device.type == "npu" else MAX_FUSED_SIZE
+    BLOCK_SIZE = min(_next_power_of_2(n), max_size)
+    # triton-ascend does not require extra num_warps tuning
+    num_warps = 4
+    if BLOCK_SIZE >= 32768:
+        num_warps = 32
+    elif BLOCK_SIZE >= 8192:
+        num_warps = 16
+    elif BLOCK_SIZE >= 2048:
+        num_warps = 8
+    if getattr(torch.version, "hip", None) is not None:  # AMD wavefronts are 64-wide
+        num_warps //= 2
+    return BLOCK_SIZE, num_warps
+
+
+# The kernel bodies below are verbatim from speculators losses/fused.py. Their
+# ``@triton.jit`` decorators are applied lazily by ``_require_triton()`` below
+# (which also publishes ``tl`` and the constexpr-wrapped globals the bodies
+# resolve at compile time), so importing this module never requires Triton.
+# The ``tl.constexpr`` annotations stay unevaluated strings thanks to the
+# ``__future__`` annotations import at the top of the file.
+def _online_stats(row_ptr, n_cols, BLOCK_SIZE: tl.constexpr):
+    """Online max (m) and sum-exp (d) over one row."""
+    m = float("-inf")
+    d = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(row_ptr + offsets, mask=mask, other=float("-inf")).cast(tl.float32)
+        block_max = tl.max(tl.where(mask, x, float("-inf")))
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.where(mask, tl.exp(x - m_new), 0.0))
+        m = m_new
+    return m, d
+
+
+def _log_mix(ldp, ltp):
+    """log((exp(ldp) + exp(ltp)) / 2): the JSD mixture, stable in log space."""
+    mx = tl.maximum(ldp, ltp)
+    return mx + tl.log(tl.exp(ldp - mx) + tl.exp(ltp - mx)) - _LOG2
+
+
+def loss_forward_kernel(  # noqa: C901 -- constexpr OP branches, pruned per instance
+    logits_ptr,
+    targets_ptr,
+    loss_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    OP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """One row per program: online softmax stats, then the OP's reduction.
+
+    Masked tail lanes can hold inf/nan before ``tl.where`` selects; they
+    never enter an accumulator.
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    targets_ptr += pid * n_cols
+
+    m_d, z_d = _online_stats(logits_ptr, n_cols, BLOCK_SIZE)
+    lse_d = m_d + tl.log(z_d)
+    tl.store(stats_ptr + 0 * stats_row + pid, m_d)
+    tl.store(stats_ptr + 1 * stats_row + pid, z_d)
+
+    if OP == _OP_CE:
+        # Only the target argmax is needed; no target softmax stats.
+        best_val = float("-inf")
+        best_idx = 0
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            y = tl.load(targets_ptr + offsets, mask=mask, other=float("-inf")).cast(
+                tl.float32
+            )
+            block_max = tl.max(y)
+            block_arg = tl.argmax(y, axis=0)
+            # strict > keeps the first occurrence, the torch.argmax convention
+            update = block_max > best_val
+            best_idx = tl.where(update, i + block_arg, best_idx)
+            best_val = tl.where(update, block_max, best_val)
+        logit_at_target = tl.load(logits_ptr + best_idx).cast(tl.float32)
+        tl.store(loss_ptr + pid, lse_d - logit_at_target)
+        # mypy reads traced Triton code as Python and types best_idx as int
+        tl.store(stats_ptr + 4 * stats_row + pid, best_idx.to(tl.float32))  # type: ignore[attr-defined]
+    else:
+        m_t, z_t = _online_stats(targets_ptr, n_cols, BLOCK_SIZE)
+        lse_t = m_t + tl.log(z_t)
+        tl.store(stats_ptr + 2 * stats_row + pid, m_t)
+        tl.store(stats_ptr + 3 * stats_row + pid, z_t)
+
+        acc = 0.0
+        extra = 0.0
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            ldp = x - lse_d
+            ltp = y - lse_t
+            dp = tl.exp(ldp)
+            tp = tl.exp(ltp)
+            if OP == _OP_KL:
+                acc += tl.sum(tl.where(mask, tp * (ltp - ldp), 0.0))
+            elif OP == _OP_RKL:
+                acc += tl.sum(tl.where(mask, dp * (ldp - ltp), 0.0))
+            elif OP == _OP_JSD:
+                lmp = _log_mix(ldp, ltp)
+                acc += tl.sum(tl.where(mask, dp * (ldp - lmp), 0.0))
+                extra += tl.sum(tl.where(mask, tp * (ltp - lmp), 0.0))
+            elif OP == _OP_TV:
+                acc += tl.sum(tl.where(mask, tl.minimum(dp, tp), 0.0))
+                extra += tl.sum(tl.where(mask & (dp <= tp), dp, 0.0))
+
+        # Lint exemptions: `in`/merged compares aren't constexpr-foldable here.
+        if OP == _OP_KL or OP == _OP_RKL:  # noqa: PLR1714, SIM109
+            tl.store(loss_ptr + pid, acc)
+            tl.store(stats_ptr + 4 * stats_row + pid, acc)
+        elif OP == _OP_JSD:
+            tl.store(loss_ptr + pid, 0.5 * (acc + extra))
+            tl.store(stats_ptr + 4 * stats_row + pid, acc)
+        elif OP == _OP_TV:
+            tl.store(loss_ptr + pid, 1.0 - acc)
+            tl.store(stats_ptr + 4 * stats_row + pid, extra)
+
+
+def loss_backward_kernel(
+    logits_ptr,
+    targets_ptr,
+    grad_in_ptr,
+    grad_out_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    OP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Recompute probabilities from the saved stats and apply the OP gradient."""
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    grad_in_ptr += pid * n_cols
+
+    go = tl.load(grad_out_ptr + pid).cast(tl.float32)
+    if go == 0.0:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            tl.store(grad_in_ptr + offsets, 0.0, mask=mask)
+        return
+
+    m_d = tl.load(stats_ptr + 0 * stats_row + pid)
+    z_d = tl.load(stats_ptr + 1 * stats_row + pid)
+    lse_d = m_d + tl.log(z_d)
+    extra = tl.load(stats_ptr + 4 * stats_row + pid)
+    if OP != _OP_CE:
+        # CE passes None for targets_ptr.
+        targets_ptr += pid * n_cols
+        m_t = tl.load(stats_ptr + 2 * stats_row + pid)
+        z_t = tl.load(stats_ptr + 3 * stats_row + pid)
+        lse_t = m_t + tl.log(z_t)
+    else:
+        target_idx = extra.to(tl.int32)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        ldp = x - lse_d
+        dp = tl.exp(ldp)
+        if OP == _OP_CE:
+            grad = dp - (offsets == target_idx).to(tl.float32)
+        else:
+            y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            ltp = y - lse_t
+            tp = tl.exp(ltp)
+            if OP == _OP_KL:
+                grad = dp - tp
+            elif OP == _OP_RKL:
+                grad = dp * (ldp - ltp - extra)
+            elif OP == _OP_JSD:
+                grad = 0.5 * dp * (ldp - _log_mix(ldp, ltp) - extra)
+            elif OP == _OP_TV:
+                grad = -dp * ((dp <= tp).to(tl.float32) - extra)
+        tl.store(grad_in_ptr + offsets, go * grad, mask=mask)
+
+
+def _require_triton():
+    """Import Triton and assemble the fused kernels on first fused-path use.
+
+    Triton is imported here rather than at module scope so this file still
+    imports on hosts without Triton (CPU-only boxes, or NPU images before
+    triton-ascend is installed); only the fused losses then fail, with a clear
+    error, while the eager references below remain usable.
+    """
+    global _TRITON_READY
+    if _TRITON_READY:
+        return
+    try:
+        import triton
+        import triton.language as tl
+    except ImportError as exc:
+        raise RuntimeError(
+            "The fused losses in specforge.core.fused_loss require Triton "
+            "(CUDA) or triton-ascend (NPU), which is not importable on this "
+            "host. Use the eager reference losses in this module instead."
+        ) from exc
+    module_globals = globals()
+    # Publish what the kernel bodies resolve from module globals at compile
+    # time, re-wrap the selectors/globals as tl.constexpr exactly as upstream
+    # defines them, and apply the deferred @triton.jit decorators.
+    module_globals["tl"] = tl
+    module_globals["_LOG2"] = tl.constexpr(_LOG2)
+    module_globals["_OP_KL"] = tl.constexpr(_OP_KL)
+    module_globals["_OP_RKL"] = tl.constexpr(_OP_RKL)
+    module_globals["_OP_JSD"] = tl.constexpr(_OP_JSD)
+    module_globals["_OP_CE"] = tl.constexpr(_OP_CE)
+    module_globals["_OP_TV"] = tl.constexpr(_OP_TV)
+    module_globals["_online_stats"] = triton.jit(_online_stats)
+    module_globals["_log_mix"] = triton.jit(_log_mix)
+    module_globals["loss_forward_kernel"] = triton.jit(loss_forward_kernel)
+    module_globals["loss_backward_kernel"] = triton.jit(loss_backward_kernel)
+    _TRITON_READY = True
+
+
+class _FusedLoss(torch.autograd.Function):
+    """Shared autograd wrapper; ``op`` selects the loss reduction.
+
+    Targets intentionally receive no gradient; use the eager implementation when
+    target gradients are required.
+    """
+
+    @staticmethod
+    def forward(ctx, logits, targets, op):
+        B, T, V = logits.shape
+        logits_flat = logits.contiguous().view(B * T, V)
+        targets_flat = targets.contiguous().view(B * T, V)
+        loss = torch.empty(B * T, device=logits.device, dtype=torch.float32)
+        stats = torch.empty(_N_STATS, B * T, device=logits.device, dtype=torch.float32)
+        BLOCK_SIZE, num_warps = _calculate_settings(V, logits_flat.device)
+        loss_forward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            loss,
+            stats,
+            stats.stride(0),
+            V,
+            OP=op,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        # CE backward only needs the target argmax cached in stats.
+        ctx.save_for_backward(
+            logits_flat, None if op == _OP_CE.value else targets_flat, stats
+        )
+        ctx.op = op
+        ctx.shape = (B, T, V)
+        ctx.settings = (BLOCK_SIZE, num_warps)
+        return loss.view(B, T)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits_flat, targets_flat, stats = ctx.saved_tensors
+        B, T, V = ctx.shape
+        BLOCK_SIZE, num_warps = ctx.settings
+        grad_in = torch.empty_like(logits_flat)
+        loss_backward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            grad_in,
+            grad_output.contiguous().view(-1),
+            stats,
+            stats.stride(0),
+            V,
+            OP=ctx.op,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        return grad_in.view(B, T, V), None, None
+
+
+def fused_kl_div_loss(logits, targets):
+    """Per-position forward KL ``[1, T]``; fused twin of ``kl_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_KL.value)
+
+
+def fused_reverse_kl_div_loss(logits, targets):
+    """Per-position reverse KL ``[1, T]``; fused twin of ``reverse_kl_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_RKL.value)
+
+
+def fused_js_div_loss(logits, targets):
+    """Per-position JSD ``[1, T]``; fused twin of ``js_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_JSD.value)
+
+
+def fused_ce_loss(logits, targets):
+    """Per-position CE vs argmax(targets) ``[1, T]``; fused twin of ``ce_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_CE.value)
+
+
+def fused_tv_loss(logits, targets):
+    """Per-position TV distance ``[1, T]`` from draft/target logits (fused Triton)."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_TV.value)
+
+
+def fused_nla_loss(logits, targets):
+    """Per-position negative-log-acceptance ``[1, T] = -log(alpha)``; composes on TV."""
+    return -torch.log((1.0 - fused_tv_loss(logits, targets)).clamp_min(_NLA_EPS))
+
+
+def fused_lk_hybrid_loss(logits, targets, eta: float = 3.0):
+    """Per-position hybrid LK ``[1, T]``; fused KL + TV composed as in
+    ``lk_hybrid_loss`` (blend weight detached).
+    """
+    kl = fused_kl_div_loss(logits, targets)
+    tv = fused_tv_loss(logits, targets)
+    weight = torch.exp(-eta * (1.0 - tv).detach())
+    return weight * kl + (1.0 - weight) * tv
+
+
+# ---------------------------------------------------------------------------
+# Eager reference implementations (verbatim from speculators losses/eager.py).
+# They are the numerical-validation reference for the fused kernels and the
+# fallback for hosts without Triton; note they materialize full [B, T, V]
+# probabilities, so wide vocabularies can easily OOM with the eager path.
+# ---------------------------------------------------------------------------
+
+
+def kl_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position KL divergence from draft logits to target logits.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (softmax applied internally).
+
+    Returns:
+        Per-position KL divergence with shape [1, seq_len].
+    """
+    logits = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    elementwise_loss = torch.nn.functional.kl_div(
+        logits, target_p, reduction="none", log_target=False
+    ).sum(
+        dim=-1
+    )  # shape: [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def reverse_kl_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position reverse KL divergence from draft logits to target logits.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (log-softmax applied internally).
+
+    Returns:
+        Per-position reverse KL divergence with shape [1, seq_len].
+    """
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1, dtype=torch.float32)
+    elementwise_loss = torch.nn.functional.kl_div(
+        target_logp, draft_logq, reduction="none", log_target=True
+    ).sum(
+        dim=-1
+    )  # shape: [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def js_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position Jensen-Shannon divergence between draft and target.
+
+    ``JSD(p, q) = 0.5 * KL(p || m) + 0.5 * KL(q || m)`` with ``m = (p + q) / 2``.
+    Symmetric and bounded by ``log 2`` (Lin 1991, "Divergence measures based on
+    the Shannon entropy"), it balances forward KL's mass-covering pull with
+    reverse KL's mode-seeking pull and keeps gradients finite where either
+    distribution assigns near-zero probability. Compared to plain KL, this
+    avoids unbounded penalties on tokens the target barely supports; compared
+    to TV, it provides smoother, better-conditioned gradients for draft
+    training.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (log-softmax applied internally).
+
+    Returns:
+        Per-position JS divergence with shape [1, seq_len].
+    """
+    import math
+
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1, dtype=torch.float32)
+    # log m = log((p + q) / 2), computed in log space for stability
+    log_m = torch.logaddexp(draft_logq, target_logp) - math.log(2.0)
+    kl_target_to_mix = torch.nn.functional.kl_div(
+        log_m, target_logp, reduction="none", log_target=True
+    ).sum(dim=-1)
+    kl_draft_to_mix = torch.nn.functional.kl_div(
+        log_m, draft_logq, reduction="none", log_target=True
+    ).sum(dim=-1)
+    elementwise_loss = 0.5 * (kl_target_to_mix + kl_draft_to_mix)  # [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def ce_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position cross-entropy loss using argmax of target logits as labels.
+
+    Args:
+        logits: Draft model logits.
+        targets: Target model logits (argmax taken to produce hard labels).
+
+    Returns:
+        Per-position cross-entropy loss with shape [1, seq_len].
+    """
+    batch_size, seq_len, draft_vocab_size = logits.shape
+    target_ids = torch.argmax(targets, dim=-1)  # shape: [1, seq_len]
+
+    elementwise_loss = torch.nn.functional.cross_entropy(
+        logits.reshape(-1, draft_vocab_size),
+        target_ids.reshape(-1),
+        reduction="none",
+        ignore_index=-100,
+    ).reshape(batch_size, seq_len)
+
+    return elementwise_loss  # noqa: RET504
+
+
+def tv_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position total variation (TV) distance from draft to target.
+
+    The rejection-sampling acceptance rate of speculative decoding equals the
+    distributional overlap between target and draft,
+    ``alpha = sum_v min(p_v, q_v) = 1 - d_TV(p, q)``. Minimizing this TV distance
+    therefore directly optimizes the acceptance rate, whereas cross-entropy and
+    KL only optimize it indirectly (KL is a loose upper bound on TV via Pinsker).
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+
+    Returns:
+        Per-position TV distance with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # shape: [1, seq_len]
+    elementwise_loss = 1.0 - overlap
+
+    return elementwise_loss  # noqa: RET504
+
+
+def neg_log_acceptance_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position negative log-acceptance (LK) loss.
+
+    The speculative-decoding acceptance rate equals the draft/target distribution
+    overlap, ``alpha = sum_v min(p_v, q_v)`` (the same quantity computed in
+    ``tv_loss``). This loss is ``-log(alpha)``. Its gradient is
+    ``(1 / alpha) * grad(TV)``: the ``1 / alpha`` factor amplifies the otherwise
+    vanishing TV gradient when overlap is low (early training), giving TV's
+    acceptance-optimal target a usable gradient from a cold start. When the target
+    is a point mass, this loss reduces to cross-entropy.
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+
+    Returns:
+        Per-position negative log-acceptance with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
+    elementwise_loss = -torch.log(overlap.clamp_min(_NLA_EPS))
+
+    return elementwise_loss  # noqa: RET504
+
+
+def lk_hybrid_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    eta: float = 3.0,
+):
+    """Compute per-position hybrid LK loss (adaptive KL/TV blend).
+
+    Blends KL divergence and total variation per position:
+    ``L = lambda * KL(p||q) + (1 - lambda) * TV(p, q)`` with adaptive weight
+    ``lambda = exp(-eta * sg[alpha])``, where ``alpha = sum_v min(p_v, q_v)`` is the
+    acceptance rate (overlap) and ``sg`` is stop-gradient. When overlap is low
+    (early training, misaligned draft) ``lambda -> 1`` and the loss leans on KL's
+    strong gradient; as overlap grows ``lambda -> 0`` and it shifts to TV, which
+    optimizes acceptance directly. This gives TV's acceptance-optimal target a
+    usable gradient from a cold start.
+
+    ``alpha`` in the weight is detached: it controls the blend but is not
+    differentiated through; gradients flow only through the KL and TV terms.
+
+    Source: Samarin et al., "LK Losses: Direct Acceptance Rate Optimization for
+    Speculative Decoding" (arXiv 2602.23881), hybrid objective.
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+        eta: Blend temperature; larger shifts toward TV sooner. Default 3.0
+            (the paper's best hybrid setting).
+
+    Returns:
+        Per-position hybrid loss with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
+    tv = 1.0 - overlap
+    kl = kl_div_loss(logits, targets)  # reuse existing KL, shape: [1, seq_len]
+    weight = torch.exp(-eta * overlap.detach())  # lambda = exp(-eta * sg[alpha])
+    elementwise_loss = weight * kl + (1.0 - weight) * tv
+
+    return elementwise_loss  # noqa: RET504

--- a/tests/test_utils/test_fused_loss.py
+++ b/tests/test_utils/test_fused_loss.py
@@ -1,0 +1,276 @@
+"""Fused Triton losses vs their eager references (specforge.core.fused_loss).
+
+One test per loss, comparing loss value and logits-gradient against eager in
+the three regimes that catch distinct bugs: fp32 with saturated point-mass
+rows (gradient formula, log-space underflow), bf16 (the training dtype), and
+the 151936-wide vocab (multi-block streaming, non-power-of-2 tail). The
+upstream gradient contains exact zeros, so masked rows take the backward
+kernel's early-out and must return exact zeros from an uninitialized buffer.
+
+The accelerator is auto-detected: CUDA when present, otherwise Ascend NPU
+(via triton-ascend). Without Triton or an accelerator the fused legs skip
+gracefully, while the device-cap and eager legs still run on CPU. The
+151936-wide leg also exercises the smaller NPU BLOCK_SIZE cap
+(MAX_FUSED_SIZE_NPU = 4096), which forces the tighter multi-block streaming
+loop.
+"""
+
+import math
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from specforge.core import fused_loss
+
+
+def _triton_available() -> bool:
+    """True only for a real Triton install; a stray ``triton/`` namespace
+    directory on sys.path (no ``jit``, no ``language``) must not count."""
+    try:
+        import triton
+        import triton.language  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(triton, "jit")
+
+
+def _npu_available() -> bool:
+    # torch.npu is only bound once torch_npu has been imported; nothing on the
+    # test collection path imports it, so probe explicitly here.
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    npu = getattr(torch, "npu", None)
+    return npu is not None and npu.is_available()
+
+
+def _accelerator_device() -> str | None:
+    """Pick the accelerator the fused kernels can run on, or None to skip."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if _npu_available():
+        return "npu"
+    return None
+
+
+DEVICE = _accelerator_device()
+requires_fused = unittest.skipUnless(
+    DEVICE is not None and _triton_available(),
+    "fused Triton losses require Triton plus a CUDA or Ascend NPU accelerator",
+)
+
+# (name, eager fn name, fused fn name); both resolved lazily from the module
+CASES = [
+    ("kl_div", "kl_div_loss", "fused_kl_div_loss"),
+    ("rkl", "reverse_kl_div_loss", "fused_reverse_kl_div_loss"),
+    ("jsd", "js_div_loss", "fused_js_div_loss"),
+    ("ce", "ce_loss", "fused_ce_loss"),
+    ("tv", "tv_loss", "fused_tv_loss"),
+    ("nla", "neg_log_acceptance_loss", "fused_nla_loss"),
+    ("lk_hybrid", "lk_hybrid_loss", "fused_lk_hybrid_loss"),
+]
+
+# Loss values are fp32 on both paths; gradients allow bf16 1-ulp rounding
+# (both paths quantize at the leaf). A wrong gradient formula errs by orders
+# of magnitude more than either bound.
+LOSS_TOL = {"atol": 1e-4, "rtol": 1e-3}
+GRAD_TOL = {"atol": 1e-3, "rtol": 1e-2}
+# eager ce computes cross_entropy in bf16, so its bf16 legs are bounded by
+# eager's own rounding, not by the (fp32) fused kernel
+CE_BF16_LOSS_TOL = {"atol": 0.2, "rtol": 1e-2}
+CE_BF16_GRAD_TOL = {"atol": 1e-2, "rtol": 2e-2}
+
+
+def _assert_fused_matches_eager(
+    eager_fn, fused_fn, logits, targets, loss_tol, grad_tol
+):
+    le = logits.detach().clone().requires_grad_(True)
+    lf = logits.detach().clone().requires_grad_(True)
+    out_e = eager_fn(le, targets)
+    out_f = fused_fn(lf, targets)
+    assert out_f.dtype == torch.float32  # like the eager fp32 softmax (#788)
+    torch.testing.assert_close(out_f, out_e.float(), **loss_tol)
+
+    go = torch.randn_like(out_e, dtype=torch.float32)
+    go[:, ::3] = 0.0  # rows taking the go == 0 early-out
+    (out_e.float() * go).sum().backward()
+    (out_f * go).sum().backward()
+    assert le.grad is not None
+    assert lf.grad is not None
+    torch.testing.assert_close(lf.grad.float(), le.grad.float(), **grad_tol)
+
+
+class TestFusedLoss(unittest.TestCase):
+    @requires_fused
+    def test_fused_matches_eager(self):
+        """Fused == eager (value + gradient) across the three failure-mode regimes."""
+        for name, eager_name, fused_name in CASES:
+            with self.subTest(name=name):
+                eager_fn = getattr(fused_loss, eager_name)
+                fused_fn = getattr(fused_loss, fused_name)
+
+                # fp32, with saturated +-30 point-mass rows (one agreeing, one disagreeing)
+                torch.manual_seed(0)
+                logits = torch.randn(1, 32, 512, device=DEVICE) * 3
+                targets = torch.randn(1, 32, 512, device=DEVICE) * 3
+                logits[0, -2:] = -30.0
+                targets[0, -2:] = -30.0
+                logits[0, -2:, 0] = 30.0
+                targets[0, -2, 0] = 30.0  # last two rows: draft==target, then disagree
+                targets[0, -1, 7] = 30.0
+                _assert_fused_matches_eager(
+                    eager_fn, fused_fn, logits, targets, LOSS_TOL, GRAD_TOL
+                )
+
+                # bf16, the training dtype
+                torch.manual_seed(1)
+                logits = (torch.randn(1, 64, 512, device=DEVICE) * 3).bfloat16()
+                targets = (torch.randn(1, 64, 512, device=DEVICE) * 3).bfloat16()
+                _assert_fused_matches_eager(
+                    eager_fn,
+                    fused_fn,
+                    logits,
+                    targets,
+                    CE_BF16_LOSS_TOL if name == "ce" else LOSS_TOL,
+                    CE_BF16_GRAD_TOL if name == "ce" else GRAD_TOL,
+                )
+
+                # Qwen3's 151936 vocab exceeds MAX_FUSED_SIZE (and
+                # MAX_FUSED_SIZE_NPU): multi-block streaming plus a
+                # non-power-of-2 masked tail. On NPU the per-block cap is 4096,
+                # so this leg also covers the tighter block loop.
+                torch.manual_seed(2)
+                logits = torch.randn(1, 3, 151936, device=DEVICE) * 3
+                targets = torch.randn(1, 3, 151936, device=DEVICE) * 3
+                _assert_fused_matches_eager(
+                    eager_fn, fused_fn, logits, targets, LOSS_TOL, GRAD_TOL
+                )
+
+    @requires_fused
+    def test_compiles_fullgraph(self):
+        """torch.compile(fullgraph=True) must trace the fused losses.
+
+        The OP selector crosses the autograd.Function boundary, and Dynamo cannot
+        represent a tl.constexpr object there -- passing one graph-breaks (or
+        fails under fullgraph). Model forwards are wrapped in torch.compile, so
+        this guards the compiled training path.
+        """
+        for name, _eager_name, fused_name in CASES:
+            with self.subTest(name=name):
+                fused_fn = getattr(fused_loss, fused_name)
+                logits = torch.randn(1, 8, 512, device=DEVICE, requires_grad=True)
+                targets = torch.randn(1, 8, 512, device=DEVICE)
+
+                # Eager warmup first: the lazy Triton assembly in
+                # _require_triton() is not Dynamo-traceable, so it must happen
+                # before the compiled region runs.
+                fused_fn(logits.detach(), targets)
+
+                compiled = torch.compile(
+                    lambda a, b: fused_fn(a, b).sum(), fullgraph=True
+                )
+                compiled(logits, targets).backward()
+                assert logits.grad is not None
+                assert torch.isfinite(logits.grad).all()
+
+    def test_calculate_settings_respects_device_cap(self):
+        """`_calculate_settings` picks the right BLOCK_SIZE for each device without
+        needing NPU or CUDA hardware -- the helper only reads ``device.type`` and
+        is intentionally Triton-free so this test runs on CPU-only hosts.
+
+        Exercises the NPU cap (MAX_FUSED_SIZE_NPU = 4096) and the CUDA cap
+        (MAX_FUSED_SIZE = 131072) at vocab sizes that span the boundaries, so
+        upstream CI (which typically has no NPU) still covers the NPU branch.
+        """
+        npu_cases = (
+            (512, 512),
+            (4096, 4096),
+            (8192, 4096),
+            (32768, 4096),
+            (131072, 4096),
+            (151936, 4096),
+        )
+        for vocab, expected in npu_cases:
+            block, _ = fused_loss._calculate_settings(
+                vocab, SimpleNamespace(type="npu")
+            )
+            assert (
+                block == expected
+            ), f"NPU cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
+
+        cuda_cases = (
+            (512, 512),
+            (4096, 4096),
+            (8192, 8192),
+            (131072, 131072),
+            (151936, 131072),
+        )
+        for vocab, expected in cuda_cases:
+            block, _ = fused_loss._calculate_settings(
+                vocab, SimpleNamespace(type="cuda")
+            )
+            assert (
+                block == expected
+            ), f"CUDA cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
+
+    def test_eager_implementation_supports_differentiable_targets(self):
+        """The explicit eager implementation preserves target gradients."""
+        torch.manual_seed(3)
+        for eager_name in (
+            "kl_div_loss",
+            "reverse_kl_div_loss",
+            "js_div_loss",
+            "tv_loss",
+            "neg_log_acceptance_loss",
+            "lk_hybrid_loss",
+        ):
+            with self.subTest(eager_name=eager_name):
+                logits = torch.randn(1, 4, 64, requires_grad=True)
+                targets = torch.randn(1, 4, 64, requires_grad=True)
+                loss_fn = getattr(fused_loss, eager_name)
+                loss_fn(logits, targets).sum().backward()
+                assert logits.grad is not None, eager_name
+                assert targets.grad is not None, eager_name
+
+    def test_eager_losses_self_consistent(self):
+        """CPU-checkable identities among the eager references, including a
+        saturated point-mass row mirroring the fused parity regimes."""
+        torch.manual_seed(4)
+        logits = torch.randn(1, 8, 128) * 3
+        targets = torch.randn(1, 8, 128) * 3
+        logits[0, -1] = -30.0
+        targets[0, -1] = -30.0
+        logits[0, -1, 0] = 30.0
+        targets[0, -1, 7] = 30.0  # disagreeing point masses
+
+        kl = fused_loss.kl_div_loss(logits, targets)
+        rkl = fused_loss.reverse_kl_div_loss(logits, targets)
+        jsd = fused_loss.js_div_loss(logits, targets)
+        tv = fused_loss.tv_loss(logits, targets)
+        nla = fused_loss.neg_log_acceptance_loss(logits, targets)
+        hybrid = fused_loss.lk_hybrid_loss(logits, targets)
+
+        assert torch.isfinite(kl).all() and (kl >= -1e-6).all()
+        assert torch.isfinite(rkl).all() and (rkl >= -1e-6).all()
+        assert (jsd >= -1e-6).all() and (jsd <= math.log(2.0) + 1e-6).all()
+        assert (tv >= 0.0).all() and (tv <= 1.0).all()
+        # nla = -log(alpha) with alpha = 1 - tv; hybrid blends kl/tv with the
+        # detached overlap weight exp(-eta * alpha)
+        torch.testing.assert_close(nla, -torch.log((1.0 - tv).clamp_min(1e-5)))
+        weight = torch.exp(-3.0 * (1.0 - tv))
+        torch.testing.assert_close(hybrid, weight * kl + (1.0 - weight) * tv)
+
+        # ce uses argmax(targets) as hard labels
+        ce = fused_loss.ce_loss(logits, targets)
+        ref = torch.nn.functional.cross_entropy(
+            logits.reshape(-1, 128),
+            targets.argmax(dim=-1).reshape(-1),
+            reduction="none",
+        ).reshape(1, 8)
+        torch.testing.assert_close(ce, ref)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The training losses materialize `[T, V]` fp32 intermediates (e.g. DSpark's two full-vocab softmaxes), and the KL kernel in `core/loss.py` raises for vocab sizes above 131072 (Qwen3's 151936). This PR adds a fused loss family as a standalone module: a Triton kernel pair covering KL/RKL/JSD/CE/TV with online-softmax streaming and a closed-form backward that stores five fp32 scalars per row, plus `nla` / `lk_hybrid` in plain torch on top of the primitives. No `[T, V]` intermediate is materialized or saved. No call sites are touched; integration follows in later PRs.

The kernels are ported from vllm-project/speculators (Apache-2.0), which derived them from `specforge/core/loss.py` in the first place (Unsloth / Liger-Kernel lineage) — so this is a round-trip. Upstream measured eager `kl_div` peaking at 23.2 GB beyond inputs vs 2.3 GB for the fused path (bf16, V=151936, T=8192, GB10; vllm-project/speculators#951). The port keeps the upstream Ascend NPU block-size cap (triton-ascend raises `ub overflow` at BLOCK_SIZE >= 8192, so NPU caps at 4096; vllm-project/speculators#993) and adds a lazy Triton import so the module loads without Triton.

## Modifications

- `specforge/core/fused_loss.py`: fused kernel pair + eager references, co-located as fallback and parity baseline. Kernel bodies are verbatim from upstream, including the CE backward that rebuilds its label from the cached argmax instead of pinning the full target tensor through backward (vllm-project/speculators#1000). Deviations: lazy Triton import, and a Triton-free `_next_power_of_2` so the block-size logic runs anywhere.
- `tests/test_utils/test_fused_loss.py`: fused-vs-eager value and gradient parity over fp32 saturated rows, bf16, and a 151936-wide vocab (multi-block streaming); `torch.compile(fullgraph=True)`; device-cap tests including the NPU branch (CPU-runnable); eager self-consistency identities.

## Accuracy Test

CPU: 3 passed, 14 skipped — the skips are the accelerator-gated parity and fullgraph legs over the 7 losses; the device-cap and eager legs are CPU-runnable by design.

Ascend NPU (triton-ascend, exercised through the DSpark integration path), five scales up to Qwen3-4B production (vocab=151936, hidden=2560, 38 chunks per row). Relative differences vs eager:

fp32:

| Scale | Vocab | Hidden | Chunks | Loss rel diff | Draft-grad rel diff | lm_head-grad rel diff | Draft-grad max diff | lm_head-grad max diff |
|---|---|---|---|---|---|---|---|---|
| tiny | 100 | 4 | 1 | 7.47e-08 | 7.85e-08 | 9.14e-08 | 2.98e-08 | 5.82e-10 |
| vocab=4096 | 4096 | 256 | 1 | 0.00e+00 | 1.82e-07 | 0.00e+00 | 2.98e-08 | 1.16e-10 |
| vocab=16384 | 16384 | 1024 | 4 | 1.11e-07 | 9.34e-08 | 0.00e+00 | 2.98e-08 | 2.33e-10 |
| vocab=65536 | 65536 | 2048 | 16 | 1.05e-07 | 1.84e-07 | 1.12e-07 | 5.96e-08 | 2.60e-07 |
| production | 151936 | 2560 | 38 | 2.02e-07 | 4.62e-07 | 0.00e+00 | 1.19e-07 | 2.33e-10 |

bf16:

| Scale | Vocab | Hidden | Chunks | Loss rel diff | Draft-grad rel diff | lm_head-grad rel diff | Draft-grad max diff | lm_head-grad max diff |
|---|---|---|---|---|---|---|---|---|
| tiny | 100 | 4 | 1 | 7.47e-08 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| vocab=4096 | 4096 | 256 | 1 | 6.00e-08 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 |
| vocab=16384 | 16384 | 1024 | 4 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 1.49e-08 |
| vocab=65536 | 65536 | 2048 | 16 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 9.54e-07 | 7.45e-09 |
| production | 151936 | 2560 | 38 | 0.00e+00 | 0.00e+00 | 0.00e+00 | 2.98e-08 | 3.73e-09 |

Differences stay at the 1e-7 level and don't grow with scale; bf16 is closer still since both paths upcast to fp32 internally.

## Credits

- [WindChimeRan](https://github.com/WindChimeRan) — original fused kernel pair and eager references (vllm-project/speculators#951, vllm-project/speculators#1000)
- [PHOEBEMOON0802](https://github.com/PHOEBEMOON0802) — Ascend NPU block-size cap (vllm-project/speculators#993)

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/writing-documentation-running-docs-ci). (Docstrings only; user-facing docs land with the integration PRs.)
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html). (No throughput run yet; upstream memory numbers quoted in the Motivation, parity numbers above.)
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.