### PR TITLE
feat(dflash): clarify W&B metrics and diagnose prefix acceptance failures

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -194,7 +194,7 @@ The DFlash2 config additionally defines `conv_kernel_size` and
 configured CE/LK/TV objective. The selector always uses categorical CE over the
 target head's strict unary top-k, exactly as it will be used during inference.
 If the gold token is outside that candidate set, the token contributes no
-selector loss; `selector_coverage` reports how often the gold token is present.
+selector loss; `dflash/hard_label/unary_topK_recall` reports how often the gold token is present.
 Both objectives receive the configured fixed-decay or D-PACE position weight,
 and their combined numerator is normalized by the sum of valid effective token
 weights rather than by batch or anchor count.
@@ -216,36 +216,126 @@ still train, and the primary DFlash/D-PACE/LK objective keeps its normal draft
 gradient path. The option defaults to `false`, preserving coupled training.
 
 External tracking reports DFlash-family diagnostics on optimizer steps that
-reach `training.log_interval`. Aggregates live under `train/dflash/*` for every
-DFlash-family draft and under `train/dflash2/selector/*` for drafts with a
-candidate selector. The same families are broken down per predicted block
-position under their own `position_1/*` through `position_<block_size-1>/*`
-sections (the verified anchor is omitted), so each position renders as one
-dashboard group:
+reach `training.log_interval`. Aggregates live under `train/dflash/*` and
+`train/dflash2/selector/*`. Per-position metrics live under `position_1/*`
+through `position_<block_size-1>/*`, without the `train/` or algorithm prefix.
+Position 0 is the verified anchor and is omitted from token rates. K is the
+selector's `selector_top_k`, or `metric_top_k` (default 16) for plain DFlash.
 
-- `dflash/hard_label/*`: unary top-1 accuracy, top-K recall and probability
-  mass, and gold-token probability. K is the selector's `selector_top_k` when
-  present, otherwise the model's `metric_top_k` (default 16). Two aggregate-only
-  per-block accepted-length proxies apply `1 + sum_k prod_{j<=k} a_j` over the
-  supervised slots with `a_j` being coverage by the unary top-K
-  (`unary_topK_oracle_accepted_length`) or the gold-token probability
-  (`expected_accepted_length`, the smooth D-PACE surrogate).
-- `position_<k>/objective/loss_weight_share`: the fraction of the effective
-  objective weight each block position receives under the configured
-  fixed-decay or D-PACE weighting.
-- `train/objective/lk_kl_weight`: the CE weight of the `lambda` LK objective.
-- `dflash/teacher/*` (online capture only): full-vocabulary expected
-  acceptance, unary top-1 agreement, and unary top-K teacher mass against the
-  frozen target head, plus the aggregate `expected_accepted_length` that chains
-  the per-slot expected acceptance, the sampling-regime counterpart of the
-  hard-label surrogate.
-- `dflash2/selector/*` (DFlash2 only): selector loss, conditional accuracy
-  (uniform over covered slots, so comparable across loss types), the realized
-  greedy serving path's per-slot accuracy, its per-block
-  `serving_accepted_length`, and, with online capture, its agreement with the
-  target argmax (`teacher_serving_agreement`).
+### Reading the acceptance metrics
 
-All accepted-length proxies are teacher-forced on the real prefix and anchor.
+The following metrics compare predictions to **recorded hard labels on fixed
+training blocks**. The greedy selector conditions on its own preceding choices
+within each block; the block still starts from the recorded prefix and anchor.
+These are training diagnostics, not measured serving acceptance at the eval
+sampling temperature, top-p, or top-K.
+
+| Metric | Population and meaning |
+| --- | --- |
+| `dflash/hard_label/unary_top1_accuracy` | Unary argmax matches, over all supervised slots; a marginal rate. |
+| `dflash/hard_label/unary_topK_recall` | Gold token is in the strict unary top-K, over all supervised slots. |
+| `dflash/hard_label/unary_probability`, `unary_topK_mass` | Full-softmax gold probability and mass assigned to the candidate set. |
+| `dflash2/selector/teacher_forced_covered_accuracy` | Selector argmax accuracy given a gold predecessor and gold in top-K; uniform over covered slots. |
+| `dflash2/selector/self_conditioned_marginal_accuracy` | Greedy selector matches over all supervised slots, including slots after an earlier error. |
+| `dflash2/selector/greedy_prefix_acceptance` | Accepted / reached slots on the greedy selector prefix. A slot is reached only when all earlier slots matched and the current slot is supervised. |
+| `position_<j>/selector/greedy_prefix_survival` | Fraction of valid blocks whose selector prefix matches through position j. |
+| `dflash2/selector/greedy_accepted_length` | Mean `1 + number of leading matches`, including the anchor. |
+
+Unary greedy and top-K oracle paths have their own `*_prefix_acceptance`,
+`*_prefix_survival`, and `*_accepted_length` under `dflash/hard_label/`, with
+stems `unary_greedy` and `unary_topK_oracle`. Each path uses its own reached
+population. The oracle assumes the recorded gold token is always selected when
+it is in top-K; it is a candidate-coverage bound on these blocks, not a serving
+performance ceiling.
+
+For each path, `position_<j>/*` also logs `*_reached_count`,
+`*_accepted_count`, and `*_first_failure_count`. Counts are summed across metric
+chunks, gradient-accumulation microbatches, and data-parallel ranks before
+forming any rate. They describe the optimizer window being logged, not all
+steps since the last log. Aggregate prefix rates use total accepted / total
+reached, rather than averaging per-position percentages.
+
+To separate candidate misses from selector ranking errors on the **same
+selector-reached prefixes**, use:
+
+- `dflash2/selector/greedy_prefix_unary_top1_accuracy` and
+  `greedy_prefix_topK_recall`: unary accuracy and candidate recall on that population.
+- `greedy_prefix_covered_accuracy`: selector matches / covered reached slots.
+- `greedy_prefix_coverage_miss_rate`: uncovered reached slots / reached slots.
+- `greedy_prefix_ranking_error_rate`: covered but incorrect slots / reached slots.
+
+The last two rates plus `greedy_prefix_acceptance` sum to one whenever there
+are observations. Their per-position counts are `greedy_covered_count`,
+`greedy_coverage_miss_count`, and `greedy_ranking_error_count` in the selector
+section. A ratio with zero denominator logs zero by the trainer's existing
+convention; **ignore it when the corresponding reached or covered count is
+zero**, rather than treating it as measured 0% accuracy.
+
+Chains stop at the first unsupervised slot. Padding, masked tails, and internal
+mask gaps are not model failures. `dflash/hard_label/block_count` counts blocks
+with at least one supervised prediction; per-position `hard_label/supervised_count`
+and `hard_label/valid_prefix_count` expose the raw mask and contiguous supervised
+prefix populations. `dflash/hard_label/supervised_prefix_length` is the mean
+maximum observable chain length including the anchor. This distinguishes a
+short supervision window from a short accepted prefix.
+
+For each path, length is exactly `1 + sum_j survival_j` (when block count is
+positive). With fully supervised blocks, survival is also the cumulative product
+of the conditional prefix rates. With masked tails, inspect the counts as well.
+Plot length and survival over optimizer steps first, then prefix acceptance and
+the coverage/ranking split at early versus late positions. Marginal accuracy
+alone cannot identify where the acceptance chain breaks.
+
+### Probability and objective diagnostics
+
+- `dflash/hard_label/unary_gold_probability_chain_length` is the smooth D-PACE
+  surrogate `1 + sum_j prod_{i<=j} q_i(gold_i)` on recorded labels.
+- `dflash/teacher/unary_distribution_overlap` is `1 - TV(q_unary, p_teacher)`
+  over the full-vocabulary softmax distributions, when target final hidden
+  states are available. `unary_overlap_chain_length` chains these overlaps
+  along the recorded blocks. Neither includes the final selector distribution
+  or eval sampling filters. Unary top-1 teacher agreement and top-K teacher
+  mass remain in this family.
+- `dflash2/selector/self_conditioned_teacher_argmax_agreement` compares the
+  greedy selector to the target argmax at recorded prefixes.
+- `dflash2/selector/loss` is the weighted selector CE. Its gold probability is
+  `teacher_forced_covered_gold_probability`, uniform over covered slots.
+  `dflash2/objective/weighted_covered_accuracy` uses the selector loss weights;
+  use the uniform accuracy metrics above for comparisons across objectives.
+- `position_<j>/objective/loss_weight_share` reports the effective fixed-decay
+  or D-PACE objective weight per position. `train/objective/lk_kl_weight` is the
+  CE weight of the `lambda` LK objective.
+
+### Dashboard migration and checkpoint alignment
+
+The following old DFlash metric names are no longer emitted. Update existing
+panels; historical W&B rows are not renamed or deleted. Per-position variants
+follow the same changes.
+
+| Old name | Replacement |
+| --- | --- |
+| `expected_acceptance`, `dflash/hard_label/expected_acceptance` | `target_probability` or `dflash/hard_label/unary_probability` (duplicate aliases removed) |
+| `dflash/hard_label/expected_accepted_length` | `dflash/hard_label/unary_gold_probability_chain_length` |
+| `dflash/teacher/expected_acceptance` | `dflash/teacher/unary_distribution_overlap` |
+| `dflash/teacher/expected_accepted_length` | `dflash/teacher/unary_overlap_chain_length` |
+| `dflash2/selector/serving_accuracy` | `dflash2/selector/self_conditioned_marginal_accuracy` |
+| `dflash2/selector/conditional_accuracy` | `dflash2/selector/teacher_forced_covered_accuracy` |
+| `dflash2/selector/serving_accepted_length` | `dflash2/selector/greedy_accepted_length` |
+| `dflash2/selector/teacher_serving_agreement` | `dflash2/selector/self_conditioned_teacher_argmax_agreement` |
+| `selector_loss` | `dflash2/selector/loss` (duplicate removed) |
+| `selector_coverage` | `dflash/hard_label/unary_topK_recall` (duplicate removed) |
+| `selector_accuracy` | `dflash2/objective/weighted_covered_accuracy` |
+| `selector_target_probability` | `dflash2/selector/teacher_forced_covered_gold_probability` |
+
+The generic `acc` and `target_probability` remain available for lightweight
+logging and evaluation consumers. EAGLE3 and DSpark metric names are unchanged.
+Every tracker row now includes `train/optimizer_step`, supplied by the same
+controller counter used for checkpoints. Join external eval results by run ID
+and checkpoint optimizer step, not by a tracker's internal row index. An eval
+comparison must also record its dataset, target/draft revisions, block size,
+sampling settings, and whether acceptance length is proposal-weighted or a
+mean of per-request lengths; the training proxies above do not replace those
+measurements.
 
 The exported computation and parameter names match the public SGLang DFlash2
 contract, including optional `output_multiplier` and

--- a/docs/concepts/DFlash2.md
+++ b/docs/concepts/DFlash2.md
@@ -63,7 +63,9 @@ whose `config.json` declares `DFlash2DraftModel`.
 The base head keeps the configured DFlash, D-PACE, CE/LK, and TV behavior. The
 selector has a separate categorical cross-entropy objective over the strict
 unary top-k candidate set. Tokens whose gold target is outside that set do not
-contribute selector CE; `selector_coverage` measures how often it is present.
+contribute selector CE; `dflash/hard_label/unary_topK_recall` measures how often it is present.
+See the [training metrics guide](../basic_usage/training.md#reading-the-acceptance-metrics)
+for prefix survival, candidate misses, selector errors, and dashboard migration.
 
 Configure its weight and optimizer-step schedule in the training YAML:
 

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from specforge.algorithms.common.dflash_metrics import hard_label_prefix_counts
 from specforge.core.chunking import checkpointed_chunk_reduce
 from specforge.modeling.draft.dflash import DFlashDraftModel
 from specforge.modeling.draft.flex_attention_backend import flex_attention_backend
@@ -93,17 +94,22 @@ class DFlashMetricTerms(NamedTuple):
     selector_weight_den: torch.Tensor
     selector_conditional_correct_num: torch.Tensor
     selector_covered_den: torch.Tensor
-    selector_serving_correct_num: torch.Tensor
+    selector_greedy_correct_num: torch.Tensor
     loss_weight_num: torch.Tensor
     teacher_expected_acceptance_num: torch.Tensor
     teacher_unary_top1_agreement_num: torch.Tensor
     teacher_unary_topk_mass_num: torch.Tensor
-    teacher_selector_serving_agreement_num: torch.Tensor
+    teacher_selector_greedy_agreement_num: torch.Tensor
     block_den: torch.Tensor
     oracle_accepted_length_num: torch.Tensor
-    serving_accepted_length_num: torch.Tensor
+    greedy_accepted_length_num: torch.Tensor
     expected_accepted_length_num: torch.Tensor
     teacher_expected_accepted_length_num: torch.Tensor
+    prefix_reached_num: torch.Tensor
+    prefix_accepted_num: torch.Tensor
+    selector_prefix_covered_num: torch.Tensor
+    selector_prefix_unary_correct_num: torch.Tensor
+    prefix_eligible_num: torch.Tensor
 
 
 def _expected_accepted_length_num(
@@ -142,7 +148,7 @@ class _DFlashSelectorDiagnostics(NamedTuple):
     covered_mask: torch.Tensor
 
 
-class _DFlashServingDiagnostics(NamedTuple):
+class _DFlashGreedyDiagnostics(NamedTuple):
     """Per-block acceptance chains plus the greedy selector path when present."""
 
     selected_ids: Optional[torch.Tensor]
@@ -159,7 +165,7 @@ class _DFlashTeacherTerms(NamedTuple):
     expected_acceptance_num: torch.Tensor
     unary_top1_agreement_num: torch.Tensor
     unary_topk_mass_num: torch.Tensor
-    selector_serving_agreement_num: torch.Tensor
+    selector_greedy_agreement_num: torch.Tensor
     expected_accepted_length_num: torch.Tensor
 
     @classmethod
@@ -538,6 +544,96 @@ class OnlineDFlashModel(nn.Module):
         )
         cls._add_position_ratios(metrics, name, numerators, denominators)
 
+    @staticmethod
+    def _add_position_counts(
+        metrics: Dict[str, torch.Tensor], name: str, counts: torch.Tensor
+    ) -> None:
+        family = name.split("/", 1)[1]
+        for position in range(1, counts.numel()):
+            metrics[f"position_{position}/{family}"] = counts[position].detach()
+
+    @classmethod
+    def _add_prefix_metrics(
+        cls,
+        ratios: Dict[str, Tuple[torch.Tensor, torch.Tensor]],
+        counts: Dict[str, torch.Tensor],
+        terms: DFlashMetricTerms,
+        top_k: int,
+        *,
+        has_selector: bool,
+    ) -> None:
+        """Expose survival and first-failure diagnostics with exact counts."""
+        block_den = terms.block_den.detach()
+        counts["dflash/hard_label/block_count"] = block_den
+        cls._add_position_counts(
+            counts, "dflash/hard_label/supervised_count", terms.position_den
+        )
+        cls._add_position_counts(
+            counts, "dflash/hard_label/valid_prefix_count", terms.prefix_eligible_num
+        )
+        ratios["dflash/hard_label/supervised_prefix_length"] = (
+            block_den + terms.prefix_eligible_num.sum().detach(),
+            block_den,
+        )
+        ratios["dflash/hard_label/unary_greedy_accepted_length"] = (
+            block_den + terms.prefix_accepted_num[0].sum().detach(),
+            block_den,
+        )
+        paths = [
+            "dflash/hard_label/unary_greedy",
+            f"dflash/hard_label/unary_top{top_k}_oracle",
+        ]
+        if has_selector:
+            paths.append("dflash2/selector/greedy")
+        for index, path in enumerate(paths):
+            reached = terms.prefix_reached_num[index]
+            accepted = terms.prefix_accepted_num[index]
+            cls._add_ratio_family(
+                ratios, f"{path}_prefix_acceptance", accepted, reached
+            )
+            cls._add_position_ratios(
+                ratios,
+                f"{path}_prefix_survival",
+                accepted,
+                block_den.expand_as(accepted),
+            )
+            for suffix, values in (
+                ("reached_count", reached),
+                ("accepted_count", accepted),
+                ("first_failure_count", reached - accepted),
+            ):
+                cls._add_position_counts(counts, f"{path}_{suffix}", values)
+
+        if has_selector:
+            reached = terms.prefix_reached_num[2]
+            accepted = terms.prefix_accepted_num[2]
+            covered = terms.selector_prefix_covered_num
+            for name, numerator, denominator in (
+                (
+                    "unary_top1_accuracy",
+                    terms.selector_prefix_unary_correct_num,
+                    reached,
+                ),
+                (f"top{top_k}_recall", covered, reached),
+                ("covered_accuracy", accepted, covered),
+                ("coverage_miss_rate", reached - covered, reached),
+                ("ranking_error_rate", covered - accepted, reached),
+            ):
+                cls._add_ratio_family(
+                    ratios,
+                    f"dflash2/selector/greedy_prefix_{name}",
+                    numerator,
+                    denominator,
+                )
+            for name, values in (
+                ("covered_count", covered),
+                ("coverage_miss_count", reached - covered),
+                ("ranking_error_count", covered - accepted),
+            ):
+                cls._add_position_counts(
+                    counts, f"dflash2/selector/greedy_{name}", values
+                )
+
     def _forward_draft_blocks(
         self,
         input_ids: torch.Tensor,
@@ -810,7 +906,7 @@ class OnlineDFlashModel(nn.Module):
         """Return additive unary, selector, and teacher diagnostics for one chunk.
 
         The unary, objective-weight, and teacher families apply to every
-        DFlash-family draft; the selector and serving-path families are only
+        DFlash-family draft; the selector and greedy-path families are only
         computed when the draft carries a DFlash2 candidate selector.
         """
 
@@ -835,7 +931,7 @@ class OnlineDFlashModel(nn.Module):
                 weight_mask=weight_mask,
             )
         position_den = weight_mask.sum(dim=(0, 1))
-        serving = self._dflash_serving_diagnostics(
+        greedy = self._dflash_greedy_diagnostics(
             candidate_selector=candidate_selector,
             unary=unary,
             hidden=hidden,
@@ -845,7 +941,7 @@ class OnlineDFlashModel(nn.Module):
         )
         teacher = self._dflash_teacher_terms(
             unary=unary,
-            serving_ids=serving.selected_ids,
+            greedy_ids=greedy.selected_ids,
             aligned_target_hidden=aligned_target_hidden,
             weight_mask=weight_mask,
             position_den=position_den,
@@ -853,7 +949,7 @@ class OnlineDFlashModel(nn.Module):
         return self._reduce_dflash_metric_terms(
             unary=unary,
             selector=selector,
-            serving=serving,
+            greedy=greedy,
             teacher=teacher,
             target_ids=target_ids,
             weight_mask=weight_mask,
@@ -957,7 +1053,7 @@ class OnlineDFlashModel(nn.Module):
         )
 
     @staticmethod
-    def _dflash_serving_diagnostics(
+    def _dflash_greedy_diagnostics(
         *,
         candidate_selector: Optional[nn.Module],
         unary: _DFlashUnaryDiagnostics,
@@ -965,13 +1061,13 @@ class OnlineDFlashModel(nn.Module):
         target_ids: torch.Tensor,
         weight_mask: torch.Tensor,
         position_den: torch.Tensor,
-    ) -> _DFlashServingDiagnostics:
+    ) -> _DFlashGreedyDiagnostics:
         """Reduce per-block acceptance chains; walk the selector path if any."""
 
         batch_size, num_blocks, block_size, hidden_size = hidden.shape
         zero = position_den.new_zeros(())
         if block_size <= 1:
-            return _DFlashServingDiagnostics(
+            return _DFlashGreedyDiagnostics(
                 selected_ids=None,
                 correct_num=position_den.new_zeros(position_den.shape),
                 block_den=zero,
@@ -981,7 +1077,7 @@ class OnlineDFlashModel(nn.Module):
             )
 
         # A block accepts its anchor, then only its leading run of supervised
-        # slots: covered (oracle), hit by the serving path (realized), or, for
+        # slots: covered (oracle), hit by the greedy path (realized), or, for
         # the smooth D-PACE surrogate, weighted by the gold-token probability.
         supervised = weight_mask[:, :, 1:] > 0.5
         block_valid = supervised.any(dim=-1).float()
@@ -992,7 +1088,7 @@ class OnlineDFlashModel(nn.Module):
             unary.hard_label_probability[:, :, 1:], supervised, block_valid
         )
         if candidate_selector is None:
-            return _DFlashServingDiagnostics(
+            return _DFlashGreedyDiagnostics(
                 selected_ids=None,
                 correct_num=position_den.new_zeros(position_den.shape),
                 block_den=block_valid.sum(),
@@ -1001,7 +1097,7 @@ class OnlineDFlashModel(nn.Module):
                 expected_accepted_length_num=expected_accepted_length_num,
             )
 
-        serving_ids = candidate_selector.greedy_path(
+        greedy_ids = candidate_selector.greedy_path(
             candidate_ids=unary.candidate_ids[:, :, 1:].reshape(
                 batch_size * num_blocks,
                 block_size - 1,
@@ -1019,19 +1115,19 @@ class OnlineDFlashModel(nn.Module):
             ),
             anchor_token_ids=target_ids[:, :, 0].reshape(-1),
         ).reshape(batch_size, num_blocks, block_size - 1)
-        serving_hit = serving_ids == target_ids[:, :, 1:]
-        return _DFlashServingDiagnostics(
-            selected_ids=serving_ids,
+        greedy_hit = greedy_ids == target_ids[:, :, 1:]
+        return _DFlashGreedyDiagnostics(
+            selected_ids=greedy_ids,
             correct_num=torch.cat(
                 (
                     position_den.new_zeros(1),
-                    (serving_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
+                    (greedy_hit.float() * weight_mask[:, :, 1:]).sum(dim=(0, 1)),
                 )
             ),
             block_den=block_valid.sum(),
             oracle_accepted_length_num=oracle_accepted_length_num,
             accepted_length_num=_expected_accepted_length_num(
-                serving_hit, supervised, block_valid
+                greedy_hit, supervised, block_valid
             ),
             expected_accepted_length_num=expected_accepted_length_num,
         )
@@ -1040,12 +1136,12 @@ class OnlineDFlashModel(nn.Module):
         self,
         *,
         unary: _DFlashUnaryDiagnostics,
-        serving_ids: Optional[torch.Tensor],
+        greedy_ids: Optional[torch.Tensor],
         aligned_target_hidden: Optional[torch.Tensor],
         weight_mask: torch.Tensor,
         position_den: torch.Tensor,
     ) -> _DFlashTeacherTerms:
-        """Compare unary and serving predictions with the frozen target head."""
+        """Compare unary and greedy predictions with the frozen target head."""
 
         if aligned_target_hidden is None:
             return _DFlashTeacherTerms.zeros(position_den)
@@ -1064,15 +1160,15 @@ class OnlineDFlashModel(nn.Module):
             1.0 - 0.5 * (unary.probabilities - teacher_probabilities).abs().sum(dim=-1)
         ).clamp(0.0, 1.0)
 
-        selector_serving_agreement_num = position_den.new_zeros(position_den.shape)
+        selector_greedy_agreement_num = position_den.new_zeros(position_den.shape)
         expected_accepted_length_num = position_den.new_zeros(())
         if block_size > 1:
-            if serving_ids is not None:
-                selector_serving_agreement_num = torch.cat(
+            if greedy_ids is not None:
+                selector_greedy_agreement_num = torch.cat(
                     (
                         position_den.new_zeros(1),
                         (
-                            (serving_ids == teacher_ids[:, :, 1:]).float()
+                            (greedy_ids == teacher_ids[:, :, 1:]).float()
                             * weight_mask[:, :, 1:]
                         ).sum(dim=(0, 1)),
                     )
@@ -1092,7 +1188,7 @@ class OnlineDFlashModel(nn.Module):
                 teacher_probabilities.gather(-1, unary.candidate_ids).sum(dim=-1)
                 * weight_mask
             ).sum(dim=(0, 1)),
-            selector_serving_agreement_num=selector_serving_agreement_num,
+            selector_greedy_agreement_num=selector_greedy_agreement_num,
             expected_accepted_length_num=expected_accepted_length_num,
         )
 
@@ -1101,7 +1197,7 @@ class OnlineDFlashModel(nn.Module):
         *,
         unary: _DFlashUnaryDiagnostics,
         selector: Optional[_DFlashSelectorDiagnostics],
-        serving: _DFlashServingDiagnostics,
+        greedy: _DFlashGreedyDiagnostics,
         teacher: _DFlashTeacherTerms,
         target_ids: torch.Tensor,
         weight_mask: torch.Tensor,
@@ -1124,6 +1220,16 @@ class OnlineDFlashModel(nn.Module):
             selector_conditional_correct_num = (
                 (selector.selected_ids == target_ids).float() * selector.covered_mask
             ).sum(dim=(0, 1))
+        prefix = hard_label_prefix_counts(
+            unary_hit=unary.predicted_ids[:, :, 1:] == target_ids[:, :, 1:],
+            covered=unary.target_is_candidate[:, :, 1:],
+            selector_hit=(
+                None
+                if greedy.selected_ids is None
+                else greedy.selected_ids == target_ids[:, :, 1:]
+            ),
+            supervised=weight_mask[:, :, 1:] > 0.5,
+        )
         return DFlashMetricTerms(
             hard_label_probability_num=(unary.hard_label_probability * weight_mask).sum(
                 dim=(0, 1)
@@ -1141,17 +1247,22 @@ class OnlineDFlashModel(nn.Module):
             selector_weight_den=selector_weight_den,
             selector_conditional_correct_num=selector_conditional_correct_num,
             selector_covered_den=covered_mask.sum(dim=(0, 1)),
-            selector_serving_correct_num=serving.correct_num,
+            selector_greedy_correct_num=greedy.correct_num,
             loss_weight_num=loss_weights.sum(dim=(0, 1)),
             teacher_expected_acceptance_num=teacher.expected_acceptance_num,
             teacher_unary_top1_agreement_num=teacher.unary_top1_agreement_num,
             teacher_unary_topk_mass_num=teacher.unary_topk_mass_num,
-            teacher_selector_serving_agreement_num=teacher.selector_serving_agreement_num,
-            block_den=serving.block_den,
-            oracle_accepted_length_num=serving.oracle_accepted_length_num,
-            serving_accepted_length_num=serving.accepted_length_num,
-            expected_accepted_length_num=serving.expected_accepted_length_num,
+            teacher_selector_greedy_agreement_num=teacher.selector_greedy_agreement_num,
+            block_den=greedy.block_den,
+            oracle_accepted_length_num=greedy.oracle_accepted_length_num,
+            greedy_accepted_length_num=greedy.accepted_length_num,
+            expected_accepted_length_num=greedy.expected_accepted_length_num,
             teacher_expected_accepted_length_num=teacher.expected_accepted_length_num,
+            prefix_reached_num=prefix.reached,
+            prefix_accepted_num=prefix.accepted,
+            selector_prefix_covered_num=prefix.selector_covered,
+            selector_prefix_unary_correct_num=prefix.selector_unary_correct,
+            prefix_eligible_num=prefix.eligible,
         )
 
     def _lk_kl_weight(
@@ -1308,10 +1419,6 @@ class OnlineDFlashModel(nn.Module):
                 target_probability_num.detach(),
                 accuracy_denom.detach(),
             ),
-            "expected_acceptance": (
-                target_probability_num.detach(),
-                accuracy_denom.detach(),
-            ),
             "lk_loss" if self.lk_loss_type is not None else "ce_loss": (
                 token_loss_num.detach(),
                 loss_denominator.detach(),
@@ -1324,145 +1431,122 @@ class OnlineDFlashModel(nn.Module):
                 accuracy_denom.detach(),
             )
         candidate_selector = getattr(self.draft_model, "candidate_selector", None)
+        sum_metrics = {}
         if collect_detailed_metrics:
-            (
-                hard_label_probability_position_num,
-                unary_correct_position_num,
-                position_den,
-                unary_topk_recall_position_num,
-                unary_topk_mass_position_num,
-                selector_ce_position_num,
-                selector_weight_position_den,
-                selector_correct_position_num,
-                selector_covered_position_den,
-                selector_serving_correct_position_num,
-                loss_weight_position_num,
-                teacher_expected_acceptance_position_num,
-                teacher_unary_top1_agreement_position_num,
-                teacher_unary_topk_mass_position_num,
-                teacher_selector_serving_agreement_position_num,
-                block_den,
-                oracle_accepted_length_num,
-                serving_accepted_length_num,
-                expected_accepted_length_num,
-                teacher_expected_accepted_length_num,
-            ) = checkpointed_chunk_reduce(
-                self._dflash_metric_chunk_terms,
-                hidden_4d.detach(),
-                target_ids,
-                weight_mask,
-                predecessor_ids,
-                aligned_target_hidden,
-                chunk_size=self.objective_chunk_blocks,
-                dim=1,
+            terms = DFlashMetricTerms(
+                *checkpointed_chunk_reduce(
+                    self._dflash_metric_chunk_terms,
+                    hidden_4d.detach(),
+                    target_ids,
+                    weight_mask,
+                    predecessor_ids,
+                    aligned_target_hidden,
+                    chunk_size=self.objective_chunk_blocks,
+                    dim=1,
+                )
             )
             top_k = self._metric_top_k()
             for name, numerators in (
                 (
                     "dflash/hard_label/unary_top1_accuracy",
-                    unary_correct_position_num,
+                    terms.unary_correct_num,
                 ),
                 (
                     "dflash/hard_label/unary_probability",
-                    hard_label_probability_position_num,
-                ),
-                (
-                    "dflash/hard_label/expected_acceptance",
-                    hard_label_probability_position_num,
+                    terms.hard_label_probability_num,
                 ),
                 (
                     f"dflash/hard_label/unary_top{top_k}_recall",
-                    unary_topk_recall_position_num,
+                    terms.unary_topk_recall_num,
                 ),
                 (
                     f"dflash/hard_label/unary_top{top_k}_mass",
-                    unary_topk_mass_position_num,
+                    terms.unary_topk_mass_num,
                 ),
             ):
                 self._add_ratio_family(
                     ratio_metrics,
                     name,
                     numerators,
-                    position_den,
+                    terms.position_den,
                 )
             self._add_position_ratios(
                 ratio_metrics,
                 "dflash/objective/loss_weight_share",
-                loss_weight_position_num,
-                loss_weight_position_num.sum().expand_as(loss_weight_position_num),
+                terms.loss_weight_num,
+                terms.loss_weight_num.sum().expand_as(terms.loss_weight_num),
             )
             ratio_metrics[
                 f"dflash/hard_label/unary_top{top_k}_oracle_accepted_length"
-            ] = (oracle_accepted_length_num.detach(), block_den.detach())
-            ratio_metrics["dflash/hard_label/expected_accepted_length"] = (
-                expected_accepted_length_num.detach(),
-                block_den.detach(),
+            ] = (terms.oracle_accepted_length_num.detach(), terms.block_den.detach())
+            ratio_metrics["dflash/hard_label/unary_gold_probability_chain_length"] = (
+                terms.expected_accepted_length_num.detach(),
+                terms.block_den.detach(),
+            )
+            self._add_prefix_metrics(
+                ratio_metrics,
+                sum_metrics,
+                terms,
+                top_k,
+                has_selector=candidate_selector is not None,
             )
             if aligned_target_hidden is not None:
-                ratio_metrics["dflash/teacher/expected_accepted_length"] = (
-                    teacher_expected_accepted_length_num.detach(),
-                    block_den.detach(),
+                ratio_metrics["dflash/teacher/unary_overlap_chain_length"] = (
+                    terms.teacher_expected_accepted_length_num.detach(),
+                    terms.block_den.detach(),
                 )
                 for name, numerators in (
                     (
-                        "dflash/teacher/expected_acceptance",
-                        teacher_expected_acceptance_position_num,
+                        "dflash/teacher/unary_distribution_overlap",
+                        terms.teacher_expected_acceptance_num,
                     ),
                     (
                         "dflash/teacher/unary_top1_agreement",
-                        teacher_unary_top1_agreement_position_num,
+                        terms.teacher_unary_top1_agreement_num,
                     ),
                     (
                         f"dflash/teacher/unary_top{top_k}_mass",
-                        teacher_unary_topk_mass_position_num,
+                        terms.teacher_unary_topk_mass_num,
                     ),
                 ):
                     self._add_ratio_family(
                         ratio_metrics,
                         name,
                         numerators,
-                        position_den,
+                        terms.position_den,
                     )
             if candidate_selector is not None:
                 self._add_ratio_family(
                     ratio_metrics,
-                    "dflash2/selector/serving_accuracy",
-                    selector_serving_correct_position_num,
-                    position_den,
+                    "dflash2/selector/self_conditioned_marginal_accuracy",
+                    terms.selector_greedy_correct_num,
+                    terms.position_den,
                 )
                 self._add_ratio_family(
                     ratio_metrics,
-                    "dflash2/selector/conditional_accuracy",
-                    selector_correct_position_num,
-                    selector_covered_position_den,
+                    "dflash2/selector/teacher_forced_covered_accuracy",
+                    terms.selector_conditional_correct_num,
+                    terms.selector_covered_den,
                 )
-                ratio_metrics["dflash2/selector/serving_accepted_length"] = (
-                    serving_accepted_length_num.detach(),
-                    block_den.detach(),
+                ratio_metrics["dflash2/selector/greedy_accepted_length"] = (
+                    terms.greedy_accepted_length_num.detach(),
+                    terms.block_den.detach(),
                 )
                 if aligned_target_hidden is not None:
                     self._add_ratio_family(
                         ratio_metrics,
-                        "dflash2/selector/teacher_serving_agreement",
-                        teacher_selector_serving_agreement_position_num,
-                        position_den,
+                        "dflash2/selector/self_conditioned_teacher_argmax_agreement",
+                        terms.teacher_selector_greedy_agreement_num,
+                        terms.position_den,
                     )
         if has_selector_objective:
             ratio_metrics.update(
                 {
-                    "selector_loss": (
-                        selector_loss_num.detach(),
-                        selector_weight_den.detach(),
-                    ),
-                    "selector_accuracy": (
+                    "dflash2/objective/weighted_covered_accuracy": (
                         selector_correct_num.detach(),
                         selector_weight_den.detach(),
                     ),
-                    "selector_coverage": (
-                        selector_covered_num.detach(),
-                        accuracy_denom.detach(),
-                    ),
-                    "selector_target_probability": (
+                    "dflash2/selector/teacher_forced_covered_gold_probability": (
                         selector_probability_num.detach(),
                         selector_covered_num.detach(),
                     ),
@@ -1476,12 +1560,13 @@ class OnlineDFlashModel(nn.Module):
                 self._add_position_ratios(
                     ratio_metrics,
                     "dflash2/selector/loss",
-                    selector_ce_position_num,
-                    selector_weight_position_den,
+                    terms.selector_ce_num,
+                    terms.selector_weight_den,
                 )
         metrics: Dict[str, object] = {
             "accuracy_denom": accuracy_denom.detach(),
             "ratio_metrics": ratio_metrics,
+            "sum_metrics": sum_metrics,
         }
         if has_selector_objective:
             metrics["selector_loss_alpha"] = effective_selector_alpha

--- a/specforge/algorithms/common/dflash_metrics.py
+++ b/specforge/algorithms/common/dflash_metrics.py
@@ -1,0 +1,64 @@
+"""Additive, hard-label prefix diagnostics on fixed training blocks.
+
+These measure greedy matches to recorded labels, not stochastic verification
+against a target distribution or the cross-block serving walk.
+"""
+
+from typing import NamedTuple, Optional
+
+import torch
+import torch.nn.functional as F
+
+
+class PrefixCounts(NamedTuple):
+    # Rows are unary greedy, top-K oracle, and selector greedy, in that order.
+    # Columns include a zero anchor entry followed by the predicted positions.
+    reached: torch.Tensor
+    accepted: torch.Tensor
+    selector_covered: torch.Tensor
+    selector_unary_correct: torch.Tensor
+    eligible: torch.Tensor
+
+
+def _prefix_events(hit: torch.Tensor, supervised: torch.Tensor):
+    accepted = (hit & supervised).long().cumprod(dim=-1).bool()
+    previous_accepted = torch.cat(
+        (torch.ones_like(accepted[..., :1]), accepted[..., :-1]), dim=-1
+    )
+    return previous_accepted & supervised, accepted
+
+
+def hard_label_prefix_counts(
+    unary_hit: torch.Tensor,
+    covered: torch.Tensor,
+    selector_hit: Optional[torch.Tensor],
+    supervised: torch.Tensor,
+) -> PrefixCounts:
+    """Count reached and accepted slots, stopping at the first miss or mask.
+
+    Inputs have shape [batch, blocks, predicted positions], without the anchor.
+    A slot is reached only if it is supervised and all preceding slots matched.
+    Coverage and unary correctness are also counted on the *selector's* reached
+    prefixes, so candidate recall and ranking accuracy share a population.
+    """
+    if selector_hit is None:
+        selector_reached = selector_accepted = torch.zeros_like(supervised)
+    else:
+        selector_reached, selector_accepted = _prefix_events(selector_hit, supervised)
+    unary_reached, unary_accepted = _prefix_events(unary_hit, supervised)
+    oracle_reached, oracle_accepted = _prefix_events(covered, supervised)
+
+    def count(events):
+        return F.pad(events.float().sum(dim=(0, 1)), (1, 0))
+
+    return PrefixCounts(
+        reached=torch.stack(
+            [count(unary_reached), count(oracle_reached), count(selector_reached)]
+        ),
+        accepted=torch.stack(
+            [count(unary_accepted), count(oracle_accepted), count(selector_accepted)]
+        ),
+        selector_covered=count(selector_reached & covered),
+        selector_unary_correct=count(selector_reached & unary_hit),
+        eligible=count(supervised.long().cumprod(dim=-1).bool()),
+    )

--- a/specforge/training/controller.py
+++ b/specforge/training/controller.py
@@ -178,11 +178,19 @@ def _reduce_ratio_metrics(
     device: torch.device,
     process_group: Any,
     reduce: bool,
+    sums: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, torch.Tensor]:
-    """Form telemetry ratios only after summing their numerators and counts."""
+    """Reduce ratios and additive telemetry in one collective.
 
-    if not values:
+    Ratios with no observations retain the existing zero convention; log their
+    counts through ``sums`` when consumers need to distinguish missing data.
+    """
+
+    sums = sums or {}
+    if not values and not sums:
         return {}
+    if values.keys() & sums.keys():
+        raise ValueError("ratio and sum metric names must be distinct")
     normalized = []
     for name in sorted(values):
         pair = values[name]
@@ -199,12 +207,17 @@ def _reduce_ratio_metrics(
             )
         normalized.append((name, numerator, denominator))
 
+    normalized_sums = [
+        (name, torch.as_tensor(sums[name]).detach().float().flatten().to(device))
+        for name in sorted(sums)
+    ]
     packed = torch.cat(
         [
             tensor
             for _, numerator, denominator in normalized
             for tensor in (numerator, denominator)
         ]
+        + [tensor for _, tensor in normalized_sums]
     )
     if reduce:
         import torch.distributed as dist
@@ -234,6 +247,14 @@ def _reduce_ratio_metrics(
             output[name] = ratios.reshape(())
         else:
             output.update({f"{name}_{index}": ratios[index] for index in range(width)})
+    for name, tensor in normalized_sums:
+        width = tensor.numel()
+        total = packed[cursor : cursor + width]
+        cursor += width
+        if width == 1:
+            output[name] = total.reshape(())
+        else:
+            output.update({f"{name}_{index}": total[index] for index in range(width)})
     return output
 
 
@@ -394,6 +415,7 @@ class TrainerCore:
         self.accumulation_steps = max(1, accumulation_steps)
         self._micro = 0
         self._ratio_totals: Dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._sum_totals: Dict[str, torch.Tensor] = {}
 
     @property
     def accumulation_remainder(self) -> int:
@@ -417,6 +439,10 @@ class TrainerCore:
                 denominator,
             )
         self._accumulate_ratio_metrics(ratio_metrics)
+        for name, value in out.sum_metrics.items():
+            self._sum_totals[name] = (
+                self._sum_totals.get(name, 0) + torch.as_tensor(value).detach()
+            )
         loss = loss / self.accumulation_steps
         self._micro += 1
         # The boundary is known before backward so the backend can defer the FSDP
@@ -432,9 +458,11 @@ class TrainerCore:
             grad_norm,
             stepped,
             ratio_metrics=result_ratio_metrics,
+            sum_metrics=self._sum_totals if stepped else out.sum_metrics,
         )
         if stepped:
             self._ratio_totals = {}
+            self._sum_totals = {}
         return result
 
     def _accumulate_ratio_metrics(self, values: Dict[str, Any]) -> None:
@@ -477,6 +505,7 @@ class TrainerCore:
         stepped: bool,
         *,
         ratio_metrics: Optional[Dict[str, Any]] = None,
+        sum_metrics: Optional[Dict[str, Any]] = None,
     ) -> StepResult:
         # EAGLE3 carries per-TTT numerators and denominators.  Preserve those
         # positions and reduce counts before ratios; scalarizing its lists here
@@ -515,6 +544,7 @@ class TrainerCore:
                 device=metric_device,
                 process_group=process_group,
                 reduce=stepped,
+                sums=out.sum_metrics if sum_metrics is None else sum_metrics,
             )
         )
         scalar_metrics: Dict[str, Any] = {}

--- a/specforge/training/strategies/base.py
+++ b/specforge/training/strategies/base.py
@@ -40,6 +40,9 @@ class StepOutput:
     metrics: Dict[str, Any]
     ratio_metrics: Dict[str, Tuple[Any, Any]] = field(default_factory=dict)
     loss_terms: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    # Additive telemetry (for example reached/accepted counts), summed across
+    # the optimizer window and data-parallel ranks, never averaged.
+    sum_metrics: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -528,6 +531,7 @@ class DFlashTrainStrategy(DraftTrainStrategy):
             metrics=metrics,
             ratio_metrics=model_metrics.get("ratio_metrics", {}),
             loss_terms=model_metrics.get("loss_terms"),
+            sum_metrics=model_metrics.get("sum_metrics", {}),
         )
 
     def checkpoint_state_filter(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:

--- a/specforge/training/tracking.py
+++ b/specforge/training/tracking.py
@@ -88,6 +88,9 @@ class TrackerLogger:
         if self._closed:
             raise RuntimeError("cannot log after TrackerLogger.close()")
         values = training_metric_names(scalar_metrics(metrics))
+        # Use the controller's optimizer step as an explicit join key for
+        # checkpoint/eval comparisons, independent of a tracker's row counter.
+        values["train/optimizer_step"] = float(step)
         if self.console_logger is not None:
             self.console_logger(values, step)
         self.tracker.log(values, step=step)

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -9,6 +9,7 @@ from transformers import Qwen3Config
 
 from specforge.algorithms.common.dflash_family_model import OnlineDFlashModel
 from specforge.algorithms.dflash.providers import resume_contract
+from specforge.core.chunking import checkpointed_chunk_reduce
 from specforge.modeling.draft.dflash import Qwen3DFlashDecoderLayer
 from specforge.modeling.draft.dflash2 import (
     CandidateSelector,
@@ -386,6 +387,7 @@ class CandidateSelectorTest(unittest.TestCase):
             output_hidden,
         )
 
+        output_hidden.requires_grad_()
         _loss, _accuracy, metrics = model(
             input_ids=torch.tensor([[0, 1, 3]]),
             hidden_states=torch.zeros(1, 3, 4),
@@ -396,26 +398,41 @@ class CandidateSelectorTest(unittest.TestCase):
         ratios = metrics["ratio_metrics"]
         expected_keys = {
             "lk_loss",
-            "expected_acceptance",
+            "target_probability",
             "dflash/hard_label/unary_top1_accuracy",
             "dflash/hard_label/unary_top2_oracle_accepted_length",
-            "dflash2/selector/conditional_accuracy",
-            "dflash2/selector/serving_accepted_length",
+            "dflash2/selector/teacher_forced_covered_accuracy",
+            "dflash2/selector/greedy_accepted_length",
             "position_1/hard_label/unary_top1_accuracy",
             "position_2/hard_label/unary_top1_accuracy",
             "position_1/hard_label/unary_top2_recall",
             "position_2/hard_label/unary_top2_recall",
             "position_1/hard_label/unary_top2_mass",
             "position_1/selector/loss",
-            "position_2/selector/conditional_accuracy",
-            "position_2/selector/teacher_serving_agreement",
+            "position_2/selector/teacher_forced_covered_accuracy",
+            "position_2/selector/self_conditioned_teacher_argmax_agreement",
             "position_1/objective/loss_weight_share",
-            "position_1/teacher/expected_acceptance",
-            "position_2/teacher/expected_acceptance",
+            "position_1/teacher/unary_distribution_overlap",
+            "position_2/teacher/unary_distribution_overlap",
             "position_1/teacher/unary_top1_agreement",
             "position_2/teacher/unary_top2_mass",
         }
         self.assertTrue(expected_keys.issubset(ratios))
+        for removed in (
+            "expected_acceptance",
+            "dflash/hard_label/expected_acceptance",
+            "selector_loss",
+            "selector_accuracy",
+            "selector_coverage",
+            "selector_target_probability",
+        ):
+            self.assertNotIn(removed, ratios)
+        self.assertFalse(any("serving" in key for key in ratios))
+        counts = metrics["sum_metrics"]
+        self.assertEqual(counts["dflash/hard_label/block_count"], 1)
+        self.assertEqual(counts["position_1/selector/greedy_reached_count"], 1)
+        self.assertEqual(counts["position_2/selector/greedy_coverage_miss_count"], 1)
+        self.assertEqual(counts["position_2/selector/greedy_ranking_error_count"], 0)
         self.assertFalse(any(key.startswith("position_0/") for key in ratios))
         self.assertFalse(any("/position_" in key for key in ratios))
         self.assertNotIn("objective/lk_kl_weight", ratios)
@@ -435,19 +452,29 @@ class CandidateSelectorTest(unittest.TestCase):
         self.assertEqual(
             ratio("dflash/hard_label/unary_top2_oracle_accepted_length"), 2.0
         )
-        self.assertEqual(ratio("dflash2/selector/serving_accepted_length"), 2.0)
+        self.assertEqual(ratio("dflash2/selector/greedy_accepted_length"), 2.0)
+        self.assertEqual(ratio("dflash/hard_label/unary_greedy_accepted_length"), 2.0)
+        self.assertEqual(ratio("position_1/selector/greedy_prefix_acceptance"), 1.0)
+        self.assertEqual(ratio("position_2/selector/greedy_prefix_acceptance"), 0.0)
+        self.assertEqual(
+            ratio("position_2/selector/greedy_prefix_coverage_miss_rate"), 1.0
+        )
+        self.assertEqual(
+            ratio("position_2/selector/greedy_prefix_ranking_error_rate"), 0.0
+        )
+        self.assertEqual(ratio("dflash/hard_label/supervised_prefix_length"), 3.0)
         # Uniform dflash weights split the objective evenly over both slots.
         self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
         self.assertEqual(ratio("position_2/objective/loss_weight_share"), 0.5)
         # Expected accepted lengths chain the per-slot probabilities of the two
         # predicted slots; the teacher rows are aligned to label index - 1.
-        draft_probabilities = torch.softmax(output_hidden[0, 1:], dim=-1)
+        draft_probabilities = torch.softmax(output_hidden[0, 1:].detach(), dim=-1)
         teacher_probabilities = torch.softmax(target_hidden[0, :2], dim=-1)
         gold_probability = draft_probabilities.gather(
             -1, torch.tensor([[1], [3]])
         ).squeeze(-1)
         self.assertAlmostEqual(
-            ratio("dflash/hard_label/expected_accepted_length"),
+            ratio("dflash/hard_label/unary_gold_probability_chain_length"),
             float(1.0 + gold_probability.cumprod(dim=-1).sum()),
             places=5,
         )
@@ -455,10 +482,23 @@ class CandidateSelectorTest(unittest.TestCase):
             draft_probabilities - teacher_probabilities
         ).abs().sum(dim=-1)
         self.assertAlmostEqual(
-            ratio("dflash/teacher/expected_accepted_length"),
+            ratio("dflash/teacher/unary_overlap_chain_length"),
             float(1.0 + acceptance.cumprod(dim=-1).sum()),
             places=5,
         )
+
+        reference_loss, _, _ = model(
+            input_ids=torch.tensor([[0, 1, 3]]),
+            hidden_states=torch.zeros(1, 3, 4),
+            loss_mask=torch.ones(1, 3),
+            collect_detailed_metrics=False,
+        )
+        torch.testing.assert_close(_loss, reference_loss)
+        parameters = (output_hidden, *draft.parameters())
+        detailed_gradients = torch.autograd.grad(_loss, parameters)
+        reference_gradients = torch.autograd.grad(reference_loss, parameters)
+        for actual, expected in zip(detailed_gradients, reference_gradients):
+            torch.testing.assert_close(actual, expected)
 
     def test_plain_dflash_draft_reports_family_metrics_without_selector_keys(self):
         # A DFlash draft has neither a candidate selector nor a unary transform.
@@ -511,7 +551,7 @@ class CandidateSelectorTest(unittest.TestCase):
         )
         self.assertEqual(ratio("position_1/objective/loss_weight_share"), 0.5)
         self.assertEqual(ratio("position_1/teacher/unary_top1_agreement"), 1.0)
-        self.assertIn("dflash/teacher/expected_accepted_length", ratios)
+        self.assertIn("dflash/teacher/unary_overlap_chain_length", ratios)
         self.assertFalse(
             any(
                 key.startswith("dflash2/") or "/selector/" in key or "selector_" in key
@@ -552,7 +592,7 @@ class CandidateSelectorTest(unittest.TestCase):
             attention_backend="eager",
             loss_type="dpace",
         )
-        # Block 0: slot 1 covers gold at rank 1 (serving misses), slot 2 at
+        # Block 0: slot 1 covers gold at rank 1 (greedy misses), slot 2 at
         # rank 0. Block 1: slot 1 misses the top-2 entirely, slot 2 at rank 0.
         hidden = torch.tensor(
             [
@@ -578,11 +618,36 @@ class CandidateSelectorTest(unittest.TestCase):
             hidden, target_ids, weights, predecessors
         )
 
+        for chunk_size in (0, 1, 2):
+            chunked = checkpointed_chunk_reduce(
+                model._dflash_metric_chunk_terms,
+                hidden,
+                target_ids,
+                weights,
+                predecessors,
+                chunk_size=chunk_size,
+                dim=1,
+            )
+            for actual, expected in zip(chunked, terms):
+                torch.testing.assert_close(actual, expected)
+
         self.assertEqual(terms.block_den.item(), 2.0)
         # Oracle: anchor + 2 slots in block 0, anchor only in block 1.
         self.assertEqual(terms.oracle_accepted_length_num.item(), 4.0)
-        # Serving path misses slot 1 in both blocks, so each accepts the anchor.
-        self.assertEqual(terms.serving_accepted_length_num.item(), 2.0)
+        # Greedy path misses slot 1 in both blocks, so each accepts the anchor.
+        self.assertEqual(terms.greedy_accepted_length_num.item(), 2.0)
+        # The marginal slot-2 score is perfect, but neither selector prefix
+        # reaches slot 2. Its prefix rate must therefore have denominator zero.
+        torch.testing.assert_close(
+            terms.selector_greedy_correct_num, torch.tensor([0.0, 0.0, 2.0])
+        )
+        torch.testing.assert_close(
+            terms.prefix_reached_num[2], torch.tensor([0.0, 2.0, 0.0])
+        )
+        torch.testing.assert_close(terms.prefix_accepted_num[2], torch.zeros(3))
+        torch.testing.assert_close(
+            terms.selector_prefix_covered_num, torch.tensor([0.0, 1.0, 0.0])
+        )
         torch.testing.assert_close(
             terms.selector_covered_den, torch.tensor([0.0, 1.0, 2.0])
         )
@@ -617,7 +682,7 @@ class CandidateSelectorTest(unittest.TestCase):
             terms.teacher_expected_acceptance_num,
             terms.teacher_unary_top1_agreement_num,
             terms.teacher_unary_topk_mass_num,
-            terms.teacher_selector_serving_agreement_num,
+            terms.teacher_selector_greedy_agreement_num,
         ):
             torch.testing.assert_close(teacher_term, torch.zeros(3))
 
@@ -706,14 +771,15 @@ class CandidateSelectorTest(unittest.TestCase):
             collect_detailed_metrics=False,
         )
 
+        self.assertEqual(metrics["sum_metrics"], {})
         self.assertFalse(
             any(
                 name.startswith(
                     (
                         "dflash/",
                         "position_",
-                        "dflash2/selector/serving_",
-                        "dflash2/selector/conditional_",
+                        "dflash2/selector/greedy_",
+                        "dflash2/selector/teacher_forced_covered_accuracy",
                     )
                 )
                 for name in metrics["ratio_metrics"]
@@ -980,7 +1046,7 @@ class CandidateSelectorTest(unittest.TestCase):
             torch.tensor([1]),
         )
         torch.testing.assert_close(loss, (1.0 - target_probability) + selector_ce)
-        selector_num, selector_den = metrics["ratio_metrics"]["selector_loss"]
+        selector_num, selector_den = metrics["ratio_metrics"]["dflash2/selector/loss"]
         torch.testing.assert_close(selector_num / selector_den, selector_ce)
 
     def test_selector_objective_backpropagates_to_all_selector_factors(self):

--- a/tests/test_runtime/test_seam_fixes.py
+++ b/tests/test_runtime/test_seam_fixes.py
@@ -170,7 +170,18 @@ class _FakeDFlashModel(nn.Module):
         self.target_last_hidden_states = target_last_hidden_states
         loss = (self.w * hidden_states.float().sum()).abs()
         acc = torch.tensor(0.5)
-        return loss, acc, {"accuracy_denom": loss_mask.sum()}
+        return (
+            loss,
+            acc,
+            {
+                "accuracy_denom": loss_mask.sum(),
+                "sum_metrics": (
+                    {"dflash/hard_label/block_count": torch.tensor(2.0)}
+                    if collect_detailed_metrics
+                    else {}
+                ),
+            },
+        )
 
 
 class TestDFlashSharesLifecycle(unittest.TestCase):
@@ -195,9 +206,11 @@ class TestDFlashSharesLifecycle(unittest.TestCase):
         self.assertEqual(model.max_valid_anchors, 3)
         self.assertEqual(model.received_selector_loss_alpha, 0.0)
         self.assertAlmostEqual(rep.metrics["acc"], 0.5)
+        self.assertEqual(rep.metrics["dflash/hard_label/block_count"], 2)
         out = strat.forward_loss(batch)
         self.assertAlmostEqual(float(out.metrics["accuracy"]), 0.5)
         self.assertEqual(float(out.metrics["accuracy_denom"]), 4.0)
+        self.assertEqual(out.sum_metrics["dflash/hard_label/block_count"], 2)
 
     def test_dflash_strategy_forwards_teacher_hidden_only_for_detailed_metrics(self):
         model = _FakeDFlashModel()
@@ -219,11 +232,12 @@ class TestDFlashSharesLifecycle(unittest.TestCase):
         self.assertIs(model.target_last_hidden_states, teacher_hidden)
 
         model.target_last_hidden_states = None
-        strategy.forward_loss(
+        out = strategy.forward_loss(
             batch,
             ctx=StepContext(collect_detailed_metrics=False),
         )
         self.assertIsNone(model.target_last_hidden_states)
+        self.assertEqual(out.sum_metrics, {})
 
     def test_dflash_validate_batch_rejects_missing(self):
         strat = DFlashTrainStrategy(_FakeDFlashModel())

--- a/tests/test_runtime/test_tracking_logger.py
+++ b/tests/test_runtime/test_tracking_logger.py
@@ -125,8 +125,18 @@ class TrackingLoggerTest(unittest.TestCase):
 
         logger({"loss": 1.5}, 7)
 
-        self.assertEqual(tracker.logged, [({"train/loss": 1.5}, 7)])
-        console.assert_called_once_with({"train/loss": 1.5}, 7)
+        expected = {"train/loss": 1.5, "train/optimizer_step": 7.0}
+        self.assertEqual(tracker.logged, [(expected, 7)])
+        console.assert_called_once_with(expected, 7)
+
+    def test_optimizer_step_is_authoritative_for_training_and_eval_rows(self):
+        tracker = _Tracker()
+        logger = TrackerLogger(tracker)
+        logger({"loss": 1, "optimizer_step": 0}, 500)
+        logger({"eval/loss": 2}, 500)
+        self.assertEqual(
+            [row[0]["train/optimizer_step"] for row in tracker.logged], [500.0, 500.0]
+        )
 
     def test_training_namespace_keeps_explicit_namespaces_unchanged(self):
         self.assertEqual(
@@ -167,7 +177,9 @@ class TrackingLoggerTest(unittest.TestCase):
         make.assert_called_once_with("tensorboard")
         tracker_class.validate_args.assert_called_once()
         logger({"loss": 2.0}, 3)
-        self.assertEqual(tracker.logged, [({"train/loss": 2.0}, 3)])
+        self.assertEqual(
+            tracker.logged, [({"train/loss": 2.0, "train/optimizer_step": 3.0}, 3)]
+        )
 
     def test_wandb_tracker_logs_through_its_owned_run_handle(self):
         run = mock.Mock()

--- a/tests/test_runtime/test_trainer.py
+++ b/tests/test_runtime/test_trainer.py
@@ -79,6 +79,7 @@ class WeightedStrategy(FakeStrategy):
                 "acc": (correct, denominator),
             },
             loss_terms=(numerator, denominator),
+            sum_metrics={"correct_count": correct, "sample_count": denominator},
         )
 
 
@@ -370,6 +371,65 @@ class TestTrainerCore(unittest.TestCase):
         self.assertEqual(metrics["acc"], 0.5)
         self.assertEqual(metrics["ce_position_0"], 0.5)
         self.assertEqual(metrics["ce_position_1"], 0.5)
+
+    def test_additive_telemetry_accumulates_and_resets_each_optimizer_window(self):
+        strat = WeightedStrategy()
+        core = TrainerCore(strat, FakeBackend(strat.model), accumulation_steps=2)
+        first = core.train_step(_weighted_batch(2, 1, 1))
+        second = core.train_step(_weighted_batch(30, 3, 1))
+        self.assertEqual(first.metrics["sample_count"], 1)
+        self.assertEqual(second.metrics["sample_count"], 4)
+        self.assertEqual(second.metrics["correct_count"], 2)
+        self.assertEqual(second.metrics["acc"], 0.5)
+        core.train_step(_weighted_batch(1, 2, 0))
+        fourth = core.train_step(_weighted_batch(1, 3, 1))
+        self.assertEqual(fourth.metrics["sample_count"], 5)
+        self.assertEqual(fourth.metrics["correct_count"], 1)
+        self.assertAlmostEqual(fourth.metrics["acc"], 0.2)
+
+    def test_prefix_counts_and_ratios_share_one_dp_sum_with_unequal_populations(self):
+        accepted = torch.tensor([2.0, 0.0], requires_grad=True)
+        reached = torch.tensor([3.0, 0.0])
+        remote = torch.tensor([1.0, 0.0, 7.0, 0.0, 1.0, 0.0, 7.0, 0.0])
+
+        def all_reduce(packed, *, group):
+            self.assertEqual(group, "dp")
+            self.assertFalse(packed.requires_grad)
+            packed.add_(remote)
+
+        with (
+            mock.patch("torch.distributed.is_available", return_value=True),
+            mock.patch("torch.distributed.is_initialized", return_value=True),
+            mock.patch("torch.distributed.get_world_size", return_value=2),
+            mock.patch(
+                "torch.distributed.all_reduce", side_effect=all_reduce
+            ) as reduce,
+        ):
+            metrics = _reduce_ratio_metrics(
+                {"acceptance": (accepted, reached)},
+                sums={"accepted_count": accepted, "reached_count": reached},
+                device=torch.device("cpu"),
+                process_group="dp",
+                reduce=True,
+            )
+        reduce.assert_called_once()
+        self.assertAlmostEqual(float(metrics["acceptance_0"]), 0.3)
+        self.assertEqual(metrics["accepted_count_0"], 3)
+        self.assertEqual(metrics["reached_count_0"], 10)
+        # Zero is the established empty-ratio convention; count zero explicitly
+        # distinguishes this from an observed 0% acceptance rate.
+        self.assertEqual(metrics["acceptance_1"], 0)
+        self.assertEqual(metrics["reached_count_1"], 0)
+
+    def test_additive_telemetry_without_ratios(self):
+        metrics = _reduce_ratio_metrics(
+            {},
+            sums={"count": torch.tensor(7.0)},
+            device=torch.device("cpu"),
+            process_group=None,
+            reduce=False,
+        )
+        self.assertEqual(metrics["count"], 7)
 
     @staticmethod
     def _eagle_output(

--- a/tests/test_utils/test_dflash_metrics.py
+++ b/tests/test_utils/test_dflash_metrics.py
@@ -1,0 +1,84 @@
+"""CPU checks for prefix survival, censoring, and first-failure attribution."""
+
+import unittest
+
+import torch
+
+from specforge.algorithms.common.dflash_metrics import hard_label_prefix_counts
+from specforge.core.chunking import checkpointed_chunk_reduce
+
+
+class PrefixMetricsTest(unittest.TestCase):
+    @staticmethod
+    def _inputs():
+        def events(rows):
+            return torch.tensor([rows], dtype=torch.bool)
+
+        # Four blocks: a late error, a covered selector error, a coverage miss,
+        # and an immediate selector error followed by later marginal hits.
+        unary = events([[1, 1, 1, 0], [0, 1, 1, 1], [1, 0, 0, 1], [0, 1, 0, 1]])
+        covered = events([[1, 1, 1, 1], [1, 1, 1, 1], [1, 0, 1, 1], [1, 1, 0, 1]])
+        selector = events([[1, 1, 1, 0], [1, 0, 1, 1], [1, 0, 0, 1], [0, 1, 0, 1]])
+        return unary, covered, selector, torch.ones_like(unary)
+
+    def test_distinct_prefix_populations_and_failure_decomposition(self):
+        counts = hard_label_prefix_counts(*self._inputs())
+        torch.testing.assert_close(
+            counts.reached,
+            torch.tensor([[0.0, 4, 2, 1, 1], [0.0, 4, 4, 3, 2], [0.0, 4, 3, 1, 1]]),
+        )
+        torch.testing.assert_close(
+            counts.accepted,
+            torch.tensor([[0.0, 2, 1, 1, 0], [0.0, 4, 3, 2, 2], [0.0, 3, 1, 1, 0]]),
+        )
+        torch.testing.assert_close(
+            counts.selector_covered, torch.tensor([0.0, 4, 2, 1, 1])
+        )
+        torch.testing.assert_close(
+            counts.selector_unary_correct, torch.tensor([0.0, 2, 2, 1, 0])
+        )
+        # At position 2, the three reached selector prefixes split equally into
+        # an accepted token, a missing candidate, and a covered ranking error.
+        self.assertEqual(counts.accepted[2, 2], 1)
+        self.assertEqual((counts.reached[2] - counts.selector_covered)[2], 1)
+        self.assertEqual((counts.selector_covered - counts.accepted[2])[2], 1)
+        # Unary / oracle / selector lengths, each including one anchor.
+        torch.testing.assert_close(
+            1 + counts.accepted.sum(-1) / 4, torch.tensor([2.0, 3.75, 2.25])
+        )
+        survival = counts.accepted / 4
+        self.assertTrue(torch.all((survival >= 0) & (survival <= 1)))
+        self.assertTrue(torch.all(survival[:, 2:] <= survival[:, 1:-1]))
+
+    def test_masked_tails_and_internal_gaps_are_not_model_failures(self):
+        supervised = torch.tensor(
+            [[[1, 1, 0, 0], [1, 0, 1, 1], [0, 0, 0, 0]]], dtype=torch.bool
+        )
+        hit = torch.ones_like(supervised)
+        counts = hard_label_prefix_counts(hit, hit, hit, supervised)
+        expected = torch.tensor([0.0, 2, 1, 0, 0])
+        torch.testing.assert_close(counts.eligible, expected)
+        torch.testing.assert_close(counts.reached, expected.expand(3, -1))
+        torch.testing.assert_close(counts.accepted, counts.reached)
+
+    def test_plain_dflash_and_anchor_only_blocks(self):
+        unary, covered, _, supervised = self._inputs()
+        counts = hard_label_prefix_counts(unary, covered, None, supervised)
+        torch.testing.assert_close(counts.reached[2], torch.zeros(5))
+        torch.testing.assert_close(counts.accepted[2], torch.zeros(5))
+        torch.testing.assert_close(counts.selector_covered, torch.zeros(5))
+        empty = unary[..., :0]
+        counts = hard_label_prefix_counts(empty, empty, None, empty)
+        torch.testing.assert_close(counts.reached, torch.zeros(3, 1))
+        torch.testing.assert_close(counts.eligible, torch.zeros(1))
+
+    def test_counts_are_invariant_to_metric_chunk_size(self):
+        inputs = self._inputs()
+        expected = hard_label_prefix_counts(*inputs)
+        for chunk_size in (0, 1, 2, 3):
+            with self.subTest(chunk_size=chunk_size):
+                actual = checkpointed_chunk_reduce(
+                    hard_label_prefix_counts, *inputs, chunk_size=chunk_size, dim=1
+                )
+                for value, reference in zip(actual, expected):
+                    torch.testing.assert_close(value, reference)


### PR DESCRIPTION
## Motivation

DFlash2's `serving_accuracy` scores every supervised position, including tokens after an earlier mismatch. Its `conditional_accuracy` conditions on candidate coverage, rather than a correct preceding prefix. These names make it difficult to tell whether short accepted lengths come from early errors, later errors, missing candidates, or selector ranking.

This PR makes those populations explicit and adds prefix diagnostics for unary greedy, top-K oracle, and selector greedy paths on recorded training blocks.

## Modifications

- Rename the marginal and covered selector metrics, and label gold-probability / teacher-overlap chain lengths as training proxies. Remove duplicate `expected_acceptance`, `selector_loss`, and `selector_coverage` aliases; clarify the weighted selector objective metrics.
- Add per-position prefix acceptance, survival, reached/accepted/first-failure counts, and unary greedy accepted length. On selector-reached prefixes, report unary accuracy, top-K recall, covered selector accuracy, and the split between candidate misses and ranking errors.
- Report supervised-prefix counts and length so masked tails are distinguishable from model failures. Preserve the trainer's zero-denominator convention and document how counts identify unobserved rates.
- Carry additive counts through gradient accumulation and the existing packed DP sum before calculating rates. Reuse the existing diagnostic logits and greedy path, with no additional LM-head call or distributed collective.
- Add `train/optimizer_step` as an explicit checkpoint/eval join key and document every dashboard rename. Existing W&B history is unchanged.

These metrics describe fixed training blocks; they do not claim stochastic serving acceptance or a cross-block serving walk. Objectives, model parameters, and checkpoint formats are unchanged.

## Related Issues

Follow-up to #810.

## Accuracy Test

135 CPU tests and 12 subtests passed with Python 3.12, PyTorch 2.13.0, and Transformers 5.12.1:

```bash
python -m pytest -q \
  tests/test_utils/test_dflash_metrics.py \
  tests/test_utils/test_dflash_losses.py \
  tests/test_runtime/test_trainer.py \
  tests/test_runtime/test_tracking_logger.py \
  tests/test_runtime/test_evaluator_aggregation.py \
  tests/test_runtime/test_seam_fixes.py \
  tests/test_modeling/test_dflash2.py
```

Coverage includes hand-counted early/late failures, candidate-versus-ranking errors, masked tails and internal gaps, empty prefixes, plain DFlash, chunk invariance, unequal DP populations, accumulation/reset behavior, strategy-to-tracker plumbing, loss/gradient parity with diagnostics enabled or disabled, and the existing two-process Gloo eval regression.

`pre-commit run --all-files` and `git diff --check` passed.

## Benchmark & Profiling

No GPU training-throughput benchmark or serving eval was run. Detailed diagnostics retain the existing log-step gate; the added work consists of prefix masks, small reductions, and scalar telemetry. This draft is ready for code review and a GPU smoke test before rollout.

## Checklist

- [x] Run the repository formatting hooks.
- [x] Add and run relevant unit tests.
- [x] Update documentation, including the dashboard migration table.
- [ ] GPU smoke test / throughput measurement before rollout.
