### PR TITLE
docs: add MTP to configs README capability matrix

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -486,6 +486,7 @@ For deeper lifecycle and recovery semantics, see the
 | DFlash | consumer DP | DP | consumer DP |
 | Domino | consumer DP | DP | consumer DP |
 | DSpark | consumer DP | DP | consumer DP |
+| MTP | consumer DP | DP | consumer DP |
 | P-EAGLE | consumer DP, batch size 1 | No | No |
 
 `qwen3-8b-dpace-online.yaml` is the D-PACE recipe. It deliberately uses the


### PR DESCRIPTION
## Summary

The Capability matrix in `examples/configs/README.md` listed EAGLE3 / DFlash / Domino / DSpark / P-EAGLE but omitted **MTP**, which is already a builtin algorithm and is documented in the training guide's Supported combinations table.

Add an MTP row (`consumer DP` / `DP` / `consumer DP`) so the recipe catalog matrix matches the training guide.

## Repro

1. At `953d43a0`, open `examples/configs/README.md` → Capability matrix (no MTP row).
2. Compare `docs/basic_usage/training.md` Supported combinations (MTP: Yes / Yes / Yes).
3. Confirm `specforge/algorithms/builtin.py` registers `mtp()`, and `examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml` uses `training.strategy: mtp`.

## Test plan

- [ ] Diff is a single Capability matrix row addition in `examples/configs/README.md`
- [ ] Wording matches the existing matrix style and the training guide MTP support cells