### PR TITLE
docs: add Domino Ascend config to training starting points

### DIFF
--- a/docs/basic_usage/training.md
+++ b/docs/basic_usage/training.md
@@ -322,6 +322,7 @@ The checked-in examples are the canonical starting points:
 | Domino | Online disaggregated, external | [`qwen3-8b-domino-online.yaml`](../../examples/configs/online/disaggregated/external/qwen3-8b-domino-online.yaml) |
 | Domino | Online disaggregated, managed-local | [`qwen3-8b-domino-multiserver-disaggregated.yaml`](../../examples/configs/online/disaggregated/managed-local/qwen3-8b-domino-multiserver-disaggregated.yaml) |
 | Domino | Offline colocated | [`qwen3-8b-domino-offline.yaml`](../../examples/configs/offline/colocated/qwen3-8b-domino-offline.yaml) |
+| Domino (Ascend) | Online disaggregated, external | [`qwen3.5-4b-domino-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml) |
 | DSpark | Online disaggregated, external | [`qwen3-4b-dspark-disaggregated.yaml`](../../examples/configs/online/disaggregated/external/qwen3-4b-dspark-disaggregated.yaml) |
 | DSpark | Offline colocated | [`qwen3-4b-dspark-offline.yaml`](../../examples/configs/offline/colocated/qwen3-4b-dspark-offline.yaml) |
 | DFlash (Ascend) | Online disaggregated, external | [`qwen3.5-4b-dflash-online-npu.yaml`](../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash-online-npu.yaml) |


### PR DESCRIPTION
## Summary
- Add `Domino (Ascend)` to the canonical starting points table in `docs/basic_usage/training.md`.
- Point at the checked-in [`qwen3.5-4b-domino-online-npu.yaml`](examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml), which is already referenced from the Ascend NPU section of `docs/get_started/installation.md`, so the training guide matches the other Ascend recipes listed there.

## Test plan
- [ ] Confirm the relative markdown link resolves to the existing config on `main`.
- [ ] Confirm the table still renders correctly next to the Domino offline and Ascend DFlash/MTP rows.