### PR TITLE
docs: fix Ascend DFlash2 recipe relative link after sections/ move

### DIFF
--- a/docs/sections/basic_usage/Ascend/ascend_npu.md
+++ b/docs/sections/basic_usage/Ascend/ascend_npu.md
@@ -161,7 +161,7 @@ DFlash 2 reuses the DFlash strategy and capture path end to end, so the
 external-server setup above carries over unchanged — including the
 `--spec-capture-aux-layer-ids 1 8 15 22 29` flags, which match
 `configs/qwen3.5-4b-dflash2.json`. Use the checked-in
-[`qwen3.5-4b-dflash2-online-npu.yaml`](../../../examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml)
+[`qwen3.5-4b-dflash2-online-npu.yaml`](https://github.com/sgl-project/SpecForge/blob/main/examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml)
 recipe:
 
 ```bash


### PR DESCRIPTION
## Summary
- After the VitePress docs layout move (`docs/basic_usage/...` → `docs/sections/basic_usage/...`), the Ascend NPU guide's relative link to `qwen3.5-4b-dflash2-online-npu.yaml` (`../../../examples/...`) resolves to a non-existent `docs/examples/...` path.
- Switch that recipe link to the same absolute GitHub blob URL style already used for the other Ascend recipe links on the page.

## Test plan
- [x] Confirm `examples/configs/online/disaggregated/external/qwen3.5-4b-dflash2-online-npu.yaml` exists at HEAD
- [x] Confirm `../../../examples/...` from `docs/sections/basic_usage/Ascend/ascend_npu.md` normalizes to `docs/examples/...` (missing)
- [x] Confirm the replacement absolute URL matches the on-disk recipe path
- [ ] Docs site / Markdown preview: DFlash2 Ascend recipe link opens the YAML