### PR TITLE
fix(mooncake): treat OBJECT_NOT_FOUND as a completed removal

### DIFF
--- a/specforge/runtime/data_plane/mooncake_store.py
+++ b/specforge/runtime/data_plane/mooncake_store.py
@@ -80,6 +80,10 @@ from specforge.runtime.data_plane.feature_store import (
 logger = logging.getLogger(__name__)
 
 # Defaults for MooncakeDistributedStore.setup(); override via ``setup_kwargs``.
+#: Mooncake ``ErrorCode`` values the store reasons about explicitly.
+MOONCAKE_OBJECT_NOT_FOUND = -704  # remove()/get() on an already-freed key
+MOONCAKE_OBJECT_HAS_LEASE = -706  # remove() during a live read lease
+
 _MOONCAKE_SETUP_DEFAULTS = {
     "global_segment_size": 1 << 30,  # 1 GiB per-node segment
     "local_buffer_size": 1 << 30,
@@ -396,13 +400,18 @@ class MooncakeFeatureStore(FeatureStore):
             )
 
     def _store_remove(self, key: str, *, force: bool = False) -> bool:
-        """Best-effort physical free. Returns True on confirmed removal.
+        """Best-effort physical free. Returns True once the key is gone.
 
         Recent Mooncake bindings expose ``remove(key, force=True)`` so a
         lifecycle authority can reclaim an object after all application-level
         leases have closed without waiting for Mooncake's (potentially
         minutes-long) KV lease TTL.  Older bindings only accept ``key``; keep
         those usable and let their normal bounded retry behavior apply.
+
+        ``OBJECT_NOT_FOUND`` is a completed removal, not a failure: a sample's
+        tensors are freed one key at a time, and a retry after a partial free
+        (some keys removed, others still under a read lease) must not keep the
+        sample pending until the bounded drain probes the absent keys.
         """
         try:
             if force:
@@ -414,7 +423,7 @@ class MooncakeFeatureStore(FeatureStore):
                 rc = self._store.remove(key)
         except Exception:  # pragma: no cover - transient RPC failure
             return False
-        return rc is None or int(rc) == 0
+        return rc is None or int(rc) in (0, MOONCAKE_OBJECT_NOT_FOUND)
 
     # -- write -------------------------------------------------------------
     def put(

--- a/tests/test_runtime/test_mooncake_store.py
+++ b/tests/test_runtime/test_mooncake_store.py
@@ -379,6 +379,53 @@ class TestMooncakeFeatureStore(unittest.TestCase):
         self.assertEqual(fake.force_values[:num_features], [False] * num_features)
         self.assertEqual(fake.force_values[num_features:], [True] * num_features)
 
+    def test_retry_treats_already_removed_keys_as_freed(self):
+        """A partially freed sample must not stay pending until the slow drain.
+
+        The first free removes the keys whose read lease has expired and fails
+        on the still-leased ones (-706). The next forced retry then sees -704
+        (OBJECT_NOT_FOUND) for the keys that are already gone; that is a
+        completed removal, not a failure.
+        """
+
+        class PartialLeaseFake(_FakeMooncakeStore):
+            def __init__(self):
+                super().__init__()
+                self.leased = set()
+                self.codes = []
+
+            def remove(self, key, force=False):
+                self.remove_calls += 1
+                if key not in self._d:
+                    rc = -704
+                elif key in self.leased and not force:
+                    rc = -706
+                else:
+                    self._d.pop(key, None)
+                    rc = 0
+                self.codes.append((key, force, rc))
+                return rc
+
+        fake = PartialLeaseFake()
+        fs = MooncakeFeatureStore(store=fake, store_id="run0")
+        ref = fs.put(_tensors(), sample_id="s0", metadata=_meta())
+        _, handle = fs.get(ref)
+        keys = sorted(fake._d)
+        self.assertGreaterEqual(len(keys), 2)
+        fake.leased.add(keys[-1])  # one tensor still under Mooncake's read lease
+
+        fs.release(handle)
+        self.assertEqual(fs.health()["release_pending"], 1)
+        self.assertEqual(len(fake._d), 1)  # the unleased keys were freed
+
+        report = fs.retry_sample_removals(["s0"])
+
+        self.assertEqual(report["removed"], 1)
+        self.assertEqual(report["release_pending"], 0)
+        self.assertEqual(fs.health()["release_pending"], 0)
+        self.assertFalse(_phys_resident(fake))
+        self.assertIn((keys[0], True, -704), fake.codes)
+
     def test_optimizer_ack_forces_only_durable_samples(self):
         class ForceAwareFake(_FakeMooncakeStore):
             def __init__(self):


### PR DESCRIPTION
## Problem

`MooncakeFeatureStore._store_remove` treats every non-zero return code as a failed removal. A sample's tensors are freed one key at a time, so the optimizer-boundary `abort()` (no force) removes the keys whose read lease has expired and gets `OBJECT_HAS_LEASE` (-706) on the rest; the sample stays in `_release_pending`. The forced retry at the next boundary (`retry_sample_removals`, no probing) then gets `OBJECT_NOT_FOUND` (-704) for the keys that are already gone and counts that as a failure too. The sample can only be classified as freed by the escalation drain (`_CLEANUP_ESCALATION_BOUNDARIES`), whose 40 x 0.25 s retry loop probes `is_exist` only on the final attempt.

Observed on a Qwen3.8-27B NVFP4 / DFlash2 disaggregated run (1 capture server + DP7 trainers, B300, sglang 0.5.18, mooncake-transfer-engine-cuda13 0.3.13): the durable ack alternated between 0.01 s and exactly 9.78 s on every rank, 50% of rank time, independent of the lease TTL (3 s and 5 s both).

## Verified Mooncake semantics (standalone `mooncake_master`, 0.3.13 binding)

| call | rc |
|---|---|
| `remove(key)` during a live read lease | -706 |
| `remove(key, force=True)` during a live read lease | 0 |
| `remove(key)` / `remove(key, force=True)` on an absent key | -704 |
| `is_exist(key)` | renews the lease (`remove` right after it fails with -706) |

## Change

`_store_remove` returns True for rc 0 **or -704**; the two codes get named constants. No other behaviour changes: leased keys still fail with -706 and go through the existing retry/force path.

## Test

`test_retry_treats_already_removed_keys_as_freed`: a fake store whose first free removes the unleased key and fails the leased one with -706, then answers -704 for the removed key on the forced retry. Before the fix the sample stays pending; after it `retry_sample_removals` frees it. `tests.test_runtime.test_mooncake_store`, `test_offline_mooncake_cleanup`, `test_mooncake_architecture` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)