### PR TITLE
docs: note MTP requires explicit draft_model_config

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -270,11 +270,13 @@ See the dedicated [DFlash2 guide](../concepts/DFlash2.md) for the complete
 model-field constraints, offline feature workflow, selector schedule, and
 serving compatibility boundary.
 
-Domino and DSpark need their projector/head metadata, so they require an
-explicit draft config (or a pretrained warm-start source that contains
-`config.json`). The old Domino parser exposed an optional config flag, but its
-no-config branch immediately failed because those required projector fields
-had no defaults; the unified schema rejects that unusable combination early.
+Domino, DSpark, and MTP require an explicit draft config (or a pretrained
+warm-start source that contains `config.json`). Domino and DSpark need their
+projector/head metadata; MTP selects the Qwen3.5 native MTP draft architecture
+(`Qwen3_5MTPDraftModel`) and has no automatic target-derived draft defaults.
+The old Domino parser exposed an optional config flag, but its no-config branch
+immediately failed because those required projector fields had no defaults; the
+unified schema rejects that unusable combination early.
 
 There are two deliberately separate checkpoint operations:
 


### PR DESCRIPTION
## Motivation

`docs/basic_usage/training.md` documents that Domino and DSpark require an
explicit `model.draft_model_config` (or a warm-start source with
`config.json`), but omits MTP.

On `main`, MTP is registered without automatic target-derived draft defaults:

```python
# specforge/algorithms/mtp/providers.py
draft_config=DraftConfigProvider(
    architecture=DRAFT_ARCHITECTURE,
    expected_auto_map_model="mtp.Qwen3_5MTPDraftModel",
)
# no target_defaults=...
```

`specforge/application/planning.py` rejects a missing draft config whenever
`provider.target_defaults is None`:

```text
training.strategy='mtp' requires model.draft_model_config; automatic
target-derived configs are not registered for this algorithm
```

The checked-in Ascend recipe already sets an explicit config:

`examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml`
→ `draft_model_config: "configs/qwen3.5-4b-mtp.json"`.

EAGLE3 / P-EAGLE / DFlash still may omit the field because they register
`target_defaults=TargetDerivedDraftDefaults(...)`.

## Repro steps

```bash
# 1. Confirm MTP has no target-derived defaults
python - <<'PY'
from specforge.algorithms.builtin import builtin_algorithm_registry
reg = builtin_algorithm_registry()
mtp = reg.get("mtp")
print("target_defaults:", mtp.providers.model.draft_config.target_defaults)
PY
# expected: target_defaults: None

# 2. Confirm planning requires draft_model_config for MTP
python - <<'PY'
from copy import deepcopy
from specforge.cli import load_config
from specforge.application.planning import ensure_draft_config_source
from specforge.algorithms.builtin import builtin_algorithm_registry

cfg = load_config(
    "examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml",
    [],
)
raw = deepcopy(cfg)
# strip draft config
object.__setattr__(cfg.model, "draft_model_config", None) if False else None
cfg.model.draft_model_config = None
cfg.model.draft_checkpoint_path = None
algo = builtin_algorithm_registry().get("mtp")
try:
    ensure_draft_config_source(cfg, algo)
except Exception as e:
    print(type(e).__name__ + ":", e)
PY
# expected: ValueError: training.strategy='mtp' requires model.draft_model_config; ...

# 3. Doc gap on main
grep -n "Domino and DSpark need their projector" docs/basic_usage/training.md
# MTP is missing from that sentence before this PR
```

## Modifications

- `docs/basic_usage/training.md`: state that Domino, DSpark, **and MTP** require
  an explicit draft config; keep the Domino/DSpark projector rationale and note
  MTP uses `Qwen3_5MTPDraftModel` with no automatic target-derived defaults.

Docs only; one file.

## Related Issues

None.

## Accuracy Test

Not applicable — documentation only.

## Benchmark & Profiling

Not applicable — documentation only.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/references/contribution_guide.html#writing-documentation).
- [x] Provide accuracy test results and benchmark results if needed (N/A for docs).
- [x] For changes that might introduce different code paths across hardware backends or backends (e.g., `flashinfer`, `triton`), please thoroughly test them on each backend and leave a note.
- [x] Please leave a note if you need to wait for an unofficial PyTorch release or a CUDA version to be ready (N/A).