### PR TITLE
feat(dflash): KDA draft attention with context scan (block-local policy, scan policy, batched scan)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,7 +78,7 @@ jobs:
           uv pip install wheel setuptools psutil packaging ninja
           uv pip install torch==2.13.0 --index-url https://download.pytorch.org/whl/cu130
           MAX_JOBS=8  uv pip install -v flash-attn --no-build-isolation
-          uv pip install -v . --prerelease=allow
+          uv pip install -v ".[kda]" --prerelease=allow
           # SGLang 0.5.18 installs cubin separately and requires it to match
           # flashinfer-python; replace the 0.6.12 copy in cached venvs.
           uv pip install flashinfer-cubin==0.6.17 --index-url https://flashinfer.ai/whl

--- a/configs/qwen3-4b-dspark-kda-scan.json
+++ b/configs/qwen3-4b-dspark-kda-scan.json
@@ -1,0 +1,73 @@
+{
+  "architectures": [
+    "DSparkDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "dspark.DSparkDraftModel"
+  },
+  "block_size": 7,
+  "bos_token_id": 151643,
+  "dflash_config": {
+    "attention_modes": [
+      "kda",
+      "kda",
+      "gqa",
+      "kda",
+      "kda"
+    ],
+    "mask_token_id": 151669,
+    "target_layer_ids": [
+      1,
+      9,
+      17,
+      25,
+      33
+    ],
+    "projector_type": "dspark",
+    "markov_rank": 256,
+    "markov_head_type": "vanilla",
+    "confidence_head_alpha": 1.0,
+    "enable_confidence_head": true,
+    "confidence_head_with_markov": true
+  },
+  "dtype": "bfloat16",
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 2560,
+  "initializer_range": 0.02,
+  "intermediate_size": 9728,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "linear_attn_config": {
+    "backend": "fla",
+    "context_state": "scan",
+    "gate_lower_bound": -5.0,
+    "head_dim": 128,
+    "num_heads": 16,
+    "short_conv_kernel_size": 4,
+    "use_full_rank_gate": false
+  },
+  "max_position_embeddings": 40960,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 36,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/configs/qwen3-4b-dspark-kda.json
+++ b/configs/qwen3-4b-dspark-kda.json
@@ -1,0 +1,66 @@
+{
+  "architectures": [
+    "DSparkDraftModel"
+  ],
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "auto_map": {
+    "AutoModel": "dspark.DSparkDraftModel"
+  },
+  "block_size": 7,
+  "bos_token_id": 151643,
+  "dflash_config": {
+    "attention_modes": [
+      "kda",
+      "kda",
+      "gqa",
+      "kda",
+      "kda"
+    ],
+    "mask_token_id": 151669,
+    "target_layer_ids": [1, 9, 17, 25, 33],
+    "projector_type": "dspark",
+    "markov_rank": 256,
+    "markov_head_type": "vanilla",
+    "confidence_head_alpha": 1.0,
+    "enable_confidence_head": true,
+    "confidence_head_with_markov": true
+  },
+  "dtype": "bfloat16",
+  "eos_token_id": 151645,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 2560,
+  "initializer_range": 0.02,
+  "intermediate_size": 9728,
+  "layer_types": [
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention",
+    "full_attention"
+  ],
+  "linear_attn_config": {
+    "backend": "fla",
+    "gate_lower_bound": -5.0,
+    "head_dim": 128,
+    "num_heads": 16,
+    "short_conv_kernel_size": 4,
+    "use_full_rank_gate": false
+  },
+  "max_position_embeddings": 40960,
+  "max_window_layers": 5,
+  "model_type": "qwen3",
+  "num_attention_heads": 32,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 8,
+  "num_target_layers": 36,
+  "rms_norm_eps": 1e-06,
+  "rope_scaling": null,
+  "rope_theta": 1000000,
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "use_sliding_window": false,
+  "vocab_size": 151936
+}

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -156,6 +156,7 @@ assume the command runs from the repository root.
 | DFlash offline, colocated | [`offline/colocated/qwen3-8b-dflash-offline.yaml`](offline/colocated/qwen3-8b-dflash-offline.yaml) |
 | Domino offline, colocated | [`offline/colocated/qwen3-8b-domino-offline.yaml`](offline/colocated/qwen3-8b-domino-offline.yaml) |
 | DSpark offline, colocated | [`offline/colocated/qwen3-4b-dspark-offline.yaml`](offline/colocated/qwen3-4b-dspark-offline.yaml) |
+| DSpark KDA offline, colocated | [`offline/colocated/qwen3-4b-dspark-kda-offline.yaml`](offline/colocated/qwen3-4b-dspark-kda-offline.yaml) |
 | EAGLE3 offline, disaggregated | [`offline/disaggregated/qwen3-8b-eagle3-offline-disaggregated.yaml`](offline/disaggregated/qwen3-8b-eagle3-offline-disaggregated.yaml) |
 | EAGLE3 online, external services | [`online/disaggregated/external/qwen3-8b-eagle3-disaggregated.yaml`](online/disaggregated/external/qwen3-8b-eagle3-disaggregated.yaml) |
 | DFlash online, managed-local stack | [`online/disaggregated/managed-local/qwen3-8b-dflash-1server-dp7-disaggregated.yaml`](online/disaggregated/managed-local/qwen3-8b-dflash-1server-dp7-disaggregated.yaml) |
@@ -164,6 +165,11 @@ assume the command runs from the repository root.
 The runtime derives online/offline mode from the selected `data` source and
 reads topology from `deployment.mode`; it does not parse the filename or its
 historical suffixes.
+
+The Qwen3-4B KDA recipe is offline-only until SGLang's DFlash serving loader
+supports recurrent KDA draft layers. It uses the same captured target features
+as the GQA recipe and selects a hybrid `4×KDA + 1×GQA` draft stack. Install the
+optional kernel dependency with `pip install -e '.[kda]'` before running it.
 
 ### Top-level fields
 

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -157,6 +157,7 @@ assume the command runs from the repository root.
 | Domino offline, colocated | [`offline/colocated/qwen3-8b-domino-offline.yaml`](offline/colocated/qwen3-8b-domino-offline.yaml) |
 | DSpark offline, colocated | [`offline/colocated/qwen3-4b-dspark-offline.yaml`](offline/colocated/qwen3-4b-dspark-offline.yaml) |
 | DSpark KDA offline, colocated | [`offline/colocated/qwen3-4b-dspark-kda-offline.yaml`](offline/colocated/qwen3-4b-dspark-kda-offline.yaml) |
+| DSpark KDA (context scan) offline, colocated | [`offline/colocated/qwen3-4b-dspark-kda-scan-offline.yaml`](offline/colocated/qwen3-4b-dspark-kda-scan-offline.yaml) |
 | EAGLE3 offline, disaggregated | [`offline/disaggregated/qwen3-8b-eagle3-offline-disaggregated.yaml`](offline/disaggregated/qwen3-8b-eagle3-offline-disaggregated.yaml) |
 | EAGLE3 online, external services | [`online/disaggregated/external/qwen3-8b-eagle3-disaggregated.yaml`](online/disaggregated/external/qwen3-8b-eagle3-disaggregated.yaml) |
 | DFlash online, managed-local stack | [`online/disaggregated/managed-local/qwen3-8b-dflash-1server-dp7-disaggregated.yaml`](online/disaggregated/managed-local/qwen3-8b-dflash-1server-dp7-disaggregated.yaml) |
@@ -170,6 +171,15 @@ The Qwen3-4B KDA recipe is offline-only until SGLang's DFlash serving loader
 supports recurrent KDA draft layers. It uses the same captured target features
 as the GQA recipe and selects a hybrid `4×KDA + 1×GQA` draft stack. Install the
 optional kernel dependency with `pip install -e '.[kda]'` before running it.
+
+`linear_attn_config.context_state` selects where each KDA proposal block's
+recurrent state starts. The default `reset` starts every block from zero, so KDA
+layers only mix the block's own positions and target context enters through the
+GQA layer. `scan` (the `-kda-scan` recipe) first runs the recurrence over the
+target features of the positions before the anchor, so every KDA layer reads
+the context with block-conditioned queries; training resolves one state per
+anchor with a two-level segment scan and SpecForge generation keeps a running
+state per request. Both policies share weights and checkpoint layout.
 
 ### Top-level fields
 

--- a/examples/configs/offline/colocated/qwen3-4b-dspark-kda-offline.yaml
+++ b/examples/configs/offline/colocated/qwen3-4b-dspark-kda-offline.yaml
@@ -1,0 +1,36 @@
+model:
+  target_model_path: Qwen/Qwen3-4B
+  draft_model_config: configs/qwen3-4b-dspark-kda.json
+  target_backend: sglang
+  embedding_key: model.embed_tokens.weight
+  torch_dtype: bfloat16
+
+data:
+  hidden_states_path: ./cache/hidden_states/qwen3-4b-dspark-sharegpt
+  max_length: 3072
+  chat_template: qwen
+  cache_dir: ./cache
+
+training:
+  strategy: dspark
+  num_epochs: 6
+  max_steps: 10000
+  batch_size: 1
+  learning_rate: 6.0e-4
+  warmup_ratio: 0.04
+  max_grad_norm: 1.0
+  attention_backend: flex_attention
+  num_anchors: 512
+  save_interval: 1000
+  log_interval: 50
+  dist_timeout: 30
+  seed: 42
+
+run_id: qwen3-4b-dspark-kda-offline
+output_dir: ./outputs/qwen3-4b-dspark-kda-offline
+
+deployment:
+  mode: local_colocated
+  trainer:
+    nnodes: 1
+    nproc_per_node: 1

--- a/examples/configs/offline/colocated/qwen3-4b-dspark-kda-scan-offline.yaml
+++ b/examples/configs/offline/colocated/qwen3-4b-dspark-kda-scan-offline.yaml
@@ -1,0 +1,36 @@
+model:
+  target_model_path: Qwen/Qwen3-4B
+  draft_model_config: configs/qwen3-4b-dspark-kda-scan.json
+  target_backend: sglang
+  embedding_key: model.embed_tokens.weight
+  torch_dtype: bfloat16
+
+data:
+  hidden_states_path: ./cache/hidden_states/qwen3-4b-dspark-sharegpt
+  max_length: 3072
+  chat_template: qwen
+  cache_dir: ./cache
+
+training:
+  strategy: dspark
+  num_epochs: 6
+  max_steps: 10000
+  batch_size: 1
+  learning_rate: 6.0e-4
+  warmup_ratio: 0.04
+  max_grad_norm: 1.0
+  attention_backend: flex_attention
+  num_anchors: 512
+  save_interval: 1000
+  log_interval: 50
+  dist_timeout: 30
+  seed: 42
+
+run_id: qwen3-4b-dspark-kda-scan-offline
+output_dir: ./outputs/qwen3-4b-dspark-kda-scan-offline
+
+deployment:
+  mode: local_colocated
+  trainer:
+    nnodes: 1
+    nproc_per_node: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pre-commit",
 ]
 fa = ["flash-attn", "ninja", "packaging"]
+kda = ["fla-core==0.5.1"]
 liger = ["liger-kernel"]
 
 [tool.setuptools.dynamic]

--- a/scripts/gates/normalize_dflash_export.py
+++ b/scripts/gates/normalize_dflash_export.py
@@ -116,14 +116,28 @@ def normalize_export(config_path: str, expected_block_size: int) -> Dict[str, An
             "export is not DFlash-family: "
             f"dflash_config.projector_type={projector_type!r}"
         )
-    attention_mode = method_config.get("attention_mode", "gqa")
-    if not isinstance(attention_mode, str) or attention_mode.lower() not in {
-        "gqa",
-        "mha",
-    }:
+    attention_mode = method_config.get("attention_mode")
+    attention_modes = method_config.get("attention_modes")
+    if attention_mode is not None and attention_modes is not None:
+        raise ValueError(
+            "DFlash export must set only one of attention_mode or attention_modes"
+        )
+    if attention_modes is None:
+        attention_modes = [attention_mode or "gqa"]
+    if not isinstance(attention_modes, list) or not all(
+        isinstance(mode, str) for mode in attention_modes
+    ):
+        raise ValueError(
+            "DFlash export attention mode(s) must be strings, "
+            f"got {attention_modes!r}"
+        )
+    unsupported_modes = {
+        mode.lower() for mode in attention_modes if mode.lower() not in {"gqa", "mha"}
+    }
+    if unsupported_modes:
         raise ValueError(
             "SGLang DFlash-family serving supports only GQA/MHA exports, "
-            f"got dflash_config.attention_mode={attention_mode!r}"
+            f"got {sorted(unsupported_modes)}"
         )
 
     if projector_type == "dspark":

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -613,6 +613,11 @@ class OnlineDFlashModel(nn.Module):
                 draft_kwargs["kernel_options"] = {"BACKEND": "TRITON"}
             else:
                 draft_kwargs["kernel_options"] = {"FORCE_USE_FLEX_ATTENTION": True}
+        if getattr(self.draft_model, "accepts_anchor_positions", False):
+            # Recurrent draft layers (context-scanning KDA) need the anchor of
+            # every proposal block; dense drafts recover it from the mask and
+            # legacy draft modules may not accept the keyword at all.
+            draft_kwargs["anchor_positions"] = anchor_positions
         output_hidden = self.draft_model(
             position_ids=full_position_ids,
             noise_embedding=noise_embedding,

--- a/specforge/algorithms/model_providers.py
+++ b/specforge/algorithms/model_providers.py
@@ -509,8 +509,19 @@ def apply_dflash_overrides(cfg: Config, draft_config: Any) -> None:
                 )
             draft_config.layer_types = [layer_types[0]] * requested_layers
 
+        dflash_config = dict(getattr(draft_config, "dflash_config", None) or {})
+        attention_modes = dflash_config.get("attention_modes")
+        if attention_modes is not None and len(attention_modes) != requested_layers:
+            if len(set(attention_modes)) > 1:
+                raise ValueError(
+                    "model.draft_num_hidden_layers cannot resize mixed DFlash "
+                    "attention_modes; provide a draft config with exactly the "
+                    "requested per-layer architecture"
+                )
+            dflash_config["attention_modes"] = [attention_modes[0]] * requested_layers
+
         draft_config.dflash_config = {
-            **method_config,
+            **dflash_config,
             "target_layer_ids": build_target_layer_ids(
                 int(draft_config.num_target_layers),
                 requested_layers,

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -1,5 +1,7 @@
 import copy
 import math
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 import torch
@@ -27,6 +29,22 @@ from .registry import register_draft
 FULL_ATTENTION = "full_attention"
 SLIDING_ATTENTION = "sliding_attention"
 _VALID_DFLASH_LAYER_TYPES = {FULL_ATTENTION, SLIDING_ATTENTION}
+_CONTEXT_ATTENTION_MODES = {"gqa", "mha", "mla"}
+_VALID_DFLASH_ATTENTION_MODES = _CONTEXT_ATTENTION_MODES | {"kda"}
+
+
+@dataclass(frozen=True)
+class DFlashGenerationOutput:
+    """Speculative sequences and per-verification accepted-token counts."""
+
+    sequences: torch.LongTensor
+    acceptance_lengths: tuple[int, ...]
+
+    @property
+    def mean_acceptance_length(self) -> float:
+        if not self.acceptance_lengths:
+            return 0.0
+        return sum(self.acceptance_lengths) / len(self.acceptance_lengths)
 
 
 def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
@@ -72,22 +90,62 @@ def resolve_dflash_attention_layout(
     return layer_types, sliding_window
 
 
-def resolve_dflash_attention_mode(config: Qwen3Config) -> str:
-    """Validate and return the configured draft attention mode.
+def resolve_dflash_attention_modes(config: Qwen3Config) -> tuple[str, ...]:
+    """Return one normalized attention mode for every draft layer.
 
-    ``gqa`` and ``mha`` share :class:`Qwen3DFlashAttention`; ``mla`` swaps in
-    the latent parameterization while retaining the family decoder,
-    target-context injection, masks, and objectives.
+    ``attention_mode`` remains the compact, backwards-compatible spelling for
+    a uniform stack. ``attention_modes`` describes a hybrid stack explicitly.
+    Keeping the two forms mutually exclusive prevents a stale uniform value
+    from silently overriding a per-layer architecture.
     """
 
     dflash_config = getattr(config, "dflash_config", None) or {}
-    attention_mode = str(dflash_config.get("attention_mode", "gqa")).lower()
-    if attention_mode not in _DFLASH_ATTENTION_CLASSES:
+    has_uniform_mode = "attention_mode" in dflash_config
+    has_layer_modes = "attention_modes" in dflash_config
+    if has_uniform_mode and has_layer_modes:
         raise ValueError(
-            "DFlash dflash_config.attention_mode must be one of "
-            f"{sorted(_DFLASH_ATTENTION_CLASSES)}, got {attention_mode!r}"
+            "DFlash dflash_config must set only one of attention_mode or "
+            "attention_modes"
         )
-    return attention_mode
+
+    if has_layer_modes:
+        raw_modes = dflash_config["attention_modes"]
+        if not isinstance(raw_modes, (list, tuple)):
+            raise ValueError(
+                "DFlash dflash_config.attention_modes must be a list with one "
+                f"entry per draft layer, got {raw_modes!r}"
+            )
+        if len(raw_modes) != int(config.num_hidden_layers):
+            raise ValueError(
+                "DFlash dflash_config.attention_modes must contain exactly "
+                f"num_hidden_layers={config.num_hidden_layers} entries, got "
+                f"{len(raw_modes)}"
+            )
+    else:
+        raw_modes = [dflash_config.get("attention_mode", "gqa")] * int(
+            config.num_hidden_layers
+        )
+
+    modes = tuple(str(mode).lower() for mode in raw_modes)
+    invalid = set(modes) - _VALID_DFLASH_ATTENTION_MODES
+    if invalid:
+        raise ValueError(
+            "DFlash dflash_config attention_mode(s) must be selected from "
+            f"{sorted(_VALID_DFLASH_ATTENTION_MODES)}, got {sorted(invalid)}"
+        )
+    return modes
+
+
+def resolve_dflash_attention_mode(config: Qwen3Config) -> str:
+    """Return the uniform attention mode used by legacy callers."""
+
+    modes = resolve_dflash_attention_modes(config)
+    if len(set(modes)) != 1:
+        raise ValueError(
+            "DFlash uses a hybrid attention stack; inspect attention_modes "
+            "instead of attention_mode"
+        )
+    return modes[0]
 
 
 def _require_bool_config(value: object, field: str) -> bool:
@@ -138,11 +196,28 @@ def validate_dflash_mla_config(config: Qwen3Config) -> None:
     _resolve_mla_rope_interleaved(config)
 
 
-def validate_dflash_attention_config(config: Qwen3Config) -> str:
-    """Validate the selected attention parameterization and return its mode."""
+def validate_dflash_attention_config(config: Qwen3Config) -> tuple[str, ...]:
+    """Validate the selected attention parameterizations and their composition."""
 
-    attention_mode = resolve_dflash_attention_mode(config)
-    if attention_mode == "mha" and int(config.num_key_value_heads) != int(
+    attention_modes = resolve_dflash_attention_modes(config)
+    context_modes = set(attention_modes) & _CONTEXT_ATTENTION_MODES
+    if not context_modes:
+        raise ValueError(
+            "KDA draft stacks require at least one GQA, MHA, or MLA layer "
+            "to inject target context"
+        )
+    if len(context_modes) != 1:
+        raise ValueError(
+            "DFlash stacks require one consistent target-context attention "
+            f"mode, got {sorted(context_modes)}"
+        )
+    if "kda" in attention_modes:
+        from .kda import validate_dflash_kda_config
+
+        validate_dflash_kda_config(config)
+
+    context_mode = next(iter(context_modes))
+    if context_mode == "mha" and int(config.num_key_value_heads) != int(
         config.num_attention_heads
     ):
         raise ValueError(
@@ -150,9 +225,9 @@ def validate_dflash_attention_config(config: Qwen3Config) -> str:
             f"num_attention_heads, got {config.num_key_value_heads} and "
             f"{config.num_attention_heads}"
         )
-    if attention_mode == "mla":
+    if context_mode == "mla":
         validate_dflash_mla_config(config)
-    return attention_mode
+    return attention_modes
 
 
 def _rope_config(config: Qwen3Config, attention_mode: str) -> Qwen3Config:
@@ -216,8 +291,41 @@ def _prepare_dflash_eager_mask(
     return additive_mask, valid_queries
 
 
-class Qwen3DFlashAttentionBase(nn.Module):
-    """Shared scaffold for the DFlash-family attention modes.
+class Qwen3DFlashAttentionBase(nn.Module, ABC):
+    """Stable decoder-facing contract for DFlash-family attention.
+
+    Dense/latent attention and recurrent KDA do not share cache or mask math,
+    but decoder layers, FSDP wrapping, and algorithms should not need to know
+    which parameterization is installed. This base owns that narrow contract.
+    """
+
+    def __init__(
+        self,
+        config: Qwen3Config,
+        layer_idx: int,
+        kernels: DFlashKernels,
+    ) -> None:
+        super().__init__()
+        del kernels
+        self.config = config
+        self.layer_idx = layer_idx
+
+    @abstractmethod
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        target_hidden: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        """Apply one attention layer to the proposal hidden states."""
+
+
+class Qwen3DFlashKVAttentionBase(Qwen3DFlashAttentionBase):
+    """Shared cache, mask, and backend scaffold for GQA/MHA/MLA.
 
     Subclasses own only the projection parameterization: ``_init_projections``
     builds the weights and must define ``scaling``, ``num_key_value_groups``,
@@ -234,9 +342,7 @@ class Qwen3DFlashAttentionBase(nn.Module):
         layer_idx: int,
         kernels: DFlashKernels,
     ):
-        super().__init__()
-        self.config = config
-        self.layer_idx = layer_idx
+        super().__init__(config, layer_idx, kernels)
         self.attention_dropout = config.attention_dropout
         if config._attn_implementation == "flex_attention":
             assert (
@@ -330,7 +436,7 @@ class Qwen3DFlashAttentionBase(nn.Module):
         return attn_output, attn_weights
 
 
-class Qwen3DFlashAttention(Qwen3DFlashAttentionBase):
+class Qwen3DFlashAttention(Qwen3DFlashKVAttentionBase):
     """GQA/MHA projections over the family's context-then-draft KV layout."""
 
     def _init_projections(self, config: Qwen3Config, kernels: DFlashKernels) -> None:
@@ -392,7 +498,7 @@ class Qwen3DFlashAttention(Qwen3DFlashAttentionBase):
         return q, k, v
 
 
-class Qwen3DFlashMLAAttention(Qwen3DFlashAttentionBase):
+class Qwen3DFlashMLAAttention(Qwen3DFlashKVAttentionBase):
     """Multi-head Latent Attention projections for DFlash-family drafts.
 
     Standard MLA parameterization: an optional low-rank Q path, a shared
@@ -543,6 +649,25 @@ _DFLASH_ATTENTION_CLASSES = {
 }
 
 
+def build_dflash_attention(
+    config: Qwen3Config,
+    layer_idx: int,
+    kernels: DFlashKernels,
+) -> Qwen3DFlashAttentionBase:
+    """Build one configured attention layer without algorithm-specific dispatch."""
+
+    attention_mode = resolve_dflash_attention_modes(config)[layer_idx]
+    if attention_mode == "kda":
+        # KDA depends on the base contract above; keeping the import at the
+        # construction boundary also keeps fla-core optional for non-KDA runs.
+        from .kda import Qwen3DFlashKDAAttention
+
+        attention_cls = Qwen3DFlashKDAAttention
+    else:
+        attention_cls = _DFLASH_ATTENTION_CLASSES[attention_mode]
+    return attention_cls(config=config, layer_idx=layer_idx, kernels=kernels)
+
+
 class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
     def __init__(
         self,
@@ -552,12 +677,7 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
     ):
         super().__init__()
         self.hidden_size = config.hidden_size
-        attention_cls = _DFLASH_ATTENTION_CLASSES[resolve_dflash_attention_mode(config)]
-        self.self_attn = attention_cls(
-            config=config,
-            layer_idx=layer_idx,
-            kernels=kernels,
-        )
+        self.self_attn = build_dflash_attention(config, layer_idx, kernels)
         self.mlp = kernels.make_mlp(config)
         self.input_layernorm = kernels.make_rms_norm(
             config.hidden_size, config.rms_norm_eps
@@ -681,7 +801,17 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         super().__init__(config)
         self.config = config
         self.layer_types, self.sliding_window = resolve_dflash_attention_layout(config)
-        self.attention_mode = validate_dflash_attention_config(config)
+        self.attention_modes = validate_dflash_attention_config(config)
+        unique_modes = set(self.attention_modes)
+        self.attention_mode = (
+            self.attention_modes[0] if len(unique_modes) == 1 else "hybrid"
+        )
+        self.context_attention_mode = next(
+            mode for mode in self.attention_modes if mode != "kda"
+        )
+        self.context_cache_layer_idx = next(
+            index for index, mode in enumerate(self.attention_modes) if mode != "kda"
+        )
         kernels = dflash_kernels or DEFAULT_DFLASH_KERNELS
         dflash_config = getattr(config, "dflash_config", {}) or {}
         block_size = getattr(config, "block_size", None)
@@ -705,7 +835,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         )
         self.norm = kernels.make_rms_norm(config.hidden_size, config.rms_norm_eps)
         self.rotary_emb = Qwen3RotaryEmbedding(
-            _rope_config(config, self.attention_mode)
+            _rope_config(config, self.context_attention_mode)
         )
         self.fc = nn.Linear(
             len(self.target_layer_ids) * config.hidden_size,
@@ -824,7 +954,9 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         max_new_tokens: int,
         stop_token_ids: list[int],
         temperature: float,
-    ):
+        *,
+        return_dict: bool = False,
+    ) -> torch.LongTensor | DFlashGenerationOutput:
         self.eval()
         num_input_tokens = input_ids.shape[1]
         max_length = num_input_tokens + max_new_tokens
@@ -872,7 +1004,11 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
                 target_hidden=target_hidden,
                 noise_embedding=noise_embedding,
                 position_ids=position_ids[
-                    :, past_key_values_draft.get_seq_length() : start + block_size
+                    :,
+                    past_key_values_draft.get_seq_length(
+                        self.context_cache_layer_idx
+                    ) : start
+                    + block_size,
                 ],
                 past_key_values=past_key_values_draft,
                 use_cache=True,
@@ -929,4 +1065,9 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
                     :, : num_input_tokens + stop_token_indices[0] + 1
                 ]
 
+        if return_dict:
+            return DFlashGenerationOutput(
+                sequences=output_ids,
+                acceptance_lengths=tuple(acceptance_lengths),
+            )
         return output_ids

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -700,6 +700,7 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
             Tuple[torch.Tensor, torch.Tensor]
         ] = None,  # necessary, but kept here for BC
         anchor_positions: Optional[torch.Tensor] = None,
+        scan_layout: Optional[object] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -707,8 +708,10 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
         attention_kwargs = dict(kwargs)
         if getattr(self.self_attn, "uses_anchor_positions", False):
             # Only recurrent layers need to know where each proposal block
-            # starts; dense attention learns that from the mask.
+            # starts; dense attention learns that from the mask. The scan
+            # layout is the host-precomputed launch plan shared by all of them.
             attention_kwargs["anchor_positions"] = anchor_positions
+            attention_kwargs["scan_layout"] = scan_layout
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             target_hidden=target_hidden,
@@ -938,6 +941,9 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         hidden_states = noise_embedding
         target_hidden = self.hidden_norm(self.fc(target_hidden))
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        scan_layout = self._build_scan_layout(
+            target_hidden, anchor_positions, past_key_values
+        )
         for layer_type, layer in zip(self.layer_types, self.layers):
             layer_attention_mask = (
                 attention_mask[layer_type]
@@ -953,9 +959,37 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
                 anchor_positions=anchor_positions,
+                scan_layout=scan_layout,
                 **kwargs,
             )
         return self.norm(hidden_states)
+
+    def _build_scan_layout(
+        self,
+        target_hidden: torch.Tensor,
+        anchor_positions: Optional[torch.Tensor],
+        past_key_values: Optional[Cache],
+    ):
+        """One host-side launch plan for every context-scanning KDA layer.
+
+        Parameter-free, so it may run outside the per-layer FSDP units; the
+        single ``anchor_positions`` device->host copy replaces one sync per
+        (row, layer) inside the layers. Generation keeps its running state and
+        needs no plan.
+        """
+
+        if anchor_positions is None or past_key_values is not None:
+            return None
+        if not any(
+            getattr(getattr(layer, "self_attn", None), "scans_context", False)
+            for layer in self.layers
+        ):
+            return None
+        from .kda import build_scan_layout
+
+        return build_scan_layout(
+            anchor_positions, target_hidden.shape[1], target_hidden.device
+        )
 
     def reset_recurrent_state(self) -> None:
         """Drop per-request state that recurrent attention keeps across steps."""

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -699,10 +699,16 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
         position_embeddings: Optional[
             Tuple[torch.Tensor, torch.Tensor]
         ] = None,  # necessary, but kept here for BC
+        anchor_positions: Optional[torch.Tensor] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
+        attention_kwargs = dict(kwargs)
+        if getattr(self.self_attn, "uses_anchor_positions", False):
+            # Only recurrent layers need to know where each proposal block
+            # starts; dense attention learns that from the mask.
+            attention_kwargs["anchor_positions"] = anchor_positions
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             target_hidden=target_hidden,
@@ -713,7 +719,7 @@ class Qwen3DFlashDecoderLayer(GradientCheckpointingLayer):
             use_cache=use_cache,
             cache_position=cache_position,
             position_embeddings=position_embeddings,
-            **kwargs,
+            **attention_kwargs,
         )[0]
         hidden_states = residual + hidden_states
         residual = hidden_states
@@ -791,6 +797,9 @@ def normalize_draft_head_checkpoint_keys(
 class DFlashDraftModel(Qwen3PreTrainedModel):
     config_class = Qwen3Config
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
+    # The DFlash-family trainer passes per-block anchors only to drafts that
+    # declare it; recurrent layers consume them, dense layers ignore them.
+    accepts_anchor_positions = True
     decoder_layer_class = Qwen3DFlashDecoderLayer
 
     def __init__(
@@ -923,6 +932,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         target_hidden: Optional[torch.Tensor] = None,
         past_key_values: Optional[Cache] = None,
         use_cache: bool = False,
+        anchor_positions: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> CausalLMOutputWithPast:
         hidden_states = noise_embedding
@@ -942,9 +952,18 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
                 past_key_value=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
+                anchor_positions=anchor_positions,
                 **kwargs,
             )
         return self.norm(hidden_states)
+
+    def reset_recurrent_state(self) -> None:
+        """Drop per-request state that recurrent attention keeps across steps."""
+
+        for layer in self.layers:
+            reset = getattr(layer.self_attn, "reset_state", None)
+            if reset is not None:
+                reset()
 
     @torch.inference_mode()
     def spec_generate(
@@ -958,6 +977,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         return_dict: bool = False,
     ) -> torch.LongTensor | DFlashGenerationOutput:
         self.eval()
+        self.reset_recurrent_state()
         num_input_tokens = input_ids.shape[1]
         max_length = num_input_tokens + max_new_tokens
 

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -90,6 +90,19 @@ def resolve_dflash_attention_layout(
     return layer_types, sliding_window
 
 
+def resolve_dflash_block_size(config: Qwen3Config) -> int:
+    dflash_config = getattr(config, "dflash_config", {}) or {}
+    block_size = getattr(config, "block_size", None)
+    if block_size is None:
+        block_size = dflash_config.get("block_size")
+    if not isinstance(block_size, int) or isinstance(block_size, bool):
+        raise ValueError(
+            "DFlash config must define an integer block_size either at "
+            "config.block_size or config.dflash_config.block_size"
+        )
+    return block_size
+
+
 def resolve_dflash_attention_modes(config: Qwen3Config) -> tuple[str, ...]:
     """Return one normalized attention mode for every draft layer.
 
@@ -826,15 +839,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         )
         kernels = dflash_kernels or DEFAULT_DFLASH_KERNELS
         dflash_config = getattr(config, "dflash_config", {}) or {}
-        block_size = getattr(config, "block_size", None)
-        if block_size is None:
-            block_size = dflash_config.get("block_size")
-        if not isinstance(block_size, int) or isinstance(block_size, bool):
-            raise ValueError(
-                "DFlash config must define an integer block_size either at "
-                "config.block_size or config.dflash_config.block_size"
-            )
-        self.block_size = block_size
+        self.block_size = resolve_dflash_block_size(config)
         self.layers = nn.ModuleList(
             [
                 self._build_decoder_layer(config, layer_idx, kernels)

--- a/specforge/modeling/draft/dflash2.py
+++ b/specforge/modeling/draft/dflash2.py
@@ -167,6 +167,7 @@ class Qwen3DFlash2DecoderLayer(Qwen3DFlashDecoderLayer):
         cache_position: Optional[torch.LongTensor] = None,
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         anchor_positions: Optional[torch.Tensor] = None,
+        scan_layout: Optional[object] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
@@ -174,8 +175,10 @@ class Qwen3DFlash2DecoderLayer(Qwen3DFlashDecoderLayer):
         hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
         attention_kwargs = dict(kwargs)
         if getattr(self.self_attn, "uses_anchor_positions", False):
-            # Recurrent (context-scanning KDA) layers need each block's anchor.
+            # Recurrent (context-scanning KDA) layers need each block's anchor
+            # and the shared host-precomputed scan launch plan.
             attention_kwargs["anchor_positions"] = anchor_positions
+            attention_kwargs["scan_layout"] = scan_layout
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             target_hidden=target_hidden,

--- a/specforge/modeling/draft/dflash2.py
+++ b/specforge/modeling/draft/dflash2.py
@@ -166,11 +166,16 @@ class Qwen3DFlash2DecoderLayer(Qwen3DFlashDecoderLayer):
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
         position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        anchor_positions: Optional[torch.Tensor] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> torch.Tensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
         hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
+        attention_kwargs = dict(kwargs)
+        if getattr(self.self_attn, "uses_anchor_positions", False):
+            # Recurrent (context-scanning KDA) layers need each block's anchor.
+            attention_kwargs["anchor_positions"] = anchor_positions
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             target_hidden=target_hidden,
@@ -181,7 +186,7 @@ class Qwen3DFlash2DecoderLayer(Qwen3DFlashDecoderLayer):
             use_cache=use_cache,
             cache_position=cache_position,
             position_embeddings=position_embeddings,
-            **kwargs,
+            **attention_kwargs,
         )[0]
         hidden_states = self.attention_conv.finish(
             hidden_states,

--- a/specforge/modeling/draft/dspark.py
+++ b/specforge/modeling/draft/dspark.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
-from .dflash import DFlashDraftModel, resolve_dflash_attention_mode
+from .dflash import DFlashDraftModel, resolve_dflash_attention_modes
 from .registry import register_draft
 
 
@@ -287,17 +287,18 @@ class DSparkDraftModel(DFlashDraftModel):
 
     def __init__(self, config) -> None:
         dflash_config = dict(getattr(config, "dflash_config", None) or {})
-        attention_mode = resolve_dflash_attention_mode(config)
+        attention_modes = resolve_dflash_attention_modes(config)
+        context_modes = set(attention_modes) - {"kda"}
         num_heads = int(config.num_attention_heads)
         num_kv_heads = int(config.num_key_value_heads)
         # MLA carries its own head geometry; the query/KV head-count policy
         # below only constrains the GQA/MHA projections.
-        if attention_mode != "mla" and num_heads % num_kv_heads:
+        if context_modes & {"gqa", "mha"} and num_heads % num_kv_heads:
             raise ValueError(
                 "DSpark requires num_key_value_heads to divide "
                 f"num_attention_heads, got {num_kv_heads} and {num_heads}"
             )
-        if attention_mode == "gqa" and num_kv_heads >= num_heads:
+        if "gqa" in context_modes and num_kv_heads >= num_heads:
             raise ValueError(
                 "DSpark defaults to GQA and requires num_key_value_heads < "
                 "num_attention_heads; set dflash_config.attention_mode='mha' "
@@ -305,7 +306,10 @@ class DSparkDraftModel(DFlashDraftModel):
             )
         # 'mha' head-count consistency is enforced by the shared
         # validate_dflash_attention_config at model init.
-        dflash_config["attention_mode"] = attention_mode
+        if "attention_modes" in dflash_config:
+            dflash_config["attention_modes"] = list(attention_modes)
+        else:
+            dflash_config["attention_mode"] = attention_modes[0]
         projector_type = dflash_config.get("projector_type")
         if projector_type is None:
             dflash_config["projector_type"] = self.expected_projector_type

--- a/specforge/modeling/draft/kda.py
+++ b/specforge/modeling/draft/kda.py
@@ -1,13 +1,25 @@
 """Kimi Delta Attention for DFlash-family draft models.
 
-KDA is recurrent rather than KV-cache attention. During block-parallel draft
-training, every proposal block is therefore an independent sequence: recurrent
-state resets at each block boundary and cannot bypass the DFlash mask. Target
-context is injected by another attention layer in the hybrid stack.
+KDA is recurrent rather than KV-cache attention, so the layer has to decide
+where the recurrent state of a proposal block starts. ``linear_attn_config``
+selects one of two policies through ``context_state``:
+
+* ``"reset"`` (default): every proposal block is an independent sequence. The
+  state starts from zero at each block boundary, the DFlash mask cannot be
+  bypassed by a linear-attention scan, and target context reaches the layer
+  only through the hybrid stack's GQA/MHA/MLA layers.
+* ``"scan"``: the recurrence first consumes the target context, so a block
+  anchored at position ``t`` starts from the state that has read positions
+  strictly before ``t`` (the same visibility as the DFlash attention mask) and
+  its short convolution sees the last context rows. Block-parallel training
+  produces one state per anchor with a two-level segment scan; SpecForge
+  generation keeps a per-request running state that is advanced with every
+  newly verified context slice.
 """
 
 from __future__ import annotations
 
+import itertools
 import math
 from dataclasses import dataclass
 from typing import Callable, Optional
@@ -24,6 +36,9 @@ from .dflash_kernels import DFlashKernels
 
 _CUDA_MAX_GRID_DIM_Z = 65_535
 _KDA_BACKENDS = {"fla", "reference"}
+_KDA_CONTEXT_STATES = ("reset", "scan")
+# FLA processes chunks of 64 tokens; variable-length launches are padded to it.
+_FLA_CHUNK_SIZE = 64
 
 
 @dataclass(frozen=True)
@@ -38,10 +53,15 @@ class KDAConfig:
     use_full_rank_gate: bool
     gate_lower_bound: Optional[float]
     backend: str
+    context_state: str = "reset"
 
     @property
     def projection_size(self) -> int:
         return self.num_heads * self.head_dim
+
+    @property
+    def scans_context(self) -> bool:
+        return self.context_state == "scan"
 
     @classmethod
     def from_config(cls, config: Qwen3Config) -> KDAConfig:
@@ -86,11 +106,19 @@ class KDAConfig:
                 "KDA linear_attn_config.backend must be one of "
                 f"{sorted(_KDA_BACKENDS)}, got {backend!r}"
             )
+
+        context_state = str(linear_config.get("context_state", "reset")).lower()
+        if context_state not in _KDA_CONTEXT_STATES:
+            raise ValueError(
+                "KDA linear_attn_config.context_state must be one of "
+                f"{list(_KDA_CONTEXT_STATES)}, got {context_state!r}"
+            )
         return cls(
             **dimensions,
             use_full_rank_gate=use_full_rank_gate,
             gate_lower_bound=lower_bound,
             backend=backend,
+            context_state=context_state,
         )
 
 
@@ -144,8 +172,48 @@ def reference_kda(
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
     lower_bound: Optional[float],
-) -> torch.Tensor:
-    """Differentiable KDA recurrence used as the correctness oracle."""
+    *,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+):
+    """Differentiable KDA recurrence used as the correctness oracle.
+
+    Mirrors the FLA ``chunk_kda`` contract: ``initial_state`` (``[N, H, K, V]``)
+    seeds the recurrence, ``output_final_state`` also returns the state after
+    the last step, and ``cu_seqlens`` selects the variable-length layout (a
+    batch of one with sequences flattened along time and one initial/final
+    state per sequence).
+    """
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                "variable-length KDA expects a flattened batch of size 1, "
+                f"got {q.shape[0]}"
+            )
+        bounds = [int(bound) for bound in cu_seqlens.tolist()]
+        outputs, final_states = [], []
+        for index, (start, end) in enumerate(zip(bounds[:-1], bounds[1:])):
+            state = None if initial_state is None else initial_state[index : index + 1]
+            output, final_state = reference_kda(
+                q[:, start:end],
+                k[:, start:end],
+                v[:, start:end],
+                raw_gate[:, start:end],
+                beta[:, start:end],
+                A_log,
+                dt_bias,
+                lower_bound,
+                initial_state=state,
+                output_final_state=True,
+            )
+            outputs.append(output)
+            final_states.append(final_state)
+        output = torch.cat(outputs, dim=1)
+        if output_final_state:
+            return output, torch.cat(final_states, dim=0)
+        return output
 
     q = F.normalize(q.float(), dim=-1).to(q.dtype)
     k = F.normalize(k.float(), dim=-1).to(k.dtype)
@@ -158,14 +226,17 @@ def reference_kda(
     else:
         log_decay = float(lower_bound) * torch.sigmoid(decay_scale * gate_input)
 
-    state = torch.zeros(
-        q.shape[0],
-        q.shape[2],
-        q.shape[3],
-        v.shape[3],
-        dtype=torch.float32,
-        device=q.device,
-    )
+    if initial_state is None:
+        state = torch.zeros(
+            q.shape[0],
+            q.shape[2],
+            q.shape[3],
+            v.shape[3],
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        state = initial_state.to(device=q.device, dtype=torch.float32)
     outputs = []
     score_scale = q.shape[-1] ** -0.5
     for step in range(q.shape[1]):
@@ -177,7 +248,13 @@ def reference_kda(
         state = state + torch.einsum("bhd,bhv->bhdv", step_key, delta)
         output = torch.einsum("bhd,bhdv->bhv", q[:, step].float(), state)
         outputs.append((output * score_scale).to(q.dtype))
-    return torch.stack(outputs, dim=1)
+    if outputs:
+        output = torch.stack(outputs, dim=1)
+    else:
+        output = q.new_zeros((q.shape[0], 0, q.shape[2], v.shape[3]))
+    if output_final_state:
+        return output, state
+    return output
 
 
 def _load_fla_chunk_kda() -> Callable[..., tuple[torch.Tensor, object]]:
@@ -201,6 +278,104 @@ def _pad_batch_to(tensor: torch.Tensor, size: int) -> torch.Tensor:
     )
 
 
+def _pad_time_to(tensor: torch.Tensor, size: int) -> torch.Tensor:
+    padding = size - int(tensor.shape[1])
+    if padding <= 0:
+        return tensor
+    return torch.cat(
+        (tensor, tensor.new_zeros((tensor.shape[0], padding, *tensor.shape[2:]))),
+        dim=1,
+    )
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return -(-value // multiple) * multiple
+
+
+def _fla_kernel_kwargs(
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+) -> dict:
+    return {
+        # FSDP1 requires each decoder block to have one parameter dtype.
+        # SpecForge therefore shards these as BF16 (with FP32 optimizer
+        # masters) and materializes the tiny FP32 kernel inputs here.
+        "A_log": A_log.float(),
+        "dt_bias": dt_bias.float(),
+        "use_qk_l2norm_in_kernel": True,
+        "use_gate_in_kernel": True,
+        "use_beta_sigmoid_in_kernel": True,
+        "safe_gate": lower_bound is not None,
+        "lower_bound": lower_bound,
+    }
+
+
+def _fla_kda_varlen(
+    chunk_kda: Callable[..., tuple[torch.Tensor, object]],
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    *,
+    initial_state: Optional[torch.Tensor],
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor,
+    kernel_kwargs: dict,
+):
+    """One variable-length FLA launch over flattened context segments.
+
+    Anchor segments have arbitrary lengths and counts, and FLA/TileLang
+    specialize kernels on launch shapes. The flattened batch is therefore
+    padded with dummy sequences (one token each, the last one absorbing the
+    remainder) to a power-of-two sequence count and a chunk-aligned token
+    count. Dummy sequences never share state with real ones; their outputs and
+    final states are sliced away.
+    """
+
+    if q.shape[0] != 1:
+        raise ValueError(
+            "variable-length KDA expects a flattened batch of size 1, "
+            f"got {q.shape[0]}"
+        )
+    bounds = cu_seqlens.to(device=q.device, dtype=torch.long)
+    num_sequences = int(bounds.numel()) - 1
+    total = int(q.shape[1])
+    padded_sequences = 1 << max(num_sequences - 1, 0).bit_length()
+    extra_sequences = padded_sequences - num_sequences
+    padded_total = _round_up(total + extra_sequences, _FLA_CHUNK_SIZE)
+    if padded_total > total and extra_sequences == 0:
+        # The length remainder needs a dummy sequence to live in.
+        padded_sequences *= 2
+        extra_sequences = padded_sequences - num_sequences
+        padded_total = _round_up(total + extra_sequences, _FLA_CHUNK_SIZE)
+    if extra_sequences:
+        dummy_ends = total + torch.arange(
+            1, extra_sequences + 1, device=bounds.device, dtype=torch.long
+        )
+        dummy_ends[-1] = padded_total
+        bounds = torch.cat((bounds, dummy_ends))
+    state = initial_state
+    if state is not None and extra_sequences:
+        state = _pad_batch_to(state, padded_sequences)
+    output, final_state = chunk_kda(
+        q=_pad_time_to(q, padded_total),
+        k=_pad_time_to(k, padded_total),
+        v=_pad_time_to(v, padded_total),
+        g=_pad_time_to(raw_gate, padded_total),
+        beta=_pad_time_to(beta, padded_total),
+        initial_state=state,
+        output_final_state=output_final_state,
+        cu_seqlens=bounds,
+        **kernel_kwargs,
+    )
+    output = output[:, :total]
+    if output_final_state:
+        return output, final_state[:num_sequences]
+    return output
+
+
 def fla_kda(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -210,12 +385,34 @@ def fla_kda(
     A_log: torch.Tensor,
     dt_bias: torch.Tensor,
     lower_bound: Optional[float],
-) -> torch.Tensor:
-    """Run FLA KDA while respecting the CUDA grid-z launch limit."""
+    *,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+):
+    """Run FLA KDA while respecting the CUDA grid-z launch limit.
+
+    Same optional state contract as :func:`reference_kda`.
+    """
 
     chunk_kda = _load_fla_chunk_kda()
+    kernel_kwargs = _fla_kernel_kwargs(A_log, dt_bias, lower_bound)
+    if cu_seqlens is not None:
+        return _fla_kda_varlen(
+            chunk_kda,
+            q,
+            k,
+            v,
+            raw_gate,
+            beta,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            kernel_kwargs=kernel_kwargs,
+        )
+
     max_blocks_per_launch = max(1, _CUDA_MAX_GRID_DIM_Z // int(q.shape[2]))
-    outputs = []
+    outputs, final_states = [], []
     for start in range(0, int(q.shape[0]), max_blocks_per_launch):
         end = min(start + max_blocks_per_launch, int(q.shape[0]))
         batch_size = end - start
@@ -228,30 +425,215 @@ def fla_kda(
             1 << (batch_size - 1).bit_length(),
             max_blocks_per_launch,
         )
-        output, _ = chunk_kda(
-            q=_pad_batch_to(q[start:end], padded_size),
-            k=_pad_batch_to(k[start:end], padded_size),
-            v=_pad_batch_to(v[start:end], padded_size),
-            g=_pad_batch_to(raw_gate[start:end], padded_size),
-            beta=_pad_batch_to(beta[start:end], padded_size),
-            # FSDP1 requires each decoder block to have one parameter dtype.
-            # SpecForge therefore shards these as BF16 (with FP32 optimizer
-            # masters) and materializes the tiny FP32 kernel inputs here.
-            A_log=A_log.float(),
-            dt_bias=dt_bias.float(),
-            output_final_state=False,
-            use_qk_l2norm_in_kernel=True,
-            use_gate_in_kernel=True,
-            use_beta_sigmoid_in_kernel=True,
-            safe_gate=lower_bound is not None,
-            lower_bound=lower_bound,
+        launch_kwargs = {
+            "q": _pad_batch_to(q[start:end], padded_size),
+            "k": _pad_batch_to(k[start:end], padded_size),
+            "v": _pad_batch_to(v[start:end], padded_size),
+            "g": _pad_batch_to(raw_gate[start:end], padded_size),
+            "beta": _pad_batch_to(beta[start:end], padded_size),
+        }
+        if initial_state is not None:
+            launch_kwargs["initial_state"] = _pad_batch_to(
+                initial_state[start:end], padded_size
+            )
+        output, final_state = chunk_kda(
+            **launch_kwargs,
+            output_final_state=output_final_state,
+            **kernel_kwargs,
         )
         outputs.append(output[:batch_size])
-    return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+        if output_final_state:
+            final_states.append(final_state[:batch_size])
+    output = outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+    if output_final_state:
+        final_state = (
+            final_states[0] if len(final_states) == 1 else torch.cat(final_states)
+        )
+        return output, final_state
+    return output
+
+
+def _scan_segments(
+    kda_fn: Callable,
+    tensors: tuple[torch.Tensor, ...],
+    segments: list[tuple[int, int]],
+    initial_states: list[torch.Tensor],
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+) -> torch.Tensor:
+    """Advance several disjoint context segments in one variable-length launch."""
+
+    q, k, v, raw_gate, beta = tensors
+    lengths = [end - start for start, end in segments]
+    cu_seqlens = torch.tensor(
+        [0, *itertools.accumulate(lengths)], device=k.device, dtype=torch.long
+    )
+
+    def gather(tensor: torch.Tensor) -> torch.Tensor:
+        return torch.cat([tensor[:, start:end] for start, end in segments], dim=1)
+
+    _, final_states = kda_fn(
+        gather(q),
+        gather(k),
+        gather(v),
+        gather(raw_gate),
+        gather(beta),
+        A_log,
+        dt_bias,
+        lower_bound,
+        initial_state=torch.cat(initial_states, dim=0),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+    return final_states
+
+
+def _scan_row_states(
+    kda_fn: Callable,
+    tensors: tuple[torch.Tensor, ...],
+    anchors: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+    group_size: Optional[int],
+) -> torch.Tensor:
+    """States before every anchor of one context row, ``[N, H, K, V]``."""
+
+    _, k, v, _, _ = tensors
+    unique_anchors, inverse = torch.unique(anchors, sorted=True, return_inverse=True)
+    boundaries = [0, *unique_anchors.tolist()]
+    num_segments = len(boundaries) - 1
+    group = group_size or max(1, math.isqrt(num_segments))
+    num_groups = -(-num_segments // group)
+    zero_state = k.new_zeros(
+        (1, k.shape[2], k.shape[3], v.shape[3]), dtype=torch.float32
+    )
+
+    # Level 1: sequential over groups, one launch per group span.
+    group_inputs, group_outputs = [], []
+    state = zero_state
+    for index in range(num_groups):
+        group_inputs.append(state)
+        start = boundaries[index * group]
+        end = boundaries[min((index + 1) * group, num_segments)]
+        if end > start:
+            state = _scan_segments(
+                kda_fn, tensors, [(start, end)], [state], A_log, dt_bias, lower_bound
+            )
+        group_outputs.append(state)
+
+    # Level 2: the same in-group offset of every group shares one launch. The
+    # last segment of a group ends at the group boundary and reuses level 1.
+    anchor_states: list[Optional[torch.Tensor]] = [None] * num_segments
+    current = list(group_inputs)
+    for offset in range(group):
+        launch: list[tuple[int, int, int]] = []
+        for index in range(num_groups):
+            segment = index * group + offset
+            last = min((index + 1) * group, num_segments) - 1
+            if segment > last:
+                continue
+            if segment == last:
+                anchor_states[segment] = group_outputs[index]
+                continue
+            start, end = boundaries[segment], boundaries[segment + 1]
+            if end == start:
+                anchor_states[segment] = current[index]
+                continue
+            launch.append((index, start, end))
+        if launch:
+            final_states = _scan_segments(
+                kda_fn,
+                tensors,
+                [(start, end) for _, start, end in launch],
+                [current[index] for index, _, _ in launch],
+                A_log,
+                dt_bias,
+                lower_bound,
+            )
+            for position, (index, _, _) in enumerate(launch):
+                current[index] = final_states[position : position + 1]
+                anchor_states[index * group + offset] = current[index]
+    stacked = torch.cat(anchor_states, dim=0)
+    return stacked[inverse]
+
+
+def scan_kda_context_states(
+    kda_fn: Callable,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+    anchor_positions: torch.Tensor,
+    *,
+    group_size: Optional[int] = None,
+) -> torch.Tensor:
+    """Recurrent state after the context positions strictly before each anchor.
+
+    ``k``/``v`` are the convolved context projections ``[B, S, H, D]``,
+    ``raw_gate`` ``[B, S, H, D]`` and ``beta`` ``[B, S, H]`` the context gates,
+    and ``anchor_positions`` ``[B, N]`` the anchor of every proposal block
+    (values are clamped to ``[0, S]``). Returns fp32 states ``[B, N, H, K, V]``.
+
+    Rows are independent. Within a row the unique sorted anchors cut the
+    context into segments, and a two-level scan (sequential over groups of
+    ``group_size`` segments, then one variable-length launch per in-group
+    offset across all groups) reaches every anchor with about ``2 * sqrt(N)``
+    launches instead of ``N`` sequential ones while staying exact.
+    """
+
+    batch_size, context_len = k.shape[:2]
+    if anchor_positions.shape[0] != batch_size:
+        raise ValueError(
+            "anchor_positions must carry one row per context row, got "
+            f"{tuple(anchor_positions.shape)} for {batch_size} rows"
+        )
+    anchors = anchor_positions.to(torch.long).clamp(0, context_len)
+    # The recurrent state does not depend on queries; zeros keep the launch
+    # shape uniform without paying for a context query projection.
+    queries = torch.zeros_like(k)
+    rows = []
+    for row in range(batch_size):
+        tensors = tuple(
+            tensor[row : row + 1] for tensor in (queries, k, v, raw_gate, beta)
+        )
+        rows.append(
+            _scan_row_states(
+                kda_fn, tensors, anchors[row], A_log, dt_bias, lower_bound, group_size
+            )
+        )
+    return torch.stack(rows, dim=0)
+
+
+def _gather_left_rows(
+    context: torch.Tensor,
+    anchors: torch.Tensor,
+    window: int,
+) -> torch.Tensor:
+    """The ``window`` context rows before each anchor, zero where none exist."""
+
+    batch_size, _, hidden_size = context.shape
+    num_blocks = anchors.shape[1]
+    if window == 0:
+        return context.new_zeros((batch_size, num_blocks, 0, hidden_size))
+    offsets = torch.arange(window, 0, -1, device=anchors.device)
+    positions = anchors.unsqueeze(-1) - offsets
+    valid = positions >= 0
+    flat = positions.clamp(min=0).reshape(batch_size, -1)
+    rows = context.gather(1, flat.unsqueeze(-1).expand(-1, -1, hidden_size))
+    rows = rows.reshape(batch_size, num_blocks, window, hidden_size)
+    return rows * valid.unsqueeze(-1).to(rows.dtype)
 
 
 class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
-    """KDA applied independently to every block-parallel proposal."""
+    """KDA over proposal blocks with block-local or context-scanned state."""
+
+    # The decoder layer forwards training anchors only to layers that ask.
+    uses_anchor_positions = True
 
     def __init__(
         self,
@@ -268,6 +650,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
         self.block_size = spec.block_size
         self.backend = spec.backend
         self.lower_bound = spec.gate_lower_bound
+        self.context_state = spec.context_state
         projection_size = spec.projection_size
 
         self.q_proj = nn.Linear(spec.hidden_size, projection_size, bias=False)
@@ -298,6 +681,25 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
         self.o_norm = KDAGatedRMSNorm(spec.head_dim, eps=float(config.rms_norm_eps))
         self.o_proj = nn.Linear(projection_size, spec.hidden_size, bias=False)
 
+        # Per-request running context for the "scan" policy during generation.
+        # Plain attributes: never checkpointed, reset per generated sequence.
+        self._running_state: Optional[torch.Tensor] = None
+        self._running_tail: Optional[torch.Tensor] = None
+
+    @property
+    def scans_context(self) -> bool:
+        return self.kda_config.scans_context
+
+    @property
+    def _kda_fn(self) -> Callable:
+        return reference_kda if self.backend == "reference" else fla_kda
+
+    def reset_state(self) -> None:
+        """Forget the running context state kept across generation steps."""
+
+        self._running_state = None
+        self._running_tail = None
+
     def _independent_blocks(
         self, hidden_states: torch.Tensor
     ) -> tuple[torch.Tensor, int, int]:
@@ -318,6 +720,160 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
             return self.g_proj(blocks)
         return self.g_b_proj(self.g_a_proj(blocks))
 
+    def _gates(self, rows: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Raw decay gate ``[..., H, D]`` and raw beta ``[..., H]`` for rows."""
+
+        leading = rows.shape[:-1]
+        raw_gate = self.f_b_proj(self.f_a_proj(rows)).view(
+            *leading, self.num_heads, self.head_dim
+        )
+        beta = self.b_proj(rows).view(*leading, self.num_heads)
+        return raw_gate, beta
+
+    def _convolve_with_left_rows(
+        self,
+        conv: KDAShortConvolution,
+        proj: nn.Linear,
+        left_rows: torch.Tensor,
+        rows: torch.Tensor,
+    ) -> torch.Tensor:
+        """Convolve ``rows`` as if ``left_rows`` immediately preceded them."""
+
+        joined = torch.cat((proj(left_rows), proj(rows)), dim=1)
+        return conv(joined)[:, left_rows.shape[1] :]
+
+    def _scan_rows(
+        self,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        raw_gate: torch.Tensor,
+        beta: torch.Tensor,
+        state: torch.Tensor,
+    ) -> torch.Tensor:
+        """Advance one state per row over that row's context slice."""
+
+        batch_size, length = k.shape[:2]
+        cu_seqlens = torch.arange(
+            0, (batch_size + 1) * length, length, device=k.device, dtype=torch.long
+        )
+        _, state = self._kda_fn(
+            torch.zeros_like(k).reshape(1, batch_size * length, *k.shape[2:]),
+            k.reshape(1, batch_size * length, *k.shape[2:]),
+            v.reshape(1, batch_size * length, *v.shape[2:]),
+            raw_gate.reshape(1, batch_size * length, *raw_gate.shape[2:]),
+            beta.reshape(1, batch_size * length, *beta.shape[2:]),
+            self.A_log,
+            self.dt_bias,
+            self.lower_bound,
+            initial_state=state,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+        )
+        return state
+
+    def _advance_running_state(
+        self, target_hidden: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Consume a newly verified context slice during generation."""
+
+        batch_size, length, hidden_size = target_hidden.shape
+        window = self.kda_config.short_conv_kernel_size - 1
+        tail, state = self._running_tail, self._running_state
+        if tail is None or state is None or tail.shape[0] != batch_size:
+            tail = target_hidden.new_zeros((batch_size, window, hidden_size))
+            state = target_hidden.new_zeros(
+                (batch_size, self.num_heads, self.head_dim, self.head_dim),
+                dtype=torch.float32,
+            )
+        if length > 0:
+            shape = (batch_size, length, self.num_heads, self.head_dim)
+            k = self._convolve_with_left_rows(
+                self.k_conv1d, self.k_proj, tail, target_hidden
+            ).view(shape)
+            v = self._convolve_with_left_rows(
+                self.v_conv1d, self.v_proj, tail, target_hidden
+            ).view(shape)
+            raw_gate, beta = self._gates(target_hidden)
+            state = self._scan_rows(k, v, raw_gate, beta, state)
+            if window:
+                tail = torch.cat((tail, target_hidden), dim=1)[:, -window:]
+        self._running_state = state.detach()
+        self._running_tail = tail.detach()
+        return state, tail
+
+    def _anchor_context(
+        self,
+        target_hidden: torch.Tensor,
+        anchor_positions: Optional[torch.Tensor],
+        batch_size: int,
+        num_blocks: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Per-block initial states and left conv rows for block-parallel use."""
+
+        context_len = target_hidden.shape[1]
+        window = self.kda_config.short_conv_kernel_size - 1
+        if anchor_positions is None:
+            anchors = target_hidden.new_full(
+                (batch_size, num_blocks), context_len, dtype=torch.long
+            )
+        else:
+            anchors = anchor_positions.to(device=target_hidden.device, dtype=torch.long)
+            if tuple(anchors.shape) != (batch_size, num_blocks):
+                raise ValueError(
+                    "anchor_positions must have shape (batch, num_blocks)="
+                    f"{(batch_size, num_blocks)}, got {tuple(anchors.shape)}"
+                )
+            anchors = anchors.clamp(0, context_len)
+        shape = (batch_size, context_len, self.num_heads, self.head_dim)
+        k = self.k_conv1d(self.k_proj(target_hidden)).view(shape)
+        v = self.v_conv1d(self.v_proj(target_hidden)).view(shape)
+        raw_gate, beta = self._gates(target_hidden)
+        states = scan_kda_context_states(
+            self._kda_fn,
+            k,
+            v,
+            raw_gate,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            self.lower_bound,
+            anchors,
+        )
+        left_rows = _gather_left_rows(target_hidden, anchors, window)
+        return states, left_rows
+
+    def _recur(
+        self,
+        blocks: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        initial_state: Optional[torch.Tensor],
+        batch_size: int,
+        query_len: int,
+    ) -> tuple[torch.Tensor, None]:
+        block_count = blocks.shape[0]
+        shape = (block_count, self.block_size, self.num_heads, self.head_dim)
+        raw_gate, beta = self._gates(blocks)
+        attention_output = self._kda_fn(
+            q.view(shape),
+            k.view(shape),
+            v.view(shape),
+            raw_gate,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            self.lower_bound,
+            initial_state=initial_state,
+        )
+        output_gate = self._output_gate(blocks).view(shape)
+        attention_output = self.o_norm(attention_output, output_gate)
+        attention_output = self.o_proj(attention_output.flatten(-2))
+        attention_output = attention_output.reshape(
+            batch_size, query_len, self.kda_config.hidden_size
+        )
+        return attention_output, None
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -326,52 +882,42 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
         attention_mask: Optional[torch.Tensor],
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        anchor_positions: Optional[torch.Tensor] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         # Dense/MLA siblings may use the shared cache during SpecForge decode.
-        # KDA deliberately leaves it untouched because every proposal block is
-        # an independent recurrent sequence.
-        del (
-            target_hidden,
-            position_embeddings,
-            attention_mask,
-            past_key_values,
-            cache_position,
-            kwargs,
-        )
+        # KDA leaves it untouched: "reset" needs no context at all and "scan"
+        # keeps its own running state on the module.
+        del position_embeddings, attention_mask, cache_position, kwargs
 
         blocks, batch_size, query_len = self._independent_blocks(hidden_states)
-        block_count = blocks.shape[0]
-        projection_shape = (
-            block_count,
-            self.block_size,
-            self.num_heads,
-            self.head_dim,
-        )
-        q = self.q_conv1d(self.q_proj(blocks)).view(projection_shape)
-        k = self.k_conv1d(self.k_proj(blocks)).view(projection_shape)
-        v = self.v_conv1d(self.v_proj(blocks)).view(projection_shape)
-        raw_gate = self.f_b_proj(self.f_a_proj(blocks)).view(projection_shape)
-        beta = self.b_proj(blocks).view(block_count, self.block_size, self.num_heads)
+        if not self.scans_context:
+            del target_hidden, past_key_values, anchor_positions
+            q = self.q_conv1d(self.q_proj(blocks))
+            k = self.k_conv1d(self.k_proj(blocks))
+            v = self.v_conv1d(self.v_proj(blocks))
+            return self._recur(blocks, q, k, v, None, batch_size, query_len)
 
-        kda_fn = reference_kda if self.backend == "reference" else fla_kda
-        attention_output = kda_fn(
-            q,
-            k,
-            v,
-            raw_gate,
-            beta,
-            self.A_log,
-            self.dt_bias,
-            self.lower_bound,
+        block_count = blocks.shape[0]
+        num_blocks = block_count // batch_size
+        if past_key_values is not None:
+            # Generation: the slice holds the context verified since the last
+            # call; every block of this step starts from the advanced state.
+            state, tail = self._advance_running_state(target_hidden)
+            states = state.unsqueeze(1).expand(-1, num_blocks, -1, -1, -1)
+            left_rows = tail.unsqueeze(1).expand(-1, num_blocks, -1, -1)
+        else:
+            states, left_rows = self._anchor_context(
+                target_hidden, anchor_positions, batch_size, num_blocks
+            )
+        initial_state = states.reshape(
+            block_count, self.num_heads, self.head_dim, self.head_dim
         )
-        output_gate = self._output_gate(blocks).view(projection_shape)
-        attention_output = self.o_norm(attention_output, output_gate)
-        attention_output = self.o_proj(attention_output.flatten(-2))
-        attention_output = attention_output.reshape(
-            batch_size, query_len, self.kda_config.hidden_size
-        )
-        return attention_output, None
+        left_rows = left_rows.reshape(block_count, -1, left_rows.shape[-1])
+        q = self._convolve_with_left_rows(self.q_conv1d, self.q_proj, left_rows, blocks)
+        k = self._convolve_with_left_rows(self.k_conv1d, self.k_proj, left_rows, blocks)
+        v = self._convolve_with_left_rows(self.v_conv1d, self.v_proj, left_rows, blocks)
+        return self._recur(blocks, q, k, v, initial_state, batch_size, query_len)
 
 
 __all__ = [
@@ -379,5 +925,6 @@ __all__ = [
     "Qwen3DFlashKDAAttention",
     "fla_kda",
     "reference_kda",
+    "scan_kda_context_states",
     "validate_dflash_kda_config",
 ]

--- a/specforge/modeling/draft/kda.py
+++ b/specforge/modeling/draft/kda.py
@@ -1,0 +1,383 @@
+"""Kimi Delta Attention for DFlash-family draft models.
+
+KDA is recurrent rather than KV-cache attention. During block-parallel draft
+training, every proposal block is therefore an independent sequence: recurrent
+state resets at each block boundary and cannot bypass the DFlash mask. Target
+context is injected by another attention layer in the hybrid stack.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers.cache_utils import Cache
+from transformers.models.qwen3.modeling_qwen3 import FlashAttentionKwargs, Qwen3Config
+from typing_extensions import Unpack
+
+from .dflash import Qwen3DFlashAttentionBase
+from .dflash_kernels import DFlashKernels
+
+_CUDA_MAX_GRID_DIM_Z = 65_535
+_KDA_BACKENDS = {"fla", "reference"}
+
+
+@dataclass(frozen=True)
+class KDAConfig:
+    """Validated KDA dimensions and execution policy."""
+
+    hidden_size: int
+    head_dim: int
+    num_heads: int
+    block_size: int
+    short_conv_kernel_size: int
+    use_full_rank_gate: bool
+    gate_lower_bound: Optional[float]
+    backend: str
+
+    @property
+    def projection_size(self) -> int:
+        return self.num_heads * self.head_dim
+
+    @classmethod
+    def from_config(cls, config: Qwen3Config) -> KDAConfig:
+        linear_config = dict(getattr(config, "linear_attn_config", None) or {})
+        required = ("head_dim", "num_heads", "short_conv_kernel_size")
+        missing = [name for name in required if linear_config.get(name) is None]
+        if missing:
+            raise ValueError(
+                f"KDA linear_attn_config is missing required fields: {missing}"
+            )
+
+        dimensions = {
+            "hidden_size": int(config.hidden_size),
+            "head_dim": int(linear_config["head_dim"]),
+            "num_heads": int(linear_config["num_heads"]),
+            "block_size": int(config.block_size),
+            "short_conv_kernel_size": int(linear_config["short_conv_kernel_size"]),
+        }
+        for name, value in dimensions.items():
+            if value <= 0:
+                raise ValueError(f"KDA {name} must be positive, got {value}")
+
+        use_full_rank_gate = linear_config.get("use_full_rank_gate", False)
+        if not isinstance(use_full_rank_gate, bool):
+            raise ValueError(
+                "KDA linear_attn_config.use_full_rank_gate must be a boolean, "
+                f"got {use_full_rank_gate!r}"
+            )
+
+        lower_bound = linear_config.get("gate_lower_bound")
+        if lower_bound is not None:
+            lower_bound = float(lower_bound)
+            if not math.isfinite(lower_bound) or lower_bound >= 0:
+                raise ValueError(
+                    "KDA linear_attn_config.gate_lower_bound must be a finite "
+                    f"negative number or null, got {lower_bound!r}"
+                )
+
+        backend = str(linear_config.get("backend", "fla")).lower()
+        if backend not in _KDA_BACKENDS:
+            raise ValueError(
+                "KDA linear_attn_config.backend must be one of "
+                f"{sorted(_KDA_BACKENDS)}, got {backend!r}"
+            )
+        return cls(
+            **dimensions,
+            use_full_rank_gate=use_full_rank_gate,
+            gate_lower_bound=lower_bound,
+            backend=backend,
+        )
+
+
+def validate_dflash_kda_config(config: Qwen3Config) -> None:
+    """Validate KDA fields without importing the optional FLA backend."""
+
+    KDAConfig.from_config(config)
+
+
+class KDAShortConvolution(nn.Module):
+    """Causal depthwise convolution with Kimi checkpoint-compatible weights."""
+
+    def __init__(self, channels: int, kernel_size: int) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.weight = nn.Parameter(torch.empty(channels, kernel_size))
+        nn.init.normal_(self.weight, mean=0.0, std=0.02)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        channels_first = inputs.transpose(1, 2)
+        channels_first = F.pad(channels_first, (self.kernel_size - 1, 0))
+        convolved = F.conv1d(
+            channels_first,
+            self.weight.unsqueeze(1),
+            bias=None,
+            groups=self.weight.shape[0],
+        )
+        return F.silu(convolved.transpose(1, 2))
+
+
+class KDAGatedRMSNorm(nn.Module):
+    """RMSNorm followed by KDA's sigmoid output gate."""
+
+    def __init__(self, hidden_size: int, eps: float) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = float(eps)
+
+    def forward(self, inputs: torch.Tensor, gate: torch.Tensor) -> torch.Tensor:
+        variance = inputs.float().square().mean(dim=-1, keepdim=True)
+        normalized = inputs * torch.rsqrt(variance + self.eps).to(inputs.dtype)
+        return normalized * self.weight.to(inputs.dtype) * torch.sigmoid(gate)
+
+
+def reference_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+) -> torch.Tensor:
+    """Differentiable KDA recurrence used as the correctness oracle."""
+
+    q = F.normalize(q.float(), dim=-1).to(q.dtype)
+    k = F.normalize(k.float(), dim=-1).to(k.dtype)
+    beta = torch.sigmoid(beta.float()).to(q.dtype)
+
+    gate_input = raw_gate.float() + dt_bias.view(1, 1, *raw_gate.shape[-2:])
+    decay_scale = A_log.float().exp().view(1, 1, -1, 1)
+    if lower_bound is None:
+        log_decay = -decay_scale * F.softplus(gate_input)
+    else:
+        log_decay = float(lower_bound) * torch.sigmoid(decay_scale * gate_input)
+
+    state = torch.zeros(
+        q.shape[0],
+        q.shape[2],
+        q.shape[3],
+        v.shape[3],
+        dtype=torch.float32,
+        device=q.device,
+    )
+    outputs = []
+    score_scale = q.shape[-1] ** -0.5
+    for step in range(q.shape[1]):
+        state = state * log_decay[:, step].exp().unsqueeze(-1)
+        step_key = k[:, step].float()
+        step_value = v[:, step].float()
+        prediction = torch.einsum("bhd,bhdv->bhv", step_key, state)
+        delta = (step_value - prediction) * beta[:, step].float().unsqueeze(-1)
+        state = state + torch.einsum("bhd,bhv->bhdv", step_key, delta)
+        output = torch.einsum("bhd,bhdv->bhv", q[:, step].float(), state)
+        outputs.append((output * score_scale).to(q.dtype))
+    return torch.stack(outputs, dim=1)
+
+
+def _load_fla_chunk_kda() -> Callable[..., tuple[torch.Tensor, object]]:
+    try:
+        from fla.ops.kda import chunk_kda
+    except ImportError as exc:
+        raise ImportError(
+            "KDA training with backend='fla' requires fla-core==0.5.1; "
+            "install SpecForge with the 'kda' extra"
+        ) from exc
+    return chunk_kda
+
+
+def _pad_batch_to(tensor: torch.Tensor, size: int) -> torch.Tensor:
+    padding = size - int(tensor.shape[0])
+    if padding <= 0:
+        return tensor
+    return torch.cat(
+        (tensor, tensor.new_zeros((padding, *tensor.shape[1:]))),
+        dim=0,
+    )
+
+
+def fla_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+) -> torch.Tensor:
+    """Run FLA KDA while respecting the CUDA grid-z launch limit."""
+
+    chunk_kda = _load_fla_chunk_kda()
+    max_blocks_per_launch = max(1, _CUDA_MAX_GRID_DIM_Z // int(q.shape[2]))
+    outputs = []
+    for start in range(0, int(q.shape[0]), max_blocks_per_launch):
+        end = min(start + max_blocks_per_launch, int(q.shape[0]))
+        batch_size = end - start
+        # TileLang specializes KDA on the independent-sequence count. DSpark's
+        # valid anchor width changes per sample, so launching the exact width
+        # would compile hundreds of kernels during a training run. Power-of-two
+        # buckets bound the specialization set without imposing a fixed anchor
+        # count or leaking KDA policy into the shared DFlash training path.
+        padded_size = min(
+            1 << (batch_size - 1).bit_length(),
+            max_blocks_per_launch,
+        )
+        output, _ = chunk_kda(
+            q=_pad_batch_to(q[start:end], padded_size),
+            k=_pad_batch_to(k[start:end], padded_size),
+            v=_pad_batch_to(v[start:end], padded_size),
+            g=_pad_batch_to(raw_gate[start:end], padded_size),
+            beta=_pad_batch_to(beta[start:end], padded_size),
+            # FSDP1 requires each decoder block to have one parameter dtype.
+            # SpecForge therefore shards these as BF16 (with FP32 optimizer
+            # masters) and materializes the tiny FP32 kernel inputs here.
+            A_log=A_log.float(),
+            dt_bias=dt_bias.float(),
+            output_final_state=False,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=True,
+            safe_gate=lower_bound is not None,
+            lower_bound=lower_bound,
+        )
+        outputs.append(output[:batch_size])
+    return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=0)
+
+
+class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
+    """KDA applied independently to every block-parallel proposal."""
+
+    def __init__(
+        self,
+        config: Qwen3Config,
+        layer_idx: int,
+        kernels: DFlashKernels,
+    ) -> None:
+        super().__init__(config, layer_idx, kernels)
+        self.kda_config = KDAConfig.from_config(config)
+        spec = self.kda_config
+
+        self.head_dim = spec.head_dim
+        self.num_heads = spec.num_heads
+        self.block_size = spec.block_size
+        self.backend = spec.backend
+        self.lower_bound = spec.gate_lower_bound
+        projection_size = spec.projection_size
+
+        self.q_proj = nn.Linear(spec.hidden_size, projection_size, bias=False)
+        self.k_proj = nn.Linear(spec.hidden_size, projection_size, bias=False)
+        self.v_proj = nn.Linear(spec.hidden_size, projection_size, bias=False)
+        self.q_conv1d = KDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+        self.k_conv1d = KDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+        self.v_conv1d = KDAShortConvolution(
+            projection_size, spec.short_conv_kernel_size
+        )
+
+        self.A_log = nn.Parameter(
+            torch.log(torch.empty(spec.num_heads, dtype=torch.float32).uniform_(1, 16))
+        )
+        self.f_a_proj = nn.Linear(spec.hidden_size, spec.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(spec.head_dim, projection_size, bias=False)
+        self.dt_bias = nn.Parameter(torch.zeros(projection_size, dtype=torch.float32))
+        self.b_proj = nn.Linear(spec.hidden_size, spec.num_heads, bias=False)
+        if spec.use_full_rank_gate:
+            self.g_proj = nn.Linear(spec.hidden_size, projection_size, bias=False)
+        else:
+            self.g_a_proj = nn.Linear(spec.hidden_size, spec.head_dim, bias=False)
+            self.g_b_proj = nn.Linear(spec.head_dim, projection_size, bias=False)
+        self.o_norm = KDAGatedRMSNorm(spec.head_dim, eps=float(config.rms_norm_eps))
+        self.o_proj = nn.Linear(projection_size, spec.hidden_size, bias=False)
+
+    def _independent_blocks(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, int, int]:
+        batch_size, query_len, hidden_size = hidden_states.shape
+        if query_len % self.block_size:
+            raise ValueError(
+                "KDA draft query length must be divisible by block_size; "
+                f"got query_len={query_len}, block_size={self.block_size}"
+            )
+        num_blocks = query_len // self.block_size
+        blocks = hidden_states.reshape(
+            batch_size * num_blocks, self.block_size, hidden_size
+        )
+        return blocks, batch_size, query_len
+
+    def _output_gate(self, blocks: torch.Tensor) -> torch.Tensor:
+        if self.kda_config.use_full_rank_gate:
+            return self.g_proj(blocks)
+        return self.g_b_proj(self.g_a_proj(blocks))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        target_hidden: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        # Dense/MLA siblings may use the shared cache during SpecForge decode.
+        # KDA deliberately leaves it untouched because every proposal block is
+        # an independent recurrent sequence.
+        del (
+            target_hidden,
+            position_embeddings,
+            attention_mask,
+            past_key_values,
+            cache_position,
+            kwargs,
+        )
+
+        blocks, batch_size, query_len = self._independent_blocks(hidden_states)
+        block_count = blocks.shape[0]
+        projection_shape = (
+            block_count,
+            self.block_size,
+            self.num_heads,
+            self.head_dim,
+        )
+        q = self.q_conv1d(self.q_proj(blocks)).view(projection_shape)
+        k = self.k_conv1d(self.k_proj(blocks)).view(projection_shape)
+        v = self.v_conv1d(self.v_proj(blocks)).view(projection_shape)
+        raw_gate = self.f_b_proj(self.f_a_proj(blocks)).view(projection_shape)
+        beta = self.b_proj(blocks).view(block_count, self.block_size, self.num_heads)
+
+        kda_fn = reference_kda if self.backend == "reference" else fla_kda
+        attention_output = kda_fn(
+            q,
+            k,
+            v,
+            raw_gate,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            self.lower_bound,
+        )
+        output_gate = self._output_gate(blocks).view(projection_shape)
+        attention_output = self.o_norm(attention_output, output_gate)
+        attention_output = self.o_proj(attention_output.flatten(-2))
+        attention_output = attention_output.reshape(
+            batch_size, query_len, self.kda_config.hidden_size
+        )
+        return attention_output, None
+
+
+__all__ = [
+    "KDAConfig",
+    "Qwen3DFlashKDAAttention",
+    "fla_kda",
+    "reference_kda",
+    "validate_dflash_kda_config",
+]

--- a/specforge/modeling/draft/kda.py
+++ b/specforge/modeling/draft/kda.py
@@ -176,6 +176,7 @@ def reference_kda(
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
+    cu_seqlens_cpu: Optional[torch.Tensor] = None,
 ):
     """Differentiable KDA recurrence used as the correctness oracle.
 
@@ -192,7 +193,8 @@ def reference_kda(
                 "variable-length KDA expects a flattened batch of size 1, "
                 f"got {q.shape[0]}"
             )
-        bounds = [int(bound) for bound in cu_seqlens.tolist()]
+        source = cu_seqlens_cpu if cu_seqlens_cpu is not None else cu_seqlens
+        bounds = [int(bound) for bound in source.tolist()]
         outputs, final_states = [], []
         for index, (start, end) in enumerate(zip(bounds[:-1], bounds[1:])):
             state = None if initial_state is None else initial_state[index : index + 1]
@@ -323,6 +325,7 @@ def _fla_kda_varlen(
     output_final_state: bool,
     cu_seqlens: torch.Tensor,
     kernel_kwargs: dict,
+    cu_seqlens_cpu: Optional[torch.Tensor] = None,
 ):
     """One variable-length FLA launch over flattened context segments.
 
@@ -350,12 +353,14 @@ def _fla_kda_varlen(
         padded_sequences *= 2
         extra_sequences = padded_sequences - num_sequences
         padded_total = _round_up(total + extra_sequences, _FLA_CHUNK_SIZE)
+    bounds_cpu = cu_seqlens_cpu
     if extra_sequences:
         dummy_ends = total + torch.arange(
             1, extra_sequences + 1, device=bounds.device, dtype=torch.long
         )
         dummy_ends[-1] = padded_total
         bounds = torch.cat((bounds, dummy_ends))
+        bounds_cpu = None  # padded on device only; FLA falls back to the device copy
     state = initial_state
     if state is not None and extra_sequences:
         state = _pad_batch_to(state, padded_sequences)
@@ -368,6 +373,7 @@ def _fla_kda_varlen(
         initial_state=state,
         output_final_state=output_final_state,
         cu_seqlens=bounds,
+        **({"cu_seqlens_cpu": bounds_cpu} if bounds_cpu is not None else {}),
         **kernel_kwargs,
     )
     output = output[:, :total]
@@ -389,6 +395,7 @@ def fla_kda(
     initial_state: Optional[torch.Tensor] = None,
     output_final_state: bool = False,
     cu_seqlens: Optional[torch.Tensor] = None,
+    cu_seqlens_cpu: Optional[torch.Tensor] = None,
 ):
     """Run FLA KDA while respecting the CUDA grid-z launch limit.
 
@@ -409,6 +416,7 @@ def fla_kda(
             output_final_state=output_final_state,
             cu_seqlens=cu_seqlens,
             kernel_kwargs=kernel_kwargs,
+            cu_seqlens_cpu=cu_seqlens_cpu,
         )
 
     max_blocks_per_launch = max(1, _CUDA_MAX_GRID_DIM_Z // int(q.shape[2]))
@@ -559,7 +567,7 @@ def _scan_row_states(
     return stacked[inverse]
 
 
-def scan_kda_context_states(
+def scan_kda_context_states_rowwise(
     kda_fn: Callable,
     k: torch.Tensor,
     v: torch.Tensor,
@@ -572,7 +580,13 @@ def scan_kda_context_states(
     *,
     group_size: Optional[int] = None,
 ) -> torch.Tensor:
-    """Recurrent state after the context positions strictly before each anchor.
+    """Row-by-row reference of :func:`scan_kda_context_states` (one launch chain per row).
+
+    Kept as the exactness oracle for the batched implementation; it issues
+    ``rows * (num_groups + group)`` launches with per-launch gathers and a
+    host sync per row, which is what made the scan launch-bound in training.
+
+    Recurrent state after the context positions strictly before each anchor.
 
     ``k``/``v`` are the convolved context projections ``[B, S, H, D]``,
     ``raw_gate`` ``[B, S, H, D]`` and ``beta`` ``[B, S, H]`` the context gates,
@@ -607,6 +621,329 @@ def scan_kda_context_states(
             )
         )
     return torch.stack(rows, dim=0)
+
+
+# ---------------------------------------------------------------------------
+# Batched context scan: one launch chain for all rows, host-side layout
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ScanLaunch:
+    """One variable-length KDA launch of the two-level scan, fully described on the host."""
+
+    length: int  # padded token count (multiple of _FLA_CHUNK_SIZE)
+    real: int  # real sequences; the rest are one-token dummies feeding the zero slot
+    cu_seqlens_cpu: torch.Tensor  # [padded_sequences + 1], CPU long
+    cu_seqlens: torch.Tensor  # same, on the compute device
+    state_in: torch.Tensor  # [padded_sequences] pool slots feeding initial states
+    out_slots: torch.Tensor  # [real] pool slots receiving the final states
+
+
+@dataclass
+class ScanLayout:
+    """Host-precomputed launch plan of the two-level anchor scan for one micro-batch.
+
+    Built once per forward from ``anchor_positions`` (one device->host copy) and
+    shared by every context-scanning KDA layer, so the layers themselves issue
+    no host syncs and no per-launch index arithmetic. Parameter-free, hence
+    safe to build outside the FSDP units.
+    """
+
+    batch_size: int
+    context_len: int
+    num_anchors: int
+    group: int
+    num_slots: int
+    level1: list
+    level2: list
+    index1: torch.Tensor  # device long: token gather for all level-1 launches (concatenated)
+    index2: torch.Tensor  # device long: token gather for all level-2 launches (concatenated)
+    gin_slots: torch.Tensor  # device long: level-1 group-input slots ...
+    cur_slots: torch.Tensor  # ... copied into these running slots before level 2
+    anchor_gather: torch.Tensor  # device long [batch * num_anchors] -> row of the collected finals
+    total_finals: int
+
+
+def _pad_launch(
+    sequences: list, zero_index: int
+) -> tuple[list, list, int, int]:
+    """Pad real (start, end, token_base) sequences to FLA's launch buckets.
+
+    Returns ``(token_index_list, cu_seqlens_list, padded_sequences, padded_total)``
+    using the same policy as :func:`_fla_kda_varlen`: a power-of-two sequence
+    count via one-token dummy sequences and a chunk-aligned token count, the
+    last dummy absorbing the remainder. Dummy tokens gather the zero row.
+    """
+
+    lengths = [end - start for start, end, _ in sequences]
+    total = sum(lengths)
+    num_sequences = len(sequences)
+    padded_sequences = 1 << max(num_sequences - 1, 0).bit_length()
+    extra = padded_sequences - num_sequences
+    padded_total = _round_up(total + extra, _FLA_CHUNK_SIZE)
+    if padded_total > total and extra == 0:
+        padded_sequences *= 2
+        extra = padded_sequences - num_sequences
+        padded_total = _round_up(total + extra, _FLA_CHUNK_SIZE)
+    index: list[int] = []
+    for start, end, base in sequences:
+        index.extend(range(base + start, base + end))
+    index.extend([zero_index] * (padded_total - total))
+    cu = [0]
+    for length in lengths:
+        cu.append(cu[-1] + length)
+    for j in range(extra):
+        cu.append(total + j + 1 if j < extra - 1 else padded_total)
+    if extra == 0:
+        assert padded_total == total
+    return index, cu, padded_sequences, padded_total
+
+
+def build_scan_layout(
+    anchor_positions: torch.Tensor,
+    context_len: int,
+    device: torch.device,
+    *,
+    group_size: Optional[int] = None,
+) -> ScanLayout:
+    """Plan the two-level anchor scan for ``anchor_positions`` ``[B, N]``.
+
+    Rows are cut at their unique sorted anchors into segments; ``group``
+    consecutive segments form a group. Level 1 chains the group spans of every
+    row in ``max_groups`` launches (one launch per group index, all rows
+    together); level 2 advances the in-group offsets of every group of every
+    row in ``group`` launches. Exactly the launches of the row-wise scheme,
+    batched across rows, with the launch plan computed here on the host.
+    """
+
+    anchors = anchor_positions.detach().to("cpu", torch.long).clamp(0, int(context_len))
+    batch_size, num_anchors = anchors.shape
+    rows_unique = [sorted(set(anchors[r].tolist())) for r in range(batch_size)]
+    num_segments = [len(u) for u in rows_unique]
+    max_segments = max(num_segments) if num_segments else 0
+    group = int(group_size) if group_size else max(1, math.isqrt(max(max_segments, 1)))
+    num_groups = [-(-m // group) for m in num_segments]
+    max_groups = max(num_groups) if num_groups else 0
+
+    # Pool slots: 0 = zero state; gin(r, g) for g >= 1; cur(r, g) for all g.
+    next_slot = 1
+    gin: list[list[int]] = []
+    cur: list[list[int]] = []
+    for r in range(batch_size):
+        gin.append([0] + [next_slot + i for i in range(max(num_groups[r] - 1, 0))])
+        next_slot += max(num_groups[r] - 1, 0)
+        cur.append([next_slot + i for i in range(num_groups[r])])
+        next_slot += num_groups[r]
+    num_slots = next_slot
+    zero_index = batch_size * context_len  # the appended zero row of the flattened context
+
+    finals_row: dict = {}  # (row, segment) -> row index in the concatenated finals
+    total_finals = 0
+    level1: list = []
+    index1: list[int] = []
+    for g in range(max_groups):
+        seqs, state_in, out_slots, owners = [], [], [], []
+        for r in range(batch_size):
+            if g >= num_groups[r]:
+                continue
+            bounds = [0] + rows_unique[r]
+            start = bounds[g * group]
+            last = min((g + 1) * group, num_segments[r]) - 1
+            end = bounds[last + 1]
+            if end <= start:
+                continue  # empty group span (only possible for anchor 0 alone)
+            seqs.append((start, end, r * context_len))
+            state_in.append(gin[r][g])
+            out_slots.append(gin[r][g + 1] if g + 1 < num_groups[r] else cur[r][g])
+            owners.append((r, last))
+        if not seqs:
+            continue
+        index, cu, padded_sequences, padded_total = _pad_launch(seqs, zero_index)
+        state_in += [0] * (padded_sequences - len(seqs))
+        for owner in owners:
+            finals_row[owner] = total_finals
+            total_finals += 1
+        index1.extend(index)
+        level1.append(
+            _ScanLaunch(
+                length=padded_total,
+                real=len(seqs),
+                cu_seqlens_cpu=torch.tensor(cu, dtype=torch.long),
+                cu_seqlens=torch.tensor(cu, dtype=torch.long, device=device),
+                state_in=torch.tensor(state_in, dtype=torch.long, device=device),
+                out_slots=torch.tensor(out_slots, dtype=torch.long, device=device),
+            )
+        )
+    # Level-1 launches write the *next* group's input; a group that is the row's
+    # last writes into its own running slot, which level 2 never reads for that
+    # group's last segment, so the value is only collected as a final.
+
+    level2: list = []
+    index2: list[int] = []
+    for offset in range(group):
+        seqs, state_in, out_slots, owners = [], [], [], []
+        for r in range(batch_size):
+            bounds = [0] + rows_unique[r]
+            for g in range(num_groups[r]):
+                segment = g * group + offset
+                last = min((g + 1) * group, num_segments[r]) - 1
+                if segment > last or segment == last:
+                    continue
+                start, end = bounds[segment], bounds[segment + 1]
+                if end <= start:
+                    continue  # anchor 0: state before it is the zero state
+                seqs.append((start, end, r * context_len))
+                state_in.append(cur[r][g])
+                out_slots.append(cur[r][g])
+                owners.append((r, segment))
+        if not seqs:
+            continue
+        index, cu, padded_sequences, padded_total = _pad_launch(seqs, zero_index)
+        state_in += [0] * (padded_sequences - len(seqs))
+        for owner in owners:
+            finals_row[owner] = total_finals
+            total_finals += 1
+        index2.extend(index)
+        level2.append(
+            _ScanLaunch(
+                length=padded_total,
+                real=len(seqs),
+                cu_seqlens_cpu=torch.tensor(cu, dtype=torch.long),
+                cu_seqlens=torch.tensor(cu, dtype=torch.long, device=device),
+                state_in=torch.tensor(state_in, dtype=torch.long, device=device),
+                out_slots=torch.tensor(out_slots, dtype=torch.long, device=device),
+            )
+        )
+
+    # Every anchor maps to the final state of its segment; anchor 0 (an empty
+    # segment) maps to the zero row appended after the collected finals.
+    gather: list[int] = []
+    for r in range(batch_size):
+        position = {anchor: i for i, anchor in enumerate(rows_unique[r])}
+        for anchor in anchors[r].tolist():
+            segment = position[anchor]
+            gather.append(finals_row.get((r, segment), total_finals))
+    gin_slots = [slot for r in range(batch_size) for slot in gin[r]]
+    cur_slots = [slot for r in range(batch_size) for slot in cur[r]]
+    as_index = lambda values: torch.tensor(values, dtype=torch.long, device=device)
+    return ScanLayout(
+        batch_size=batch_size,
+        context_len=int(context_len),
+        num_anchors=num_anchors,
+        group=group,
+        num_slots=num_slots,
+        level1=level1,
+        level2=level2,
+        index1=as_index(index1),
+        index2=as_index(index2),
+        gin_slots=as_index(gin_slots),
+        cur_slots=as_index(cur_slots),
+        anchor_gather=as_index(gather),
+        total_finals=total_finals,
+    )
+
+
+def scan_kda_context_states(
+    kda_fn: Callable,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    raw_gate: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: Optional[float],
+    anchor_positions: torch.Tensor,
+    *,
+    group_size: Optional[int] = None,
+    layout: Optional[ScanLayout] = None,
+) -> torch.Tensor:
+    """Recurrent state after the context positions strictly before each anchor.
+
+    Same contract and the same launches as :func:`scan_kda_context_states_rowwise`
+    (``k``/``v`` ``[B, S, H, D]``, ``raw_gate`` ``[B, S, H, D]``, ``beta``
+    ``[B, S, H]``, ``anchor_positions`` ``[B, N]`` -> fp32 ``[B, N, H, K, V]``),
+    but all rows share one launch chain, token gathers are one ``index_select``
+    plus ``split`` per level, states live in one pool updated out of place, and
+    the launch plan comes from a :class:`ScanLayout` built once on the host.
+    """
+
+    batch_size, context_len = k.shape[:2]
+    if anchor_positions.shape[0] != batch_size:
+        raise ValueError(
+            "anchor_positions must carry one row per context row, got "
+            f"{tuple(anchor_positions.shape)} for {batch_size} rows"
+        )
+    if layout is None:
+        layout = build_scan_layout(
+            anchor_positions, context_len, k.device, group_size=group_size
+        )
+    elif (layout.batch_size, layout.context_len, layout.num_anchors) != (
+        batch_size,
+        int(context_len),
+        int(anchor_positions.shape[1]),
+    ):
+        raise ValueError(
+            "scan layout does not match the context/anchor shapes: "
+            f"layout=({layout.batch_size}, {layout.context_len}, {layout.num_anchors}) "
+            f"vs ({batch_size}, {context_len}, {anchor_positions.shape[1]})"
+        )
+    num_heads, key_dim = k.shape[2], k.shape[3]
+    value_dim = v.shape[3]
+
+    def flatten(tensor: torch.Tensor) -> torch.Tensor:
+        flat = tensor.reshape(batch_size * context_len, *tensor.shape[2:])
+        return torch.cat((flat, flat.new_zeros((1, *flat.shape[1:]))), dim=0)
+
+    k_flat, v_flat, g_flat, b_flat = (flatten(t) for t in (k, v, raw_gate, beta))
+    pool = k.new_zeros(
+        (layout.num_slots, num_heads, key_dim, value_dim), dtype=torch.float32
+    )
+    max_length = max(
+        [launch.length for launch in layout.level1 + layout.level2] or [0]
+    )
+    # The recurrent state does not depend on queries; one zero buffer serves
+    # every launch as a view.
+    zero_q = k.new_zeros((1, max_length, num_heads, key_dim))
+    finals: list[torch.Tensor] = []
+    for level, index, launches in (
+        (1, layout.index1, layout.level1),
+        (2, layout.index2, layout.level2),
+    ):
+        if not launches:
+            continue
+        if level == 2:
+            pool = pool.index_copy(
+                0, layout.cur_slots, pool.index_select(0, layout.gin_slots)
+            )
+        lengths = [launch.length for launch in launches]
+        ks, vs, gs, bs = (
+            torch.split(t.index_select(0, index), lengths, dim=0)
+            for t in (k_flat, v_flat, g_flat, b_flat)
+        )
+        for i, launch in enumerate(launches):
+            initial_state = pool.index_select(0, launch.state_in)
+            _, final_state = kda_fn(
+                zero_q[:, : launch.length],
+                ks[i].unsqueeze(0),
+                vs[i].unsqueeze(0),
+                gs[i].unsqueeze(0),
+                bs[i].unsqueeze(0),
+                A_log,
+                dt_bias,
+                lower_bound,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=launch.cu_seqlens,
+                cu_seqlens_cpu=launch.cu_seqlens_cpu,
+            )
+            real = final_state[: launch.real]
+            pool = pool.index_copy(0, launch.out_slots, real)
+            finals.append(real)
+    zero_row = pool[:1]
+    collected = torch.cat(finals + [zero_row], dim=0)
+    states = collected.index_select(0, layout.anchor_gather)
+    return states.view(batch_size, layout.num_anchors, num_heads, key_dim, value_dim)
 
 
 def _gather_left_rows(
@@ -807,6 +1144,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
         anchor_positions: Optional[torch.Tensor],
         batch_size: int,
         num_blocks: int,
+        scan_layout: Optional[ScanLayout] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Per-block initial states and left conv rows for block-parallel use."""
 
@@ -838,6 +1176,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
             self.dt_bias,
             self.lower_bound,
             anchors,
+            layout=scan_layout if anchor_positions is not None else None,
         )
         left_rows = _gather_left_rows(target_hidden, anchors, window)
         return states, left_rows
@@ -883,6 +1222,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
         past_key_values: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
         anchor_positions: Optional[torch.Tensor] = None,
+        scan_layout: Optional[ScanLayout] = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
         # Dense/MLA siblings may use the shared cache during SpecForge decode.
@@ -892,7 +1232,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
 
         blocks, batch_size, query_len = self._independent_blocks(hidden_states)
         if not self.scans_context:
-            del target_hidden, past_key_values, anchor_positions
+            del target_hidden, past_key_values, anchor_positions, scan_layout
             q = self.q_conv1d(self.q_proj(blocks))
             k = self.k_conv1d(self.k_proj(blocks))
             v = self.v_conv1d(self.v_proj(blocks))
@@ -908,7 +1248,7 @@ class Qwen3DFlashKDAAttention(Qwen3DFlashAttentionBase):
             left_rows = tail.unsqueeze(1).expand(-1, num_blocks, -1, -1)
         else:
             states, left_rows = self._anchor_context(
-                target_hidden, anchor_positions, batch_size, num_blocks
+                target_hidden, anchor_positions, batch_size, num_blocks, scan_layout
             )
         initial_state = states.reshape(
             block_count, self.num_heads, self.head_dim, self.head_dim
@@ -925,6 +1265,9 @@ __all__ = [
     "Qwen3DFlashKDAAttention",
     "fla_kda",
     "reference_kda",
+    "ScanLayout",
+    "build_scan_layout",
     "scan_kda_context_states",
+    "scan_kda_context_states_rowwise",
     "validate_dflash_kda_config",
 ]

--- a/specforge/modeling/draft/kda.py
+++ b/specforge/modeling/draft/kda.py
@@ -657,17 +657,21 @@ class ScanLayout:
     num_slots: int
     level1: list
     level2: list
-    index1: torch.Tensor  # device long: token gather for all level-1 launches (concatenated)
-    index2: torch.Tensor  # device long: token gather for all level-2 launches (concatenated)
+    index1: (
+        torch.Tensor
+    )  # device long: token gather for all level-1 launches (concatenated)
+    index2: (
+        torch.Tensor
+    )  # device long: token gather for all level-2 launches (concatenated)
     gin_slots: torch.Tensor  # device long: level-1 group-input slots ...
     cur_slots: torch.Tensor  # ... copied into these running slots before level 2
-    anchor_gather: torch.Tensor  # device long [batch * num_anchors] -> row of the collected finals
+    anchor_gather: (
+        torch.Tensor
+    )  # device long [batch * num_anchors] -> row of the collected finals
     total_finals: int
 
 
-def _pad_launch(
-    sequences: list, zero_index: int
-) -> tuple[list, list, int, int]:
+def _pad_launch(sequences: list, zero_index: int) -> tuple[list, list, int, int]:
     """Pad real (start, end, token_base) sequences to FLA's launch buckets.
 
     Returns ``(token_index_list, cu_seqlens_list, padded_sequences, padded_total)``
@@ -736,7 +740,9 @@ def build_scan_layout(
         cur.append([next_slot + i for i in range(num_groups[r])])
         next_slot += num_groups[r]
     num_slots = next_slot
-    zero_index = batch_size * context_len  # the appended zero row of the flattened context
+    zero_index = (
+        batch_size * context_len
+    )  # the appended zero row of the flattened context
 
     finals_row: dict = {}  # (row, segment) -> row index in the concatenated finals
     total_finals = 0
@@ -899,9 +905,7 @@ def scan_kda_context_states(
     pool = k.new_zeros(
         (layout.num_slots, num_heads, key_dim, value_dim), dtype=torch.float32
     )
-    max_length = max(
-        [launch.length for launch in layout.level1 + layout.level2] or [0]
-    )
+    max_length = max([launch.length for launch in layout.level1 + layout.level2] or [0])
     # The recurrent state does not depend on queries; one zero buffer serves
     # every launch as a view.
     zero_q = k.new_zeros((1, max_length, num_heads, key_dim))

--- a/specforge/modeling/draft/kda.py
+++ b/specforge/modeling/draft/kda.py
@@ -31,7 +31,7 @@ from transformers.cache_utils import Cache
 from transformers.models.qwen3.modeling_qwen3 import FlashAttentionKwargs, Qwen3Config
 from typing_extensions import Unpack
 
-from .dflash import Qwen3DFlashAttentionBase
+from .dflash import Qwen3DFlashAttentionBase, resolve_dflash_block_size
 from .dflash_kernels import DFlashKernels
 
 _CUDA_MAX_GRID_DIM_Z = 65_535
@@ -77,7 +77,7 @@ class KDAConfig:
             "hidden_size": int(config.hidden_size),
             "head_dim": int(linear_config["head_dim"]),
             "num_heads": int(linear_config["num_heads"]),
-            "block_size": int(config.block_size),
+            "block_size": resolve_dflash_block_size(config),
             "short_conv_kernel_size": int(linear_config["short_conv_kernel_size"]),
         }
         for name, value in dimensions.items():

--- a/tests/test_modeling/test_dflash_kda.py
+++ b/tests/test_modeling/test_dflash_kda.py
@@ -1,0 +1,580 @@
+"""Correctness and composition tests for DFlash-family KDA attention."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+from torch.testing import assert_close
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+from specforge.modeling.draft.dflash import (
+    DFlashDraftModel,
+    DFlashGenerationOutput,
+    Qwen3DFlashAttention,
+    Qwen3DFlashAttentionBase,
+    Qwen3DFlashKVAttentionBase,
+    resolve_dflash_attention_modes,
+)
+from specforge.modeling.draft.domino import DominoDraftModel
+from specforge.modeling.draft.dspark import DSparkDraftModel
+from specforge.modeling.draft.kda import Qwen3DFlashKDAAttention, fla_kda, reference_kda
+
+CUDA_AND_FLA = torch.cuda.is_available() and importlib.util.find_spec("fla") is not None
+
+
+def _kda_config(
+    *,
+    architecture: str = "DFlashDraftModel",
+    projector_type: str | None = None,
+    attention_modes: list[str] | None = None,
+    backend: str = "reference",
+) -> Qwen3Config:
+    config = Qwen3Config(
+        hidden_size=24,
+        intermediate_size=48,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=3,
+        head_dim=6,
+        max_position_embeddings=128,
+        vocab_size=64,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "eager"
+    config.architectures = [architecture]
+    config.num_target_layers = 8
+    config.block_size = 2
+    config.draft_vocab_size = 64
+    config.layer_types = ["full_attention"] * config.num_hidden_layers
+    config.use_sliding_window = False
+    config.dflash_config = {
+        "attention_modes": attention_modes or ["kda", "gqa", "kda"],
+        "mask_token_id": 0,
+    }
+    if projector_type is not None:
+        config.dflash_config["projector_type"] = projector_type
+    if projector_type == "domino":
+        config.dflash_config.update({"emb_dim": 16, "gru_hidden_dim": 12})
+    config.linear_attn_config = {
+        "head_dim": 6,
+        "num_heads": 4,
+        "short_conv_kernel_size": 3,
+        "use_full_rank_gate": False,
+        "gate_lower_bound": -5.0,
+        "backend": backend,
+    }
+    return config
+
+
+def _attention_forward(
+    attention: Qwen3DFlashKDAAttention,
+    hidden_states: torch.Tensor,
+    *,
+    target_hidden: torch.Tensor | None = None,
+    past_key_values=None,
+):
+    batch_size, query_len = hidden_states.shape[:2]
+    if target_hidden is None:
+        target_hidden = torch.randn(batch_size, 3, hidden_states.shape[-1])
+    position_embeddings = (
+        torch.ones(batch_size, target_hidden.shape[1] + query_len, 6),
+        torch.zeros(batch_size, target_hidden.shape[1] + query_len, 6),
+    )
+    return attention(
+        hidden_states=hidden_states,
+        target_hidden=target_hidden,
+        position_embeddings=position_embeddings,
+        attention_mask=None,
+        past_key_values=past_key_values,
+    )[0]
+
+
+class TestKDAComposition(unittest.TestCase):
+    def test_hybrid_layers_share_one_attention_contract(self):
+        model = DFlashDraftModel(_kda_config())
+
+        self.assertEqual(model.attention_mode, "hybrid")
+        self.assertEqual(model.attention_modes, ("kda", "gqa", "kda"))
+        self.assertIsInstance(model.layers[0].self_attn, Qwen3DFlashKDAAttention)
+        self.assertIsInstance(model.layers[1].self_attn, Qwen3DFlashAttention)
+        for layer in model.layers:
+            self.assertIsInstance(layer.self_attn, Qwen3DFlashAttentionBase)
+        self.assertIsInstance(model.layers[1].self_attn, Qwen3DFlashKVAttentionBase)
+
+    def test_dflash_dspark_and_domino_use_the_same_kda_class(self):
+        cases = (
+            (DFlashDraftModel, _kda_config()),
+            (
+                DSparkDraftModel,
+                _kda_config(
+                    architecture="DSparkDraftModel",
+                    projector_type="dspark",
+                ),
+            ),
+            (
+                DominoDraftModel,
+                _kda_config(
+                    architecture="DominoDraftModel",
+                    projector_type="domino",
+                ),
+            ),
+        )
+
+        for model_cls, config in cases:
+            with self.subTest(model=model_cls.__name__):
+                model = model_cls(config)
+                self.assertIsInstance(
+                    model.layers[0].self_attn, Qwen3DFlashKDAAttention
+                )
+                self.assertIn("Qwen3DFlashDecoderLayer", model._no_split_modules)
+
+    def test_fsdp_wraps_the_whole_hybrid_decoder_block(self):
+        model = DFlashDraftModel(_kda_config())
+        block_names = set(model._no_split_modules)
+
+        self.assertEqual(block_names, {"Qwen3DFlashDecoderLayer"})
+        self.assertTrue(
+            all(
+                type(layer).__name__ in block_names
+                and isinstance(layer.self_attn, Qwen3DFlashAttentionBase)
+                for layer in model.layers
+            )
+        )
+
+    def test_uniform_attention_mode_remains_backwards_compatible(self):
+        config = _kda_config()
+        config.dflash_config = {"attention_mode": "gqa", "mask_token_id": 0}
+
+        self.assertEqual(resolve_dflash_attention_modes(config), ("gqa",) * 3)
+        model = DFlashDraftModel(config)
+        self.assertEqual(model.attention_mode, "gqa")
+        self.assertTrue(
+            all(
+                isinstance(layer.self_attn, Qwen3DFlashAttention)
+                for layer in model.layers
+            )
+        )
+
+    def test_rejects_ambiguous_or_malformed_layer_modes(self):
+        cases = {
+            "only one": {"attention_mode": "gqa", "attention_modes": ["gqa"] * 3},
+            "exactly": {"attention_modes": ["kda", "gqa"]},
+            "selected": {"attention_modes": ["kda", "dense", "kda"]},
+        }
+        for message, dflash_config in cases.items():
+            with self.subTest(message=message):
+                config = _kda_config()
+                config.dflash_config = dflash_config
+                with self.assertRaisesRegex(ValueError, message):
+                    DFlashDraftModel(config)
+
+    def test_rejects_kda_without_context_injection(self):
+        config = _kda_config(attention_modes=["kda"] * 3)
+
+        with self.assertRaisesRegex(ValueError, "inject target context"):
+            DFlashDraftModel(config)
+
+    def test_rejects_mixed_context_families(self):
+        for modes in (["kda", "gqa", "mla"], ["gqa", "mha", "gqa"]):
+            with self.subTest(modes=modes):
+                config = _kda_config(attention_modes=modes)
+                with self.assertRaisesRegex(ValueError, "one consistent"):
+                    DFlashDraftModel(config)
+
+    def test_rejects_invalid_kda_dimensions_backend_and_gate(self):
+        cases = (
+            ("head_dim", 0, "head_dim"),
+            ("short_conv_kernel_size", -1, "short_conv_kernel_size"),
+            ("backend", "mystery", "backend"),
+            ("gate_lower_bound", 1.0, "gate_lower_bound"),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field):
+                config = _kda_config()
+                config.linear_attn_config[field] = value
+                with self.assertRaisesRegex(ValueError, message):
+                    DFlashDraftModel(config)
+
+
+class TestKDAReferenceMath(unittest.TestCase):
+    def test_recurrence_matches_independent_scalar_oracle(self):
+        q = torch.tensor([[[[2.0]], [[4.0]]]])
+        k = torch.tensor([[[[3.0]], [[5.0]]]])
+        v = torch.tensor([[[[7.0]], [[11.0]]]])
+        raw_gate = torch.zeros_like(q)
+        beta = torch.zeros(1, 2, 1)
+        A_log = torch.zeros(1)
+        dt_bias = torch.zeros(1)
+
+        actual = reference_kda(
+            q, k, v, raw_gate, beta, A_log, dt_bias, lower_bound=None
+        )
+
+        decay = torch.exp(-torch.nn.functional.softplus(torch.tensor(0.0)))
+        state_0 = torch.tensor(0.0) * decay + 1.0 * (7.0 - 0.0) * 0.5
+        output_0 = state_0
+        state_1 = state_0 * decay
+        state_1 = state_1 + 1.0 * (11.0 - state_1) * 0.5
+        expected = torch.tensor([[[[output_0]], [[state_1]]]])
+        assert_close(actual, expected)
+
+    def test_proposal_blocks_do_not_share_recurrent_or_convolution_state(self):
+        torch.manual_seed(3)
+        attention = Qwen3DFlashKDAAttention(
+            _kda_config(), layer_idx=0, kernels=mock.Mock()
+        ).eval()
+        hidden_states = torch.randn(1, 4, 24)
+        perturbed = hidden_states.clone()
+        perturbed[:, :2] += 100
+
+        output = _attention_forward(attention, hidden_states)
+        perturbed_output = _attention_forward(attention, perturbed)
+
+        self.assertFalse(torch.equal(output[:, :2], perturbed_output[:, :2]))
+        assert_close(output[:, 2:], perturbed_output[:, 2:], rtol=0, atol=0)
+
+    def test_batched_execution_matches_individual_sequences(self):
+        torch.manual_seed(5)
+        attention = Qwen3DFlashKDAAttention(
+            _kda_config(), layer_idx=0, kernels=mock.Mock()
+        ).eval()
+        hidden_states = torch.randn(2, 4, 24)
+
+        batched = _attention_forward(attention, hidden_states)
+        individual = torch.cat(
+            [_attention_forward(attention, row.unsqueeze(0)) for row in hidden_states]
+        )
+
+        assert_close(batched, individual, rtol=1e-5, atol=1e-6)
+
+    def test_forward_backward_is_finite_and_reaches_all_parameter_groups(self):
+        torch.manual_seed(7)
+        model = DFlashDraftModel(_kda_config()).train()
+        noise_embedding = torch.randn(2, 4, 24, requires_grad=True)
+        target_hidden = torch.randn(2, 5, 72, requires_grad=True)
+        position_ids = torch.arange(9).expand(2, -1)
+        attention_mask = torch.ones(2, 1, 4, 9, dtype=torch.bool)
+
+        output = model(
+            position_ids=position_ids,
+            noise_embedding=noise_embedding,
+            target_hidden=target_hidden,
+            attention_mask=attention_mask,
+        )
+
+        self.assertEqual(output.shape, (2, 4, 24))
+        self.assertTrue(torch.isfinite(output).all())
+        output.square().mean().backward()
+        for tensor in (noise_embedding, target_hidden):
+            self.assertIsNotNone(tensor.grad)
+            self.assertTrue(torch.isfinite(tensor.grad).all())
+        attention = model.layers[0].self_attn
+        for name in (
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "f_a_proj",
+            "f_b_proj",
+            "b_proj",
+            "g_a_proj",
+            "g_b_proj",
+            "o_proj",
+        ):
+            parameter = getattr(attention, name).weight
+            self.assertIsNotNone(parameter.grad, name)
+            self.assertTrue(torch.isfinite(parameter.grad).all(), name)
+        for name in ("A_log", "dt_bias"):
+            parameter = getattr(attention, name)
+            self.assertIsNotNone(parameter.grad, name)
+            self.assertTrue(torch.isfinite(parameter.grad).all(), name)
+
+    def test_checkpoint_parameter_names_match_serving_layout(self):
+        attention = Qwen3DFlashKDAAttention(
+            _kda_config(), layer_idx=0, kernels=mock.Mock()
+        )
+
+        expected = {
+            "q_proj.weight",
+            "k_proj.weight",
+            "v_proj.weight",
+            "q_conv1d.weight",
+            "k_conv1d.weight",
+            "v_conv1d.weight",
+            "A_log",
+            "dt_bias",
+            "f_a_proj.weight",
+            "f_b_proj.weight",
+            "b_proj.weight",
+            "g_a_proj.weight",
+            "g_b_proj.weight",
+            "o_norm.weight",
+            "o_proj.weight",
+        }
+        self.assertEqual(set(attention.state_dict()), expected)
+
+    def test_mixed_precision_cast_keeps_fsdp_block_dtype_uniform(self):
+        attention = Qwen3DFlashKDAAttention(
+            _kda_config(), layer_idx=0, kernels=mock.Mock()
+        ).to(dtype=torch.bfloat16)
+
+        self.assertEqual(attention.q_proj.weight.dtype, torch.bfloat16)
+        self.assertEqual(attention.A_log.dtype, torch.bfloat16)
+        self.assertEqual(attention.dt_bias.dtype, torch.bfloat16)
+
+    def test_kda_leaves_the_shared_dense_attention_cache_untouched(self):
+        attention = Qwen3DFlashKDAAttention(
+            _kda_config(), layer_idx=0, kernels=mock.Mock()
+        )
+        cache = mock.Mock()
+
+        output = _attention_forward(
+            attention,
+            torch.randn(1, 2, 24),
+            past_key_values=cache,
+        )
+
+        self.assertEqual(output.shape, (1, 2, 24))
+        cache.update.assert_not_called()
+
+
+class TestKDAFLADispatch(unittest.TestCase):
+    def test_buckets_dynamic_block_counts_without_changing_outputs(self):
+        seen_batch_sizes = []
+
+        def fake_chunk_kda(**kwargs):
+            seen_batch_sizes.append(kwargs["q"].shape[0])
+            return kwargs["q"], None
+
+        q = torch.randn(3, 2, 2, 3)
+        with mock.patch(
+            "specforge.modeling.draft.kda._load_fla_chunk_kda",
+            return_value=fake_chunk_kda,
+        ):
+            output = fla_kda(
+                q,
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn(3, 2, 2),
+                torch.randn(2),
+                torch.randn(6),
+                -5.0,
+            )
+
+        self.assertEqual(seen_batch_sizes, [4])
+        assert_close(output, q)
+
+    def test_splits_independent_blocks_below_cuda_grid_limit(self):
+        calls = []
+
+        def fake_chunk_kda(**kwargs):
+            calls.append(kwargs["q"].shape[0])
+            return kwargs["q"], None
+
+        q = torch.randn(5, 2, 2, 3)
+        args = (
+            q,
+            torch.randn_like(q),
+            torch.randn_like(q),
+            torch.randn_like(q),
+            torch.randn(5, 2, 2),
+            torch.randn(2),
+            torch.randn(6),
+            -5.0,
+        )
+        with (
+            mock.patch(
+                "specforge.modeling.draft.kda._load_fla_chunk_kda",
+                return_value=fake_chunk_kda,
+            ),
+            mock.patch("specforge.modeling.draft.kda._CUDA_MAX_GRID_DIM_Z", 5),
+        ):
+            output = fla_kda(*args)
+
+        self.assertEqual(calls, [2, 2, 1])
+        assert_close(output, q)
+
+    def test_casts_fsdp_bf16_gate_parameters_to_kernel_fp32(self):
+        seen_dtypes = []
+
+        def fake_chunk_kda(**kwargs):
+            seen_dtypes.append((kwargs["A_log"].dtype, kwargs["dt_bias"].dtype))
+            return kwargs["q"], None
+
+        q = torch.randn(1, 2, 2, 4, dtype=torch.bfloat16)
+        with mock.patch(
+            "specforge.modeling.draft.kda._load_fla_chunk_kda",
+            return_value=fake_chunk_kda,
+        ):
+            fla_kda(
+                q,
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn(1, 2, 2, dtype=torch.bfloat16),
+                torch.randn(2, dtype=torch.bfloat16),
+                torch.randn(8, dtype=torch.bfloat16),
+                lower_bound=-5.0,
+            )
+
+        self.assertEqual(seen_dtypes, [(torch.float32, torch.float32)])
+
+    @unittest.skipUnless(CUDA_AND_FLA, "FLA KDA parity requires CUDA and fla-core")
+    def test_real_kernel_matches_reference_forward_and_backward(self):
+        torch.manual_seed(13)
+        device = torch.device("cuda")
+        # Match the production KDA head width. FLA's optional TileLang backend
+        # has narrower synthetic-width specializations that are not used by
+        # the supported Qwen/Kimi configurations.
+        # Three real sequences exercises the power-of-two FLA launch bucket
+        # (padded to four) while the reference recurrence stays unpadded.
+        shape = (3, 64, 2, 128)
+        inputs = (
+            torch.randn(shape, device=device, dtype=torch.bfloat16),
+            torch.randn(shape, device=device, dtype=torch.bfloat16),
+            torch.randn(shape, device=device, dtype=torch.bfloat16),
+            torch.randn(shape, device=device, dtype=torch.bfloat16).mul_(0.1),
+            torch.randn(shape[:-1], device=device, dtype=torch.bfloat16),
+            torch.rand(shape[2], device=device, dtype=torch.float32).add_(0.5).log_(),
+            torch.randn(shape[2] * shape[3], device=device, dtype=torch.float32).mul_(
+                0.1
+            ),
+        )
+        output_weight = torch.randn(shape, device=device, dtype=torch.float32)
+
+        def run(kda_fn):
+            differentiable = tuple(
+                tensor.detach().clone().requires_grad_() for tensor in inputs
+            )
+            output = kda_fn(*differentiable, lower_bound=-5.0)
+            gradients = torch.autograd.grad(
+                (output.float() * output_weight).mean(), differentiable
+            )
+            return output.detach().float(), tuple(
+                gradient.detach().float() for gradient in gradients
+            )
+
+        expected_output, expected_gradients = run(reference_kda)
+        actual_output, actual_gradients = run(fla_kda)
+
+        assert_close(actual_output, expected_output, rtol=4e-2, atol=4e-2)
+        for index, (actual, expected) in enumerate(
+            zip(actual_gradients, expected_gradients)
+        ):
+            with self.subTest(gradient=index):
+                assert_close(actual, expected, rtol=1.5e-1, atol=2e-2)
+
+
+class TestKDAInference(unittest.TestCase):
+    def test_hf_save_and_reload_preserves_hybrid_architecture_and_outputs(self):
+        torch.manual_seed(9)
+        model = DFlashDraftModel(_kda_config()).eval()
+        inputs = {
+            "position_ids": torch.arange(7).unsqueeze(0),
+            "noise_embedding": torch.randn(1, 4, 24),
+            "target_hidden": torch.randn(1, 3, 72),
+            "attention_mask": torch.ones(1, 1, 4, 7, dtype=torch.bool),
+        }
+        expected = model(**inputs)
+
+        with tempfile.TemporaryDirectory() as directory:
+            model.save_pretrained(directory)
+            loaded = DFlashDraftModel.from_pretrained(directory).eval()
+            actual = loaded(**inputs)
+
+        self.assertEqual(loaded.attention_modes, ("kda", "gqa", "kda"))
+        assert_close(actual, expected, rtol=1e-6, atol=1e-7)
+
+    def test_spec_generate_decode_smoke(self):
+        torch.manual_seed(11)
+        target_config = Qwen3Config(
+            hidden_size=24,
+            intermediate_size=48,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=8,
+            head_dim=6,
+            max_position_embeddings=128,
+            vocab_size=64,
+            tie_word_embeddings=False,
+        )
+        target_config._attn_implementation = "sdpa"
+        target = Qwen3ForCausalLM(target_config).eval()
+        draft = DFlashDraftModel(_kda_config()).eval()
+
+        input_ids = torch.randint(1, 64, (1, 6))
+        output_ids = draft.spec_generate(
+            target,
+            input_ids,
+            max_new_tokens=6,
+            stop_token_ids=None,
+            temperature=0.0,
+        )
+
+        self.assertEqual(output_ids.shape[0], 1)
+        self.assertLessEqual(output_ids.shape[1], input_ids.shape[1] + 6)
+        self.assertTrue(torch.equal(output_ids[:, :6], input_ids))
+
+    def test_spec_generate_can_return_acceptance_telemetry(self):
+        torch.manual_seed(12)
+        target_config = Qwen3Config(
+            hidden_size=24,
+            intermediate_size=48,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=8,
+            head_dim=6,
+            max_position_embeddings=128,
+            vocab_size=64,
+            tie_word_embeddings=False,
+        )
+        target_config._attn_implementation = "sdpa"
+        target = Qwen3ForCausalLM(target_config).eval()
+        draft = DFlashDraftModel(_kda_config()).eval()
+
+        input_ids = torch.randint(1, 64, (1, 6))
+        output = draft.spec_generate(
+            target,
+            input_ids,
+            max_new_tokens=6,
+            stop_token_ids=None,
+            temperature=0.0,
+            return_dict=True,
+        )
+
+        self.assertIsInstance(output, DFlashGenerationOutput)
+        self.assertGreater(len(output.acceptance_lengths), 0)
+        self.assertTrue(all(length >= 1 for length in output.acceptance_lengths))
+        self.assertAlmostEqual(
+            output.mean_acceptance_length,
+            sum(output.acceptance_lengths) / len(output.acceptance_lengths),
+        )
+        self.assertTrue(torch.equal(output.sequences[:, :6], input_ids))
+
+    def test_train_and_eval_forward_match_without_dropout(self):
+        torch.manual_seed(13)
+        model = DFlashDraftModel(_kda_config())
+        inputs = {
+            "position_ids": torch.arange(7).unsqueeze(0),
+            "noise_embedding": torch.randn(1, 4, 24),
+            "target_hidden": torch.randn(1, 3, 72),
+            "attention_mask": torch.ones(1, 1, 4, 7, dtype=torch.bool),
+        }
+
+        model.train()
+        train_output = model(**copy.deepcopy(inputs))
+        model.eval()
+        eval_output = model(**copy.deepcopy(inputs))
+
+        assert_close(train_output, eval_output, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_modeling/test_dflash_kda.py
+++ b/tests/test_modeling/test_dflash_kda.py
@@ -162,6 +162,22 @@ class TestKDAComposition(unittest.TestCase):
             )
         )
 
+    def test_nested_block_size_matches_top_level_outputs(self):
+        config = _kda_config()
+        model = DFlashDraftModel(config).eval()
+        nested = copy.deepcopy(config)
+        nested.dflash_config["block_size"] = nested.block_size
+        del nested.block_size
+        loaded = DFlashDraftModel(nested).eval()
+        loaded.load_state_dict(model.state_dict())
+        inputs = {
+            "position_ids": torch.arange(7).unsqueeze(0),
+            "noise_embedding": torch.randn(1, 4, 24),
+            "target_hidden": torch.randn(1, 3, 72),
+            "attention_mask": torch.ones(1, 1, 4, 7, dtype=torch.bool),
+        }
+        assert_close(loaded(**inputs), model(**inputs), rtol=0, atol=0)
+
     def test_rejects_ambiguous_or_malformed_layer_modes(self):
         cases = {
             "only one": {"attention_mode": "gqa", "attention_modes": ["gqa"] * 3},

--- a/tests/test_modeling/test_dflash_kda_batched_scan.py
+++ b/tests/test_modeling/test_dflash_kda_batched_scan.py
@@ -1,0 +1,213 @@
+"""The batched (row-shared, host-planned) context scan must match the row-wise scan exactly."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from unittest import mock
+
+import torch
+from torch.testing import assert_close
+from transformers import Qwen3Config
+
+import specforge.modeling.draft.kda as kda_module
+from specforge.modeling.draft.dflash import DFlashDraftModel
+from specforge.modeling.draft.kda import (
+    build_scan_layout,
+    fla_kda,
+    reference_kda,
+    scan_kda_context_states,
+    scan_kda_context_states_rowwise,
+)
+
+CUDA_AND_FLA = torch.cuda.is_available() and importlib.util.find_spec("fla") is not None
+HIDDEN, HEADS, HEAD_DIM, BLOCK, CONV = 24, 4, 6, 2, 3
+
+
+def _config() -> Qwen3Config:
+    config = Qwen3Config(
+        hidden_size=HIDDEN,
+        intermediate_size=48,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=3,
+        head_dim=HEAD_DIM,
+        max_position_embeddings=128,
+        vocab_size=64,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "eager"
+    config.architectures = ["DFlashDraftModel"]
+    config.num_target_layers = 8
+    config.block_size = BLOCK
+    config.draft_vocab_size = 64
+    config.layer_types = ["full_attention"] * config.num_hidden_layers
+    config.use_sliding_window = False
+    config.dflash_config = {"attention_modes": ["kda", "gqa", "kda"], "mask_token_id": 0}
+    config.linear_attn_config = {
+        "head_dim": HEAD_DIM,
+        "num_heads": HEADS,
+        "short_conv_kernel_size": CONV,
+        "use_full_rank_gate": False,
+        "gate_lower_bound": -5.0,
+        "backend": "reference",
+        "context_state": "scan",
+    }
+    return config
+
+
+def _inputs(batch_size: int, context_len: int, heads: int, dim: int, **kw):
+    k = torch.randn(batch_size, context_len, heads, dim, requires_grad=True, **kw)
+    v = torch.randn(batch_size, context_len, heads, dim, requires_grad=True, **kw)
+    raw_gate = (torch.randn(batch_size, context_len, heads, dim, **kw) * 0.1).requires_grad_(True)
+    beta = torch.randn(batch_size, context_len, heads, requires_grad=True, **kw)
+    A_log = torch.rand(heads, **kw).add_(0.5).log_().requires_grad_(True)
+    dt_bias = (torch.randn(heads * dim, **kw) * 0.1).requires_grad_(True)
+    return k, v, raw_gate, beta, A_log, dt_bias
+
+
+ANCHORS = torch.tensor(
+    [
+        [0, 7, 7, 31, 3, 31, 37, 12, 19, 2],  # duplicates, empty context, full context
+        [5, 5, 5, 5, 5, 5, 5, 5, 5, 5],  # one unique anchor
+        [36, 1, 2, 3, 4, 6, 8, 10, 13, 17],  # many segments, unsorted
+    ]
+)
+
+
+class TestBatchedScanMatchesRowwise(unittest.TestCase):
+    def _compare(self, group_size, anchors=ANCHORS, context_len=37, seed=3):
+        torch.manual_seed(seed)
+        inputs = _inputs(anchors.shape[0], context_len, 2, 4)
+        k, v, raw_gate, beta, A_log, dt_bias = inputs
+        weight = torch.randn(anchors.shape[0], anchors.shape[1], 2, 4, 4)
+        results = []
+        for fn in (scan_kda_context_states_rowwise, scan_kda_context_states):
+            states = fn(
+                reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors,
+                group_size=group_size,
+            )
+            grads = (
+                torch.autograd.grad((states * weight).sum(), inputs)
+                if states.requires_grad  # all-zero anchors yield a constant zero state
+                else None
+            )
+            results.append((states, grads))
+        (expected, expected_grads), (actual, actual_grads) = results
+        assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+        self.assertEqual(actual_grads is None, expected_grads is None)
+        for got, want in zip(actual_grads or (), expected_grads or ()):
+            assert_close(got, want, rtol=1e-5, atol=1e-6)
+
+    def test_default_group_size(self):
+        self._compare(None)
+
+    def test_small_and_large_groups(self):
+        for group_size in (1, 2, 3, 5, 10, 64):
+            with self.subTest(group_size=group_size):
+                self._compare(group_size)
+
+    def test_single_row_and_all_zero_anchors(self):
+        self._compare(None, anchors=torch.tensor([[0, 0, 0]]), context_len=9)
+        self._compare(2, anchors=torch.tensor([[9, 4, 0, 9]]), context_len=9)
+
+    def test_layout_is_reusable_and_shape_checked(self):
+        torch.manual_seed(5)
+        k, v, raw_gate, beta, A_log, dt_bias = _inputs(3, 37, 2, 4)
+        layout = build_scan_layout(ANCHORS, 37, k.device)
+        expected = scan_kda_context_states_rowwise(
+            reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, ANCHORS
+        )
+        for _ in range(2):
+            actual = scan_kda_context_states(
+                reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, ANCHORS,
+                layout=layout,
+            )
+            assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+        with self.assertRaises(ValueError):
+            scan_kda_context_states(
+                reference_kda, k[:2], v[:2], raw_gate[:2], beta[:2], A_log, dt_bias,
+                -5.0, ANCHORS[:2], layout=layout,
+            )
+
+    def test_launch_count_is_two_level(self):
+        anchors = torch.arange(1, 65).unsqueeze(0) * 3  # 64 segments in one row
+        layout = build_scan_layout(anchors, 200, torch.device("cpu"))
+        self.assertEqual(layout.group, 8)
+        self.assertEqual(len(layout.level1), 8)
+        self.assertLessEqual(len(layout.level2), 7)
+        two_rows = build_scan_layout(torch.cat([anchors, anchors - 1]), 200, torch.device("cpu"))
+        # Batching rows adds no launches.
+        self.assertEqual(len(two_rows.level1), len(layout.level1))
+        self.assertEqual(len(two_rows.level2), len(layout.level2))
+
+
+class TestModelUsesSharedLayout(unittest.TestCase):
+    def _model_inputs(self, batch_size, num_blocks, context_len):
+        draft_len = num_blocks * BLOCK
+        return {
+            "position_ids": torch.arange(context_len + draft_len).expand(batch_size, -1),
+            "noise_embedding": torch.randn(batch_size, draft_len, HIDDEN),
+            "target_hidden": torch.randn(batch_size, context_len, 3 * HIDDEN),
+            "attention_mask": torch.ones(
+                batch_size, 1, draft_len, context_len + draft_len, dtype=torch.bool
+            ),
+            "anchor_positions": torch.tensor([[0, 3, 3, 9, 6], [9, 1, 4, 4, 2]]),
+        }
+
+    def test_forward_matches_rowwise_scan_and_builds_one_layout(self):
+        torch.manual_seed(11)
+        model = DFlashDraftModel(_config()).eval()
+        inputs = self._model_inputs(batch_size=2, num_blocks=5, context_len=9)
+
+        def rowwise(*args, layout=None, **kwargs):
+            return scan_kda_context_states_rowwise(*args, **kwargs)
+
+        with mock.patch.object(kda_module, "scan_kda_context_states", rowwise):
+            expected = model(**inputs)
+        with mock.patch.object(
+            kda_module, "build_scan_layout", wraps=kda_module.build_scan_layout
+        ) as build:
+            actual = model(**inputs)
+        assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+        self.assertEqual(build.call_count, 1)  # once per forward, not once per layer
+
+    def test_generation_path_builds_no_layout(self):
+        model = DFlashDraftModel(_config()).eval()
+        self.assertIsNone(model._build_scan_layout(torch.zeros(1, 4, HIDDEN), None, None))
+
+
+@unittest.skipUnless(CUDA_AND_FLA, "requires CUDA and fla")
+class TestBatchedScanWithFLA(unittest.TestCase):
+    def test_fla_batched_matches_rowwise_and_reference(self):
+        torch.manual_seed(16)
+        device = torch.device("cuda")
+        heads, dim, context_len = 2, 128, 200
+        k, v, raw_gate, beta, A_log, dt_bias = _inputs(
+            2, context_len, heads, dim, device=device, dtype=torch.bfloat16
+        )
+        A_log = A_log.detach().float().requires_grad_(True)
+        dt_bias = dt_bias.detach().float().requires_grad_(True)
+        anchors = torch.tensor([[0, 37, 37, 130, 200, 64], [5, 199, 12, 12, 100, 3]], device=device)
+        rowwise = scan_kda_context_states_rowwise(
+            fla_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
+        )
+        batched = scan_kda_context_states(
+            fla_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
+        )
+        reference = scan_kda_context_states_rowwise(
+            reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
+        )
+        assert_close(batched, rowwise, rtol=1e-4, atol=1e-4)  # same kernel, same launches
+        assert_close(batched, reference, rtol=4e-2, atol=4e-2)
+        weight = torch.randn_like(batched)
+        grads_rowwise = torch.autograd.grad((rowwise * weight).sum(), (k, v, raw_gate, beta))
+        grads_batched = torch.autograd.grad((batched * weight).sum(), (k, v, raw_gate, beta))
+        for got, want in zip(grads_batched, grads_rowwise):
+            assert_close(got.float(), want.float(), rtol=2e-2, atol=2e-2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_modeling/test_dflash_kda_batched_scan.py
+++ b/tests/test_modeling/test_dflash_kda_batched_scan.py
@@ -45,7 +45,10 @@ def _config() -> Qwen3Config:
     config.draft_vocab_size = 64
     config.layer_types = ["full_attention"] * config.num_hidden_layers
     config.use_sliding_window = False
-    config.dflash_config = {"attention_modes": ["kda", "gqa", "kda"], "mask_token_id": 0}
+    config.dflash_config = {
+        "attention_modes": ["kda", "gqa", "kda"],
+        "mask_token_id": 0,
+    }
     config.linear_attn_config = {
         "head_dim": HEAD_DIM,
         "num_heads": HEADS,
@@ -61,7 +64,9 @@ def _config() -> Qwen3Config:
 def _inputs(batch_size: int, context_len: int, heads: int, dim: int, **kw):
     k = torch.randn(batch_size, context_len, heads, dim, requires_grad=True, **kw)
     v = torch.randn(batch_size, context_len, heads, dim, requires_grad=True, **kw)
-    raw_gate = (torch.randn(batch_size, context_len, heads, dim, **kw) * 0.1).requires_grad_(True)
+    raw_gate = (
+        torch.randn(batch_size, context_len, heads, dim, **kw) * 0.1
+    ).requires_grad_(True)
     beta = torch.randn(batch_size, context_len, heads, requires_grad=True, **kw)
     A_log = torch.rand(heads, **kw).add_(0.5).log_().requires_grad_(True)
     dt_bias = (torch.randn(heads * dim, **kw) * 0.1).requires_grad_(True)
@@ -86,7 +91,15 @@ class TestBatchedScanMatchesRowwise(unittest.TestCase):
         results = []
         for fn in (scan_kda_context_states_rowwise, scan_kda_context_states):
             states = fn(
-                reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors,
+                reference_kda,
+                k,
+                v,
+                raw_gate,
+                beta,
+                A_log,
+                dt_bias,
+                -5.0,
+                anchors,
                 group_size=group_size,
             )
             grads = (
@@ -122,14 +135,30 @@ class TestBatchedScanMatchesRowwise(unittest.TestCase):
         )
         for _ in range(2):
             actual = scan_kda_context_states(
-                reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, ANCHORS,
+                reference_kda,
+                k,
+                v,
+                raw_gate,
+                beta,
+                A_log,
+                dt_bias,
+                -5.0,
+                ANCHORS,
                 layout=layout,
             )
             assert_close(actual, expected, rtol=1e-6, atol=1e-6)
         with self.assertRaises(ValueError):
             scan_kda_context_states(
-                reference_kda, k[:2], v[:2], raw_gate[:2], beta[:2], A_log, dt_bias,
-                -5.0, ANCHORS[:2], layout=layout,
+                reference_kda,
+                k[:2],
+                v[:2],
+                raw_gate[:2],
+                beta[:2],
+                A_log,
+                dt_bias,
+                -5.0,
+                ANCHORS[:2],
+                layout=layout,
             )
 
     def test_launch_count_is_two_level(self):
@@ -138,7 +167,9 @@ class TestBatchedScanMatchesRowwise(unittest.TestCase):
         self.assertEqual(layout.group, 8)
         self.assertEqual(len(layout.level1), 8)
         self.assertLessEqual(len(layout.level2), 7)
-        two_rows = build_scan_layout(torch.cat([anchors, anchors - 1]), 200, torch.device("cpu"))
+        two_rows = build_scan_layout(
+            torch.cat([anchors, anchors - 1]), 200, torch.device("cpu")
+        )
         # Batching rows adds no launches.
         self.assertEqual(len(two_rows.level1), len(layout.level1))
         self.assertEqual(len(two_rows.level2), len(layout.level2))
@@ -148,7 +179,9 @@ class TestModelUsesSharedLayout(unittest.TestCase):
     def _model_inputs(self, batch_size, num_blocks, context_len):
         draft_len = num_blocks * BLOCK
         return {
-            "position_ids": torch.arange(context_len + draft_len).expand(batch_size, -1),
+            "position_ids": torch.arange(context_len + draft_len).expand(
+                batch_size, -1
+            ),
             "noise_embedding": torch.randn(batch_size, draft_len, HIDDEN),
             "target_hidden": torch.randn(batch_size, context_len, 3 * HIDDEN),
             "attention_mask": torch.ones(
@@ -176,7 +209,9 @@ class TestModelUsesSharedLayout(unittest.TestCase):
 
     def test_generation_path_builds_no_layout(self):
         model = DFlashDraftModel(_config()).eval()
-        self.assertIsNone(model._build_scan_layout(torch.zeros(1, 4, HIDDEN), None, None))
+        self.assertIsNone(
+            model._build_scan_layout(torch.zeros(1, 4, HIDDEN), None, None)
+        )
 
 
 @unittest.skipUnless(CUDA_AND_FLA, "requires CUDA and fla")
@@ -190,7 +225,9 @@ class TestBatchedScanWithFLA(unittest.TestCase):
         )
         A_log = A_log.detach().float().requires_grad_(True)
         dt_bias = dt_bias.detach().float().requires_grad_(True)
-        anchors = torch.tensor([[0, 37, 37, 130, 200, 64], [5, 199, 12, 12, 100, 3]], device=device)
+        anchors = torch.tensor(
+            [[0, 37, 37, 130, 200, 64], [5, 199, 12, 12, 100, 3]], device=device
+        )
         rowwise = scan_kda_context_states_rowwise(
             fla_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
         )
@@ -200,11 +237,17 @@ class TestBatchedScanWithFLA(unittest.TestCase):
         reference = scan_kda_context_states_rowwise(
             reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
         )
-        assert_close(batched, rowwise, rtol=1e-4, atol=1e-4)  # same kernel, same launches
+        assert_close(
+            batched, rowwise, rtol=1e-4, atol=1e-4
+        )  # same kernel, same launches
         assert_close(batched, reference, rtol=4e-2, atol=4e-2)
         weight = torch.randn_like(batched)
-        grads_rowwise = torch.autograd.grad((rowwise * weight).sum(), (k, v, raw_gate, beta))
-        grads_batched = torch.autograd.grad((batched * weight).sum(), (k, v, raw_gate, beta))
+        grads_rowwise = torch.autograd.grad(
+            (rowwise * weight).sum(), (k, v, raw_gate, beta)
+        )
+        grads_batched = torch.autograd.grad(
+            (batched * weight).sum(), (k, v, raw_gate, beta)
+        )
         for got, want in zip(grads_batched, grads_rowwise):
             assert_close(got.float(), want.float(), rtol=2e-2, atol=2e-2)
 

--- a/tests/test_modeling/test_dflash_kda_context.py
+++ b/tests/test_modeling/test_dflash_kda_context.py
@@ -1,0 +1,692 @@
+"""Tests for the context-scanning KDA policy (``linear_attn_config.context_state``)."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from unittest import mock
+
+import torch
+from torch.testing import assert_close
+from transformers import Qwen3Config, Qwen3ForCausalLM
+
+from specforge.modeling.draft.dflash import DFlashDraftModel
+from specforge.modeling.draft.kda import (
+    Qwen3DFlashKDAAttention,
+    fla_kda,
+    reference_kda,
+    scan_kda_context_states,
+)
+
+CUDA_AND_FLA = torch.cuda.is_available() and importlib.util.find_spec("fla") is not None
+
+HIDDEN, HEADS, HEAD_DIM, BLOCK, CONV = 24, 4, 6, 2, 3
+
+
+def _config(
+    *,
+    context_state: str = "scan",
+    attention_modes: list[str] | None = None,
+    backend: str = "reference",
+) -> Qwen3Config:
+    config = Qwen3Config(
+        hidden_size=HIDDEN,
+        intermediate_size=48,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=3,
+        head_dim=HEAD_DIM,
+        max_position_embeddings=128,
+        vocab_size=64,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "eager"
+    config.architectures = ["DFlashDraftModel"]
+    config.num_target_layers = 8
+    config.block_size = BLOCK
+    config.draft_vocab_size = 64
+    config.layer_types = ["full_attention"] * config.num_hidden_layers
+    config.use_sliding_window = False
+    config.dflash_config = {
+        "attention_modes": attention_modes or ["kda", "gqa", "kda"],
+        "mask_token_id": 0,
+    }
+    config.linear_attn_config = {
+        "head_dim": HEAD_DIM,
+        "num_heads": HEADS,
+        "short_conv_kernel_size": CONV,
+        "use_full_rank_gate": False,
+        "gate_lower_bound": -5.0,
+        "backend": backend,
+        "context_state": context_state,
+    }
+    return config
+
+
+def _attention(context_state: str = "scan") -> Qwen3DFlashKDAAttention:
+    return Qwen3DFlashKDAAttention(
+        _config(context_state=context_state), layer_idx=0, kernels=mock.Mock()
+    ).eval()
+
+
+def _run(
+    attention: Qwen3DFlashKDAAttention,
+    blocks: torch.Tensor,
+    context: torch.Tensor,
+    *,
+    anchors: torch.Tensor | None = None,
+    cache=None,
+) -> torch.Tensor:
+    return attention(
+        hidden_states=blocks,
+        target_hidden=context,
+        position_embeddings=(None, None),
+        attention_mask=None,
+        past_key_values=cache,
+        anchor_positions=anchors,
+    )[0]
+
+
+def _oracle(
+    attention: Qwen3DFlashKDAAttention,
+    context_prefix: torch.Tensor,
+    block: torch.Tensor,
+) -> torch.Tensor:
+    """KDA over the contiguous sequence ``[context_prefix ; block]``."""
+
+    sequence = torch.cat((context_prefix, block), dim=1)
+    length = sequence.shape[1]
+    shape = (1, length, HEADS, HEAD_DIM)
+    q = attention.q_conv1d(attention.q_proj(sequence)).view(shape)
+    k = attention.k_conv1d(attention.k_proj(sequence)).view(shape)
+    v = attention.v_conv1d(attention.v_proj(sequence)).view(shape)
+    raw_gate = attention.f_b_proj(attention.f_a_proj(sequence)).view(shape)
+    beta = attention.b_proj(sequence).view(1, length, HEADS)
+    output = reference_kda(
+        q, k, v, raw_gate, beta, attention.A_log, attention.dt_bias, -5.0
+    )[:, context_prefix.shape[1] :]
+    gate = attention._output_gate(block).view(1, BLOCK, HEADS, HEAD_DIM)
+    return attention.o_proj(attention.o_norm(output, gate).flatten(-2))
+
+
+def _tiny_target() -> Qwen3ForCausalLM:
+    target_config = Qwen3Config(
+        hidden_size=HIDDEN,
+        intermediate_size=48,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=8,
+        head_dim=HEAD_DIM,
+        max_position_embeddings=128,
+        vocab_size=64,
+        tie_word_embeddings=False,
+    )
+    target_config._attn_implementation = "sdpa"
+    return Qwen3ForCausalLM(target_config).eval()
+
+
+class TestContextScanSemantics(unittest.TestCase):
+    def test_every_anchor_matches_the_contiguous_sequence_oracle(self):
+        torch.manual_seed(1)
+        attention = _attention()
+        context = torch.randn(1, 9, HIDDEN)
+        # Unsorted, duplicated, empty-context (0), partial-conv-window (1) and
+        # full-context (9) anchors in one block-parallel call.
+        anchors = torch.tensor([[7, 0, 3, 9, 3, 1]])
+        blocks = torch.randn(1, anchors.shape[1] * BLOCK, HIDDEN)
+
+        output = _run(attention, blocks, context, anchors=anchors)
+
+        for index, anchor in enumerate(anchors[0].tolist()):
+            with self.subTest(anchor=anchor, block=index):
+                block = blocks[:, index * BLOCK : (index + 1) * BLOCK]
+                expected = _oracle(attention, context[:, :anchor], block)
+                assert_close(
+                    output[:, index * BLOCK : (index + 1) * BLOCK],
+                    expected,
+                    rtol=1e-5,
+                    atol=1e-6,
+                )
+
+    def test_default_anchor_is_the_full_context(self):
+        torch.manual_seed(2)
+        attention = _attention()
+        context = torch.randn(1, 5, HIDDEN)
+        blocks = torch.randn(1, 2 * BLOCK, HIDDEN)
+
+        implicit = _run(attention, blocks, context)
+        explicit = _run(attention, blocks, context, anchors=torch.tensor([[5, 5]]))
+
+        assert_close(implicit, explicit, rtol=0, atol=0)
+
+    def test_rows_with_different_anchors_match_per_row_results(self):
+        torch.manual_seed(3)
+        attention = _attention()
+        context = torch.randn(2, 6, HIDDEN)
+        anchors = torch.tensor([[2, 6, 0], [5, 5, 3]])
+        blocks = torch.randn(2, 3 * BLOCK, HIDDEN)
+
+        batched = _run(attention, blocks, context, anchors=anchors)
+
+        for row in range(2):
+            single = _run(
+                attention,
+                blocks[row : row + 1],
+                context[row : row + 1],
+                anchors=anchors[row : row + 1],
+            )
+            assert_close(batched[row : row + 1], single, rtol=1e-5, atol=1e-6)
+
+    def test_context_changes_reach_the_block_output(self):
+        torch.manual_seed(4)
+        attention = _attention()
+        blocks = torch.randn(1, BLOCK, HIDDEN)
+        context = torch.randn(1, 4, HIDDEN)
+
+        output = _run(attention, blocks, context)
+        perturbed = _run(attention, blocks, context + 1.0)
+
+        self.assertFalse(torch.allclose(output, perturbed))
+
+    def test_reset_policy_keeps_block_local_semantics(self):
+        torch.manual_seed(5)
+        attention = _attention(context_state="reset")
+        blocks = torch.randn(1, 2 * BLOCK, HIDDEN)
+
+        first = _run(
+            attention, blocks, torch.randn(1, 5, HIDDEN), anchors=torch.tensor([[1, 4]])
+        )
+        second = _run(attention, blocks, torch.randn(1, 3, HIDDEN))
+
+        assert_close(first, second, rtol=0, atol=0)
+        self.assertFalse(attention.scans_context)
+
+    def test_rejects_anchor_shape_mismatch(self):
+        attention = _attention()
+        with self.assertRaisesRegex(ValueError, "anchor_positions"):
+            _run(
+                attention,
+                torch.randn(1, 2 * BLOCK, HIDDEN),
+                torch.randn(1, 4, HIDDEN),
+                anchors=torch.tensor([[1, 2, 3]]),
+            )
+
+
+class TestTwoLevelScan(unittest.TestCase):
+    def test_grouped_scan_matches_direct_prefix_states(self):
+        torch.manual_seed(6)
+        length, heads, dim = 13, 2, 3
+        k = torch.randn(1, length, heads, dim)
+        v = torch.randn(1, length, heads, dim)
+        raw_gate = torch.randn(1, length, heads, dim) * 0.1
+        beta = torch.randn(1, length, heads)
+        A_log = torch.rand(heads).add(0.5).log()
+        dt_bias = torch.randn(heads * dim) * 0.1
+        anchors = torch.tensor([[0, 5, 5, 13, 2, 8, 12, 1]])
+
+        for group_size in (None, 1, 2, 5, 8):
+            with self.subTest(group_size=group_size):
+                states = scan_kda_context_states(
+                    reference_kda,
+                    k,
+                    v,
+                    raw_gate,
+                    beta,
+                    A_log,
+                    dt_bias,
+                    -5.0,
+                    anchors,
+                    group_size=group_size,
+                )
+                self.assertEqual(states.shape, (1, 8, heads, dim, dim))
+                for index, anchor in enumerate(anchors[0].tolist()):
+                    _, expected = reference_kda(
+                        torch.zeros_like(k[:, :anchor]),
+                        k[:, :anchor],
+                        v[:, :anchor],
+                        raw_gate[:, :anchor],
+                        beta[:, :anchor],
+                        A_log,
+                        dt_bias,
+                        -5.0,
+                        output_final_state=True,
+                    )
+                    assert_close(states[0, index], expected[0], rtol=1e-5, atol=1e-6)
+
+    def test_anchors_beyond_the_context_clamp_to_its_end(self):
+        torch.manual_seed(7)
+        k = torch.randn(1, 4, 2, 3)
+        v = torch.randn(1, 4, 2, 3)
+        raw_gate = torch.zeros(1, 4, 2, 3)
+        beta = torch.zeros(1, 4, 2)
+        A_log = torch.zeros(2)
+        dt_bias = torch.zeros(6)
+
+        states = scan_kda_context_states(
+            reference_kda,
+            k,
+            v,
+            raw_gate,
+            beta,
+            A_log,
+            dt_bias,
+            None,
+            torch.tensor([[4, 9]]),
+        )
+
+        assert_close(states[0, 0], states[0, 1], rtol=0, atol=0)
+
+    def test_reference_varlen_layout_matches_per_sequence_runs(self):
+        torch.manual_seed(8)
+        heads, dim = 2, 3
+        q = torch.randn(1, 7, heads, dim)
+        k = torch.randn(1, 7, heads, dim)
+        v = torch.randn(1, 7, heads, dim)
+        raw_gate = torch.randn(1, 7, heads, dim) * 0.1
+        beta = torch.randn(1, 7, heads)
+        A_log = torch.zeros(heads)
+        dt_bias = torch.zeros(heads * dim)
+        initial_state = torch.randn(2, heads, dim, dim)
+        cu_seqlens = torch.tensor([0, 3, 7])
+
+        output, final = reference_kda(
+            q,
+            k,
+            v,
+            raw_gate,
+            beta,
+            A_log,
+            dt_bias,
+            -5.0,
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens,
+        )
+
+        for index, (start, end) in enumerate(((0, 3), (3, 7))):
+            expected_output, expected_final = reference_kda(
+                q[:, start:end],
+                k[:, start:end],
+                v[:, start:end],
+                raw_gate[:, start:end],
+                beta[:, start:end],
+                A_log,
+                dt_bias,
+                -5.0,
+                initial_state=initial_state[index : index + 1],
+                output_final_state=True,
+            )
+            assert_close(output[:, start:end], expected_output, rtol=0, atol=0)
+            assert_close(final[index : index + 1], expected_final, rtol=0, atol=0)
+
+
+class TestRunningState(unittest.TestCase):
+    def test_incremental_slices_match_the_single_shot_result(self):
+        torch.manual_seed(9)
+        attention = _attention()
+        context = torch.randn(1, 7, HIDDEN)
+        block = torch.randn(1, BLOCK, HIDDEN)
+        cache = mock.Mock()
+
+        single_prefix = _run(attention, block, context[:, :3])
+        single_full = _run(attention, block, context)
+
+        attention.reset_state()
+        first = _run(attention, block, context[:, :3], cache=cache)
+        second = _run(attention, block, context[:, 3:], cache=cache)
+
+        assert_close(first, single_prefix, rtol=1e-5, atol=1e-6)
+        assert_close(second, single_full, rtol=1e-5, atol=1e-6)
+        cache.update.assert_not_called()
+
+    def test_reset_state_starts_a_fresh_request(self):
+        torch.manual_seed(10)
+        attention = _attention()
+        context = torch.randn(1, 4, HIDDEN)
+        block = torch.randn(1, BLOCK, HIDDEN)
+        cache = mock.Mock()
+
+        expected = _run(attention, block, context)
+        _run(attention, block, torch.randn(1, 6, HIDDEN), cache=cache)
+        stale = _run(attention, block, context, cache=cache)
+        attention.reset_state()
+        fresh = _run(attention, block, context, cache=cache)
+
+        self.assertFalse(torch.allclose(stale, expected))
+        assert_close(fresh, expected, rtol=1e-5, atol=1e-6)
+
+    def test_empty_slice_leaves_the_running_state_alone(self):
+        torch.manual_seed(11)
+        attention = _attention()
+        context = torch.randn(1, 5, HIDDEN)
+        block = torch.randn(1, BLOCK, HIDDEN)
+        cache = mock.Mock()
+
+        expected = _run(attention, block, context, cache=cache)
+        again = _run(attention, block, context[:, :0], cache=cache)
+
+        assert_close(again, expected, rtol=0, atol=0)
+
+
+class TestModelIntegration(unittest.TestCase):
+    def _inputs(self, *, batch_size: int, num_blocks: int, context_len: int):
+        draft_len = num_blocks * BLOCK
+        return {
+            "position_ids": torch.arange(context_len + draft_len).expand(
+                batch_size, -1
+            ),
+            "noise_embedding": torch.randn(batch_size, draft_len, HIDDEN),
+            "target_hidden": torch.randn(batch_size, context_len, 3 * HIDDEN),
+            "attention_mask": torch.ones(
+                batch_size, 1, draft_len, context_len + draft_len, dtype=torch.bool
+            ),
+        }
+
+    def test_scan_gradients_reach_context_and_all_parameter_groups(self):
+        torch.manual_seed(12)
+        model = DFlashDraftModel(_config()).train()
+        inputs = self._inputs(batch_size=2, num_blocks=2, context_len=5)
+        inputs["noise_embedding"].requires_grad_()
+        inputs["target_hidden"].requires_grad_()
+
+        output = model(**inputs, anchor_positions=torch.tensor([[1, 5], [0, 3]]))
+        self.assertEqual(output.shape, (2, 2 * BLOCK, HIDDEN))
+        self.assertTrue(torch.isfinite(output).all())
+        output.square().mean().backward()
+
+        for name in ("noise_embedding", "target_hidden"):
+            self.assertIsNotNone(inputs[name].grad, name)
+            self.assertTrue(torch.isfinite(inputs[name].grad).all(), name)
+        attention = model.layers[0].self_attn
+        for name in (
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "q_conv1d",
+            "k_conv1d",
+            "v_conv1d",
+            "f_a_proj",
+            "f_b_proj",
+            "b_proj",
+            "g_a_proj",
+            "g_b_proj",
+            "o_proj",
+        ):
+            parameter = getattr(attention, name).weight
+            self.assertIsNotNone(parameter.grad, name)
+            self.assertTrue(torch.isfinite(parameter.grad).all(), name)
+        for name in ("A_log", "dt_bias"):
+            parameter = getattr(attention, name)
+            self.assertIsNotNone(parameter.grad, name)
+            self.assertTrue(torch.isfinite(parameter.grad).all(), name)
+
+    def test_dense_only_stacks_ignore_anchor_positions(self):
+        torch.manual_seed(13)
+        model = DFlashDraftModel(_config(attention_modes=["gqa"] * 3)).eval()
+        inputs = self._inputs(batch_size=1, num_blocks=2, context_len=4)
+
+        plain = model(**inputs)
+        with_anchors = model(**inputs, anchor_positions=torch.tensor([[1, 4]]))
+
+        assert_close(plain, with_anchors, rtol=0, atol=0)
+
+    def test_rejects_unknown_context_state(self):
+        config = _config()
+        config.linear_attn_config["context_state"] = "mystery"
+
+        with self.assertRaisesRegex(ValueError, "context_state"):
+            DFlashDraftModel(config)
+
+    def test_save_and_reload_preserves_policy_and_outputs(self):
+        torch.manual_seed(14)
+        model = DFlashDraftModel(_config()).eval()
+        inputs = self._inputs(batch_size=1, num_blocks=2, context_len=3)
+        anchors = torch.tensor([[0, 3]])
+        expected = model(**inputs, anchor_positions=anchors)
+
+        with tempfile.TemporaryDirectory() as directory:
+            model.save_pretrained(directory)
+            loaded = DFlashDraftModel.from_pretrained(directory).eval()
+            actual = loaded(**inputs, anchor_positions=anchors)
+
+        self.assertTrue(loaded.layers[0].self_attn.scans_context)
+        assert_close(actual, expected, rtol=1e-6, atol=1e-7)
+
+    def test_spec_generate_runs_and_resets_between_requests(self):
+        torch.manual_seed(15)
+        target = _tiny_target()
+        draft = DFlashDraftModel(_config()).eval()
+        input_ids = torch.randint(1, 64, (1, 6))
+
+        first = draft.spec_generate(
+            target, input_ids, max_new_tokens=6, stop_token_ids=None, temperature=0.0
+        )
+        second = draft.spec_generate(
+            target, input_ids, max_new_tokens=6, stop_token_ids=None, temperature=0.0
+        )
+
+        self.assertTrue(torch.equal(first[:, :6], input_ids))
+        self.assertLessEqual(first.shape[1], input_ids.shape[1] + 6)
+        self.assertTrue(torch.equal(first, second))
+        for layer in draft.layers:
+            attention = layer.self_attn
+            if isinstance(attention, Qwen3DFlashKDAAttention):
+                self.assertIsNotNone(attention._running_state)
+
+
+class TestFLAContextDispatch(unittest.TestCase):
+    def test_varlen_pads_sequence_count_and_length_to_buckets(self):
+        calls = []
+
+        def fake_chunk_kda(**kwargs):
+            bounds = kwargs["cu_seqlens"].tolist()
+            calls.append((tuple(kwargs["q"].shape), bounds, kwargs["initial_state"]))
+            heads, dim = kwargs["k"].shape[2], kwargs["k"].shape[3]
+            final = torch.zeros(len(bounds) - 1, heads, dim, kwargs["v"].shape[3])
+            return kwargs["q"], final
+
+        q = torch.randn(1, 10, 2, 3)
+        initial_state = torch.randn(2, 2, 3, 3)
+        with mock.patch(
+            "specforge.modeling.draft.kda._load_fla_chunk_kda",
+            return_value=fake_chunk_kda,
+        ):
+            output, final = fla_kda(
+                q,
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn(1, 10, 2),
+                torch.randn(2),
+                torch.randn(6),
+                -5.0,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=torch.tensor([0, 4, 10]),
+            )
+
+        ((shape, bounds, padded_state),) = calls
+        self.assertEqual(shape, (1, 64, 2, 3))
+        self.assertEqual(bounds[:3], [0, 4, 10])
+        self.assertEqual(len(bounds) - 1, 4)
+        self.assertEqual(bounds[-1], 64)
+        self.assertEqual(tuple(padded_state.shape), (4, 2, 3, 3))
+        assert_close(padded_state[:2], initial_state)
+        assert_close(output, q)
+        self.assertEqual(tuple(final.shape), (2, 2, 3, 3))
+
+    def test_varlen_aligned_input_needs_no_padding(self):
+        calls = []
+
+        def fake_chunk_kda(**kwargs):
+            calls.append((tuple(kwargs["q"].shape), kwargs["cu_seqlens"].tolist()))
+            return kwargs["q"], None
+
+        q = torch.randn(1, 128, 2, 3)
+        with mock.patch(
+            "specforge.modeling.draft.kda._load_fla_chunk_kda",
+            return_value=fake_chunk_kda,
+        ):
+            fla_kda(
+                q,
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn(1, 128, 2),
+                torch.randn(2),
+                torch.randn(6),
+                -5.0,
+                cu_seqlens=torch.tensor([0, 64, 128]),
+            )
+
+        self.assertEqual(calls, [((1, 128, 2, 3), [0, 64, 128])])
+
+    def test_bucketed_blocks_pad_and_slice_initial_states(self):
+        calls = []
+
+        def fake_chunk_kda(**kwargs):
+            calls.append(tuple(kwargs["initial_state"].shape))
+            return kwargs["q"], kwargs["initial_state"]
+
+        q = torch.randn(3, 2, 2, 3)
+        initial_state = torch.randn(3, 2, 3, 3)
+        with mock.patch(
+            "specforge.modeling.draft.kda._load_fla_chunk_kda",
+            return_value=fake_chunk_kda,
+        ):
+            output, final = fla_kda(
+                q,
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn_like(q),
+                torch.randn(3, 2, 2),
+                torch.randn(2),
+                torch.randn(6),
+                -5.0,
+                initial_state=initial_state,
+                output_final_state=True,
+            )
+
+        self.assertEqual(calls, [(4, 2, 3, 3)])
+        assert_close(output, q)
+        assert_close(final, initial_state)
+
+    @unittest.skipUnless(CUDA_AND_FLA, "FLA KDA parity requires CUDA and fla-core")
+    def test_real_kernel_matches_reference_with_states_and_varlen(self):
+        torch.manual_seed(16)
+        device = torch.device("cuda")
+        heads, dim = 2, 128
+        context_len, num_blocks = 200, 5
+        k = torch.randn(1, context_len, heads, dim, device=device, dtype=torch.bfloat16)
+        v = torch.randn_like(k)
+        raw_gate = torch.randn_like(k).mul_(0.1)
+        beta = torch.randn(1, context_len, heads, device=device, dtype=torch.bfloat16)
+        A_log = torch.rand(heads, device=device).add_(0.5).log_()
+        dt_bias = torch.randn(heads * dim, device=device).mul_(0.1)
+        anchors = torch.tensor([[0, 37, 37, 130, 200]], device=device)
+
+        expected = scan_kda_context_states(
+            reference_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
+        )
+        actual = scan_kda_context_states(
+            fla_kda, k, v, raw_gate, beta, A_log, dt_bias, -5.0, anchors
+        )
+        assert_close(actual, expected, rtol=4e-2, atol=4e-2)
+
+        block_shape = (num_blocks, 8, heads, dim)
+        block_inputs = (
+            torch.randn(block_shape, device=device, dtype=torch.bfloat16),
+            torch.randn(block_shape, device=device, dtype=torch.bfloat16),
+            torch.randn(block_shape, device=device, dtype=torch.bfloat16),
+            torch.randn(block_shape, device=device, dtype=torch.bfloat16).mul_(0.1),
+            torch.randn(block_shape[:-1], device=device, dtype=torch.bfloat16),
+        )
+        expected_output = reference_kda(
+            *block_inputs, A_log, dt_bias, -5.0, initial_state=expected[0]
+        )
+        actual_output = fla_kda(
+            *block_inputs, A_log, dt_bias, -5.0, initial_state=expected[0]
+        )
+        assert_close(
+            actual_output.float(), expected_output.float(), rtol=4e-2, atol=4e-2
+        )
+
+
+class _RecordingDraft(torch.nn.Module):
+    accepts_anchor_positions = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sliding_window = None
+        self.received = None
+
+    def forward(
+        self,
+        position_ids,
+        noise_embedding,
+        target_hidden,
+        attention_mask,
+        anchor_positions=None,
+        **kwargs,
+    ):
+        self.received = anchor_positions
+        return torch.zeros(*noise_embedding.shape[:2], HIDDEN)
+
+
+class _LegacyDraft(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.sliding_window = None
+
+    def forward(self, position_ids, noise_embedding, target_hidden, attention_mask):
+        return torch.zeros(*noise_embedding.shape[:2], HIDDEN)
+
+
+class TestTrainerAnchorPlumbing(unittest.TestCase):
+    def _trainer(self, draft):
+        from specforge.algorithms.common.dflash_family_model import OnlineDFlashModel
+
+        return OnlineDFlashModel(
+            draft_model=draft,
+            target_lm_head=torch.nn.Linear(HIDDEN, 64),
+            target_embed_tokens=torch.nn.Embedding(64, HIDDEN),
+            mask_token_id=0,
+            block_size=BLOCK,
+            attention_backend="sdpa",
+            num_anchors=3,
+        )
+
+    def test_declaring_drafts_receive_the_sampled_anchors(self):
+        torch.manual_seed(17)
+        draft = _RecordingDraft()
+        trainer = self._trainer(draft)
+        input_ids = torch.randint(1, 64, (1, 8))
+
+        anchors, _, output = trainer._forward_draft_blocks(
+            input_ids, torch.randn(1, 8, 3 * HIDDEN), torch.ones(1, 8)
+        )
+
+        self.assertEqual(output.shape, (1, 3 * BLOCK, HIDDEN))
+        self.assertIsNotNone(draft.received)
+        self.assertTrue(torch.equal(draft.received, anchors))
+
+    def test_legacy_drafts_are_called_without_the_keyword(self):
+        torch.manual_seed(18)
+        trainer = self._trainer(_LegacyDraft())
+        input_ids = torch.randint(1, 64, (1, 8))
+
+        _, _, output = trainer._forward_draft_blocks(
+            input_ids, torch.randn(1, 8, 3 * HIDDEN), torch.ones(1, 8)
+        )
+
+        self.assertEqual(output.shape, (1, 3 * BLOCK, HIDDEN))
+
+    def test_dflash_draft_models_declare_anchor_support(self):
+        self.assertTrue(DFlashDraftModel.accepts_anchor_positions)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_dflash_kda_fsdp.py
+++ b/tests/test_runtime/test_dflash_kda_fsdp.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+"""Two-rank FSDP smoke test for a real hybrid KDA decoder stack."""
+
+import json
+import math
+import os
+import tempfile
+import unittest
+
+import torch
+
+CUDA = torch.cuda.is_available()
+NGPU = torch.cuda.device_count() if CUDA else 0
+WORLD_SIZE = 2
+
+
+def _config():
+    from transformers import Qwen3Config
+
+    config = Qwen3Config(
+        hidden_size=256,
+        intermediate_size=512,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        num_hidden_layers=3,
+        head_dim=128,
+        max_position_embeddings=128,
+        vocab_size=64,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        attention_dropout=0.0,
+    )
+    config._attn_implementation = "eager"
+    config.architectures = ["DFlashDraftModel"]
+    config.num_target_layers = 8
+    config.block_size = 2
+    config.draft_vocab_size = 64
+    config.layer_types = ["full_attention"] * config.num_hidden_layers
+    config.use_sliding_window = False
+    config.dflash_config = {
+        "attention_modes": ["kda", "gqa", "kda"],
+        "mask_token_id": 0,
+    }
+    config.linear_attn_config = {
+        "head_dim": 128,
+        "num_heads": 2,
+        "short_conv_kernel_size": 4,
+        "use_full_rank_gate": False,
+        "gate_lower_bound": -5.0,
+        "backend": "fla",
+    }
+    return config
+
+
+def _worker(rank: int, world_size: int, port: int, results_dir: str) -> None:
+    from tests.test_runtime import _fixtures as fixtures
+
+    fixtures.init_rank_distributed(rank, world_size, port=str(port))
+    try:
+        from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+        from specforge.modeling.draft.dflash import DFlashDraftModel
+        from specforge.training.backend import FSDPTrainingBackend, ParallelConfig
+
+        torch.manual_seed(23 + rank)
+        torch.cuda.manual_seed_all(23 + rank)
+        model = DFlashDraftModel(_config()).to(
+            device=torch.device("cuda", rank), dtype=torch.bfloat16
+        )
+
+        def optimizer_factory(module):
+            return torch.optim.AdamW(module.parameters(), lr=1e-3)
+
+        backend = FSDPTrainingBackend(
+            ParallelConfig.from_distributed(param_dtype=torch.bfloat16),
+            optimizer_factory=optimizer_factory,
+        )
+        wrapped = backend.prepare_model(model, wrap=True, optimizer_target=model)
+
+        batch_size, draft_length, context_length = 2, 4, 5
+        output = wrapped(
+            position_ids=torch.arange(
+                context_length + draft_length, device=torch.device("cuda", rank)
+            ).expand(batch_size, -1),
+            noise_embedding=torch.randn(
+                batch_size,
+                draft_length,
+                model.config.hidden_size,
+                device=torch.device("cuda", rank),
+                dtype=torch.bfloat16,
+            ),
+            target_hidden=torch.randn(
+                batch_size,
+                context_length,
+                len(model.target_layer_ids) * model.config.hidden_size,
+                device=torch.device("cuda", rank),
+                dtype=torch.bfloat16,
+            ),
+            attention_mask=torch.ones(
+                batch_size,
+                1,
+                draft_length,
+                context_length + draft_length,
+                device=torch.device("cuda", rank),
+                dtype=torch.bool,
+            ),
+        )
+        loss = output.float().square().mean()
+        backend.backward(loss)
+
+        gradients = [
+            parameter.grad
+            for parameter in wrapped.parameters()
+            if parameter.grad is not None and parameter.grad.numel()
+        ]
+        gradients_finite = all(torch.isfinite(gradient).all() for gradient in gradients)
+        gradient_l1 = sum(gradient.float().abs().sum().item() for gradient in gradients)
+        backend.optimizer.step()
+        torch.cuda.synchronize()
+
+        full_state = backend.state_dict()["model"]
+        result = {
+            "rank": rank,
+            "loss": float(loss.item()),
+            "gradient_l1": gradient_l1,
+            "gradients_finite": bool(gradients_finite),
+            "fsdp_units": sum(isinstance(module, FSDP) for module in wrapped.modules()),
+            "wrapped_block_classes": sorted(
+                block_class.__name__ for block_class in backend.auto_wrap_block_classes
+            ),
+            "gate_dtypes": None,
+        }
+        if full_state:
+            result["gate_dtypes"] = {
+                name: str(full_state[name].dtype)
+                for name in (
+                    "layers.0.self_attn.A_log",
+                    "layers.0.self_attn.dt_bias",
+                    "layers.2.self_attn.A_log",
+                    "layers.2.self_attn.dt_bias",
+                )
+            }
+        with open(os.path.join(results_dir, f"rank{rank}.json"), "w") as output_file:
+            json.dump(result, output_file)
+    finally:
+        from specforge.distributed import destroy_distributed
+
+        destroy_distributed()
+
+
+@unittest.skipUnless(
+    CUDA and NGPU >= WORLD_SIZE,
+    "hybrid KDA FSDP training requires at least two CUDA devices",
+)
+class TestDFlashKDAFSDP(unittest.TestCase):
+    def test_hybrid_decoder_blocks_train_under_fsdp(self):
+        import torch.multiprocessing as mp
+
+        from tests.utils import get_available_port
+
+        with tempfile.TemporaryDirectory(prefix="dflash_kda_fsdp_") as workdir:
+            mp.spawn(
+                _worker,
+                args=(WORLD_SIZE, get_available_port(), workdir),
+                nprocs=WORLD_SIZE,
+                join=True,
+            )
+
+            rank_results = []
+            for rank in range(WORLD_SIZE):
+                with open(os.path.join(workdir, f"rank{rank}.json")) as result_file:
+                    rank_results.append(json.load(result_file))
+
+        for result in rank_results:
+            self.assertTrue(math.isfinite(result["loss"]), result)
+            self.assertTrue(result["gradients_finite"], result)
+            self.assertGreater(result["gradient_l1"], 0.0, result)
+            self.assertGreaterEqual(result["fsdp_units"], 4, result)
+            self.assertEqual(
+                result["wrapped_block_classes"], ["Qwen3DFlashDecoderLayer"]
+            )
+        gathered_dtypes = next(
+            result["gate_dtypes"]
+            for result in rank_results
+            if result["gate_dtypes"] is not None
+        )
+        self.assertEqual(set(gathered_dtypes.values()), {"torch.bfloat16"})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_model_loading.py
+++ b/tests/test_runtime/test_model_loading.py
@@ -225,6 +225,31 @@ assert not torch.cuda.is_initialized()
                     provider=_draft_config_provider("dflash"),
                 )
 
+    def test_dflash_layer_override_rejects_kda_hybrid_resize(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "draft.json")
+            payload = _draft_payload("DFlashDraftModel", layers=3, block_size=16)
+            payload["dflash_config"] = {"attention_modes": ["kda", "gqa", "kda"]}
+            payload["linear_attn_config"] = {
+                "head_dim": 8,
+                "num_heads": 4,
+                "short_conv_kernel_size": 3,
+                "backend": "reference",
+            }
+            with open(path, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream)
+            cfg = _run_config(
+                "dflash",
+                draft_model_config=path,
+                draft_num_hidden_layers=2,
+            )
+
+            with self.assertRaisesRegex(ValueError, "mixed DFlash attention_modes"):
+                resolve_draft_config(
+                    cfg,
+                    provider=_draft_config_provider("dflash"),
+                )
+
     def test_dflash_resolution_validates_mla_before_model_construction(self):
         with tempfile.TemporaryDirectory() as directory:
             path = os.path.join(directory, "draft.json")

--- a/tests/test_runtime/test_package_architecture.py
+++ b/tests/test_runtime/test_package_architecture.py
@@ -733,7 +733,10 @@ class TestPackageArchitecture(unittest.TestCase):
                     payload["num_attention_heads"] % payload["num_key_value_heads"],
                     0,
                 )
-                if name in ("qwen3-4b-dspark-kda.json", "qwen3-4b-dspark-kda-scan.json"):
+                if name in (
+                    "qwen3-4b-dspark-kda.json",
+                    "qwen3-4b-dspark-kda-scan.json",
+                ):
                     self.assertEqual(
                         payload["dflash_config"]["attention_modes"],
                         ["kda", "kda", "gqa", "kda", "kda"],

--- a/tests/test_runtime/test_package_architecture.py
+++ b/tests/test_runtime/test_package_architecture.py
@@ -701,7 +701,7 @@ class TestPackageArchitecture(unittest.TestCase):
         present = {path.name for path in (REPO_ROOT / "configs").glob("*.json")}
         self.assertTrue(CANONICAL_DRAFT_CONFIGS.issubset(present))
 
-    def test_dspark_configs_are_qwen3_gqa_only(self):
+    def test_dspark_configs_use_supported_qwen3_attention(self):
         dspark_configs = {}
         for path in sorted((REPO_ROOT / "configs").glob("*.json")):
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -715,6 +715,7 @@ class TestPackageArchitecture(unittest.TestCase):
                 "glm-5.2-dspark.json",
                 "inkling-dspark.json",
                 "kimi-k3-dspark.json",
+                "qwen3-4b-dspark-kda.json",
                 "qwen3-4b-dspark.json",
                 "qwen3-8b-dspark.json",
                 "qwen3.6-27b-dspark.json",
@@ -723,7 +724,6 @@ class TestPackageArchitecture(unittest.TestCase):
         for name, payload in dspark_configs.items():
             with self.subTest(config=name):
                 self.assertEqual(payload["model_type"], "qwen3")
-                self.assertEqual(payload["dflash_config"]["attention_mode"], "gqa")
                 self.assertLess(
                     payload["num_key_value_heads"],
                     payload["num_attention_heads"],
@@ -732,6 +732,16 @@ class TestPackageArchitecture(unittest.TestCase):
                     payload["num_attention_heads"] % payload["num_key_value_heads"],
                     0,
                 )
+                if name == "qwen3-4b-dspark-kda.json":
+                    self.assertEqual(
+                        payload["dflash_config"]["attention_modes"],
+                        ["kda", "kda", "gqa", "kda", "kda"],
+                    )
+                    self.assertEqual(payload["linear_attn_config"]["backend"], "fla")
+                    self.assertEqual(payload["linear_attn_config"]["head_dim"], 128)
+                    self.assertEqual(payload["linear_attn_config"]["num_heads"], 16)
+                else:
+                    self.assertEqual(payload["dflash_config"]["attention_mode"], "gqa")
 
     def test_examples_and_scripts_do_not_bypass_the_cli(self):
         direct_imports = []

--- a/tests/test_runtime/test_package_architecture.py
+++ b/tests/test_runtime/test_package_architecture.py
@@ -715,6 +715,7 @@ class TestPackageArchitecture(unittest.TestCase):
                 "glm-5.2-dspark.json",
                 "inkling-dspark.json",
                 "kimi-k3-dspark.json",
+                "qwen3-4b-dspark-kda-scan.json",
                 "qwen3-4b-dspark-kda.json",
                 "qwen3-4b-dspark.json",
                 "qwen3-8b-dspark.json",
@@ -732,7 +733,7 @@ class TestPackageArchitecture(unittest.TestCase):
                     payload["num_attention_heads"] % payload["num_key_value_heads"],
                     0,
                 )
-                if name == "qwen3-4b-dspark-kda.json":
+                if name in ("qwen3-4b-dspark-kda.json", "qwen3-4b-dspark-kda-scan.json"):
                     self.assertEqual(
                         payload["dflash_config"]["attention_modes"],
                         ["kda", "kda", "gqa", "kda", "kda"],
@@ -740,6 +741,11 @@ class TestPackageArchitecture(unittest.TestCase):
                     self.assertEqual(payload["linear_attn_config"]["backend"], "fla")
                     self.assertEqual(payload["linear_attn_config"]["head_dim"], 128)
                     self.assertEqual(payload["linear_attn_config"]["num_heads"], 16)
+                    expected_state = "scan" if name.endswith("-scan.json") else "reset"
+                    self.assertEqual(
+                        payload["linear_attn_config"].get("context_state", "reset"),
+                        expected_state,
+                    )
                 else:
                     self.assertEqual(payload["dflash_config"]["attention_mode"], "gqa")
 

--- a/tests/test_scripts/test_gate_orchestration.py
+++ b/tests/test_scripts/test_gate_orchestration.py
@@ -246,6 +246,28 @@ class TestNormalizeDFlashExport(unittest.TestCase):
 
             self.assertEqual(json.loads(path.read_text()), original)
 
+    def test_rejects_kda_hybrid_before_rewriting_the_export(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "config.json"
+            original = {
+                "architectures": ["DSparkDraftModel"],
+                "auto_map": {"AutoModel": "dspark.DSparkDraftModel"},
+                "block_size": 16,
+                "model_type": "qwen3",
+                "dflash_config": {
+                    "projector_type": "dspark",
+                    "attention_modes": ["kda", "gqa", "kda"],
+                    "markov_rank": 256,
+                    "markov_head_type": "vanilla",
+                },
+            }
+            path.write_text(json.dumps(original), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "only GQA/MHA"):
+                self.module.normalize_export(str(path), 16)
+
+            self.assertEqual(json.loads(path.read_text()), original)
+
     def test_rejects_dspark_without_a_positive_markov_rank(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "config.json"


### PR DESCRIPTION
## Summary

KDA draft attention for the DFlash family as one self-contained PR on `main`, three commits meant to be read in order (this PR absorbs #791, which is closed in its favour; the DSpark LK-objective commit that #791 carried is dropped, it had no KDA dependency and no result behind it):

1. `feat(dflash): add reusable hybrid KDA attention` — `specforge/modeling/draft/kda.py`: `Qwen3DFlashKDAAttention` (short conv on q/k/v, per-head decay gate, beta, gated RMSNorm output), selectable per layer through `dflash_config.attention_modes` (e.g. `[kda, kda, gqa, kda, kda]`), FLA `chunk_kda` backend (`fla-core==0.5.1`, `pip install -e .[kda]`) with a differentiable pure-PyTorch reference as the test oracle, FSDP1-safe `A_log`/`dt_bias` dtype handling, DFlash/DSpark config validation and the export gate. This is the block-local (`reset`) policy: every proposal block starts from a zero recurrent state.
2. `feat(dflash): add context-scanning KDA draft attention` — `linear_attn_config.context_state: scan` (details below).
3. `perf(kda): batch the context scan across rows with a host-planned layout shared by all layers` — same launches and math as the row-wise scan, 6.5x fewer kernels, 2.6x less trainer compute per micro-batch (section "Performance").

## Why

In #791's layout the KDA layers `del target_hidden`, so a `[kda, kda, gqa, kda, kda]` draft has exactly one context read (the GQA layer) whose queries can only depend on the anchor token and the position offset. Position 1 of a block only needs that single read, but positions 2..7 have to re-query the context conditioned on what earlier positions predicted, which a context-blind layer cannot do.

The Qwen3.8-27B DFlash2 ablation (same loss, corpus, budget, box; RadixArk internal, 2026-09-04) shows exactly that signature: KDA-hybrid vs GQA acceptance length 2.99 vs 3.43 and 3.05 vs 3.55, 0 of 60 prompts better, position-1 conditional acceptance equal (0.75 vs 0.78) and then decaying to 0.53 at position 7 while GQA stays flat at 0.69-0.72. `scan` removes the structural cause. **Update 2026-09-08:** measured on the same Qwen3.8-27B protocol (see "GPU validation" below), the scan hybrid ties the GQA draft in both training metrics and served acceptance length, while the block-local hybrid stays 0.48 acceptance length behind with either loss.

## Design

`specforge/modeling/draft/kda.py`

- `KDAConfig.context_state` (`reset` | `scan`), validated like the other `linear_attn_config` fields. Weights and checkpoint layout are unchanged, so `reset` checkpoints load as-is and both policies share the same parameter names.
- `reference_kda` and `fla_kda` gain the FLA `chunk_kda` state contract: `initial_state`, `output_final_state`, `cu_seqlens` (variable-length layout). FLA variable-length launches are padded with dummy sequences to a power-of-two sequence count and a 64-token multiple, mirroring #791's power-of-two block buckets so TileLang/Triton specializations stay bounded. The existing bucketed block path also pads and slices `initial_state`.
- `scan_kda_context_states`: exact per-anchor states for block-parallel training. Per row, the unique sorted anchors cut the context into segments; a two-level scan (sequential over groups of `sqrt(N)` segments, then one variable-length launch per in-group offset across all groups) reaches every anchor in about `2 * sqrt(N)` launches instead of `N`. Anchors are clamped to `[0, S]`; duplicates and anchor 0 (empty context) are handled.
- Block phase: the block convolution is run as if the last `kernel_size - 1` context rows preceded the block (zero rows before position 0), then the block recurrence starts from the anchor state.
- Generation (`spec_generate`): the layer keeps a per-request running state plus the conv tail and advances it with each newly verified `target_hidden` slice; blocks start from the running state and never write back, so no rollback is needed. `DFlashDraftModel.reset_recurrent_state()` is called at the start of `spec_generate`.

Plumbing

- `Qwen3DFlashDecoderLayer` / `DFlashDraftModel.forward` accept `anchor_positions`; the layer forwards it only to attention modules that set `uses_anchor_positions`, and the DFlash-family trainer passes it only to drafts that declare `accepts_anchor_positions` (legacy draft modules keep their signature).
- `configs/qwen3-4b-dspark-kda-scan.json`, `examples/configs/offline/colocated/qwen3-4b-dspark-kda-scan-offline.yaml`, README paragraph.

## GPU validation (Qwen3.8-27B DFlash2 hybrid draft, 2026-09-04 to 2026-09-08)

Arm `A-KDAscan`: this branch merged onto the RadixArk fork (main bc5d8451 + #791 + #810 + #823), `[kda, kda, gqa, kda, kda]` DFlash2 draft (inco shape, block 8, FLA KDA 16 heads x 128, short-conv 4, gate lower bound -5, `context_state: scan`), fla-core 0.5.1, 2 x 8 B300, colocated online capture from the NVFP4 Qwen3.8-27B target, one epoch of the same 1.07M-sample regen corpus and the same strict-top-k loss as the GQA arm `S1` and the block-local KDA arm `A-KDA` (#791 semantics). Training-side, mean of the last 10 of 2090 optimizer steps:

| arm | train/acc | selector coverage | teacher expected acceptance | per-position expected acceptance vs GQA | max grad norm after warmup | samples/s (2 x 8 B300) |
|---|---:|---:|---:|---|---:|---:|
| S1, GQA | 0.456 | 0.810 | 0.443 | reference | 0.25 | 38.8 (T1 arm, same footprint) |
| A-KDA, block-local KDA (#791) | 0.384 | 0.753 | 0.361 | 0.085 below at position 7 | 350 (spike at steps 1150-1250) | 46.3 |
| A-KDAscan, context-scan KDA (this PR) | 0.453 | 0.807 | 0.440 | within 0.006 at every position | 2.8 | 12.7 |

The scan arm tracks GQA at matched samples from 200k samples on and shows none of the step-1150 instability that both block-local KDA runs hit. The cost is 3.7x more wall time per sample than block-local KDA in this implementation; a kernel profile shows the two-level anchor scan is host-launch-bound (GPU busy fraction 0.34 vs 0.97, ~25x more kernel launches), so batching the scan launches is the obvious follow-up.

Served through the new SGLang path (sgl-project/sglang#38383, per-request running state advanced with every verified slice), AIME25/26 acceptance length on 60 paired prompts, T=1.0 / top-p 0.95 / top-k 20, block 8:

| draft | AIME25 | AIME26 | mean | paired vs GQA (95% CI) |
|---|---:|---:|---:|---|
| S1, GQA | 3.645 | 3.451 | 3.548 | reference |
| A-KDA, block-local KDA | 3.151 | 2.985 | 3.068 | -0.480 [-0.539, -0.422], 0 of 60 prompts better |
| A-KDAscan, context-scan KDA | 3.665 | 3.411 | 3.538 | -0.010 [-0.073, +0.053], 27 of 60 prompts better |

Within-block conditional acceptance of the scan draft is flat (0.77 at position 1 to 0.69 at position 7, GQA 0.78 to 0.69) where the block-local draft decays to 0.53. The full analysis, per-request records, configs and patches are published in the RadixArk `dspark_analysis` journal (`0904_qwen38_27b_dflash2_loss_arch_ablation`).

## Performance (commit 3)

The first scan implementation trained 3.7x slower than block-local KDA (12.7 vs 46.5 samples/s on 2 x 8 B300). A `torch.profiler` window of 4 micro-batches showed it host-launch-bound, not FLOP-bound: ~368 tiny `chunk_kda` launches per micro-batch (2 rows x 4 layers x 46), each wrapped in five `torch.cat` slice gathers whose backward materialised a full-context zero tensor per slice, plus a `torch.unique(...).tolist()` host sync per (row, layer). GPU busy fraction 0.34 vs 0.97 for the block-local draft; FLA kernels themselves were 7% of GPU time.

Commit 3 keeps the exact two-level scan (same segments, same launches, same kernel) but plans it on the host once per micro-batch (`build_scan_layout`, one `anchor_positions` device->host copy, built in `DFlashDraftModel.forward` and passed to the layers as `scan_layout`; parameter-free, so it runs outside the per-layer FSDP units), batches all rows into one launch chain (launches = `groups + group`, independent of the row count), gathers tokens with one `index_select` + `split` per level, keeps states in one pool updated out of place, folds the FLA padding into the gather index, and passes `cu_seqlens_cpu` so FLA derives chunk indices without a device sync. The row-wise implementation stays as `scan_kda_context_states_rowwise`, the oracle in `tests/test_modeling/test_dflash_kda_batched_scan.py` (values and gradients, CPU reference and FLA CUDA kernel, plus a model-level forward equivalence).

| 4 micro-batches, 1 x 8 B300, rank 0 | before | commit 3 | block-local |
|---|---:|---:|---:|
| profiled span | 18.7 s | 9.0 s | 4.8 s |
| GPU busy fraction | 0.34 | 0.62 | 0.97 |
| kernel launches | 467k | 72k | 19k |
| trainer compute per micro-batch (30-step bench) | 2.21 s | 0.85 s | 0.29 s |

Projected 2 x 8 throughput: ~27 samples/s (from 12.7), i.e. ~1.7x slower than block-local instead of 3.7x. The remaining gap is FLA's per-call Python overhead times ~190 launches per micro-batch.

## Not in this PR

- SGLang serving of `scan` drafts is sgl-project/sglang#38383 (also adds the `reset` path and fixes the kernel's beta convention).
- Sliding-window semantics: `scan` reads the whole prefix; the decay gate is the soft window. Dense layers keep their configured window.
- Scan throughput beyond commit 3: exporting FLA's chunk-boundary states with gradients (2 launches per micro-batch instead of ~190) is a follow-up that needs an FLA change.
- Colocated multi-rank resume: found while resuming the arm, `assembly.py` puts the per-rank `target_dp_rank` into the shared resume contract, so every rank other than 0 rejects the checkpoint. Not touched here; separate fix PR.

## Test plan

- [x] Rebased series on `main` (e7efece): `tests/test_modeling`, `tests/test_runtime/{test_model_loading,test_package_architecture,test_dflash_kda_fsdp}.py`, `tests/test_scripts/test_gate_orchestration.py`, `tests/test_algorithms`, `tests/test_config`, `tests/test_utils/test_dflash_losses.py`: 331 passed, 9 CUDA-gated skips (CPU).
- [x] CUDA + fla-core 0.5.1 (B300): `test_dflash_kda.py`, `test_dflash_kda_context.py`, `test_dflash_kda_batched_scan.py` incl. FLA-vs-reference parity and batched-vs-rowwise equality (values and gradients).
- [x] `tests/test_runtime/test_dflash_kda_fsdp.py` (two-rank FSDP smoke test, CUDA-gated): passes on an 8 x H200 devbox (fla-core 0.5.1, torch 2.13). It hangs inside RunPod B300 pods for the pre-series tree as well (NCCL init under `mp.spawn` in that container), so that environment is not a signal for this PR.
- [x] `tests/test_modeling/test_dflash_kda_context.py` (new, 23 tests): every anchor in a block-parallel call matches a contiguous-sequence reference (unsorted, duplicate, empty-context and partial-conv-window anchors); two-level scan equals direct prefix states for several group sizes; rows independent; incremental generation slices equal the single-shot result and `reset_state` starts a fresh request; gradients reach context and every parameter group; `reset` policy keeps #791 semantics bit-exact; save/reload preserves the policy; `spec_generate` smoke with reset between requests; FLA varlen/bucket padding via mocks; trainer passes anchors only to declaring drafts.
- [x] `tests/test_modeling/test_dflash_kda.py`: 22 passed, 1 CUDA-gated skip (unchanged).
- [x] `tests/test_modeling`, `tests/test_utils/test_dflash_losses.py`, `tests/test_algorithms/{test_builtin_providers,test_contracts,test_registry}.py`, `tests/test_config`, `tests/test_scripts/test_dflash_serving_gate.py`: 227 passed on CPU (torch 2.11, transformers 5.8.1); the 34 failures in `tests/test_utils/test_dflash_mask.py` are `Torch not compiled with CUDA enabled` and fail identically on the untouched base.
- [x] GPU gate: full one-epoch Qwen3.8-27B DFlash2 run with fla-core 0.5.1 on 2 x 8 B300 (W&B `q53gj675`), training-side parity with the GQA arm and no step-1150 instability (tables above); the smaller Qwen3-4B DSpark gate was superseded by this run.
- [x] Serving: acceptance length tie with GQA through sgl-project/sglang#38383 (tables above).
- [x] Full resume from the step-500 checkpoint reproduced the pre-crash step-510 metric after the `target_dp_rank` contract fix in the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


