### PR TITLE
feat(dspark): add fused TV loss (stacked on #826)

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from specforge.core import fused_loss
 from specforge.core.chunking import checkpointed_chunk_reduce
 from specforge.modeling.draft.dflash import DFlashDraftModel
 from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
@@ -1038,6 +1039,25 @@ class OnlineDominoModel(OnlineDFlashModel):
         return loss, accuracy, metrics
 
 
+def _fused_dspark_loss_available(tensor: torch.Tensor) -> bool:
+    """True when the fused DSpark TV loss can run for ``tensor``.
+
+    The fused kernel needs a CUDA or Ascend NPU accelerator and an importable
+    Triton (triton-ascend on NPU). A live tensor's device type already proves
+    the accelerator runtime is bound (``torch.npu`` is bound by importing
+    ``torch_npu`` before any NPU tensor can exist), so only the Triton import
+    needs probing here.
+    """
+    if tensor.device.type not in ("cuda", "npu"):
+        return False
+    try:
+        import triton
+        import triton.language  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(triton, "jit")
+
+
 class OnlineDSparkModel(OnlineDFlashModel):
     """DSpark online training wrapper over DFlash block-parallel components."""
 
@@ -1078,6 +1098,9 @@ class OnlineDSparkModel(OnlineDFlashModel):
         self.dspark_ce_loss_alpha = float(dspark_ce_loss_alpha)
         self.dspark_l1_loss_alpha = float(dspark_l1_loss_alpha)
         self.dspark_confidence_head_alpha = float(dspark_confidence_head_alpha)
+        self._use_fused_dspark_loss = (
+            os.environ.get("SPECFORGE_DSPARK_FUSED_LOSS", "0") == "1"
+        )
 
     def _build_dspark_labels_and_mask(
         self,
@@ -1186,8 +1209,8 @@ class OnlineDSparkModel(OnlineDFlashModel):
         tau_den = zero
         accept_probability = None
 
-        draft_probabilities = None
         teacher_ids = None
+        target_logits = None
         if aligned_target_hidden is not None:
             with torch.no_grad():
                 target_logits = self.lm_head(
@@ -1197,13 +1220,30 @@ class OnlineDSparkModel(OnlineDFlashModel):
                         hidden_size,
                     )
                 ).reshape_as(draft_logits)
-                target_probabilities = torch.softmax(target_logits.float(), dim=-1)
                 teacher_ids = target_logits.argmax(dim=-1)
-            draft_probabilities = torch.softmax(draft_logits.float(), dim=-1)
-            l1_per_token = (
-                (draft_probabilities - target_probabilities).abs().sum(dim=-1)
-            )
-            accept_probability = (1.0 - 0.5 * l1_per_token).clamp(0.0, 1.0)
+            if self._use_fused_dspark_loss and _fused_dspark_loss_available(
+                draft_logits
+            ):
+                # Fused TV: l1 = 2 * tv and accept = 1 - tv for normalized
+                # softmax pairs; no [B, T, V] probability tensor materialized.
+                tv_per_token = fused_loss.fused_tv_loss(
+                    draft_logits.reshape(
+                        batch_size, num_blocks * block_size, vocab_size
+                    ),
+                    target_logits.reshape(
+                        batch_size, num_blocks * block_size, vocab_size
+                    ),
+                ).reshape_as(target_ids)
+                l1_per_token = 2.0 * tv_per_token
+                accept_probability = (1.0 - tv_per_token).clamp(0.0, 1.0)
+            else:
+                with torch.no_grad():
+                    target_probabilities = torch.softmax(target_logits.float(), dim=-1)
+                draft_probabilities = torch.softmax(draft_logits.float(), dim=-1)
+                l1_per_token = (
+                    (draft_probabilities - target_probabilities).abs().sum(dim=-1)
+                )
+                accept_probability = (1.0 - 0.5 * l1_per_token).clamp(0.0, 1.0)
             if self.dspark_l1_loss_alpha > 0:
                 l1_num = (l1_per_token * loss_weights).sum()
 
@@ -1236,15 +1276,25 @@ class OnlineDSparkModel(OnlineDFlashModel):
             correct_position_num = correct.sum(dim=(0, 1))
             position_den = eval_mask.float().sum(dim=(0, 1))
             if aligned_target_hidden is not None:
-                assert draft_probabilities is not None and teacher_ids is not None
+                assert teacher_ids is not None and target_logits is not None
                 teacher_agreement_num = (
                     (predicted_ids == teacher_ids).float() * eval_mask
                 ).sum()
+                # Top-1 softmax probability without materializing probabilities:
+                # p_max = exp(max_logit - logsumexp(logits)), in fp32.
                 teacher_top1_num = (
-                    target_probabilities.max(dim=-1).values * eval_mask
+                    torch.exp(
+                        target_logits.max(dim=-1).values
+                        - target_logits.float().logsumexp(dim=-1)
+                    )
+                    * eval_mask
                 ).sum()
                 draft_top1_num = (
-                    draft_probabilities.max(dim=-1).values * eval_mask
+                    torch.exp(
+                        draft_logits.max(dim=-1).values
+                        - draft_logits.float().logsumexp(dim=-1)
+                    )
+                    * eval_mask
                 ).sum()
                 valid_blocks = eval_mask.any(dim=-1).float()
                 accepted_expectation = (

--- a/specforge/core/fused_loss.py
+++ b/specforge/core/fused_loss.py
@@ -1,0 +1,642 @@
+"""
+This file incorporates code from vllm-project/speculators licensed under
+the Apache License, Version 2.0. See the original repository at
+https://github.com/vllm-project/speculators (file: src/speculators/losses/fused.py
+and losses/eager.py), derived in turn from specforge/core/loss.py
+(Unsloth / Liger-Kernel lineage).
+Changes for SpecForge: lazy Triton import so the module loads on hosts
+without Triton; eager reference co-located in the same module.
+
+Upstream kernel documentation (speculators losses/fused.py):
+
+One kernel pair serves every fused loss: forward streams the selected
+reduction from online-softmax statistics; backward recomputes probabilities
+from five saved scalars per row and applies the closed-form gradient. No
+``[T, V]`` intermediate is ever materialized or saved -- the memory win over
+the eager losses. ``OP`` picks the reduction at Triton specialization time;
+``nla`` and ``lk_hybrid`` are ``[1, T]`` torch compositions of the primitives
+instead of kernel branches.
+
+Per-row gradients (dp = softmax(logits), draft; tp = softmax(targets),
+treated as constant), L the row loss:
+
+    kl_div  dp - tp
+    rkl     dp * (log dp - log tp - L)
+    jsd     0.5 * dp * (log(dp / mix) - KL(dp || mix)),  mix = (dp + tp) / 2
+    ce      dp - onehot(argmax tp)
+    tv      -dp * (1[dp <= tp] - s_s),  s_s = sum of dp where dp <= tp
+"""
+
+# Triton kernels idiomatically use uppercase constexpr/dim names (B, T, V,
+# BLOCK_SIZE) and inline block-size tuning thresholds; exempt this file from the
+# pep8-naming and magic-value lints rather than fight those conventions.
+# ruff: noqa: N803, N806, PLR2004
+
+from __future__ import annotations
+
+import torch
+
+__all__ = [
+    # Fused Triton losses (require Triton plus a CUDA or Ascend NPU accelerator)
+    "fused_kl_div_loss",
+    "fused_reverse_kl_div_loss",
+    "fused_js_div_loss",
+    "fused_ce_loss",
+    "fused_tv_loss",
+    "fused_nla_loss",
+    "fused_lk_hybrid_loss",
+    # Eager reference/fallback implementations (pure PyTorch, CPU-safe)
+    "kl_div_loss",
+    "reverse_kl_div_loss",
+    "js_div_loss",
+    "ce_loss",
+    "tv_loss",
+    "neg_log_acceptance_loss",
+    "lk_hybrid_loss",
+]
+
+MAX_FUSED_SIZE = 131072
+# Ascend NPU's Unified Buffer (~192 KB) cannot fit the double-row load these
+# kernels perform (logits + targets per block) beyond 4096 elements per block;
+# triton-ascend raises "ub overflow" at BLOCK_SIZE >= 8192. CE is single-row
+# but shares the same cap so all _FusedLoss OPs use one path.
+MAX_FUSED_SIZE_NPU = 4096
+
+# tl.constexpr instances: Triton kernels may only read globals wrapped this way.
+# Plain values live at module scope so importing never needs Triton;
+# _require_triton() re-wraps them as tl.constexpr before the first launch.
+_LOG2 = 0.6931471805599453
+
+# Reduction selector, baked into the kernel at specialization time. Pass
+# ``.value`` (a plain int) across the autograd boundary -- Dynamo cannot
+# represent a constexpr object as an autograd.Function argument and would
+# graph-break; the ``OP: tl.constexpr`` parameter re-wraps it in the kernel.
+_OP_KL = 0
+_OP_RKL = 1
+_OP_JSD = 2
+_OP_CE = 3
+_OP_TV = 4
+
+# stats [_N_STATS, n_rows]: [0]/[1] draft row max / sum-exp, [2]/[3] same for
+# targets (unused by ce), [4] per-OP -- kl_div/rkl: row loss L | jsd:
+# KL(dp||mix) | tv: s_s | ce: argmax as float32 (exact: vocab < 2**24).
+_N_STATS = 5
+
+_NLA_EPS = 1e-5
+
+_TRITON_READY = False
+
+
+def _next_power_of_2(n):
+    """Pure-Python twin of ``triton.next_power_of_2``.
+
+    ``_calculate_settings`` must stay Triton-free so the device-cap logic (and
+    its unit tests) runs on hosts without Triton.
+    """
+    return 1 << (n - 1).bit_length() if n > 1 else 1
+
+
+def _calculate_settings(n, device):
+    max_size = MAX_FUSED_SIZE_NPU if device.type == "npu" else MAX_FUSED_SIZE
+    BLOCK_SIZE = min(_next_power_of_2(n), max_size)
+    # triton-ascend does not require extra num_warps tuning
+    num_warps = 4
+    if BLOCK_SIZE >= 32768:
+        num_warps = 32
+    elif BLOCK_SIZE >= 8192:
+        num_warps = 16
+    elif BLOCK_SIZE >= 2048:
+        num_warps = 8
+    if getattr(torch.version, "hip", None) is not None:  # AMD wavefronts are 64-wide
+        num_warps //= 2
+    return BLOCK_SIZE, num_warps
+
+
+# The kernel bodies below are verbatim from speculators losses/fused.py. Their
+# ``@triton.jit`` decorators are applied lazily by ``_require_triton()`` below
+# (which also publishes ``tl`` and the constexpr-wrapped globals the bodies
+# resolve at compile time), so importing this module never requires Triton.
+# The ``tl.constexpr`` annotations stay unevaluated strings thanks to the
+# ``__future__`` annotations import at the top of the file.
+def _online_stats(row_ptr, n_cols, BLOCK_SIZE: tl.constexpr):
+    """Online max (m) and sum-exp (d) over one row."""
+    m = float("-inf")
+    d = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(row_ptr + offsets, mask=mask, other=float("-inf")).cast(tl.float32)
+        block_max = tl.max(tl.where(mask, x, float("-inf")))
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.where(mask, tl.exp(x - m_new), 0.0))
+        m = m_new
+    return m, d
+
+
+def _log_mix(ldp, ltp):
+    """log((exp(ldp) + exp(ltp)) / 2): the JSD mixture, stable in log space."""
+    mx = tl.maximum(ldp, ltp)
+    return mx + tl.log(tl.exp(ldp - mx) + tl.exp(ltp - mx)) - _LOG2
+
+
+def loss_forward_kernel(  # noqa: C901 -- constexpr OP branches, pruned per instance
+    logits_ptr,
+    targets_ptr,
+    loss_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    OP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """One row per program: online softmax stats, then the OP's reduction.
+
+    Masked tail lanes can hold inf/nan before ``tl.where`` selects; they
+    never enter an accumulator.
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    targets_ptr += pid * n_cols
+
+    m_d, z_d = _online_stats(logits_ptr, n_cols, BLOCK_SIZE)
+    lse_d = m_d + tl.log(z_d)
+    tl.store(stats_ptr + 0 * stats_row + pid, m_d)
+    tl.store(stats_ptr + 1 * stats_row + pid, z_d)
+
+    if OP == _OP_CE:
+        # Only the target argmax is needed; no target softmax stats.
+        best_val = float("-inf")
+        best_idx = 0
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            y = tl.load(targets_ptr + offsets, mask=mask, other=float("-inf")).cast(
+                tl.float32
+            )
+            block_max = tl.max(y)
+            block_arg = tl.argmax(y, axis=0)
+            # strict > keeps the first occurrence, the torch.argmax convention
+            update = block_max > best_val
+            best_idx = tl.where(update, i + block_arg, best_idx)
+            best_val = tl.where(update, block_max, best_val)
+        logit_at_target = tl.load(logits_ptr + best_idx).cast(tl.float32)
+        tl.store(loss_ptr + pid, lse_d - logit_at_target)
+        # mypy reads traced Triton code as Python and types best_idx as int
+        tl.store(stats_ptr + 4 * stats_row + pid, best_idx.to(tl.float32))  # type: ignore[attr-defined]
+    else:
+        m_t, z_t = _online_stats(targets_ptr, n_cols, BLOCK_SIZE)
+        lse_t = m_t + tl.log(z_t)
+        tl.store(stats_ptr + 2 * stats_row + pid, m_t)
+        tl.store(stats_ptr + 3 * stats_row + pid, z_t)
+
+        acc = 0.0
+        extra = 0.0
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            ldp = x - lse_d
+            ltp = y - lse_t
+            dp = tl.exp(ldp)
+            tp = tl.exp(ltp)
+            if OP == _OP_KL:
+                acc += tl.sum(tl.where(mask, tp * (ltp - ldp), 0.0))
+            elif OP == _OP_RKL:
+                acc += tl.sum(tl.where(mask, dp * (ldp - ltp), 0.0))
+            elif OP == _OP_JSD:
+                lmp = _log_mix(ldp, ltp)
+                acc += tl.sum(tl.where(mask, dp * (ldp - lmp), 0.0))
+                extra += tl.sum(tl.where(mask, tp * (ltp - lmp), 0.0))
+            elif OP == _OP_TV:
+                acc += tl.sum(tl.where(mask, tl.minimum(dp, tp), 0.0))
+                extra += tl.sum(tl.where(mask & (dp <= tp), dp, 0.0))
+
+        # Lint exemptions: `in`/merged compares aren't constexpr-foldable here.
+        if OP == _OP_KL or OP == _OP_RKL:  # noqa: PLR1714, SIM109
+            tl.store(loss_ptr + pid, acc)
+            tl.store(stats_ptr + 4 * stats_row + pid, acc)
+        elif OP == _OP_JSD:
+            tl.store(loss_ptr + pid, 0.5 * (acc + extra))
+            tl.store(stats_ptr + 4 * stats_row + pid, acc)
+        elif OP == _OP_TV:
+            tl.store(loss_ptr + pid, 1.0 - acc)
+            tl.store(stats_ptr + 4 * stats_row + pid, extra)
+
+
+def loss_backward_kernel(
+    logits_ptr,
+    targets_ptr,
+    grad_in_ptr,
+    grad_out_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    OP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Recompute probabilities from the saved stats and apply the OP gradient."""
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    grad_in_ptr += pid * n_cols
+
+    go = tl.load(grad_out_ptr + pid).cast(tl.float32)
+    if go == 0.0:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            tl.store(grad_in_ptr + offsets, 0.0, mask=mask)
+        return
+
+    m_d = tl.load(stats_ptr + 0 * stats_row + pid)
+    z_d = tl.load(stats_ptr + 1 * stats_row + pid)
+    lse_d = m_d + tl.log(z_d)
+    extra = tl.load(stats_ptr + 4 * stats_row + pid)
+    if OP != _OP_CE:
+        # CE passes None for targets_ptr.
+        targets_ptr += pid * n_cols
+        m_t = tl.load(stats_ptr + 2 * stats_row + pid)
+        z_t = tl.load(stats_ptr + 3 * stats_row + pid)
+        lse_t = m_t + tl.log(z_t)
+    else:
+        target_idx = extra.to(tl.int32)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        ldp = x - lse_d
+        dp = tl.exp(ldp)
+        if OP == _OP_CE:
+            grad = dp - (offsets == target_idx).to(tl.float32)
+        else:
+            y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+            ltp = y - lse_t
+            tp = tl.exp(ltp)
+            if OP == _OP_KL:
+                grad = dp - tp
+            elif OP == _OP_RKL:
+                grad = dp * (ldp - ltp - extra)
+            elif OP == _OP_JSD:
+                grad = 0.5 * dp * (ldp - _log_mix(ldp, ltp) - extra)
+            elif OP == _OP_TV:
+                grad = -dp * ((dp <= tp).to(tl.float32) - extra)
+        tl.store(grad_in_ptr + offsets, go * grad, mask=mask)
+
+
+def _require_triton():
+    """Import Triton and assemble the fused kernels on first fused-path use.
+
+    Triton is imported here rather than at module scope so this file still
+    imports on hosts without Triton (CPU-only boxes, or NPU images before
+    triton-ascend is installed); only the fused losses then fail, with a clear
+    error, while the eager references below remain usable.
+    """
+    global _TRITON_READY
+    if _TRITON_READY:
+        return
+    try:
+        import triton
+        import triton.language as tl
+    except ImportError as exc:
+        raise RuntimeError(
+            "The fused losses in specforge.core.fused_loss require Triton "
+            "(CUDA) or triton-ascend (NPU), which is not importable on this "
+            "host. Use the eager reference losses in this module instead."
+        ) from exc
+    module_globals = globals()
+    # Publish what the kernel bodies resolve from module globals at compile
+    # time, re-wrap the selectors/globals as tl.constexpr exactly as upstream
+    # defines them, and apply the deferred @triton.jit decorators.
+    module_globals["tl"] = tl
+    module_globals["_LOG2"] = tl.constexpr(_LOG2)
+    module_globals["_OP_KL"] = tl.constexpr(_OP_KL)
+    module_globals["_OP_RKL"] = tl.constexpr(_OP_RKL)
+    module_globals["_OP_JSD"] = tl.constexpr(_OP_JSD)
+    module_globals["_OP_CE"] = tl.constexpr(_OP_CE)
+    module_globals["_OP_TV"] = tl.constexpr(_OP_TV)
+    module_globals["_online_stats"] = triton.jit(_online_stats)
+    module_globals["_log_mix"] = triton.jit(_log_mix)
+    module_globals["loss_forward_kernel"] = triton.jit(loss_forward_kernel)
+    module_globals["loss_backward_kernel"] = triton.jit(loss_backward_kernel)
+    _TRITON_READY = True
+
+
+class _FusedLoss(torch.autograd.Function):
+    """Shared autograd wrapper; ``op`` selects the loss reduction.
+
+    Targets intentionally receive no gradient; use the eager implementation when
+    target gradients are required.
+    """
+
+    @staticmethod
+    def forward(ctx, logits, targets, op):
+        B, T, V = logits.shape
+        logits_flat = logits.contiguous().view(B * T, V)
+        targets_flat = targets.contiguous().view(B * T, V)
+        loss = torch.empty(B * T, device=logits.device, dtype=torch.float32)
+        stats = torch.empty(_N_STATS, B * T, device=logits.device, dtype=torch.float32)
+        BLOCK_SIZE, num_warps = _calculate_settings(V, logits_flat.device)
+        loss_forward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            loss,
+            stats,
+            stats.stride(0),
+            V,
+            OP=op,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        # CE backward only needs the target argmax cached in stats.
+        ctx.save_for_backward(
+            logits_flat, None if op == _OP_CE.value else targets_flat, stats
+        )
+        ctx.op = op
+        ctx.shape = (B, T, V)
+        ctx.settings = (BLOCK_SIZE, num_warps)
+        return loss.view(B, T)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits_flat, targets_flat, stats = ctx.saved_tensors
+        B, T, V = ctx.shape
+        BLOCK_SIZE, num_warps = ctx.settings
+        grad_in = torch.empty_like(logits_flat)
+        loss_backward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            grad_in,
+            grad_output.contiguous().view(-1),
+            stats,
+            stats.stride(0),
+            V,
+            OP=ctx.op,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        return grad_in.view(B, T, V), None, None
+
+
+def fused_kl_div_loss(logits, targets):
+    """Per-position forward KL ``[1, T]``; fused twin of ``kl_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_KL.value)
+
+
+def fused_reverse_kl_div_loss(logits, targets):
+    """Per-position reverse KL ``[1, T]``; fused twin of ``reverse_kl_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_RKL.value)
+
+
+def fused_js_div_loss(logits, targets):
+    """Per-position JSD ``[1, T]``; fused twin of ``js_div_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_JSD.value)
+
+
+def fused_ce_loss(logits, targets):
+    """Per-position CE vs argmax(targets) ``[1, T]``; fused twin of ``ce_loss``."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_CE.value)
+
+
+def fused_tv_loss(logits, targets):
+    """Per-position TV distance ``[1, T]`` from draft/target logits (fused Triton)."""
+    _require_triton()
+    return _FusedLoss.apply(logits, targets, _OP_TV.value)
+
+
+def fused_nla_loss(logits, targets):
+    """Per-position negative-log-acceptance ``[1, T] = -log(alpha)``; composes on TV."""
+    return -torch.log((1.0 - fused_tv_loss(logits, targets)).clamp_min(_NLA_EPS))
+
+
+def fused_lk_hybrid_loss(logits, targets, eta: float = 3.0):
+    """Per-position hybrid LK ``[1, T]``; fused KL + TV composed as in
+    ``lk_hybrid_loss`` (blend weight detached).
+    """
+    kl = fused_kl_div_loss(logits, targets)
+    tv = fused_tv_loss(logits, targets)
+    weight = torch.exp(-eta * (1.0 - tv).detach())
+    return weight * kl + (1.0 - weight) * tv
+
+
+# ---------------------------------------------------------------------------
+# Eager reference implementations (verbatim from speculators losses/eager.py).
+# They are the numerical-validation reference for the fused kernels and the
+# fallback for hosts without Triton; note they materialize full [B, T, V]
+# probabilities, so wide vocabularies can easily OOM with the eager path.
+# ---------------------------------------------------------------------------
+
+
+def kl_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position KL divergence from draft logits to target logits.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (softmax applied internally).
+
+    Returns:
+        Per-position KL divergence with shape [1, seq_len].
+    """
+    logits = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    elementwise_loss = torch.nn.functional.kl_div(
+        logits, target_p, reduction="none", log_target=False
+    ).sum(
+        dim=-1
+    )  # shape: [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def reverse_kl_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position reverse KL divergence from draft logits to target logits.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (log-softmax applied internally).
+
+    Returns:
+        Per-position reverse KL divergence with shape [1, seq_len].
+    """
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1, dtype=torch.float32)
+    elementwise_loss = torch.nn.functional.kl_div(
+        target_logp, draft_logq, reduction="none", log_target=True
+    ).sum(
+        dim=-1
+    )  # shape: [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def js_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position Jensen-Shannon divergence between draft and target.
+
+    ``JSD(p, q) = 0.5 * KL(p || m) + 0.5 * KL(q || m)`` with ``m = (p + q) / 2``.
+    Symmetric and bounded by ``log 2`` (Lin 1991, "Divergence measures based on
+    the Shannon entropy"), it balances forward KL's mass-covering pull with
+    reverse KL's mode-seeking pull and keeps gradients finite where either
+    distribution assigns near-zero probability. Compared to plain KL, this
+    avoids unbounded penalties on tokens the target barely supports; compared
+    to TV, it provides smoother, better-conditioned gradients for draft
+    training.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (log-softmax applied internally).
+
+    Returns:
+        Per-position JS divergence with shape [1, seq_len].
+    """
+    import math
+
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1, dtype=torch.float32)
+    # log m = log((p + q) / 2), computed in log space for stability
+    log_m = torch.logaddexp(draft_logq, target_logp) - math.log(2.0)
+    kl_target_to_mix = torch.nn.functional.kl_div(
+        log_m, target_logp, reduction="none", log_target=True
+    ).sum(dim=-1)
+    kl_draft_to_mix = torch.nn.functional.kl_div(
+        log_m, draft_logq, reduction="none", log_target=True
+    ).sum(dim=-1)
+    elementwise_loss = 0.5 * (kl_target_to_mix + kl_draft_to_mix)  # [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def ce_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position cross-entropy loss using argmax of target logits as labels.
+
+    Args:
+        logits: Draft model logits.
+        targets: Target model logits (argmax taken to produce hard labels).
+
+    Returns:
+        Per-position cross-entropy loss with shape [1, seq_len].
+    """
+    batch_size, seq_len, draft_vocab_size = logits.shape
+    target_ids = torch.argmax(targets, dim=-1)  # shape: [1, seq_len]
+
+    elementwise_loss = torch.nn.functional.cross_entropy(
+        logits.reshape(-1, draft_vocab_size),
+        target_ids.reshape(-1),
+        reduction="none",
+        ignore_index=-100,
+    ).reshape(batch_size, seq_len)
+
+    return elementwise_loss  # noqa: RET504
+
+
+def tv_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position total variation (TV) distance from draft to target.
+
+    The rejection-sampling acceptance rate of speculative decoding equals the
+    distributional overlap between target and draft,
+    ``alpha = sum_v min(p_v, q_v) = 1 - d_TV(p, q)``. Minimizing this TV distance
+    therefore directly optimizes the acceptance rate, whereas cross-entropy and
+    KL only optimize it indirectly (KL is a loose upper bound on TV via Pinsker).
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+
+    Returns:
+        Per-position TV distance with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # shape: [1, seq_len]
+    elementwise_loss = 1.0 - overlap
+
+    return elementwise_loss  # noqa: RET504
+
+
+def neg_log_acceptance_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position negative log-acceptance (LK) loss.
+
+    The speculative-decoding acceptance rate equals the draft/target distribution
+    overlap, ``alpha = sum_v min(p_v, q_v)`` (the same quantity computed in
+    ``tv_loss``). This loss is ``-log(alpha)``. Its gradient is
+    ``(1 / alpha) * grad(TV)``: the ``1 / alpha`` factor amplifies the otherwise
+    vanishing TV gradient when overlap is low (early training), giving TV's
+    acceptance-optimal target a usable gradient from a cold start. When the target
+    is a point mass, this loss reduces to cross-entropy.
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+
+    Returns:
+        Per-position negative log-acceptance with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
+    elementwise_loss = -torch.log(overlap.clamp_min(_NLA_EPS))
+
+    return elementwise_loss  # noqa: RET504
+
+
+def lk_hybrid_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    eta: float = 3.0,
+):
+    """Compute per-position hybrid LK loss (adaptive KL/TV blend).
+
+    Blends KL divergence and total variation per position:
+    ``L = lambda * KL(p||q) + (1 - lambda) * TV(p, q)`` with adaptive weight
+    ``lambda = exp(-eta * sg[alpha])``, where ``alpha = sum_v min(p_v, q_v)`` is the
+    acceptance rate (overlap) and ``sg`` is stop-gradient. When overlap is low
+    (early training, misaligned draft) ``lambda -> 1`` and the loss leans on KL's
+    strong gradient; as overlap grows ``lambda -> 0`` and it shifts to TV, which
+    optimizes acceptance directly. This gives TV's acceptance-optimal target a
+    usable gradient from a cold start.
+
+    ``alpha`` in the weight is detached: it controls the blend but is not
+    differentiated through; gradients flow only through the KL and TV terms.
+
+    Source: Samarin et al., "LK Losses: Direct Acceptance Rate Optimization for
+    Speculative Decoding" (arXiv 2602.23881), hybrid objective.
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+        eta: Blend temperature; larger shifts toward TV sooner. Default 3.0
+            (the paper's best hybrid setting).
+
+    Returns:
+        Per-position hybrid loss with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
+    tv = 1.0 - overlap
+    kl = kl_div_loss(logits, targets)  # reuse existing KL, shape: [1, seq_len]
+    weight = torch.exp(-eta * overlap.detach())  # lambda = exp(-eta * sg[alpha])
+    elementwise_loss = weight * kl + (1.0 - weight) * tv
+
+    return elementwise_loss  # noqa: RET504

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -9,6 +9,7 @@ output, and LM head output are made deterministic.
 
 import copy
 import importlib.util
+import os
 import sys
 import types
 import unittest
@@ -165,7 +166,7 @@ def _fixed_noise_embed(self, input_ids, anchor_positions, block_keep_mask):
         bsz,
         n_blocks * self.block_size,
         self.embed_tokens.embedding_dim,
-        dtype=torch.double,
+        dtype=self.embed_tokens.weight.dtype,
         device=input_ids.device,
     )
 
@@ -198,20 +199,26 @@ def _make_model(logits, anchors, keep_mask, draft_model=None, lm_head=None, **kw
 
 
 def _make_dspark_model(
-    logits, anchors, keep_mask, draft_model=None, lm_head=None, **kwargs
+    logits,
+    anchors,
+    keep_mask,
+    draft_model=None,
+    lm_head=None,
+    dtype=torch.double,
+    **kwargs,
 ):
     bsz, n_blocks, block_size, vocab_size = logits.shape
     model = OnlineDSparkModel(
         draft_model=draft_model or _FixedDraft(hidden_size=4),
         target_lm_head=lm_head
         or _FixedHead(logits.reshape(bsz, n_blocks * block_size, vocab_size)),
-        target_embed_tokens=nn.Embedding(vocab_size, 4).double(),
+        target_embed_tokens=nn.Embedding(vocab_size, 4).to(dtype),
         mask_token_id=0,
         block_size=block_size,
         attention_backend="sdpa",
         num_anchors=n_blocks,
         **kwargs,
-    ).double()
+    ).to(dtype)
     model._sample_anchor_positions = types.MethodType(
         _fixed_anchor_sampler(anchors, keep_mask), model
     )
@@ -941,6 +948,311 @@ class TestDFlashLosses(unittest.TestCase):
                 loss_mask=loss_mask,
                 device=loss_mask.device,
             )
+
+
+def _triton_available() -> bool:
+    """True only for a real Triton install; mirrors test_fused_loss.py."""
+    try:
+        import triton
+        import triton.language  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(triton, "jit")
+
+
+def _npu_available() -> bool:
+    # torch.npu is only bound once torch_npu has been imported; nothing on the
+    # pytest collection path imports it, so probe explicitly here.
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    npu = getattr(torch, "npu", None)
+    return npu is not None and npu.is_available()
+
+
+def _accelerator_device():
+    """Pick the accelerator the fused kernels can run on, or None to skip."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if _npu_available():
+        return "npu"
+    return None
+
+
+_ACCELERATOR_DEVICE = _accelerator_device()
+_REQUIRES_FUSED = unittest.skipUnless(
+    _ACCELERATOR_DEVICE is not None and _triton_available(),
+    "fused DSpark loss requires Triton plus a CUDA or Ascend NPU accelerator",
+)
+
+
+class TestDSparkFusedLoss(unittest.TestCase):
+    """OnlineDSparkModel fused TV loss gating (CPU) and eager parity (device).
+
+    The gating tests run everywhere: the fused path must stay dark on CPU
+    tensors and when SPECFORGE_DSPARK_FUSED_LOSS=0. The kernel parity test
+    needs a real accelerator plus Triton and skips otherwise.
+    """
+
+    def setUp(self):
+        (
+            self.logits,
+            self.input_ids,
+            self.loss_mask,
+            self.hidden_states,
+            self.anchors,
+            self.keep_mask,
+        ) = _sample_tensors()
+
+    def _forward_with_target(self, model):
+        return model(
+            input_ids=self.input_ids,
+            hidden_states=self.hidden_states,
+            loss_mask=self.loss_mask,
+            target_last_hidden_states=torch.zeros_like(self.hidden_states),
+        )
+
+    def test_fused_flag_defaults_off_and_honors_opt_in(self):
+        with patch.dict(os.environ):
+            os.environ.pop("SPECFORGE_DSPARK_FUSED_LOSS", None)
+            model = _make_dspark_model(self.logits, self.anchors, self.keep_mask)
+            self.assertFalse(model._use_fused_dspark_loss)
+        for env_value, expected in (("1", True), ("0", False)):
+            with patch.dict(os.environ, {"SPECFORGE_DSPARK_FUSED_LOSS": env_value}):
+                model = _make_dspark_model(self.logits, self.anchors, self.keep_mask)
+            self.assertEqual(model._use_fused_dspark_loss, expected)
+
+    def test_availability_helper_requires_accelerator_and_triton(self):
+        helper = _dflash_module._fused_dspark_loss_available
+        # CPU tensors never take the fused path, even on hosts with Triton.
+        self.assertFalse(helper(torch.zeros(2, 3)))
+        if not _triton_available():
+            # Without Triton even an accelerator tensor must fall back.
+            for device_type in ("cuda", "npu"):
+                fake_tensor = types.SimpleNamespace(
+                    device=types.SimpleNamespace(type=device_type)
+                )
+                self.assertFalse(helper(fake_tensor))
+
+    def test_env_off_keeps_eager_path_when_fused_available(self):
+        target_logits = torch.randn_like(self.logits)
+        with patch.dict(os.environ, {"SPECFORGE_DSPARK_FUSED_LOSS": "0"}):
+            model = _make_dspark_model(
+                self.logits,
+                self.anchors,
+                self.keep_mask,
+                lm_head=_DualFixedHead(self.logits, target_logits).double(),
+            )
+        with (
+            patch.object(
+                _dflash_module, "_fused_dspark_loss_available", return_value=True
+            ),
+            patch.object(_dflash_module.fused_loss, "fused_tv_loss") as fused_mock,
+        ):
+            loss, accuracy, _metrics = self._forward_with_target(model)
+        self.assertTrue(torch.isfinite(loss))
+        self.assertTrue(torch.isfinite(accuracy))
+        fused_mock.assert_not_called()
+
+    def test_cpu_tensors_stay_eager_with_fused_enabled(self):
+        target_logits = torch.randn_like(self.logits)
+        with patch.dict(os.environ, {"SPECFORGE_DSPARK_FUSED_LOSS": "1"}):
+            model = _make_dspark_model(
+                self.logits,
+                self.anchors,
+                self.keep_mask,
+                lm_head=_DualFixedHead(self.logits, target_logits).double(),
+            )
+        self.assertTrue(model._use_fused_dspark_loss)
+        with patch.object(_dflash_module.fused_loss, "fused_tv_loss") as fused_mock:
+            loss, _accuracy, _metrics = self._forward_with_target(model)
+        self.assertTrue(torch.isfinite(loss))
+        fused_mock.assert_not_called()
+
+    def test_top1_telemetry_matches_softmax_reference(self):
+        """Pin p_max = exp(max_logit - logsumexp) to the softmax reference."""
+        torch.manual_seed(55)
+        target_logits = torch.randn_like(self.logits)
+        model = _make_dspark_model(
+            self.logits,
+            self.anchors,
+            self.keep_mask,
+            lm_head=_DualFixedHead(self.logits, target_logits).double(),
+        )
+        _loss, _acc, metrics = self._forward_with_target(model)
+        _targets, eval_mask = _dspark_targets_and_mask(
+            self.input_ids,
+            self.loss_mask,
+            self.anchors,
+            self.keep_mask,
+            self.logits.shape[2],
+        )
+        teacher_ref = (
+            torch.softmax(target_logits.float(), dim=-1).max(dim=-1).values * eval_mask
+        ).sum()
+        draft_ref = (
+            torch.softmax(self.logits.float(), dim=-1).max(dim=-1).values * eval_mask
+        ).sum()
+        ratio = metrics["ratio_metrics"]
+        torch.testing.assert_close(
+            ratio["teacher_top1_prob"][0],
+            teacher_ref,
+            rtol=1e-4,
+            atol=1e-6,
+            check_dtype=False,
+        )
+        torch.testing.assert_close(
+            ratio["draft_top1_prob"][0],
+            draft_ref,
+            rtol=1e-4,
+            atol=1e-6,
+            check_dtype=False,
+        )
+
+    def test_fused_path_wiring_matches_eager_loss_and_gradient(self):
+        """CPU wiring check: route the fused call site to an exact eager TV.
+
+        The mock computes tv = 0.5 * l1 in fp32 with the same op order as the
+        eager branch, so l1 = 2 * tv and accept = 1 - tv are bit-identical to
+        the eager path; any mismatch means the fused call site is miswired
+        (shape, dtype, weight application, or gradient plumbing through the
+        checkpointed chunk recompute).
+        """
+        torch.manual_seed(77)
+        head = nn.Linear(4, self.logits.shape[-1], bias=False).double()
+        target_hidden = torch.randn_like(self.hidden_states)
+
+        def build(env_value):
+            with patch.dict(os.environ, {"SPECFORGE_DSPARK_FUSED_LOSS": env_value}):
+                return _make_dspark_model(
+                    self.logits,
+                    self.anchors,
+                    self.keep_mask,
+                    draft_model=_LearnableDSparkDraft(4).double(),
+                    lm_head=copy.deepcopy(head),
+                    objective_chunk_blocks=1,
+                )
+
+        eager_model = build("0")
+        fused_model = build("1")
+        fused_model.load_state_dict(eager_model.state_dict())
+
+        fused_loss_module = _dflash_module.fused_loss
+
+        def exact_eager_tv(logits, targets):
+            draft_p = torch.softmax(logits.float(), dim=-1)
+            target_p = torch.softmax(targets.float(), dim=-1)
+            return 0.5 * (draft_p - target_p).abs().sum(dim=-1)
+
+        with (
+            patch.object(
+                _dflash_module, "_fused_dspark_loss_available", return_value=True
+            ),
+            patch.object(
+                fused_loss_module, "fused_tv_loss", side_effect=exact_eager_tv
+            ) as fused_mock,
+        ):
+            fused_value, _fused_acc, fused_metrics = fused_model(
+                input_ids=self.input_ids,
+                hidden_states=self.hidden_states,
+                loss_mask=self.loss_mask,
+                target_last_hidden_states=target_hidden,
+            )
+            self.assertTrue(fused_mock.called)
+            # Checkpoint recompute re-enters the chunk function during backward,
+            # so the fused patch must still be active here.
+            fused_value.backward()
+        eager_value, _eager_acc, eager_metrics = eager_model(
+            input_ids=self.input_ids,
+            hidden_states=self.hidden_states,
+            loss_mask=self.loss_mask,
+            target_last_hidden_states=target_hidden,
+        )
+        eager_value.backward()
+        torch.testing.assert_close(fused_value, eager_value, rtol=1e-6, atol=1e-9)
+        for name, eager_pair in eager_metrics["ratio_metrics"].items():
+            fused_pair = fused_metrics["ratio_metrics"][name]
+            torch.testing.assert_close(
+                fused_pair[0], eager_pair[0], rtol=1e-6, atol=1e-9, check_dtype=False
+            )
+            torch.testing.assert_close(fused_pair[1], eager_pair[1])
+
+        torch.testing.assert_close(
+            fused_model.draft_model.signal.grad,
+            eager_model.draft_model.signal.grad,
+            rtol=1e-6,
+            atol=1e-9,
+        )
+        torch.testing.assert_close(
+            fused_model.lm_head.weight.grad,
+            eager_model.lm_head.weight.grad,
+            rtol=1e-6,
+            atol=1e-9,
+        )
+
+    @_REQUIRES_FUSED
+    def test_fused_kernel_matches_eager_on_accelerator(self):
+        """Real fused TV kernel vs the eager path: loss, telemetry, gradients."""
+        torch.manual_seed(2024)
+        device = torch.device(_ACCELERATOR_DEVICE)
+        bsz, n_blocks, block_size, vocab_size = 2, 3, 4, 100
+        seq_len = 10
+        anchors = torch.tensor([[0, 2, 5], [1, 3, 5]])
+        keep_mask = torch.tensor([[True, True, True], [True, False, True]])
+        input_ids = torch.randint(0, vocab_size, (bsz, seq_len))
+        loss_mask = torch.ones(bsz, seq_len)
+        hidden_states = torch.randn(bsz, seq_len, 4)
+        target_hidden = torch.randn(bsz, seq_len, 4)
+        head = nn.Linear(4, vocab_size, bias=False)
+        shape_stub = torch.empty(bsz, n_blocks, block_size, vocab_size)
+
+        def build(env_value):
+            with patch.dict(os.environ, {"SPECFORGE_DSPARK_FUSED_LOSS": env_value}):
+                model = _make_dspark_model(
+                    shape_stub,
+                    anchors,
+                    keep_mask,
+                    draft_model=_LearnableDSparkDraft(4),
+                    lm_head=copy.deepcopy(head),
+                    dtype=torch.float32,
+                )
+            return model.to(device)
+
+        eager_model = build("0")
+        fused_model = build("1")
+        fused_model.load_state_dict(eager_model.state_dict())
+
+        inputs = dict(
+            input_ids=input_ids.to(device),
+            hidden_states=hidden_states.to(device),
+            loss_mask=loss_mask.to(device),
+            target_last_hidden_states=target_hidden.to(device),
+        )
+        fused_value, _fused_acc, fused_metrics = fused_model(**inputs)
+        eager_value, _eager_acc, eager_metrics = eager_model(**inputs)
+        torch.testing.assert_close(fused_value, eager_value, rtol=1e-3, atol=1e-5)
+        for name, eager_pair in eager_metrics["ratio_metrics"].items():
+            fused_pair = fused_metrics["ratio_metrics"][name]
+            torch.testing.assert_close(
+                fused_pair[0], eager_pair[0], rtol=1e-3, atol=1e-5, check_dtype=False
+            )
+            torch.testing.assert_close(fused_pair[1], eager_pair[1])
+
+        fused_value.backward()
+        eager_value.backward()
+        torch.testing.assert_close(
+            fused_model.draft_model.signal.grad,
+            eager_model.draft_model.signal.grad,
+            rtol=1e-2,
+            atol=1e-4,
+        )
+        torch.testing.assert_close(
+            fused_model.lm_head.weight.grad,
+            eager_model.lm_head.weight.grad,
+            rtol=1e-2,
+            atol=1e-4,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/test_fused_loss.py
+++ b/tests/test_utils/test_fused_loss.py
@@ -1,0 +1,276 @@
+"""Fused Triton losses vs their eager references (specforge.core.fused_loss).
+
+One test per loss, comparing loss value and logits-gradient against eager in
+the three regimes that catch distinct bugs: fp32 with saturated point-mass
+rows (gradient formula, log-space underflow), bf16 (the training dtype), and
+the 151936-wide vocab (multi-block streaming, non-power-of-2 tail). The
+upstream gradient contains exact zeros, so masked rows take the backward
+kernel's early-out and must return exact zeros from an uninitialized buffer.
+
+The accelerator is auto-detected: CUDA when present, otherwise Ascend NPU
+(via triton-ascend). Without Triton or an accelerator the fused legs skip
+gracefully, while the device-cap and eager legs still run on CPU. The
+151936-wide leg also exercises the smaller NPU BLOCK_SIZE cap
+(MAX_FUSED_SIZE_NPU = 4096), which forces the tighter multi-block streaming
+loop.
+"""
+
+import math
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from specforge.core import fused_loss
+
+
+def _triton_available() -> bool:
+    """True only for a real Triton install; a stray ``triton/`` namespace
+    directory on sys.path (no ``jit``, no ``language``) must not count."""
+    try:
+        import triton
+        import triton.language  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(triton, "jit")
+
+
+def _npu_available() -> bool:
+    # torch.npu is only bound once torch_npu has been imported; nothing on the
+    # test collection path imports it, so probe explicitly here.
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    npu = getattr(torch, "npu", None)
+    return npu is not None and npu.is_available()
+
+
+def _accelerator_device() -> str | None:
+    """Pick the accelerator the fused kernels can run on, or None to skip."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if _npu_available():
+        return "npu"
+    return None
+
+
+DEVICE = _accelerator_device()
+requires_fused = unittest.skipUnless(
+    DEVICE is not None and _triton_available(),
+    "fused Triton losses require Triton plus a CUDA or Ascend NPU accelerator",
+)
+
+# (name, eager fn name, fused fn name); both resolved lazily from the module
+CASES = [
+    ("kl_div", "kl_div_loss", "fused_kl_div_loss"),
+    ("rkl", "reverse_kl_div_loss", "fused_reverse_kl_div_loss"),
+    ("jsd", "js_div_loss", "fused_js_div_loss"),
+    ("ce", "ce_loss", "fused_ce_loss"),
+    ("tv", "tv_loss", "fused_tv_loss"),
+    ("nla", "neg_log_acceptance_loss", "fused_nla_loss"),
+    ("lk_hybrid", "lk_hybrid_loss", "fused_lk_hybrid_loss"),
+]
+
+# Loss values are fp32 on both paths; gradients allow bf16 1-ulp rounding
+# (both paths quantize at the leaf). A wrong gradient formula errs by orders
+# of magnitude more than either bound.
+LOSS_TOL = {"atol": 1e-4, "rtol": 1e-3}
+GRAD_TOL = {"atol": 1e-3, "rtol": 1e-2}
+# eager ce computes cross_entropy in bf16, so its bf16 legs are bounded by
+# eager's own rounding, not by the (fp32) fused kernel
+CE_BF16_LOSS_TOL = {"atol": 0.2, "rtol": 1e-2}
+CE_BF16_GRAD_TOL = {"atol": 1e-2, "rtol": 2e-2}
+
+
+def _assert_fused_matches_eager(
+    eager_fn, fused_fn, logits, targets, loss_tol, grad_tol
+):
+    le = logits.detach().clone().requires_grad_(True)
+    lf = logits.detach().clone().requires_grad_(True)
+    out_e = eager_fn(le, targets)
+    out_f = fused_fn(lf, targets)
+    assert out_f.dtype == torch.float32  # like the eager fp32 softmax (#788)
+    torch.testing.assert_close(out_f, out_e.float(), **loss_tol)
+
+    go = torch.randn_like(out_e, dtype=torch.float32)
+    go[:, ::3] = 0.0  # rows taking the go == 0 early-out
+    (out_e.float() * go).sum().backward()
+    (out_f * go).sum().backward()
+    assert le.grad is not None
+    assert lf.grad is not None
+    torch.testing.assert_close(lf.grad.float(), le.grad.float(), **grad_tol)
+
+
+class TestFusedLoss(unittest.TestCase):
+    @requires_fused
+    def test_fused_matches_eager(self):
+        """Fused == eager (value + gradient) across the three failure-mode regimes."""
+        for name, eager_name, fused_name in CASES:
+            with self.subTest(name=name):
+                eager_fn = getattr(fused_loss, eager_name)
+                fused_fn = getattr(fused_loss, fused_name)
+
+                # fp32, with saturated +-30 point-mass rows (one agreeing, one disagreeing)
+                torch.manual_seed(0)
+                logits = torch.randn(1, 32, 512, device=DEVICE) * 3
+                targets = torch.randn(1, 32, 512, device=DEVICE) * 3
+                logits[0, -2:] = -30.0
+                targets[0, -2:] = -30.0
+                logits[0, -2:, 0] = 30.0
+                targets[0, -2, 0] = 30.0  # last two rows: draft==target, then disagree
+                targets[0, -1, 7] = 30.0
+                _assert_fused_matches_eager(
+                    eager_fn, fused_fn, logits, targets, LOSS_TOL, GRAD_TOL
+                )
+
+                # bf16, the training dtype
+                torch.manual_seed(1)
+                logits = (torch.randn(1, 64, 512, device=DEVICE) * 3).bfloat16()
+                targets = (torch.randn(1, 64, 512, device=DEVICE) * 3).bfloat16()
+                _assert_fused_matches_eager(
+                    eager_fn,
+                    fused_fn,
+                    logits,
+                    targets,
+                    CE_BF16_LOSS_TOL if name == "ce" else LOSS_TOL,
+                    CE_BF16_GRAD_TOL if name == "ce" else GRAD_TOL,
+                )
+
+                # Qwen3's 151936 vocab exceeds MAX_FUSED_SIZE (and
+                # MAX_FUSED_SIZE_NPU): multi-block streaming plus a
+                # non-power-of-2 masked tail. On NPU the per-block cap is 4096,
+                # so this leg also covers the tighter block loop.
+                torch.manual_seed(2)
+                logits = torch.randn(1, 3, 151936, device=DEVICE) * 3
+                targets = torch.randn(1, 3, 151936, device=DEVICE) * 3
+                _assert_fused_matches_eager(
+                    eager_fn, fused_fn, logits, targets, LOSS_TOL, GRAD_TOL
+                )
+
+    @requires_fused
+    def test_compiles_fullgraph(self):
+        """torch.compile(fullgraph=True) must trace the fused losses.
+
+        The OP selector crosses the autograd.Function boundary, and Dynamo cannot
+        represent a tl.constexpr object there -- passing one graph-breaks (or
+        fails under fullgraph). Model forwards are wrapped in torch.compile, so
+        this guards the compiled training path.
+        """
+        for name, _eager_name, fused_name in CASES:
+            with self.subTest(name=name):
+                fused_fn = getattr(fused_loss, fused_name)
+                logits = torch.randn(1, 8, 512, device=DEVICE, requires_grad=True)
+                targets = torch.randn(1, 8, 512, device=DEVICE)
+
+                # Eager warmup first: the lazy Triton assembly in
+                # _require_triton() is not Dynamo-traceable, so it must happen
+                # before the compiled region runs.
+                fused_fn(logits.detach(), targets)
+
+                compiled = torch.compile(
+                    lambda a, b: fused_fn(a, b).sum(), fullgraph=True
+                )
+                compiled(logits, targets).backward()
+                assert logits.grad is not None
+                assert torch.isfinite(logits.grad).all()
+
+    def test_calculate_settings_respects_device_cap(self):
+        """`_calculate_settings` picks the right BLOCK_SIZE for each device without
+        needing NPU or CUDA hardware -- the helper only reads ``device.type`` and
+        is intentionally Triton-free so this test runs on CPU-only hosts.
+
+        Exercises the NPU cap (MAX_FUSED_SIZE_NPU = 4096) and the CUDA cap
+        (MAX_FUSED_SIZE = 131072) at vocab sizes that span the boundaries, so
+        upstream CI (which typically has no NPU) still covers the NPU branch.
+        """
+        npu_cases = (
+            (512, 512),
+            (4096, 4096),
+            (8192, 4096),
+            (32768, 4096),
+            (131072, 4096),
+            (151936, 4096),
+        )
+        for vocab, expected in npu_cases:
+            block, _ = fused_loss._calculate_settings(
+                vocab, SimpleNamespace(type="npu")
+            )
+            assert (
+                block == expected
+            ), f"NPU cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
+
+        cuda_cases = (
+            (512, 512),
+            (4096, 4096),
+            (8192, 8192),
+            (131072, 131072),
+            (151936, 131072),
+        )
+        for vocab, expected in cuda_cases:
+            block, _ = fused_loss._calculate_settings(
+                vocab, SimpleNamespace(type="cuda")
+            )
+            assert (
+                block == expected
+            ), f"CUDA cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
+
+    def test_eager_implementation_supports_differentiable_targets(self):
+        """The explicit eager implementation preserves target gradients."""
+        torch.manual_seed(3)
+        for eager_name in (
+            "kl_div_loss",
+            "reverse_kl_div_loss",
+            "js_div_loss",
+            "tv_loss",
+            "neg_log_acceptance_loss",
+            "lk_hybrid_loss",
+        ):
+            with self.subTest(eager_name=eager_name):
+                logits = torch.randn(1, 4, 64, requires_grad=True)
+                targets = torch.randn(1, 4, 64, requires_grad=True)
+                loss_fn = getattr(fused_loss, eager_name)
+                loss_fn(logits, targets).sum().backward()
+                assert logits.grad is not None, eager_name
+                assert targets.grad is not None, eager_name
+
+    def test_eager_losses_self_consistent(self):
+        """CPU-checkable identities among the eager references, including a
+        saturated point-mass row mirroring the fused parity regimes."""
+        torch.manual_seed(4)
+        logits = torch.randn(1, 8, 128) * 3
+        targets = torch.randn(1, 8, 128) * 3
+        logits[0, -1] = -30.0
+        targets[0, -1] = -30.0
+        logits[0, -1, 0] = 30.0
+        targets[0, -1, 7] = 30.0  # disagreeing point masses
+
+        kl = fused_loss.kl_div_loss(logits, targets)
+        rkl = fused_loss.reverse_kl_div_loss(logits, targets)
+        jsd = fused_loss.js_div_loss(logits, targets)
+        tv = fused_loss.tv_loss(logits, targets)
+        nla = fused_loss.neg_log_acceptance_loss(logits, targets)
+        hybrid = fused_loss.lk_hybrid_loss(logits, targets)
+
+        assert torch.isfinite(kl).all() and (kl >= -1e-6).all()
+        assert torch.isfinite(rkl).all() and (rkl >= -1e-6).all()
+        assert (jsd >= -1e-6).all() and (jsd <= math.log(2.0) + 1e-6).all()
+        assert (tv >= 0.0).all() and (tv <= 1.0).all()
+        # nla = -log(alpha) with alpha = 1 - tv; hybrid blends kl/tv with the
+        # detached overlap weight exp(-eta * alpha)
+        torch.testing.assert_close(nla, -torch.log((1.0 - tv).clamp_min(1e-5)))
+        weight = torch.exp(-3.0 * (1.0 - tv))
+        torch.testing.assert_close(hybrid, weight * kl + (1.0 - weight) * tv)
+
+        # ce uses argmax(targets) as hard labels
+        ce = fused_loss.ce_loss(logits, targets)
+        ref = torch.nn.functional.cross_entropy(
+            logits.reshape(-1, 128),
+            targets.argmax(dim=-1).reshape(-1),
+            reduction="none",
+        ).reshape(1, 8)
+        torch.testing.assert_close(ce, ref)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DSpark's L1 and acceptance terms materialize two full-vocab fp32 softmaxes plus the `|p - q|` intermediate, and the draft side carries gradients, so these tensors live through backward. At V=151936 each fp32 `[T, V]` tensor is ~4.7 GiB. Upstream hit the same pattern with eager `kl_div` and measured 23.2 GB vs 2.3 GB beyond inputs after fusing (bf16, V=151936, T=8192, GB10; [vllm-project/speculators#951](https://github.com/vllm-project/speculators/pull/951)).

Both sides are normalized softmaxes, so `L1 = 2 * TV` and `accept = 1 - TV` — one fused TV call (#826) replaces both tensors. Upstream uses the kernel the same way for its DSpark confidence; here the L1 term additionally flows gradients through it. Consumers of `accept_probability` stay detached, as in eager.

Off by default; enable with `SPECFORGE_DSPARK_FUSED_LOSS=1`. Falls back to eager without Triton or an accelerator.

## Modifications

- `specforge/algorithms/common/dflash_family_model.py`:
  - `_dspark_objective_chunk_terms` calls `fused_loss.fused_tv_loss` and derives `l1 = 2 * tv`, `accept = 1 - tv` when the fused path is available; eager branch unchanged. Gradient flow matches eager: only `l1, the BCE target and tau use `accept_probability.detach()`.
  - New `_fused_dspark_loss_available` gate: CUDA/NPU device plus Triton importable, checked per call.
  - Top-1 telemetry uses `exp(max_logit - logsumexp(logits))` instead of the materialized probabilities.
- `tests/test_utils/test_dflash_losses.py`: new `TestDSparkFusedLoss` — flag default-off and opt-in, availability gating, telemetry formula, a CPU wiring test that mocks the kernel as exact eager TV (bit-identical loss, gradients, metrics), real-kernel parity test on CUDA/NPU.

## Related Issues

Stacked on #826: `specforge/core/fused_loss.py` and `tests/test_utils/test_fused_loss.py` here are that PR's files, unchanged.

## Accuracy Test

Single-step parity on Ascend NPU (triton-ascend) — PASSED: `TestDSparkFusedLoss::test_fused_kernel_matches_eager_on_accelerator` compares fused vs eager on identical inputs and weights; loss and ratio metrics within rtol=1e-3/atol=1e-5, gradients within rtol=1e-2/atol=1e-4.

Production-scale parity probe (5 scales from vocab=100/1 chunk up to Qwen3- vocab=151936, hidden=2560, 38 streaming chunks; fp32 and bf16): loss and gradient relative differences stay at the 1e-7 level in both precisions and do not grow with scale — the multi-chunk streaming path introduces no scale-dependent error, and bf16 differences are even smaller because both paths upcast to fp32 internally.

Long-run ablation, warm-start, fused=1 vs fused=0, 1100 steps on Ascend NPU (6 capture servers + 10 trainer ranks, Qwen3-4B, managed-local disaggregated):

fused loss kernels:
<img width="3000" height="4200" alt="image" src="https://github.com/user-attachments/assets/af9632db-967e-4f74-ace1-f7ff72a61e88" />

w/o fused loss kernels:
<img width="3000" height="4200" alt="image" src="https://github.com/user-attachments/assets/d07019f8-cb7c-43d5-bce2-70ded64033a0" />

<img width="2100" height="750" alt="image" src="https://github.com/user-attachments/assets/b361ac62-11b3-4746-8532-e5bae5dc98ed" />

| Metric | fused=1 | fused=0 | Note |
|---|---|---|---|
| train/acc | 0.9358 | 0.9383 | -0.27 pp |
| train/ce_loss | 0.2560 | 0.2418 | +5.6% |
| train/l1_loss | 0.1848 | 0.1776 | +3.9% |
| train/confidence_loss | 0.2198 | 0.2137 | +2.8% |
| train/loss | 0.3838 | 0.2964 | +22.8% |
| train/grad_norm | 0.0751 | 0.0690 | +8.2% |

The long-run divergence is consistent with chaotic amplification of the 1e-7-level per-step differences measured above, not with an implementation defect: training trajectories amplify perturbations multiplicatively, and3%/step of compounding turns 1e-7 into 22.8% over 1100 steps. Three observations support this reading: the parity tests pass with tight tolerances at every scale including production; the CE and confidence terms — which never touch the fused kernel — drift by the same magnitude as the swapped L1 term, i.e. the divergence is global trajectory drift rather than a wrong term; and the gap opens immediately and drifts all run with no discrete jump, flipping sign mid-run (fused leads train/loss by 0.13 at step 350, trails by 0.09 at step 1100) — the overlaid curves cross repeatedly with no persistent separation, and the end gap is sensitive to where the run stops (within ~5% at step 1000; the quoted +22.8% appears only in the final ~100 steps). Acceptance-relevant metrics land within 0.3 pp.

## Benchmark & Profiling

Same ablation setup as above. Step time 4.84 s → 3.30 s (-32%); throughput 16.5 → 24.2 samples/s (+47%). The two fp32 `[T, V]` softmaxes and the `|p - q|` intermediate no longer materialize in forward or in the autograd graph.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.