### PR TITLE
docs: note MTP requires --draft-model-config in data prep

### DIFF
--- a/docs/basic_usage/data_preparation.md
+++ b/docs/basic_usage/data_preparation.md
@@ -288,7 +288,7 @@ Use these strategy/model pairs for the checked-in offline colocated recipes:
 | DSpark | `Qwen/Qwen3-4B` | `configs/qwen3-4b-dspark.json` | `cache/hidden_states/qwen3-4b-dspark-sharegpt` |
 
 `--strategy` defaults to `eagle3` for compatibility. Pass it explicitly in
-reproducible jobs. `--draft-model-config` is required for Domino and DSpark;
+reproducible jobs. `--draft-model-config` is required for Domino, DSpark, and MTP;
 passing the same explicit config used by training is recommended for every
 strategy. Capture layers come from the resolved draft config. EAGLE3 retains
 target-derived defaults for legacy configs that do not define

--- a/docs/basic_usage/disaggregated_training.md
+++ b/docs/basic_usage/disaggregated_training.md
@@ -434,7 +434,7 @@ deployment:
 ```
 
 Both paths must be visible at the same location from producer and consumer
-nodes. The producer ingests existing EAGLE3, DFlash/DFlash2, Domino, or DSpark
+nodes. The producer ingests existing EAGLE3, DFlash/DFlash2, Domino, DSpark, or MTP
 features and publishes a fixed manifest. Offline epochs remain re-iterable.
 
 Set `backend: mooncake` instead, omit `store_root`, and provide the Mooncake


### PR DESCRIPTION
## Summary

- In `docs/basic_usage/data_preparation.md`, document that offline `--draft-model-config` is required for **MTP** as well as Domino and DSpark.
- In `docs/basic_usage/disaggregated_training.md`, include MTP in the offline-disagg producer ingest strategy list.

## Motivation

`specforge/application/planning.py` rejects a missing `model.draft_model_config` when the algorithm has no `target_defaults`. EAGLE3 / P-EAGLE / DFlash register target-derived defaults; Domino, DSpark, and MTP do not (`specforge/algorithms/mtp/providers.py`). Nearby docs already call this out for training configs, but the offline `prepare_hidden_states` guidance still said only Domino and DSpark.

MTP also exposes an offline reader/normalizer, and training docs already list MTP as offline-capable, so the offline-disagg producer sentence should list it too.

## Repro

At `953d43a0c1c0`:

```text
# data_preparation.md (before)
`--draft-model-config` is required for Domino and DSpark;

# code: planning._validate_draft_options
# raises when draft_model_config unset and provider.target_defaults is None
# mtp providers: no target_defaults
```

Related open wording fixes elsewhere do not touch these two lines.
