### PR TITLE
dflash: read selector schedule attributes through the DDP wrapper (NO_SHARD)

### DIFF
--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -468,22 +468,34 @@ class DFlashTrainStrategy(DraftTrainStrategy):
     def _device(self) -> torch.device:
         return next(self.dflash_model.parameters()).device
 
+    def _draft_attr(self, name: str, default: float) -> float:
+        """Read a schedule attribute from the draft model.
+
+        Under ``fsdp_sharding: NO_SHARD`` the backend wraps the draft in
+        ``DistributedDataParallel``, which does not forward attribute access
+        to the wrapped module, so ``selector_loss_alpha`` and the warmup and
+        ramp ratios read as their defaults and the selector objective is
+        silently disabled. Look through the wrapper when the attribute is
+        not on the outer module.
+        """
+        model = self.dflash_model
+        if not hasattr(model, name):
+            inner = getattr(model, "module", None)
+            if isinstance(inner, nn.Module):
+                model = inner
+        return float(getattr(model, name, default))
+
     def _selector_loss_alpha(self, ctx: Optional[StepContext]) -> float:
-        target = float(getattr(self.dflash_model, "selector_loss_alpha", 0.0))
+        target = self._draft_attr("selector_loss_alpha", 0.0)
         if target <= 0 or ctx is None or not ctx.total_steps:
             return target
 
         total_steps = int(ctx.total_steps)
-        warmup_steps = int(
-            total_steps
-            * float(getattr(self.dflash_model, "selector_warmup_ratio", 0.0))
-        )
+        warmup_steps = int(total_steps * self._draft_attr("selector_warmup_ratio", 0.0))
         if ctx.global_step < warmup_steps:
             return 0.0
 
-        ramp_steps = int(
-            total_steps * float(getattr(self.dflash_model, "selector_ramp_ratio", 0.0))
-        )
+        ramp_steps = int(total_steps * self._draft_attr("selector_ramp_ratio", 0.0))
         if ramp_steps <= 0:
             return target
         ramp_progress = min(

--- a/tests/test_training/test_dflash_strategy_ddp.py
+++ b/tests/test_training/test_dflash_strategy_ddp.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from specforge.training.strategies.base import DFlashTrainStrategy
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _TinyDraft(nn.Module):
+    """Stands in for a DFlash2 draft: a parameter plus the selector schedule attributes."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+        self.selector_loss_alpha = 0.7
+        self.selector_warmup_ratio = 0.0
+        self.selector_ramp_ratio = 0.0
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+class DFlashStrategySelectorAttrTest(unittest.TestCase):
+    def test_reads_selector_alpha_on_plain_module(self):
+        strategy = DFlashTrainStrategy(_TinyDraft())
+        self.assertAlmostEqual(strategy._selector_loss_alpha(None), 0.7)
+
+    def test_reads_selector_alpha_through_ddp_wrapper(self):
+        # NO_SHARD wraps the draft in DistributedDataParallel; the wrapper does not
+        # forward attribute access, so the strategy has to look through it.
+        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+        os.environ.setdefault("MASTER_PORT", str(_free_port()))
+        dist.init_process_group(backend="gloo", rank=0, world_size=1)
+        try:
+            wrapped = DDP(_TinyDraft())
+            self.assertFalse(hasattr(wrapped, "selector_loss_alpha"))
+            strategy = DFlashTrainStrategy(wrapped)
+            self.assertAlmostEqual(strategy._selector_loss_alpha(None), 0.7)
+        finally:
+            dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `fsdp_sharding: NO_SHARD` the training backend wraps the draft model in `DistributedDataParallel` (`specforge/training/backend.py`). `DFlashTrainStrategy` then reads `selector_loss_alpha`, `selector_warmup_ratio` and `selector_ramp_ratio` with `getattr(self.dflash_model, ...)`, and DDP does not forward attribute access to the wrapped module, so all three come back as their defaults. The effect is that the DFlash2 selector objective is silently disabled on that path: with `dflash2_selector_loss_alpha: 1.0` in the config, every step logs `selector_loss_alpha: 0.0` and the selector metrics are computed but never enter the loss. Seen on an offline single-GPU DFlash2 run (Qwen3.8-27B target, `nproc_per_node: 1`, `NO_SHARD`, `optimizer_cpu_offload: true`); nothing in the logs flags it apart from that one metric.

## Modifications

- `specforge/training/strategies/base.py`: `DFlashTrainStrategy._draft_attr` reads a schedule attribute from the draft and looks through a wrapper's `.module` when the attribute is not on the outer module; the three reads use it. Calls still go through the wrapper so DDP's gradient sync is unchanged.
- `tests/test_training/test_dflash_strategy_ddp.py`: a plain-module control and a single-rank gloo `DistributedDataParallel` case asserting the strategy reads `selector_loss_alpha` through the wrapper.

## Related Issues

None open that I could find (searched `selector_loss_alpha`, `NO_SHARD`, `DDP`).

## Accuracy Test

Not applicable to model output; this changes which loss terms train. Unit test run with `python -m unittest tests.test_training.test_dflash_strategy_ddp`: 2 passed with the fix; with the fix reverted the DDP case fails with `AssertionError: 0.0 != 0.7`, and passes again restored.

## Benchmark & Profiling

Not applicable (an attribute read per step).

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
