### PR TITLE
perf(disagg): default to pinned receives and automatic RDMA GPU publication

### DIFF
--- a/docs/sections/basic_usage/disaggregated_training.md
+++ b/docs/sections/basic_usage/disaggregated_training.md
@@ -35,6 +35,20 @@ The full model and strategy index is in the
 historical identifiers; the directory and typed YAML fields define the runtime
 semantics.
 
+Mooncake training uses **pinned receive pools by default**, with a lazily allocated
+8 GiB retained-pool budget per trainer rank. On CUDA with loader prefetch enabled,
+the loader copies received features to the GPU before yielding the batch. Returned
+tensors, prefetched batches, and overflow allocations consume additional memory.
+Set `deployment.disaggregated.receive_buffers: pageable` to use fresh CPU receives.
+
+Patched CUDA capture servers automatically publish device tensors when
+`MOONCAKE_PROTOCOL=rdma`. TCP and non-CUDA workers keep host publication.
+Set `SGLANG_SPEC_CAPTURE_GPU_PUT=0` on an external server, or `gpu_put: false`
+on a managed-local capture-server entry, to disable GPU publication explicitly.
+GPU publication needs RDMA-registerable allocations; custom expandable CUDA
+allocations may require `PYTORCH_ALLOC_CONF=expandable_segments:False` on the
+capture server. The trainer's allocator is independent.
+
 ## One config owns the launch topology
 
 Process topology and attempt paths live in the same typed run document as the

--- a/examples/configs/README.md
+++ b/examples/configs/README.md
@@ -323,7 +323,7 @@ For `deployment.mode: disaggregated`, also write:
 | `deployment.disaggregated.mooncake_rdma_devices` | `null` | External Mooncake RDMA-device selection. |
 | `deployment.disaggregated.producer_segment_size` | `null` | Positive allocation owned by an offline Mooncake producer. Online capture is server-owned and forces client segments to zero. |
 | `deployment.disaggregated.client_buffer_size` | `268435456` | Per-role Mooncake client buffer in bytes. For `receive_buffers: cuda`, size for the largest concurrently fetched tensors; an 8k-token Qwen3.8-27B feature can exceed this default. Use e.g. `2147483648` and increase with fetch concurrency. |
-| `deployment.disaggregated.receive_buffers` | `pageable` | Consumer receive buffers for feature reads: `pageable` (fresh host tensor per feature), `pinned` (pooled page-locked host buffers, side-stream device copy), or `cuda` (pooled device buffers; Mooncake 0.3.x stages RDMA reads through its client buffer). |
+| `deployment.disaggregated.receive_buffers` | `pinned` | Consumer receive buffers for feature reads: `pinned` (pooled page-locked host buffers, side-stream device copy), `pageable` (fresh host tensor per feature), or `cuda` (pooled device buffers; Mooncake 0.3.x stages RDMA reads through its client buffer). |
 | `deployment.disaggregated.receive_pool_bytes` | `8589934592` | Retained receive-pool budget per rank (`pinned`/`cuda`), excluding output copies and concurrent overflow. Failed-transfer buffers remain quarantined for the store lifetime. |
 | `deployment.disaggregated.idle_timeout_s` | `null` | Positive consumer idle timeout. |
 | `deployment.disaggregated.peer_wait_timeout_s` | `null` | Optional positive producer/consumer peer-completion timeout. Unset is unbounded; expiration fails the attempt. |
@@ -386,11 +386,21 @@ Managed-local fields:
 | `deployment.disaggregated.managed_local.mooncake.default_kv_lease_ttl_ms` | `500` | Master key-lease TTL (ms) forwarded to `mooncake_master --default_kv_lease_ttl`. Kept below the consumer's teardown drain window so managed_local shuts down cleanly; set `null` to inherit Mooncake's stock default. |
 | `deployment.disaggregated.managed_local.capture_servers[].port` | required | Unique capture HTTP port. |
 | `deployment.disaggregated.managed_local.capture_servers[].cuda_visible_devices` | required | Device tokens for this server. Their count must equal its `tp_size`. |
-| `deployment.disaggregated.managed_local.capture_servers[].gpu_put` | `false` | Publish captured tensors from device memory (`SGLANG_SPEC_CAPTURE_GPU_PUT=1`); requires `mooncake.protocol: rdma`. |
+| `deployment.disaggregated.managed_local.capture_servers[].gpu_put` | `null` | Automatically publish from CUDA memory when the capture worker uses RDMA. Set `false` to use host publication or `true` to require GPU publication; `true` requires `mooncake.protocol: rdma`. |
 | `deployment.disaggregated.managed_local.capture_servers[].tp_size` | `1` | Target-model tensor parallelism for this server. |
 | `deployment.disaggregated.managed_local.capture_servers[].mem_fraction_static` | `null` | Optional SGLang static-memory override in `(0, 1]`; otherwise inherit `model.sglang_mem_fraction_static`. |
 | `deployment.disaggregated.managed_local.capture_servers[].attention_backend` | `null` | Server-specific override; otherwise inherit `model.sglang_attention_backend`. |
 | `deployment.disaggregated.managed_local.capture_servers[].startup_timeout_s` | `1800` | Positive server readiness timeout. |
+
+Disaggregated Mooncake trainers use pinned receive pools without additional settings.
+With loader prefetch enabled, H2D runs in the loader before the batch reaches training.
+Select `receive_buffers: pageable` to restore fresh host receives. The 8 GiB receive-pool
+budget is allocated lazily per rank and excludes returned tensors and overflow buffers.
+
+Patched CUDA capture servers use GPU publication automatically when
+`MOONCAKE_PROTOCOL=rdma`; TCP and non-CUDA workers use host publication. External
+servers can set `SGLANG_SPEC_CAPTURE_GPU_PUT=0` to disable it or `1` to explicitly
+enable it. Managed-local `gpu_put: false` also disables an inherited enable flag.
 
 GPU publication retains a device snapshot until the asynchronous store write completes.
 Use RDMA-registerable CUDA allocations; with PyTorch, set

--- a/patches/sglang/v0.5.18/spec-capture.patch
+++ b/patches/sglang/v0.5.18/spec-capture.patch
@@ -814,10 +814,10 @@ index 5c4f3ff44a..c40bcc6c42 100644
          "Enable returning routed experts of each layer with responses.",
 diff --git a/python/sglang/srt/spec_capture_sink.py b/python/sglang/srt/spec_capture_sink.py
 new file mode 100644
-index 0000000000..91bf321f5d
+index 0000000..37692fd
 --- /dev/null
 +++ b/python/sglang/srt/spec_capture_sink.py
-@@ -0,0 +1,442 @@
+@@ -0,0 +1,455 @@
 +# Copyright 2024 SGLang Team
 +# Licensed under the Apache License, Version 2.0 (the "License");
 +# you may not use this file except in compliance with the License.
@@ -845,8 +845,9 @@ index 0000000000..91bf321f5d
 +"aux_layer_ids", "features": {name: {"shape", "dtype"}}}``.
 +
 +Mooncake connection uses the standard ``MOONCAKE_*`` env vars (see
-+``MooncakeFeatureStore``). ``SGLANG_SPEC_CAPTURE_GPU_PUT=1`` publishes the
-+captured tensors from device memory (RDMA/NVLink transports only).
++``MooncakeFeatureStore``). CUDA capture uses device publication on RDMA by
++default. ``SGLANG_SPEC_CAPTURE_GPU_PUT=0`` selects host publication; ``1``
++explicitly enables device publication and requires RDMA.
 +"""
 +
 +from __future__ import annotations
@@ -883,8 +884,16 @@ index 0000000000..91bf321f5d
 +
 +
 +def gpu_put_enabled() -> bool:
-+    enabled = os.environ.get("SGLANG_SPEC_CAPTURE_GPU_PUT", "0") == "1"
-+    if enabled and os.environ.get("MOONCAKE_PROTOCOL", "tcp") != "rdma":
++    protocol = os.environ.get("MOONCAKE_PROTOCOL", "tcp")
++    configured = os.environ.get("SGLANG_SPEC_CAPTURE_GPU_PUT")
++    if configured is None:
++        return (
++            protocol == "rdma"
++            and torch.version.cuda is not None
++            and torch.cuda.is_available()
++        )
++    enabled = configured == "1"
++    if enabled and protocol != "rdma":
 +        raise ValueError(
 +            "SGLANG_SPEC_CAPTURE_GPU_PUT=1 requires MOONCAKE_PROTOCOL=rdma"
 +        )
@@ -1253,6 +1262,10 @@ index 0000000000..91bf321f5d
 +    """
 +    global _SINK
 +    if getattr(server_args, "enable_spec_capture", False) and _SINK is None:
++        logger.info(
++            "Spec capture Mooncake publication uses %s tensors",
++            "device" if gpu_put_enabled() else "host",
++        )
 +        _SINK = SpecCaptureSink(
 +            aux_layer_ids=getattr(server_args, "spec_capture_aux_layer_ids", None)
 +        )

--- a/specforge/config/schema.py
+++ b/specforge/config/schema.py
@@ -328,8 +328,8 @@ class ManagedLocalCaptureServerConfig(StrictConfigModel):
     mem_fraction_static: Optional[float] = Field(default=None, gt=0.0, le=1.0)
     attention_backend: Optional[str] = None
     startup_timeout_s: float = Field(default=1800.0, gt=0)
-    #: Publish device snapshots through RDMA; CUDA memory must be registerable.
-    gpu_put: bool = False
+    #: None selects CUDA publication on RDMA in the capture worker.
+    gpu_put: Optional[bool] = None
 
     @model_validator(mode="after")
     def _validate_devices(self):
@@ -442,7 +442,7 @@ class DisaggregatedDeploymentConfig(StrictConfigModel):
     #: a bounded pool of page-locked, once-registered host buffers and copies to
     #: the device on a side stream; ``cuda`` keeps the pool on the trainer device
     #: for device reads (Mooncake 0.3.x stages these through its client buffer).
-    receive_buffers: Literal["pageable", "pinned", "cuda"] = "pageable"
+    receive_buffers: Literal["pageable", "pinned", "cuda"] = "pinned"
     #: Retained receive-pool budget per rank; excludes output copies and overflow.
     receive_pool_bytes: int = Field(default=8 << 30, gt=0)
     idle_timeout_s: Optional[float] = Field(default=None, gt=0)

--- a/specforge/launch_plan.py
+++ b/specforge/launch_plan.py
@@ -534,7 +534,11 @@ def _managed_local_services(
         service_env = {
             **shared_env,
             device_visibility_env: ",".join(server.cuda_visible_devices),
-            **({"SGLANG_SPEC_CAPTURE_GPU_PUT": "1"} if server.gpu_put else {}),
+            **(
+                {"SGLANG_SPEC_CAPTURE_GPU_PUT": "1" if server.gpu_put else "0"}
+                if server.gpu_put is not None
+                else {}
+            ),
             "FLASHINFER_DISABLE_VERSION_CHECK": "1",
             "MOONCAKE_GLOBAL_SEGMENT_SIZE": str(mooncake.global_segment_size_bytes),
             "MOONCAKE_LOCAL_BUFFER_SIZE": str(mooncake.local_buffer_size_bytes),

--- a/specforge/training/disaggregated.py
+++ b/specforge/training/disaggregated.py
@@ -145,7 +145,10 @@ def _mooncake_store(cfg: Config, *, retain_on_release: bool = False):
     ):
         if os.environ.get(env_name):
             setup_kwargs[key] = int(os.environ[env_name])
-    receive_kwargs: Dict[str, Any] = {}
+    deployment = cfg.deployment.disaggregated
+    receive_kwargs: Dict[str, Any] = {
+        "receive_buffers": deployment.receive_buffers if deployment else "pinned"
+    }
     if os.environ.get("DISAGG_RECEIVE_BUFFERS"):
         receive_kwargs["receive_buffers"] = os.environ["DISAGG_RECEIVE_BUFFERS"]
         if (

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -337,7 +337,7 @@ class ConfigSchemaTest(unittest.TestCase):
         self.assertTrue(server.gpu_put)
         managed["capture_servers"][0].pop("gpu_put")
         cfg = Config.model_validate(payload)
-        self.assertFalse(
+        self.assertIsNone(
             cfg.deployment.disaggregated.managed_local.capture_servers[0].gpu_put
         )
 

--- a/tests/test_runtime/test_disaggregated_defaults.py
+++ b/tests/test_runtime/test_disaggregated_defaults.py
@@ -1,0 +1,65 @@
+"""Disaggregated workers must retain defaults and explicit receive overrides."""
+
+import unittest
+from unittest import mock
+
+from specforge.config import Config
+from specforge.runtime.data_plane.mooncake_store import _InjectedReplicateConfig
+from specforge.training.disaggregated import _mooncake_store
+from tests.test_runtime.test_mooncake_store import _FakeMooncakeStore
+
+
+class DisaggregatedDefaultsTest(unittest.TestCase):
+    def test_worker_store_uses_config_unless_environment_overrides_it(self):
+        for configured, override, expected in (
+            (None, None, "pinned"),
+            ("pageable", None, "pageable"),
+            ("pageable", "pinned", "pinned"),
+            (None, "pageable", "pageable"),
+        ):
+            with self.subTest(configured=configured, override=override):
+                deployment = {
+                    "control_dir": "/control",
+                    "backend": "mooncake",
+                    "server_urls": ["http://capture:30000"],
+                }
+                if configured is not None:
+                    deployment["receive_buffers"] = configured
+                cfg = Config.model_validate(
+                    {
+                        "model": {"target_model_path": "target"},
+                        "data": {"prompts_path": "prompts.jsonl"},
+                        "deployment": {
+                            "mode": "disaggregated",
+                            "disaggregated": deployment,
+                        },
+                    }
+                )
+                self._assert_worker_mode(cfg, override, expected)
+
+    def test_legacy_environment_worker_uses_pinned_by_default(self):
+        cfg = Config.model_validate(
+            {
+                "model": {"target_model_path": "target"},
+                "data": {"hidden_states_path": "/features"},
+            }
+        )
+        self._assert_worker_mode(cfg, None, "pinned")
+
+    def _assert_worker_mode(self, cfg, override, expected):
+        env = {
+            "MOONCAKE_METADATA_SERVER": "http://metadata:8080/metadata",
+            "MOONCAKE_MASTER_SERVER_ADDR": "master:50051",
+        }
+        if override is not None:
+            env["DISAGG_RECEIVE_BUFFERS"] = override
+        with (
+            mock.patch.dict("os.environ", env, clear=True),
+            mock.patch(
+                "specforge.runtime.data_plane.mooncake_store._connect_store",
+                return_value=(_FakeMooncakeStore(), _InjectedReplicateConfig),
+            ),
+        ):
+            store = _mooncake_store(cfg)
+        self.assertEqual(store.receive_buffers, expected)
+        self.assertEqual(store._receive_pool is not None, expected != "pageable")

--- a/tests/test_runtime/test_launch_plan.py
+++ b/tests/test_runtime/test_launch_plan.py
@@ -199,6 +199,18 @@ class _FakeProcess:
 
 
 class LaunchPlanTest(unittest.TestCase):
+    def test_disaggregated_receives_default_to_pinned_and_allow_override(self):
+        for requested, expected in ((None, "pinned"), ("pageable", "pageable")):
+            with self.subTest(requested=requested):
+                cfg = _config(mode="disaggregated")
+                if requested is not None:
+                    cfg = apply_overrides(
+                        cfg, [f"deployment.disaggregated.receive_buffers={requested}"]
+                    )
+                plan = build_launch_plan(cfg, config_path="run.yaml", env=MOONCAKE_ENV)
+                for command in plan.commands:
+                    self.assertEqual(command.env["DISAGG_RECEIVE_BUFFERS"], expected)
+
     def test_local_multi_rank_self_launches_torchrun(self):
         plan = build_launch_plan(
             _config(nproc=4),
@@ -598,7 +610,7 @@ class LaunchPlanTest(unittest.TestCase):
 
         self.assertNotIn("--disable-radix-cache", plan.services[1].command.argv)
 
-    def test_managed_local_gpu_put_renders_only_on_the_opted_in_server(self):
+    def test_managed_local_gpu_put_override_can_disable_rdma_publication(self):
         servers = [
             {"port": 30000, "cuda_visible_devices": ["0"], "tp_size": 1},
             {"port": 30001, "cuda_visible_devices": ["1"], "tp_size": 1},
@@ -611,6 +623,7 @@ class LaunchPlanTest(unittest.TestCase):
             # gpu_put is only valid with an RDMA transport (see the schema test)
             managed["mooncake"].update(protocol="rdma", rdma_devices="mlx5_0")
             managed["capture_servers"][0]["gpu_put"] = True
+            managed["capture_servers"][1]["gpu_put"] = False
             cfg = Config.model_validate(raw)
             with mock.patch(
                 "specforge.training.capture_contract.resolve_server_capture_contract",
@@ -625,7 +638,7 @@ class LaunchPlanTest(unittest.TestCase):
                 )
         envs = {service.command.label: service.command.env for service in plan.services}
         self.assertEqual(envs["capture-server-0"]["SGLANG_SPEC_CAPTURE_GPU_PUT"], "1")
-        self.assertNotIn("SGLANG_SPEC_CAPTURE_GPU_PUT", envs["capture-server-1"])
+        self.assertEqual(envs["capture-server-1"]["SGLANG_SPEC_CAPTURE_GPU_PUT"], "0")
         self.assertNotIn("SGLANG_SPEC_CAPTURE_GPU_PUT", envs["mooncake"])
 
     def test_managed_local_plan_owns_mooncake_and_multiple_capture_servers(self):

--- a/tests/test_runtime/test_spec_capture_sink.py
+++ b/tests/test_runtime/test_spec_capture_sink.py
@@ -164,6 +164,38 @@ class SpecCaptureSinkTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "requires MOONCAKE_PROTOCOL=rdma"):
                 self.module.gpu_put_enabled()
 
+    def test_default_publication_requires_cuda_and_rdma(self):
+        for protocol in ("tcp", "rdma"):
+            for cuda_version in (None, "13.0"):
+                for available in (False, True):
+                    with self.subTest(
+                        protocol=protocol, cuda=cuda_version, available=available
+                    ):
+                        with (
+                            mock.patch.dict(
+                                "os.environ",
+                                {"MOONCAKE_PROTOCOL": protocol},
+                                clear=True,
+                            ),
+                            mock.patch.object(torch.version, "cuda", cuda_version),
+                            mock.patch.object(
+                                torch.cuda, "is_available", return_value=available
+                            ),
+                        ):
+                            self.assertEqual(
+                                self.module.gpu_put_enabled(),
+                                protocol == "rdma"
+                                and cuda_version is not None
+                                and available,
+                            )
+
+    def test_explicit_host_publication_overrides_the_rdma_default(self):
+        with (
+            mock.patch.object(torch.version, "cuda", "13.0"),
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+        ):
+            self.assertFalse(self.module.gpu_put_enabled())
+
     @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
     def test_gpu_snapshot_survives_overwrite_and_stream_handoff(self):
         store = self.sink._store = _BufferStore(device=True)


### PR DESCRIPTION
Existing disaggregated Mooncake configs leave the transfer paths from #840 and #841 disabled unless users discover and set the tuning options. Make those paths the training defaults: pinned receives on trainers, and GPU publication on CUDA capture workers using RDMA.

- Default `deployment.disaggregated.receive_buffers` to `pinned`, including legacy workers configured through the environment. Preserve explicit `pageable` and `cuda` selections.
- Default managed capture `gpu_put` to automatic selection in the worker. Patched external capture servers use the same selection when `SGLANG_SPEC_CAPTURE_GPU_PUT` is unset. TCP and non-CUDA workers use host publication.
- Preserve explicit GPU-publication overrides. Managed `gpu_put: false` emits `SGLANG_SPEC_CAPTURE_GPU_PUT=0`, overriding an inherited enable flag.
- Update the existing config reference and training documentation. No additional example or opt-in profile is required.

The existing 8 GiB receive-pool budget remains lazy and per rank; it excludes returned tensors, prefetched batches, and overflow allocations. The trainer client-buffer default remains 256 MiB. GPU publication retains a device snapshot during each write and requires RDMA-registerable CUDA allocations; custom expandable-segment allocators may need to be disabled on capture workers.

## Validation

- H200 regression suite: 181 tests, 180 passed and one existing expected failure concerning cross-process abort under a Mooncake read lease. Covers schema, launch plans, worker defaults, capture snapshots, Mooncake receive pools, CUDA copy completion, trainer and loader behavior, and recipe consistency.
- Two physical H200 nodes, PyTorch 2.13.0+cu130, SGLang 0.5.18, Mooncake 0.3.13.post1: RDMA and TCP publication → remote reads → loader prefetch. Each protocol published two 400 MiB BF16 tensors and verified four reads, including output stability after pool reuse. Both used pinned receives, the normal 256 MiB client buffer, and no receive/publication tuning in the input config. GPU publication and allocator environment flags were unset; RDMA selected device publication and TCP selected host publication. No active leases or quarantined buffers remained after reads.
- Local focused suite: 47 tests, 44 passed and three CUDA tests skipped; CUDA coverage passed on H200.
- `pre-commit run --all-files`, VitePress production build, and SGLang patch applicability checks passed.

This validates default selection and transfer correctness. A new full-model Qwen throughput comparison was not run for this default-only change.

## Dependencies

Stacked on `maocheng/mooncake-transfer-base`, which combines current main with unchanged #840 and #841, so this PR's diff contains only the default changes and their coverage. Retarget to main after both dependencies merge. No #832 changes are included.
