### PR TITLE
docs: add DFlash2 and MTP to offline supports in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ topology remains in YAML. The complete
 environment contract is in the [disaggregated training
 guide](../docs/basic_usage/disaggregated_training.md).
 
-Offline feature training supports EAGLE3, DFlash, Domino, and DSpark, including
+Offline feature training supports EAGLE3, DFlash, DFlash2, Domino, DSpark, and MTP, including
 local and disaggregated consumers. Optional config sections provide
 offline evaluation with `<run_id>-best` selection, compact teacher
 projection for offline text EAGLE3, and W&B, TensorBoard, SwanLab, or MLflow


### PR DESCRIPTION
## Summary

`examples/README.md` said offline feature training supports EAGLE3 / DFlash / Domino / DSpark only. At the same HEAD, `docs/basic_usage/training.md` already documents offline support for **DFlash2** and **MTP** as well, and `specforge/algorithms/mtp/providers.py` registers an `OfflineDataProvider`.

Align the examples README capability sentence with the training guide.

## Repro

1. At `953d43a0`, read `examples/README.md` offline-supports sentence (omits DFlash2 / MTP).
2. Compare `docs/basic_usage/training.md` ("offline feature training supports EAGLE3, DFlash, DFlash2, Domino, DSpark, and MTP").
3. Confirm MTP offline path in `specforge/algorithms/mtp/providers.py` (`OfflineDataProvider`).

## Test plan

- [ ] Diff is the single capability-sentence update in `examples/README.md`
- [ ] Wording matches the training guide list (EAGLE3, DFlash, DFlash2, Domino, DSpark, and MTP)