### PR TITLE
docs: note MTP requires draft_model_config in configs catalog

### DIFF
--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -174,7 +174,7 @@ should make their training strategy and topology explicit.
 | Field | Default | What to write |
 | --- | --- | --- |
 | `model.target_model_path` | required | Local target directory or Hugging Face repository ID. |
-| `model.draft_model_config` | `null` | Draft JSON, model directory containing `config.json`, or Hugging Face repository. EAGLE3, P-EAGLE, and DFlash may omit it and derive a fresh config; Domino and DSpark require one. |
+| `model.draft_model_config` | `null` | Draft JSON, model directory containing `config.json`, or Hugging Face repository. EAGLE3, P-EAGLE, and DFlash may omit it and derive a fresh config; Domino, DSpark, and MTP require one. |
 | `model.draft_checkpoint_path` | `null` | Weights-only warm start for a new run. Do not combine it with `training.resume_from`. |
 | `model.draft_num_hidden_layers` | `null` | Positive fresh-architecture override where the strategy permits it. EAGLE3 remains one layer; P-EAGLE and DFlash may override their generated defaults. |
 | `model.draft_block_size` | `null` | Positive DFlash block-size override; generated DFlash configs default to 16. |


### PR DESCRIPTION
## Summary

In examples/configs/README.md, the model.draft_model_config catalog row said EAGLE3 / P-EAGLE / DFlash may omit a draft config while Domino and DSpark require one. MTP also has no target_defaults and selects Qwen3_5MTPDraftModel, so omitting the field fails the same way.

## Change

- Update the row to: Domino, DSpark, and MTP require one.

Verified against specforge/algorithms/mtp/providers.py (DraftConfigProvider without target_defaults), the checked-in qwen3.5-4b-mtp-disaggregated-npu.yaml, and the parallel wording in docs/basic_usage/training.md.

## Test plan

- [ ] Docs-only; confirm the catalog row matches training guide semantics
- [ ] No code changes