### PR TITLE
docs: note MTP uses DFlash capture contract in disagg guide

### DIFF
--- a/docs/basic_usage/disaggregated_training.md
+++ b/docs/basic_usage/disaggregated_training.md
@@ -352,7 +352,7 @@ node-local deployment values.
 The online producer sends prompts to the URLs in
 `deployment.disaggregated.server_urls`. Start a patched SGLang server separately
 with the model, capture method, and auxiliary layer ids matching the draft
-config. DFlash, DFlash2, and Domino use the DFlash capture contract, DSpark
+config. DFlash, DFlash2, Domino, and MTP use the DFlash capture contract, DSpark
 uses its dedicated K3 capture contract, and EAGLE3 and P-EAGLE use the EAGLE3
 capture contract. Capture rejects chunked prefill and
 gives every request attempt a unique radix-cache namespace so cached prefixes


### PR DESCRIPTION
## Summary

In `docs/basic_usage/disaggregated_training.md`, the online capture-contract sentence listed DFlash / DFlash2 / Domino / DSpark / EAGLE3 / P-EAGLE but omitted **MTP**.

MTP's streaming capture uses `capture_method="dflash"` (see `specforge/algorithms/mtp/providers.py`), and the checked-in Ascend managed-local recipe is online disaggregated. List MTP with the DFlash-family capture contract so the guide matches the code.

## Repro

```bash
# on main (953d43a0)
rg -n 'DFlash, DFlash2, and Domino use the DFlash capture contract' \
  docs/basic_usage/disaggregated_training.md
# MTP is registered with capture_method="dflash":
rg -n 'capture_method="dflash"|ALGORITHM_NAME = "mtp"' \
  specforge/algorithms/mtp/providers.py
```

## Test plan

- [x] Single-sentence docs change only
- [x] Verified against `mtp/providers.py` (`capture_method="dflash"` for streaming layout)
- [x] No behavioral / code change
