### PR TITLE
docs: add mtp to accepted training.strategy values

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -246,7 +246,7 @@ Common fields:
 
 | Field | Default | What to write |
 | --- | --- | --- |
-| `training.strategy` | `eagle3` | `eagle3`, `peagle`, `dflash`, `domino`, or `dspark`. |
+| `training.strategy` | `eagle3` | `eagle3`, `peagle`, `dflash`, `domino`, `dspark`, or `mtp`. |
 | `training.num_epochs` | `1` | Positive passes over a finite source. |
 | `training.max_steps` | `null` | Positive hard stop in optimizer steps. If it is set while `total_steps` is omitted, it is also the fallback schedule horizon. |
 | `training.total_steps` | `null` | Positive optimizer/loss schedule horizon; it does not itself stop an online stream. A finite online disaggregated run may omit both fields: the producer publishes the exact horizon derived from prepared prompts, epochs, DP size, batch size, and accumulation. |


### PR DESCRIPTION
## Motivation

`examples/configs/README.md` documents the accepted `training.strategy`
values as `eagle3`, `peagle`, `dflash`, `domino`, or `dspark`. The builtin
algorithm catalog registers six algorithms, including `mtp`:

```python
# specforge/algorithms/builtin.py
return AlgorithmRegistry((eagle3(), peagle(), dflash(), domino(), dspark(), mtp()))
```

`mtp` is not an experimental name either — the checked-in recipe
`examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml`
already sets `strategy: "mtp"`, and `docs/basic_usage/training.md` documents
MTP in its strategy/attention-backend notes and its
`scripts/merge_mtp_to_base.py` deployment flow. Readers who pick their
strategy from the recipe-catalog table therefore see one fewer strategy than
the code accepts.

Verified against `main` @ `6c6b75e`:

```
$ python -c "from specforge.algorithms.builtin import builtin_algorithm_registry as r; print(sorted(r().names))"
['dflash', 'domino', 'dspark', 'eagle3', 'mtp', 'peagle']

$ python -c "from specforge.cli import load_config; print(load_config('examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml', []).training.strategy)"
mtp
```

An unknown value is rejected with the same list, confirming these are the
accepted values:

```
KeyError: "unknown algorithm 'bogus'; registered algorithms: ['dflash', 'domino', 'dspark', 'eagle3', 'mtp', 'peagle']"
```

## Modifications

- `examples/configs/README.md`: add `mtp` to the `training.strategy` row's
  accepted values.

Docs only; one line. No strategy-specific row is added to the
"Strategy-specific fields" table because `mtp` defines no extra `training.*`
fields.

## Related Issues

None.

## Accuracy Test

Not applicable — documentation only, no model-side code touched.

## Benchmark & Profiling

Not applicable — documentation only, no runtime code touched.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
