### PR TITLE
Normalise dflash-variant config

### DIFF
--- a/bench_domino_mfu.py
+++ b/bench_domino_mfu.py
@@ -29,6 +29,7 @@ CFG_PATH = "configs/qwen3-8b-domino.json"
 def build(dtype, device):
     raw = json.load(open(CFG_PATH))
     dfc = raw["dflash_config"]
+    domino_config = raw.get("domino_config", dfc)
     cfg = Qwen3Config(
         hidden_size=raw["hidden_size"],
         num_hidden_layers=raw["num_hidden_layers"],
@@ -65,7 +66,7 @@ def build(dtype, device):
         attention_backend="sdpa",
         num_anchors=NUM_ANCHORS,
         loss_decay_gamma=7.0,
-        shift_label=dfc.get("shift_label", True),
+        shift_label=domino_config.get("shift_label", True),
     )
     n_train = sum(p.numel() for p in draft.parameters() if p.requires_grad)
     return model, cfg, n_train

--- a/configs/glm-5.2-dspark.json
+++ b/configs/glm-5.2-dspark.json
@@ -12,7 +12,6 @@
     "target_layer_ids": [1, 19, 38, 57, 76]
   },
   "dspark_config": {
-    "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",

--- a/configs/glm-5.2-dspark.json
+++ b/configs/glm-5.2-dspark.json
@@ -7,14 +7,16 @@
   "bos_token_id": null,
   "dflash_config": {
     "attention_mode": "gqa",
+    "mask_token_id": 154856,
+    "projector_type": "dspark",
+    "target_layer_ids": [1, 19, 38, 57, 76]
+  },
+  "dspark_config": {
     "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",
-    "markov_rank": 256,
-    "mask_token_id": 154856,
-    "projector_type": "dspark",
-    "target_layer_ids": [1, 19, 38, 57, 76]
+    "markov_rank": 256
   },
   "dtype": "bfloat16",
   "eos_token_id": [154820, 154827, 154829],

--- a/configs/inkling-dspark.json
+++ b/configs/inkling-dspark.json
@@ -12,7 +12,6 @@
     "target_layer_ids": [5, 17, 35, 47, 59]
   },
   "dspark_config": {
-    "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",

--- a/configs/inkling-dspark.json
+++ b/configs/inkling-dspark.json
@@ -7,14 +7,16 @@
   "bos_token_id": null,
   "dflash_config": {
     "attention_mode": "gqa",
+    "mask_token_id": 200064,
+    "projector_type": "dspark",
+    "target_layer_ids": [5, 17, 35, 47, 59]
+  },
+  "dspark_config": {
     "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",
-    "markov_rank": 256,
-    "mask_token_id": 200064,
-    "projector_type": "dspark",
-    "target_layer_ids": [5, 17, 35, 47, 59]
+    "markov_rank": 256
   },
   "dtype": "bfloat16",
   "eos_token_id": 200006,

--- a/configs/kimi-k3-dspark.json
+++ b/configs/kimi-k3-dspark.json
@@ -12,7 +12,6 @@
     "target_layer_ids": [7, 23, 51, 67, 83]
   },
   "dspark_config": {
-    "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",

--- a/configs/kimi-k3-dspark.json
+++ b/configs/kimi-k3-dspark.json
@@ -7,14 +7,16 @@
   "bos_token_id": 163584,
   "dflash_config": {
     "attention_mode": "gqa",
+    "mask_token_id": 163824,
+    "projector_type": "dspark",
+    "target_layer_ids": [7, 23, 51, 67, 83]
+  },
+  "dspark_config": {
     "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",
-    "markov_rank": 256,
-    "mask_token_id": 163824,
-    "projector_type": "dspark",
-    "target_layer_ids": [7, 23, 51, 67, 83]
+    "markov_rank": 256
   },
   "dtype": "bfloat16",
   "eos_token_id": 163586,

--- a/configs/qwen3-4b-dspark.json
+++ b/configs/qwen3-4b-dspark.json
@@ -18,7 +18,6 @@
   "dspark_config": {
     "markov_rank": 256,
     "markov_head_type": "vanilla",
-    "confidence_head_alpha": 1.0,
     "enable_confidence_head": true,
     "confidence_head_with_markov": true
   },

--- a/configs/qwen3-4b-dspark.json
+++ b/configs/qwen3-4b-dspark.json
@@ -13,7 +13,9 @@
     "attention_mode": "gqa",
     "mask_token_id": 151669,
     "target_layer_ids": [1, 9, 17, 25, 33],
-    "projector_type": "dspark",
+    "projector_type": "dspark"
+  },
+  "dspark_config": {
     "markov_rank": 256,
     "markov_head_type": "vanilla",
     "confidence_head_alpha": 1.0,

--- a/configs/qwen3-8b-domino.json
+++ b/configs/qwen3-8b-domino.json
@@ -13,7 +13,9 @@
   "dflash_config": {
     "mask_token_id": 151669,
     "target_layer_ids": [1, 9, 17, 25, 33],
-    "projector_type": "domino",
+    "projector_type": "domino"
+  },
+  "domino_config": {
     "pure_draft_prefix_len": 1,
     "emb_dim": 256,
     "gru_hidden_dim": 1024,

--- a/configs/qwen3-8b-dspark.json
+++ b/configs/qwen3-8b-dspark.json
@@ -7,14 +7,16 @@
   "bos_token_id": 151643,
   "dflash_config": {
     "attention_mode": "gqa",
+    "mask_token_id": 151669,
+    "projector_type": "dspark",
+    "target_layer_ids": [1, 9, 17, 25, 33]
+  },
+  "dspark_config": {
     "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",
-    "markov_rank": 256,
-    "mask_token_id": 151669,
-    "projector_type": "dspark",
-    "target_layer_ids": [1, 9, 17, 25, 33]
+    "markov_rank": 256
   },
   "dtype": "bfloat16",
   "eos_token_id": 151645,

--- a/configs/qwen3-8b-dspark.json
+++ b/configs/qwen3-8b-dspark.json
@@ -12,7 +12,6 @@
     "target_layer_ids": [1, 9, 17, 25, 33]
   },
   "dspark_config": {
-    "confidence_head_alpha": 1.0,
     "confidence_head_with_markov": true,
     "enable_confidence_head": true,
     "markov_head_type": "vanilla",

--- a/configs/qwen3.5-4b-domino.json
+++ b/configs/qwen3.5-4b-domino.json
@@ -12,7 +12,9 @@
   "dflash_config": {
     "mask_token_id": 248070,
     "target_layer_ids": [3, 11, 19, 27, 31],
-    "projector_type": "domino",
+    "projector_type": "domino"
+  },
+  "domino_config": {
     "pure_draft_prefix_len": 1,
     "emb_dim": 256,
     "gru_hidden_dim": 1024,

--- a/configs/qwen3.6-27b-domino-full-attention.json
+++ b/configs/qwen3.6-27b-domino-full-attention.json
@@ -12,7 +12,9 @@
   "dflash_config": {
     "mask_token_id": 248070,
     "target_layer_ids": [1, 16, 31, 46, 61],
-    "projector_type": "domino",
+    "projector_type": "domino"
+  },
+  "domino_config": {
     "pure_draft_prefix_len": 1,
     "emb_dim": 256,
     "gru_hidden_dim": 1024,

--- a/configs/qwen3.6-27b-dspark.json
+++ b/configs/qwen3.6-27b-dspark.json
@@ -20,7 +20,6 @@
         ]
     },
     "dspark_config": {
-        "confidence_head_alpha": 1.0,
         "confidence_head_with_markov": true,
         "enable_confidence_head": true,
         "markov_head_type": "vanilla",

--- a/configs/qwen3.6-27b-dspark.json
+++ b/configs/qwen3.6-27b-dspark.json
@@ -9,11 +9,6 @@
     },
     "dflash_config": {
         "attention_mode": "gqa",
-        "confidence_head_alpha": 1.0,
-        "confidence_head_with_markov": true,
-        "enable_confidence_head": true,
-        "markov_head_type": "vanilla",
-        "markov_rank": 256,
         "mask_token_id": 248070,
         "projector_type": "dspark",
         "target_layer_ids": [
@@ -24,7 +19,13 @@
             62
         ]
     },
-
+    "dspark_config": {
+        "confidence_head_alpha": 1.0,
+        "confidence_head_with_markov": true,
+        "enable_confidence_head": true,
+        "markov_head_type": "vanilla",
+        "markov_rank": 256
+    },
     "block_size": 16,
     "dtype": "bfloat16",
     "target_hidden_size": null,

--- a/scripts/gates/normalize_dflash_export.py
+++ b/scripts/gates/normalize_dflash_export.py
@@ -127,10 +127,17 @@ def normalize_export(config_path: str, expected_block_size: int) -> Dict[str, An
         )
 
     if projector_type == "dspark":
-        _normalize_dspark(config, method_config)
+        dspark_config = config.get("dspark_config")
+        if dspark_config is None:
+            dspark_config = method_config
+        _normalize_dspark(config, dspark_config)
     elif _DFLASH2_ARCHITECTURE in (config.get("architectures") or []):
         _normalize_dflash2(config, method_config)
     else:
+        domino_config = config.get("domino_config")
+        if projector_type == "domino" and domino_config is not None:
+            method_config.update(domino_config)
+            config["dflash_config"] = method_config
         config["architectures"] = ["DFlashDraftModel"]
     config.pop("auto_map", None)
     with path.open("w", encoding="utf-8") as handle:

--- a/specforge/modeling/draft/dflash.py
+++ b/specforge/modeling/draft/dflash.py
@@ -39,6 +39,15 @@ def sample(logits: torch.Tensor, temperature: float = 0.0) -> torch.Tensor:
     return torch.multinomial(probs, num_samples=1).view(bsz, seq_len)
 
 
+def resolve_dflash_variant_config(config, variant_config_name: str) -> dict:
+    """Return a variant's config, falling back to the DFlash section."""
+
+    variant_config = getattr(config, variant_config_name, None)
+    if variant_config is not None:
+        return variant_config
+    return getattr(config, "dflash_config", None) or {}
+
+
 def resolve_dflash_attention_layout(
     config: Qwen3Config,
 ) -> tuple[tuple[str, ...], Optional[int]]:
@@ -719,7 +728,7 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
         self.projector_type = dflash_config.get("projector_type", None)
         self.pure_draft_prefix_len = dflash_config.get("pure_draft_prefix_len", 0)
         self.shift_label = dflash_config.get("shift_label", False)
-        self._init_draft_head(config, dflash_config)
+        self._init_draft_head(config)
         self.register_load_state_dict_pre_hook(normalize_draft_head_checkpoint_keys)
         self.post_init()
 
@@ -733,8 +742,8 @@ class DFlashDraftModel(Qwen3PreTrainedModel):
 
         return self.decoder_layer_class(config, layer_idx, kernels)
 
-    def _init_draft_head(self, config, dflash_config: dict) -> None:
-        del config, dflash_config
+    def _init_draft_head(self, config) -> None:
+        del config
 
     def apply_logits_head(
         self,

--- a/specforge/modeling/draft/dflash2.py
+++ b/specforge/modeling/draft/dflash2.py
@@ -354,7 +354,8 @@ class DFlash2DraftModel(DFlashDraftModel):
             mlp_conv=grouped_conv(),
         )
 
-    def _init_draft_head(self, config: Qwen3Config, dflash_config: dict) -> None:
+    def _init_draft_head(self, config: Qwen3Config) -> None:
+        dflash_config = getattr(config, "dflash_config", {})
         selector_rank = dflash_config.get("selector_rank")
         selector_top_k = dflash_config.get("selector_top_k")
         if not isinstance(selector_rank, int) or isinstance(selector_rank, bool):

--- a/specforge/modeling/draft/domino.py
+++ b/specforge/modeling/draft/domino.py
@@ -11,7 +11,7 @@ from torch.func import functional_call
 
 from specforge.utils import get_device_type
 
-from .dflash import DFlashDraftModel, sample
+from .dflash import DFlashDraftModel, resolve_dflash_variant_config, sample
 from .registry import register_draft
 
 
@@ -33,11 +33,12 @@ class DominoDraftModel(DFlashDraftModel):
             )
         super().__init__(config)
 
-    def _init_draft_head(self, config, dflash_config: dict) -> None:
-        self.emb_dim = int(dflash_config["emb_dim"])
-        self.gru_hidden_dim = int(dflash_config["gru_hidden_dim"])
-        self.pure_draft_prefix_len = int(dflash_config.get("pure_draft_prefix_len", 0))
-        self.shift_label = bool(dflash_config.get("shift_label", False))
+    def _init_draft_head(self, config) -> None:
+        domino_config = resolve_dflash_variant_config(config, "domino_config")
+        self.emb_dim = int(domino_config["emb_dim"])
+        self.gru_hidden_dim = int(domino_config["gru_hidden_dim"])
+        self.pure_draft_prefix_len = int(domino_config.get("pure_draft_prefix_len", 0))
+        self.shift_label = bool(domino_config.get("shift_label", False))
 
         self.prefix_gru = nn.GRU(
             input_size=config.hidden_size,

--- a/specforge/modeling/draft/dspark.py
+++ b/specforge/modeling/draft/dspark.py
@@ -8,7 +8,11 @@ from typing import Optional, Tuple
 import torch
 from torch import nn
 
-from .dflash import DFlashDraftModel, resolve_dflash_attention_mode
+from .dflash import (
+    DFlashDraftModel,
+    resolve_dflash_attention_mode,
+    resolve_dflash_variant_config,
+)
 from .registry import register_draft
 
 
@@ -336,14 +340,15 @@ class DSparkDraftModel(DFlashDraftModel):
         )
         return sampled_tokens
 
-    def _init_draft_head(self, config, dflash_config: dict) -> None:
-        self.markov_head = build_markov_head(config, dflash_config)
-        confidence_alpha = float(dflash_config.get("confidence_head_alpha", 0.0) or 0.0)
+    def _init_draft_head(self, config) -> None:
+        dspark_config = resolve_dflash_variant_config(config, "dspark_config")
+        self.markov_head = build_markov_head(config, dspark_config)
+        confidence_alpha = float(dspark_config.get("confidence_head_alpha", 0.0) or 0.0)
         self.enable_confidence_head = bool(
-            dflash_config.get("enable_confidence_head", confidence_alpha > 0.0)
+            dspark_config.get("enable_confidence_head", confidence_alpha > 0.0)
         )
         self.confidence_head_with_markov = bool(
-            dflash_config.get("confidence_head_with_markov", False)
+            dspark_config.get("confidence_head_with_markov", False)
         )
         if self.confidence_head_with_markov and self.markov_head is None:
             raise ValueError(

--- a/specforge/modeling/draft/dspark.py
+++ b/specforge/modeling/draft/dspark.py
@@ -343,9 +343,8 @@ class DSparkDraftModel(DFlashDraftModel):
     def _init_draft_head(self, config) -> None:
         dspark_config = resolve_dflash_variant_config(config, "dspark_config")
         self.markov_head = build_markov_head(config, dspark_config)
-        confidence_alpha = float(dspark_config.get("confidence_head_alpha", 0.0) or 0.0)
         self.enable_confidence_head = bool(
-            dspark_config.get("enable_confidence_head", confidence_alpha > 0.0)
+            dspark_config.get("enable_confidence_head", False)
         )
         self.confidence_head_with_markov = bool(
             dspark_config.get("confidence_head_with_markov", False)

--- a/tests/test_modeling/test_draft_registry.py
+++ b/tests/test_modeling/test_draft_registry.py
@@ -64,6 +64,8 @@ TINY_DSPARK = {
     "layer_types": ["full_attention"],
     "dflash_config": {
         "projector_type": "dspark",
+    },
+    "dspark_config": {
         "markov_rank": 8,
         "markov_head_type": "vanilla",
         "confidence_head_alpha": 1.0,
@@ -91,6 +93,8 @@ TINY_DOMINO = {
     "layer_types": ["full_attention"],
     "dflash_config": {
         "projector_type": "domino",
+    },
+    "domino_config": {
         "emb_dim": 16,
         "gru_hidden_dim": 16,
         "pure_draft_prefix_len": 0,

--- a/tests/test_modeling/test_draft_registry.py
+++ b/tests/test_modeling/test_draft_registry.py
@@ -68,7 +68,7 @@ TINY_DSPARK = {
     "dspark_config": {
         "markov_rank": 8,
         "markov_head_type": "vanilla",
-        "confidence_head_alpha": 1.0,
+        "enable_confidence_head": True,
         "confidence_head_with_markov": True,
     },
 }

--- a/tests/test_runtime/_fixtures.py
+++ b/tests/test_runtime/_fixtures.py
@@ -455,7 +455,6 @@ def build_dspark(
         "mask_token_id": mask_token_id,
         "markov_rank": markov_rank,
         "markov_head_type": "vanilla",
-        "confidence_head_alpha": 1.0,
         "enable_confidence_head": True,
         "confidence_head_with_markov": True,
     }

--- a/tests/test_runtime/test_model_loading.py
+++ b/tests/test_runtime/test_model_loading.py
@@ -448,7 +448,7 @@ class WarmStartTest(unittest.TestCase):
                         "projector_type": "dspark",
                         "markov_rank": 8,
                         "markov_head_type": "vanilla",
-                        "confidence_head_alpha": 1.0,
+                        "enable_confidence_head": True,
                         "confidence_head_with_markov": True,
                     },
                 },

--- a/tests/test_scripts/test_gate_orchestration.py
+++ b/tests/test_scripts/test_gate_orchestration.py
@@ -125,6 +125,8 @@ class TestNormalizeDFlashExport(unittest.TestCase):
                         "block_size": 16,
                         "dflash_config": {
                             "projector_type": "domino",
+                        },
+                        "domino_config": {
                             "gru_hidden_dim": 1024,
                         },
                     }
@@ -152,12 +154,14 @@ class TestNormalizeDFlashExport(unittest.TestCase):
                         "model_type": "qwen3",
                         "dflash_config": {
                             "projector_type": "dspark",
+                            "mask_token_id": 248070,
+                            "target_layer_ids": [2, 17, 32, 47, 62],
+                        },
+                        "dspark_config": {
                             "markov_rank": 256,
                             "markov_head_type": "vanilla",
                             "enable_confidence_head": True,
                             "confidence_head_with_markov": True,
-                            "mask_token_id": 248070,
-                            "target_layer_ids": [2, 17, 32, 47, 62],
                         },
                     }
                 ),


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
`sglang` parses Dspark config in [here](https://github.com/sgl-project/sglang/blob/e31e5319a0f7e3a2692c14ffeef630785c71b543/python/sglang/srt/speculative/dspark_components/dspark_config.py#L208) with the following order.
1. with `dspark_` prefix at the root
2. in `dspark_config`
3. at the root

Grouping `dspark` related configs into `dspark_config` makes things clear. `Domino` has not yet implemented in `sglang` but we could expect it to be implemented in a similar way to `Dspark`.

`confidence_head_alpha` from `domino` configs can be replaced with `enable_confidence_head` and putting training parameter in model's config and not updating it when training from `training.dspark_confidence_head_alpha` could cause a confusion that the model is trained with the alpha of 1.0 but actually it could be not.

Due to the bug in `sglang` side, `Dspark` parameters requires to be in the root, we need to run `scripts/gates/normalize_dflash_export.py` after `specforge export --to hf` but after https://github.com/sgl-project/sglang/pull/38387 is merged, we may not.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications
- Groupped `dspark`, `domino` configs.
- Removed `confidence_head_alpha` from `domino` configs.
<!-- Describe the changes made in this PR. -->

## Related Issues

<!-- Link to any related issues here. e.g. "Fixes #123" or "Closes #456" -->

## Accuracy Test

<!-- If this PR affects model-side code (e.g., kernels, model architecture), please provide accuracy test results. Ref: https://docs.sglang.io/docs/developer_guide/evaluating_new_models -->

## Benchmark & Profiling

<!-- If this PR is expected to impact performance, please provide benchmark and profiling results. Ref: https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling -->

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling) and [Accuracy Results](https://docs.sglang.io/docs/developer_guide/evaluating_new_models).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
