### PR TITLE
fix(runtime): publish consumer quantum atomically

### DIFF
--- a/docs/sections/basic_usage/disaggregated_training.md
+++ b/docs/sections/basic_usage/disaggregated_training.md
@@ -71,9 +71,11 @@ multi-node trainers. By default rank inboxes stay under the shared
 `inbox_server_url` to a private rank-0 HTTP origin: rank 0 keeps the inbox files
 locally and relays only tensor-free references and consumed counters to remote
 ranks. The producer and consumer rank 0 must still resolve `control_dir` to the
-same path. A fresh attempt requires fresh control and consumer-state
-directories. `store_id` defaults to `run_id` and can be set explicitly when the
-Mooncake deployment requires another namespace.
+same path. For online training, its filesystem must support atomic hard links
+so the consumer can publish a complete optimizer-window contract without
+overwriting another consumer's claim. A fresh attempt requires fresh control
+and consumer-state directories. `store_id` defaults to `run_id` and can be set
+explicitly when the Mooncake deployment requires another namespace.
 
 Long producer/consumer waits are unbounded unless `idle_timeout_s`,
 `peer_wait_timeout_s`, or `producer_hold_s` is explicitly configured. This

--- a/specforge/runtime/data_plane/streaming_ref_channel.py
+++ b/specforge/runtime/data_plane/streaming_ref_channel.py
@@ -41,6 +41,7 @@ import json
 import os
 import threading
 import time
+import uuid
 from collections import deque
 from dataclasses import dataclass
 from typing import Iterator, List, Optional, Sequence
@@ -244,25 +245,32 @@ class StreamingRefChannel:
         if quantum < 1:
             raise ValueError(f"consumer quantum must be >= 1, got {quantum}")
         path = self.path + _CONSUMER_QUANTUM_SUFFIX
+        tmp = f"{path}.tmp.{uuid.uuid4().hex}"
+        fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
         try:
-            fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
-        except FileExistsError as exc:
-            if allow_existing:
-                existing = self.consumer_quantum()
-                if existing == quantum:
-                    return
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                stream.write(str(quantum))
+                stream.flush()
+                os.fsync(stream.fileno())
+            # Publish only the complete value. A hard link claims the final
+            # name atomically without replacing another consumer's contract.
+            try:
+                os.link(tmp, path)
+            except FileExistsError as exc:
+                if allow_existing:
+                    existing = self.consumer_quantum()
+                    if existing == quantum:
+                        return
+                    raise ValueError(
+                        f"consumer quantum changed across resume for {self.path!r}: "
+                        f"existing={existing}, requested={quantum}"
+                    ) from exc
                 raise ValueError(
-                    f"consumer quantum changed across resume for {self.path!r}: "
-                    f"existing={existing}, requested={quantum}"
+                    f"consumer quantum already exists for {self.path!r}; every online "
+                    "attempt requires a fresh reference channel"
                 ) from exc
-            raise ValueError(
-                f"consumer quantum already exists for {self.path!r}; every online "
-                "attempt requires a fresh reference channel"
-            ) from exc
-        with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            stream.write(str(quantum))
-            stream.flush()
-            os.fsync(stream.fileno())
+        finally:
+            os.unlink(tmp)
 
     def consumer_quantum(self) -> Optional[int]:
         """Return the consumer's global optimizer-step ref quantum, if ready."""

--- a/tests/test_runtime/test_streaming_ref_channel.py
+++ b/tests/test_runtime/test_streaming_ref_channel.py
@@ -6,6 +6,8 @@ import tempfile
 import threading
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from unittest import mock
 
 from specforge.runtime.contracts import FeatureSpec, SampleRef
@@ -333,6 +335,93 @@ class TestStreamingRefChannel(unittest.TestCase):
         consumer.publish_consumer_quantum(8, allow_existing=True)
         with self.assertRaisesRegex(ValueError, "changed across resume"):
             consumer.publish_consumer_quantum(16, allow_existing=True)
+
+    def test_consumer_quantum_is_invisible_until_the_write_is_synced(self):
+        consumer = StreamingRefChannel(self.path)
+        producer = StreamingRefChannel(self.path)
+        observations = []
+        real_fdopen = os.fdopen
+        real_fsync = os.fsync
+
+        @contextmanager
+        def poll_before_write(fd, *args, **kwargs):
+            with real_fdopen(fd, *args, **kwargs) as stream:
+                # Interleave the producer after file creation, before the
+                # consumer has written any bytes into its buffered stream.
+                observations.append(producer.consumer_quantum())
+                yield stream
+
+        def poll_before_sync(fd):
+            observations.append(producer.consumer_quantum())
+            return real_fsync(fd)
+
+        with (
+            mock.patch(
+                "specforge.runtime.data_plane.streaming_ref_channel.os.fdopen",
+                side_effect=poll_before_write,
+            ),
+            mock.patch(
+                "specforge.runtime.data_plane.streaming_ref_channel.os.fsync",
+                side_effect=poll_before_sync,
+            ),
+        ):
+            consumer.publish_consumer_quantum(32)
+
+        self.assertEqual(observations, [None, None])
+        self.assertEqual(producer.consumer_quantum(), 32)
+
+    def test_failed_consumer_quantum_write_leaves_no_claim(self):
+        consumer = StreamingRefChannel(self.path)
+        with (
+            mock.patch(
+                "specforge.runtime.data_plane.streaming_ref_channel.os.fsync",
+                side_effect=OSError("injected quantum fsync failure"),
+            ),
+            self.assertRaisesRegex(OSError, "injected quantum fsync failure"),
+        ):
+            consumer.publish_consumer_quantum(32)
+
+        self.assertIsNone(consumer.consumer_quantum())
+        self.assertEqual(os.listdir(self.dir), [])
+        consumer.publish_consumer_quantum(32)
+        self.assertEqual(consumer.consumer_quantum(), 32)
+
+    def test_concurrent_consumers_cannot_replace_the_winning_quantum(self):
+        ready = threading.Barrier(2)
+
+        def publish(quantum):
+            consumer = StreamingRefChannel(self.path)
+            ready.wait(timeout=5)
+            try:
+                consumer.publish_consumer_quantum(quantum)
+            except ValueError:
+                return None
+            return quantum
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            attempts = [pool.submit(publish, quantum) for quantum in (8, 32)]
+            winners = [
+                quantum
+                for attempt in attempts
+                if (quantum := attempt.result(timeout=5)) is not None
+            ]
+
+        self.assertEqual(len(winners), 1)
+        self.assertEqual(StreamingRefChannel(self.path).consumer_quantum(), winners[0])
+        self.assertEqual(
+            os.listdir(self.dir), [os.path.basename(self.path) + ".consumer_quantum"]
+        )
+
+    def test_consumer_quantum_rejects_corrupt_existing_state(self):
+        consumer = StreamingRefChannel(self.path)
+        for value in ("", "invalid", "0", "-1"):
+            with self.subTest(value=value):
+                with open(self.path + ".consumer_quantum", "w") as stream:
+                    stream.write(value)
+                with self.assertRaisesRegex(RuntimeError, "invalid consumer quantum"):
+                    consumer.consumer_quantum()
+                with self.assertRaisesRegex(RuntimeError, "invalid consumer quantum"):
+                    consumer.publish_consumer_quantum(32, allow_existing=True)
 
     def test_queue_get_does_not_advance_consumed_before_explicit_ack(self):
         producer = StreamingRefChannel(self.path)


### PR DESCRIPTION
## Motivation

Online disaggregated training can abort during startup when the producer reads `.consumer_quantum` after consumer rank 0 creates the file but before it writes the optimizer-window size. On current main `e7efece4c3d80ccf071d1f5f20573873409a4fb9`, the empty read raises `RuntimeError: invalid consumer quantum`, and the producer publishes a terminal failure before starting capture.

A two-process reproduction using the unmodified channel APIs observed 863 fatal empty reads across 1,000 synchronized starts on current main, with every consumer write succeeding. The same reproduction at committed head `52280eec532ca02f846227c2a526771cdfb0eda1` observed 0/1,000. This deliberately concurrent workload demonstrates the race; its frequency is not an estimate of production incidence.

## Modifications

- Write and fsync the positive quantum in a unique temporary file, then atomically hard-link it to the final name. A competing consumer cannot overwrite the winner. Remove the temporary name on success and ordinary failure.
- Preserve duplicate-claim rejection, matching-quantum resume, changed-quantum rejection, file permissions, and corrupt-state errors.
- Add four regression tests for visibility during publication, fsync failure, competing publishers, and corrupt existing contracts. The visibility and fsync tests fail against unmodified current main.
- Document the atomic-hard-link requirement in `docs/sections/basic_usage/disaggregated_training.md`.

Consumer rank 0 publishes `dp_size * batch_size * accumulation_steps`; the producer validates its flow-control window before capture. External and managed-local online runs share this path, including one-rank consumers and remote HTTP inboxes. Offline fixed-reference/USP paths use separate contracts. Target SGLang parallelism, feature tensors, optimizer acknowledgements, checkpoint reconciliation, and serving export retain their existing behavior.

## Related Issues

No linked issue. The live audit covered all 100 open PRs and 73 open issues, compared changed PR patches, and checked current main; no competing consumer-quantum fix was found.

## Accuracy Test

Validated exact committed head `52280eec532ca02f846227c2a526771cdfb0eda1` in a fresh clean worktree against unmodified main `e7efece4c3d80ccf071d1f5f20573873409a4fb9`:

- The focused and neighboring suite completed successfully: 192 tests, two skips and one expected failure. Coverage includes the channel, distributor, consumer recovery, producer fanout, timeouts, CLI lifecycle, HTTP inboxes, feature-loader ownership, Mooncake storage, and package architecture.
- Actual producer-loop interleaving with repository CPU capture/store doubles: main publishes a failure with zero captures; the fix waits, publishes one sample and closes successfully. Both controls clean their feature objects and consumer thread.
- Full `python -m unittest discover -s ./tests -p "test_*.py" -v`: main ran 1,083 tests; head ran 1,087. Both report 17 failures, 44 errors, 35 skips and one expected failure. All 61 failing tracebacks match after normalizing checkout paths, temporary paths and object addresses; there are no new failures. Neither local full suite passed.
- Full `pre-commit run --all-files --show-diff-on-failure` passed.
- The current VitePress workflow's `npm ci` and `npm run build` passed; the built training page contains the complete filesystem requirement.

Local environment: macOS, Python 3.11.9, CPU PyTorch 2.11.0, Transformers 4.57.6, with offline Hugging Face flags. Matching full-suite failures concern unavailable CUDA/SGLang/Triton/Yunchang, uncached model files, and the older Transformers API.

Hosted [Lint](https://github.com/sgl-project/SpecForge/actions/runs/33996050167) and [PR Test](https://github.com/sgl-project/SpecForge/actions/runs/33996050166) passed for the previous head `950bc02b1a2f7b489d5c86d5eef9b6e90192a3a9`: two live server-capture tests and 1,144 unittest tests (10 skips, one expected failure). Those runs checked out GitHub's merge commit `d2bfeafdfb598da6daa8405f3457e1d424f04882`. The implementation and regression-test files are byte-identical in the refreshed head, but **the refreshed SHA still requires its own hosted CUDA/live-capture and full-suite results**.

The separate disproof audit checked competing claims, malformed contracts, unsupported-hard-link failure cleanup, matching-resume inode preservation, and umasks 0022/0027/0077. SIGKILL before the atomic link leaves no final claim and permits a subsequent channel claim; after the link, the complete value and matching-resume inode survive. A hard kill can leave a temporary file. These are channel-level checks, not full training-run recovery, NFS, or power-loss durability validation.

## Benchmark & Profiling

The reproduction measures startup correctness. No training-throughput or convergence claim is made.

## Checklist

- [x] Run full pre-commit checks.
- [x] Add regression tests for the demonstrated defect.
- [x] Document the control-filesystem requirement and build the current documentation.
- [x] Validate the committed head from a fresh worktree and compare current-main controls.
- [ ] Complete hosted CUDA/live server-capture validation for refreshed head `52280eec532ca02f846227c2a526771cdfb0eda1`.
