### PR TITLE
[Bugfix] Fix Issue 828

### DIFF
--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -693,12 +693,26 @@ class OnlineDFlashModel(nn.Module):
             covered_num=covered_num,
         )
 
+    @staticmethod
+    def _sequence_anchor_scale(weight_mask: torch.Tensor) -> torch.Tensor:
+        """Return 1 / valid-anchor-count for every anchor in each sequence."""
+
+        valid_anchor_counts = (weight_mask > 0).any(dim=-1).sum(dim=1, keepdim=True)
+        return (
+            valid_anchor_counts.to(weight_mask.dtype)
+            .clamp_min(1.0)
+            .reciprocal()
+            .unsqueeze(-1)
+            .expand(-1, weight_mask.shape[1], -1)
+        )
+
     def _dflash_objective_chunk_terms(
         self,
         hidden: torch.Tensor,
         target_ids: torch.Tensor,
         weight_mask: torch.Tensor,
         predecessor_ids: torch.Tensor,
+        sequence_anchor_scale: Optional[torch.Tensor] = None,
     ) -> DFlashObjectiveTerms:
         """Return a flat tuple of additive objective and metric tensors."""
 
@@ -740,7 +754,18 @@ class OnlineDFlashModel(nn.Module):
                     self.loss_type,
                 )
             loss_weights = weight_mask * dpace_weights
-            loss_den = loss_weights.sum()
+            valid_anchors = (weight_mask > 0).any(dim=-1)
+            if sequence_anchor_scale is None:
+                sequence_anchor_scale = self._sequence_anchor_scale(weight_mask)
+            loss_weights = loss_weights * sequence_anchor_scale
+            # Each valid anchor contributes 1 / A_b to the denominator, so
+            # reducing all chunks yields the number of valid sequences. This
+            # preserves D-PACE's total credit mass while balancing sequences
+            # with different numbers of sampled anchors.
+            loss_den = (
+                valid_anchors.to(weight_mask.dtype)
+                * sequence_anchor_scale.squeeze(-1)
+            ).sum()
         else:  # defensive: __init__ validates the configured loss type.
             raise ValueError(f"unknown loss_type {self.loss_type!r}")
 
@@ -806,6 +831,7 @@ class OnlineDFlashModel(nn.Module):
         weight_mask: torch.Tensor,
         predecessor_ids: torch.Tensor,
         aligned_target_hidden: Optional[torch.Tensor] = None,
+        sequence_anchor_scale: Optional[torch.Tensor] = None,
     ) -> DFlashMetricTerms:
         """Return additive unary, selector, and teacher diagnostics for one chunk.
 
@@ -823,6 +849,7 @@ class OnlineDFlashModel(nn.Module):
         loss_weights = self._dflash_metric_loss_weights(
             unary.hard_label_probability,
             weight_mask,
+            sequence_anchor_scale,
         )
         selector = None
         if candidate_selector is not None:
@@ -899,6 +926,7 @@ class OnlineDFlashModel(nn.Module):
         self,
         hard_label_probability: torch.Tensor,
         weight_mask: torch.Tensor,
+        sequence_anchor_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Reconstruct effective objective weights for position-share metrics."""
 
@@ -920,7 +948,9 @@ class OnlineDFlashModel(nn.Module):
             weight_mask > 0,
             self.loss_type,
         )
-        return weight_mask * dpace_weights
+        if sequence_anchor_scale is None:
+            sequence_anchor_scale = self._sequence_anchor_scale(weight_mask)
+        return weight_mask * dpace_weights * sequence_anchor_scale
 
     @staticmethod
     def _dflash2_selector_diagnostics(
@@ -1257,6 +1287,9 @@ class OnlineDFlashModel(nn.Module):
             if target_last_hidden_states is not None and collect_detailed_metrics
             else None
         )
+        sequence_anchor_scale = None
+        if self.loss_type in _DPACE_LOSS_TYPES:
+            sequence_anchor_scale = self._sequence_anchor_scale(weight_mask)
         (
             ce_loss_num,
             tv_loss_num,
@@ -1275,6 +1308,7 @@ class OnlineDFlashModel(nn.Module):
             target_ids,
             weight_mask,
             predecessor_ids,
+            sequence_anchor_scale,
             chunk_size=self.objective_chunk_blocks,
             dim=1,
         )
@@ -1353,6 +1387,7 @@ class OnlineDFlashModel(nn.Module):
                 weight_mask,
                 predecessor_ids,
                 aligned_target_hidden,
+                sequence_anchor_scale,
                 chunk_size=self.objective_chunk_blocks,
                 dim=1,
             )

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -763,8 +763,7 @@ class OnlineDFlashModel(nn.Module):
             # preserves D-PACE's total credit mass while balancing sequences
             # with different numbers of sampled anchors.
             loss_den = (
-                valid_anchors.to(weight_mask.dtype)
-                * sequence_anchor_scale.squeeze(-1)
+                valid_anchors.to(weight_mask.dtype) * sequence_anchor_scale.squeeze(-1)
             ).sum()
         else:  # defensive: __init__ validates the configured loss type.
             raise ValueError(f"unknown loss_type {self.loss_type!r}")

--- a/tests/test_modeling/test_dflash2.py
+++ b/tests/test_modeling/test_dflash2.py
@@ -604,6 +604,20 @@ class CandidateSelectorTest(unittest.TestCase):
             .gather(-1, target_ids[0].unsqueeze(-1))
             .squeeze(-1)
         )
+        expected_loss_weights = (
+            weights
+            * model._dpace_weight(
+                gold_probability.unsqueeze(0),
+                weights,
+                weights > 0,
+                "dpace",
+            )
+            / 2.0
+        )
+        torch.testing.assert_close(
+            terms.loss_weight_num,
+            expected_loss_weights.sum(dim=(0, 1)),
+        )
         torch.testing.assert_close(
             terms.expected_accepted_length_num,
             (1.0 + gold_probability[:, 1:].cumprod(dim=-1).sum(dim=-1)).sum(),
@@ -928,6 +942,41 @@ class CandidateSelectorTest(unittest.TestCase):
             selector_ce * dpace_weight,
         )
         torch.testing.assert_close(dpace_terms.selector_weight_den, dpace_weight)
+        self.assertEqual(dpace_terms.loss_den.item(), 1.0)
+
+        # Sequence-balanced anchor normalization applies the same 1 / A_b
+        # scale to the shared base and selector numerators. The first sequence
+        # has two valid anchors while the second has one.
+        multi_hidden = hidden.expand(2, 2, -1, -1).clone()
+        multi_targets = covered_targets.expand(2, 2, -1).clone()
+        multi_weights = torch.tensor(
+            [
+                [[0.0, 1.0], [0.0, 1.0]],
+                [[0.0, 1.0], [0.0, 0.0]],
+            ]
+        )
+        multi_predecessors = predecessors.expand(2, 2, -1).clone()
+
+        multi_terms = model._dflash_objective_chunk_terms(
+            multi_hidden,
+            multi_targets,
+            multi_weights,
+            multi_predecessors,
+        )
+
+        torch.testing.assert_close(
+            multi_terms.ce_loss_num,
+            2.0 * covered_base_ce * dpace_weight,
+        )
+        torch.testing.assert_close(
+            multi_terms.selector_ce_num,
+            2.0 * selector_ce * dpace_weight,
+        )
+        torch.testing.assert_close(
+            multi_terms.selector_weight_den,
+            2.0 * dpace_weight,
+        )
+        self.assertEqual(multi_terms.loss_den.item(), 2.0)
 
     def test_selector_keeps_ce_when_base_uses_tv(self):
         class Draft(nn.Module):

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -325,6 +325,22 @@ def _naive_dflash_loss(neg_log_q, binary_mask, gamma):
     return (neg_log_q * weight).sum() / weight.sum()
 
 
+def _sequence_balanced_anchor_terms(per_token_loss, loss_weights, binary_mask):
+    valid_anchors = (binary_mask > 0).any(dim=-1)
+    anchor_counts = valid_anchors.sum(dim=1).to(per_token_loss.dtype)
+    sequence_numerators = (per_token_loss * loss_weights).sum(dim=(1, 2))
+    valid_sequences = anchor_counts > 0
+    normalized_sequence_numerators = torch.where(
+        valid_sequences,
+        sequence_numerators / anchor_counts.clamp_min(1.0),
+        torch.zeros_like(sequence_numerators),
+    )
+    return (
+        normalized_sequence_numerators.sum(),
+        valid_sequences.sum().to(per_token_loss.dtype),
+    )
+
+
 class TestDFlashLosses(unittest.TestCase):
     def setUp(self):
         (
@@ -440,7 +456,12 @@ class TestDFlashLosses(unittest.TestCase):
         got = self._forward_loss(loss_type="dpace", dpace_alpha=alpha)
         weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
         effective_weight = weight * self.binary_mask
-        want = (self.neg_log_q * effective_weight).sum() / effective_weight.sum()
+        numerator, denominator = _sequence_balanced_anchor_terms(
+            self.neg_log_q,
+            effective_weight,
+            self.binary_mask,
+        )
+        want = numerator / denominator
         torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
 
     def test_dpace_tv_uses_dynamic_position_weights(self):
@@ -452,7 +473,12 @@ class TestDFlashLosses(unittest.TestCase):
         )
         weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
         effective_weight = weight * self.binary_mask
-        want = ((1.0 - self.q) * effective_weight).sum() / effective_weight.sum()
+        numerator, denominator = _sequence_balanced_anchor_terms(
+            1.0 - self.q,
+            effective_weight,
+            self.binary_mask,
+        )
+        want = numerator / denominator
         torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
 
     def test_cumulative_confidence_ablation_matches_naive_reference(self):
@@ -467,7 +493,12 @@ class TestDFlashLosses(unittest.TestCase):
             "dpace-cumulative-confidence-only",
         )
         effective_weight = weight * self.binary_mask
-        want = (self.neg_log_q * effective_weight).sum() / effective_weight.sum()
+        numerator, denominator = _sequence_balanced_anchor_terms(
+            self.neg_log_q,
+            effective_weight,
+            self.binary_mask,
+        )
+        want = numerator / denominator
         torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
 
     def test_continuation_value_ablation_matches_naive_reference(self):
@@ -482,10 +513,15 @@ class TestDFlashLosses(unittest.TestCase):
             "dpace-continuation-value-only",
         )
         effective_weight = weight * self.binary_mask
-        want = (self.neg_log_q * effective_weight).sum() / effective_weight.sum()
+        numerator, denominator = _sequence_balanced_anchor_terms(
+            self.neg_log_q,
+            effective_weight,
+            self.binary_mask,
+        )
+        want = numerator / denominator
         torch.testing.assert_close(got, want, rtol=0, atol=1e-10)
 
-    def test_dpace_loss_reduces_by_effective_token_weight(self):
+    def test_dpace_loss_reduces_by_sequence_balanced_anchor_count(self):
         alpha = 0.5
         model = _make_model(
             self.logits,
@@ -501,12 +537,14 @@ class TestDFlashLosses(unittest.TestCase):
         )
         weight = _naive_dpace_weight(self.q, self.binary_mask, alpha, "dpace")
         effective_weight = weight * self.binary_mask
-        weighted_sum = (self.neg_log_q * effective_weight).sum()
-        effective_weight_sum = effective_weight.sum()
-        token_loss = weighted_sum / effective_weight_sum
-        torch.testing.assert_close(got, token_loss, rtol=0, atol=1e-10)
-        torch.testing.assert_close(metrics["loss_terms"][0], weighted_sum)
-        torch.testing.assert_close(metrics["loss_terms"][1], effective_weight_sum)
+        numerator, denominator = _sequence_balanced_anchor_terms(
+            self.neg_log_q,
+            effective_weight,
+            self.binary_mask,
+        )
+        torch.testing.assert_close(got, numerator / denominator, rtol=0, atol=1e-10)
+        torch.testing.assert_close(metrics["loss_terms"][0], numerator)
+        torch.testing.assert_close(metrics["loss_terms"][1], denominator)
 
     def test_dpace_zero_effective_weight_has_finite_local_loss(self):
         logits = torch.zeros_like(self.logits)
@@ -527,7 +565,10 @@ class TestDFlashLosses(unittest.TestCase):
 
         self.assertTrue(torch.isfinite(loss))
         self.assertEqual(loss.item(), 0.0)
-        self.assertEqual(metrics["loss_terms"][1].item(), 0.0)
+        valid_sequences = (
+            (self.binary_mask > 0).any(dim=-1).any(dim=-1).sum().item()
+        )
+        self.assertEqual(metrics["loss_terms"][1].item(), valid_sequences)
 
     def test_alpha_changes_dpace_loss(self):
         low_alpha = self._forward_loss(loss_type="dpace", dpace_alpha=0.1)

--- a/tests/test_utils/test_dflash_losses.py
+++ b/tests/test_utils/test_dflash_losses.py
@@ -565,9 +565,7 @@ class TestDFlashLosses(unittest.TestCase):
 
         self.assertTrue(torch.isfinite(loss))
         self.assertEqual(loss.item(), 0.0)
-        valid_sequences = (
-            (self.binary_mask > 0).any(dim=-1).any(dim=-1).sum().item()
-        )
+        valid_sequences = (self.binary_mask > 0).any(dim=-1).any(dim=-1).sum().item()
         self.assertEqual(metrics["loss_terms"][1].item(), valid_sequences)
 
     def test_alpha_changes_dpace_loss(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

  The D-PACE objective was normalized by the sum of its position weights:

$$ L = \frac{\sum_{b,i} w_{b,i}\ell_{b,i}}{\sum_{b,i} w_{b,i}} $$

  Because D-PACE position weights represent expected accepted-length credit, dividing by their sum removes the overall credit mass and changes the intended objective.

  This PR changes the denominator to use sequence-balanced valid-anchor normalization. It preserves D-PACE credit while preventing sequences with more sampled anchors
  from receiving disproportionately larger weight:

  $$L =\frac{1}{B_{\mathrm{valid}}}\sum_b  \frac{\sum_i w_{b,i}\ell_{b,i}}{A_b}$$
  where $\(A_b\)$ is the number of valid sampled anchors in sequence $\(b\)$, and $\(B_{\mathrm{valid}}\)$ is the number of sequences containing at least one valid anchor.

  ## Modifications

  - Normalize D-PACE losses by valid sampled anchors instead of the sum of D-PACE position weights.
  - Balance each sequence by scaling its objective terms by $$\(1 / A_b\)$$.
  - Preserve additive numerator/denominator semantics across:
    - objective chunking
    - gradient accumulation
    - distributed data-parallel reduction
  - Apply the same per-sequence scaling to:
    - D-PACE CE
    - D-PACE with TV/LK objectives
    - cumulative-confidence-only and continuation-value-only ablations
    - the DFlash2 selector objective
  - Align detailed DFlash2 loss-weight metrics with the effective training weights.
  - Keep the standard `loss_type=dflash` behavior unchanged.
  - Add regression tests for:
    - batches with unequal valid-anchor counts
    - D-PACE CE and TV/LK variants
    - D-PACE ablations
    - zero-credit edge cases
    - DFlash2 selector scaling
    - chunked and unchunked objective equivalence
    - trainer accumulation and reduction behavior

  ## Related Issues

  Fixes #828

  ## Accuracy Test

  This PR changes the D-PACE loss normalization but does not modify the model architecture, inference path, or kernels.

  Formula-level and model-side regression tests pass:

  - 106 tests passed
  - 50 subtests passed
  - DFlash and DFlash2 objective tests passed
  - Chunked and unchunked loss/gradient equivalence tests passed
  - Trainer accumulation and reduction tests passed

  A full checkpoint training comparison is not included in this PR.

  ## Benchmark & Profiling
## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling) and [Accuracy Results](https://docs.sglang.io/docs/developer_guide/evaluating_new_models).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
