### PR TITLE
docs: add DFlash2 Ascend config to training starting points

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -325,6 +325,7 @@ The checked-in examples are the canonical starting points:
 | DSpark | Online disaggregated, external | [`qwen3-4b-dspark-disaggregated.yaml`](../../examples/configs/online/disaggregated/external/qwen3-4b-dspark-disaggregated.yaml) |
 | DSpark | Offline colocated | [`qwen3-4b-dspark-offline.yaml`](../../examples/configs/offline/colocated/qwen3-4b-dspark-offline.yaml) |
 | DFlash (Ascend) | Online disaggregated, external | [`qwen3.5-4b-dflash-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash-online-npu.yaml) |
+| DFlash2 (Ascend) | Online disaggregated, external | [`qwen3.5-4b-dflash2-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml) |
 | MTP (Ascend) | Online disaggregated, managed-local | [`qwen3.5-4b-mtp-disaggregated-npu.yaml`](../../examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml) |
 
 ## Online and offline data


### PR DESCRIPTION
## Summary

The canonical starting points table in `docs/basic_usage/training.md` already lists DFlash (Ascend), MTP (Ascend), and DFlash2 (managed-local). After #789, `examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml` is checked in and referenced from the Ascend NPU guide, but the training starting-points table was missing a **DFlash2 (Ascend)** row.

This PR adds that single table row after the DFlash (Ascend) entry:

| DFlash2 (Ascend) | Online disaggregated, external | `qwen3.5-4b-dflash2-online-npu.yaml` |

## Local repro / verification

```bash
# 1) Confirm the Ascend DFlash2 config exists on main
curl -sI \
  https://raw.githubusercontent.com/sgl-project/SpecForge/main/examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml \
  | head -n 1
# expect: HTTP/2 200

# 2) Confirm main training.md lacks the DFlash2 Ascend row
curl -sL \
  https://raw.githubusercontent.com/sgl-project/SpecForge/main/docs/basic_usage/training.md \
  | rg 'DFlash2 \(Ascend\)|dflash2-online-npu' || echo 'missing on main (expected before merge)'

# 3) Confirm the Ascend guide already documents the same config
curl -sL \
  https://raw.githubusercontent.com/sgl-project/SpecForge/main/docs/basic_usage/Ascend/ascend_npu.md \
  | rg 'qwen3.5-4b-dflash2-online-npu'

# 4) After checkout of this branch, the training table includes:
# | DFlash2 (Ascend) | Online disaggregated, external | ...qwen3.5-4b-dflash2-online-npu.yaml...
rg -n 'DFlash2 \(Ascend\)' docs/basic_usage/training.md
```

## Test plan

- [x] YAML path returns 200 on `main`
- [x] Diff is a single added markdown table row in `docs/basic_usage/training.md`
- [x] Relative link matches the checked-in config path under `examples/configs/online/disaggregated/external/`