### PR TITLE
docs: retarget PR template links to docs.sglang.io developer guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,17 +14,17 @@
 
 ## Accuracy Test
 
-<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.ai/references/accuracy_evaluation.html -->
+<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->
 
 ## Benchmark & Profiling
 
-<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.ai/references/benchmark_and_profiling.html -->
+<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->
 
 ## Checklist
 
-- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
-- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
-- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
-- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
+- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/docs/developer_guide/contribution_guide).
+- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/docs/developer_guide/contribution_guide).
+- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/docs/developer_guide/contribution_guide).
+- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling) and [Accuracy Results](https://docs.sglang.io/docs/developer_guide/evaluating_new_models).
 - [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
 - [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.


### PR DESCRIPTION
## Summary

`.github/pull_request_template.md` still points at stale `docs.sglang.ai/references/*` URLs (404). Retarget those references to the live `docs.sglang.io` developer guide pages. Dead `#anchors` from the old HTML docs are dropped (point at page roots).

## Modifications

- Accuracy / evaluating refs → `https://docs.sglang.io/docs/developer_guide/evaluating_new_models`
- Benchmark & profiling refs → `https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling`
- Contribution guide refs → `https://docs.sglang.io/docs/developer_guide/contribution_guide`

File touched: `.github/pull_request_template.md` only.

## Repro

```bash
# stale (404)
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.ai/references/accuracy_evaluation.html
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.ai/references/benchmark_and_profiling.html
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.ai/references/contribution_guide.html

# live (200)
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.io/docs/developer_guide/evaluating_new_models
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling
curl -sS -o /dev/null -w '%{http_code}\n' -L https://docs.sglang.io/docs/developer_guide/contribution_guide
```

Observed: 404 / 404 / 404 and 200 / 200 / 200.