### PR TITLE
docs: add MTP to llama3 offline also-supports list

### DIFF
--- a/docs/examples/llama3-eagle3-offline.md
+++ b/docs/examples/llama3-eagle3-offline.md
@@ -63,7 +63,7 @@ exists. The same recipe supports offline data parallelism through the typed
 For long sequences, EAGLE3 offline can instead use USP by setting
 `training.attention_backend=usp` and choosing
 `training.sp_ulysses_size`/`training.sp_ring_size`. Offline feature training
-also supports DFlash, DFlash2, Domino, and DSpark when the feature
+also supports DFlash, DFlash2, Domino, DSpark, and MTP when the feature
 checkpoints and draft config use that strategy's contract.
 `training.compact_teacher: true` enables
 the exact lower-memory teacher projection for offline text EAGLE3. See


### PR DESCRIPTION
## Summary

In `docs/examples/llama3-eagle3-offline.md`, the offline feature-training "also supports" sentence listed DFlash / DFlash2 / Domino / DSpark but omitted **MTP**.

At the same HEAD, `docs/basic_usage/training.md` already documents offline support for MTP, and `specforge/algorithms/mtp/providers.py` registers an `OfflineDataProvider`. Align the walkthrough with the training guide.

## Repro

1. At `953d43a0`, read `docs/examples/llama3-eagle3-offline.md` (omits MTP in the also-supports sentence).
2. Compare `docs/basic_usage/training.md` ("offline feature training supports EAGLE3, DFlash, DFlash2, Domino, DSpark, and MTP").
3. Confirm MTP offline path in `specforge/algorithms/mtp/providers.py` (`OfflineDataProvider`).

## Test plan

- [ ] Diff is the single also-supports sentence update in `docs/examples/llama3-eagle3-offline.md`
- [ ] Wording matches the training guide list (adds MTP after DSpark)