### PR TITLE
docs: add DFlash2 Ascend recipe to installation NPU list

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -57,7 +57,8 @@ forms on AMD Instinct GPUs, follow the
 
 Install the vendor-matched PyTorch and `torch_npu` packages first, then install
 SpecForge. The checked-in
-[`qwen3.5-4b-dflash-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash-online-npu.yaml)
+[`qwen3.5-4b-dflash-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash-online-npu.yaml),
+[`qwen3.5-4b-dflash2-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml),
 and
 [`qwen3.5-4b-domino-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml)
 recipes use external SGLang server capture with SDPA consumers. Install a


### PR DESCRIPTION
## Summary
- After #789 landed `qwen3.5-4b-dflash2-online-npu.yaml`, the get-started Ascend install section still listed only the DFlash and Domino external NPU recipes.
- Add the DFlash2 Ascend external recipe to that list so new users see the checked-in starting point.

## Test plan
- [x] Confirmed tip `configs/qwen3.5-4b-dflash2.json` + `examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml` exist at `b95365cae7`
- [x] Confirmed relative link resolves under `docs/get_started/`
- [x] No other open docs PR touches `docs/get_started/installation.md`