### PR TITLE
feat(config): add model.target_head_path for quantized targets

### DIFF
--- a/docs/advanced_features/customization.md
+++ b/docs/advanced_features/customization.md
@@ -73,6 +73,12 @@ model:
   lm_head_key: lm_head.weight
 ```
 
+`model.target_head_path` is an optional trainer-only checkpoint for the
+`embedding_key` / `lm_head_key` tensors. Set it when `target_model_path` is a
+quantized export (for example NVFP4) whose packed `lm_head` the trainer cannot
+load: SGLang keeps serving the quantized target while the trainer reads the
+full-width BF16 head from the unquantized checkpoint or a head-only export.
+
 Every online run uses `model.target_backend: sglang`. Add target-model support
 to the SGLang capture server instead of adding an HF/custom target loader to
 the trainer. Target TP/EP and model-specific inference stay on that server;

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -185,6 +185,7 @@ should make their training strategy and topology explicit.
 | `model.use_liger_kernel` | `false` | Enable Liger Qwen3 RMSNorm/SwiGLU kernels for DFlash training. Requires the `specforge[liger]` extra. |
 | `model.embedding_key` | `model.embed_tokens.weight` | Target checkpoint key copied into or used by the draft embedding. |
 | `model.lm_head_key` | `lm_head.weight` | Target checkpoint key used for the frozen output head. |
+| `model.target_head_path` | `null` | Optional trainer-only checkpoint for the `embedding_key` / `lm_head_key` tensors when `target_model_path` is a quantized export whose packed head the trainer cannot load; SGLang keeps serving `target_model_path`. |
 | `model.vocab_mapping_path` | `""` | Target-to-draft vocabulary mapping. EAGLE3 disaggregated runs require an explicit shared file. |
 | `model.load_target_embedding` | `true` | Copy the frozen target embedding into a fresh draft when supported. |
 | `model.aux_hidden_state_layer_ids` | `null` | Optional EAGLE3/P-EAGLE capture override containing exactly three non-negative layer IDs. Other strategies derive layers from the draft config. |

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -280,7 +280,7 @@ def build_eagle3_model(
         from specforge.modeling.target.target_head import TargetHead
 
         target_head = TargetHead.from_pretrained(
-            cfg.model.target_model_path,
+            cfg.model.target_head_path or cfg.model.target_model_path,
             lm_head_key=cfg.model.lm_head_key,
             cache_dir=cfg.model.cache_dir,
             trust_remote_code=cfg.model.trust_remote_code,
@@ -321,7 +321,7 @@ def build_peagle_model(
         from specforge.modeling.target.target_head import TargetHead
 
         target_head = TargetHead.from_pretrained(
-            cfg.model.target_model_path,
+            cfg.model.target_head_path or cfg.model.target_model_path,
             lm_head_key=cfg.model.lm_head_key,
             cache_dir=cfg.model.cache_dir,
             trust_remote_code=cfg.model.trust_remote_code,
@@ -348,7 +348,7 @@ def _build_dflash_family_model(
     method_config["target_layer_ids"] = list(draft_model.target_layer_ids)
 
     target_parts = TargetEmbeddingsAndHead.from_pretrained(
-        cfg.model.target_model_path,
+        cfg.model.target_head_path or cfg.model.target_model_path,
         embed_key=cfg.model.embedding_key,
         lm_head_key=cfg.model.lm_head_key,
         cache_dir=cfg.model.cache_dir,

--- a/specforge/config/schema.py
+++ b/specforge/config/schema.py
@@ -36,6 +36,12 @@ class StrictConfigModel(BaseModel):
 
 class ModelConfig(StrictConfigModel):
     target_model_path: str
+    #: Optional trainer-only checkpoint for the full-width embedding and LM-head
+    #: tensors (``embedding_key`` / ``lm_head_key``). Quantized targets such as
+    #: NVFP4 checkpoints ship a packed ``lm_head`` that the trainer cannot use;
+    #: point this at the unquantized checkpoint (or a small head-only export)
+    #: while SGLang keeps serving ``target_model_path``.
+    target_head_path: Optional[str] = None
     #: Draft config as a local JSON file, a directory containing config.json,
     #: or a Hugging Face repository. EAGLE3, P-EAGLE, and DFlash can derive it
     #: from the target when omitted.

--- a/specforge/training/provenance.py
+++ b/specforge/training/provenance.py
@@ -272,7 +272,7 @@ def _compute_model_resume_provenance(
         "_name_or_path",
         None,
     )
-    return {
+    provenance = {
         MODEL_SOURCE_IDENTITY_FORMAT_FIELD: MODEL_SOURCE_IDENTITY_FORMAT,
         "target_model": model_source_identity(cfg.model.target_model_path),
         "target_revision": getattr(target_config, "_commit_hash", None),
@@ -290,6 +290,12 @@ def _compute_model_resume_provenance(
         "input_modality": cfg.model.input_modality,
         "torch_dtype": cfg.model.torch_dtype,
     }
+    target_head_path = getattr(cfg.model, "target_head_path", None)
+    if target_head_path:
+        # Recorded only when configured so checkpoints written before this
+        # field existed keep comparing equal on resume.
+        provenance["target_head"] = model_source_identity(target_head_path)
+    return provenance
 
 
 def model_resume_provenance(

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -93,6 +93,19 @@ class ConfigSchemaTest(unittest.TestCase):
         self.assertIsNone(config.training.max_steps)
         self.assertIsNone(config.training.total_steps)
 
+    def test_target_head_path_is_optional_and_typed(self):
+        cfg = Config.model_validate(MINIMAL)
+        self.assertIsNone(cfg.model.target_head_path)
+
+        payload = copy.deepcopy(MINIMAL)
+        payload["model"]["target_head_path"] = "/heads/bf16-head"
+        cfg = Config.model_validate(payload)
+        self.assertEqual(cfg.model.target_head_path, "/heads/bf16-head")
+
+        payload["model"]["target_head_path"] = ["/heads/bf16-head"]
+        with self.assertRaises(ValidationError):
+            Config.model_validate(payload)
+
     def test_fsdp_sharding_is_typed(self):
         payload = copy.deepcopy(MINIMAL)
         payload["training"] = {"fsdp_sharding": "NO_SHARD"}

--- a/tests/test_runtime/test_target_head_path.py
+++ b/tests/test_runtime/test_target_head_path.py
@@ -66,9 +66,7 @@ class TargetHeadPathTest(unittest.TestCase):
 
     def test_dflash_family_head_reads_the_configured_head_checkpoint(self):
         from_pretrained = self._build(_cfg(target_head_path="/models/target-bf16-head"))
-        self.assertEqual(
-            from_pretrained.call_args.args, ("/models/target-bf16-head",)
-        )
+        self.assertEqual(from_pretrained.call_args.args, ("/models/target-bf16-head",))
         self.assertEqual(
             from_pretrained.call_args.kwargs["lm_head_key"], "lm_head.weight"
         )

--- a/tests/test_runtime/test_target_head_path.py
+++ b/tests/test_runtime/test_target_head_path.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+"""``model.target_head_path`` routes trainer-side head loading to another checkpoint."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import mock
+
+from specforge.algorithms import model_providers
+from specforge.training import provenance
+
+
+def _cfg(target_head_path=None) -> SimpleNamespace:
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            target_model_path="/models/target-nvfp4",
+            target_head_path=target_head_path,
+            embedding_key="model.embed_tokens.weight",
+            lm_head_key="lm_head.weight",
+            cache_dir=None,
+            trust_remote_code=False,
+            mask_token_id=7,
+            torch_dtype="bfloat16",
+        ),
+        training=SimpleNamespace(
+            attention_backend="sdpa",
+            num_anchors=4,
+            loss_decay_gamma=1.0,
+            objective_chunk_blocks=0,
+        ),
+    )
+
+
+class _Draft:
+    block_size = 4
+    target_layer_ids = (1, 2)
+
+    def __init__(self):
+        self.config = SimpleNamespace(dflash_config={}, vocab_size=16)
+        self.mask_token_id = None
+
+
+class _Built:
+    def to(self, **_kwargs):
+        return self
+
+
+class TargetHeadPathTest(unittest.TestCase):
+    def _build(self, cfg):
+        parts = SimpleNamespace(lm_head="lm_head", embed_tokens="embed")
+        with mock.patch(
+            "specforge.modeling.target.target_utils.TargetEmbeddingsAndHead.from_pretrained",
+            return_value=parts,
+        ) as from_pretrained:
+            model_providers._build_dflash_family_model(
+                cfg, _Draft(), tokenizer=None, model_factory=lambda common: _Built()
+            )
+        return from_pretrained
+
+    def test_dflash_family_head_defaults_to_the_target_checkpoint(self):
+        from_pretrained = self._build(_cfg())
+        self.assertEqual(from_pretrained.call_args.args, ("/models/target-nvfp4",))
+
+    def test_dflash_family_head_reads_the_configured_head_checkpoint(self):
+        from_pretrained = self._build(_cfg(target_head_path="/models/target-bf16-head"))
+        self.assertEqual(
+            from_pretrained.call_args.args, ("/models/target-bf16-head",)
+        )
+        self.assertEqual(
+            from_pretrained.call_args.kwargs["lm_head_key"], "lm_head.weight"
+        )
+
+
+class TargetHeadProvenanceTest(unittest.TestCase):
+    def _provenance(self, cfg):
+        return provenance._compute_model_resume_provenance(
+            cfg,
+            SimpleNamespace(_commit_hash=None),
+            SimpleNamespace(_commit_hash=None),
+            capture_layers=[1, 2],
+        )
+
+    def _cfg(self, target_head_path):
+        cfg = _cfg(target_head_path)
+        cfg.model.draft_model_config = "remote/draft"
+        cfg.model.vocab_mapping_path = ""
+        cfg.model.load_target_embedding = True
+        cfg.model.input_modality = "text"
+        return cfg
+
+    def test_unset_head_path_keeps_the_existing_contract_shape(self):
+        mapping = self._provenance(self._cfg(None))
+        self.assertNotIn("target_head", mapping)
+
+    def test_head_path_is_recorded_with_its_source_identity(self):
+        with TemporaryDirectory(prefix="target-head-") as directory:
+            head = Path(directory)
+            (head / "config.json").write_text("{}", encoding="utf-8")
+            (head / "model.safetensors").write_bytes(b"head")
+            mapping = self._provenance(self._cfg(str(head)))
+            self.assertEqual(
+                mapping["target_head"], provenance.model_source_identity(str(head))
+            )
+            self.assertNotEqual(mapping["target_head"], mapping["target_model"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Quantized target exports (e.g. NVFP4 checkpoints produced by ModelOpt) ship a packed `lm_head.weight` plus `lm_head.weight_scale*`. SGLang serves them fine, but the trainer side (`TargetHead` for EAGLE3/P-EAGLE, `TargetEmbeddingsAndHead` for the DFlash family) reads `lm_head_key` from `model.target_model_path` and cannot use the packed tensor. Today the only workaround is a hand-built overlay directory, which also changes what SGLang loads.

## Change

- `model.target_head_path: Optional[str]` — a trainer-only checkpoint (the unquantized model, or a small head-only export) for the `embedding_key` / `lm_head_key` tensors. Defaults to `None` = current behaviour (`target_model_path`).
- All three trainer-side head loaders resolve `target_head_path or target_model_path`; the SGLang serving path is untouched.
- Model resume provenance records `target_head` **only when set**, so checkpoints written before this field existed keep comparing equal on resume.
- Docs: `docs/advanced_features/customization.md` (Target models).

## Tests

`tests/test_runtime/test_target_head_path.py` (head resolution default vs configured; provenance shape unchanged when unset, source identity recorded when set), `tests/test_config/test_schema.py` (optional + typed). CPU: `test_config.test_schema`, `test_runtime.test_model_provenance`, new file — all pass.

Used for the Qwen3.8-27B NVFP4 target (bf16 head exported from the public checkpoint) in the colocated-vs-disaggregated throughput comparison on B300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)