### PR TITLE
docs: add Domino Ascend recipe to ascend_npu guide

### DIFF
--- a/docs/basic_usage/Ascend/ascend_npu.md
+++ b/docs/basic_usage/Ascend/ascend_npu.md
@@ -185,6 +185,32 @@ Notes specific to DFlash 2 on Ascend:
 - **Serving the export** still requires an SGLang build with DFlash 2 support
   (SGLang PR #35371); training-side capture is unchanged.
 
+### Training Domino drafts
+
+Domino reuses the same external Mooncake + SGLang capture flow and the DFlash
+capture contract (`--spec-capture-method dflash`), but its auxiliary layer IDs
+differ. Restart the capture server with the Domino
+`--spec-capture-aux-layer-ids` from `configs/qwen3.5-4b-domino.json`:
+`3 11 19 27 31`. A mismatch with the DFlash IDs above produces zero features.
+Use the checked-in
+[`qwen3.5-4b-domino-online-npu.yaml`](../../../examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml)
+recipe:
+
+```bash
+ASCEND_RT_VISIBLE_DEVICES=1,2,3,4,5,6,7,8 \
+specforge train -c examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml
+```
+
+Notes specific to Domino on Ascend:
+
+- **`draft_model_config` is required** (already set to
+  `configs/qwen3.5-4b-domino.json` in the recipe). Domino needs projector/head
+  metadata and will not derive a fresh draft config.
+- **`attention_backend: sdpa` is mandatory** (already set in the recipe), for
+  the same Ascend reason as DFlash / DFlash 2.
+- Clear stale control state before reruns:
+  `rm -rf outputs/qwen3.5-4b-domino-npu-online`.
+
 ---
 
 ## 4. Managed-local full stack (one command)


### PR DESCRIPTION
## Summary

- The Ascend NPU walkthrough documented DFlash and DFlash 2 external recipes but omitted the checked-in Domino Ascend recipe [`qwen3.5-4b-domino-online-npu.yaml`](examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml) (already linked from the get-started install section).
- Domino reuses `--spec-capture-method dflash` but needs different `--spec-capture-aux-layer-ids` (`3 11 19 27 31` from `configs/qwen3.5-4b-domino.json`); reusing the DFlash IDs silently yields zero features.
- Add a short "Training Domino drafts" subsection with the recipe path, layer IDs, and Ascend notes (`draft_model_config` required, `sdpa` mandatory).

## Test plan

- [x] Confirmed tip has `examples/configs/online/disaggregated/external/qwen3.5-4b-domino-online-npu.yaml` and `configs/qwen3.5-4b-domino.json` with `target_layer_ids: [3, 11, 19, 27, 31]`
- [x] Relative markdown link matches the DFlash / DFlash 2 subsection style
- [ ] Docs render / link check on the PR preview