### PR TITLE
docs: fix --tp to --tp-size in SpecBundle Usage

### DIFF
--- a/docs/web/specbundle.md
+++ b/docs/web/specbundle.md
@@ -44,7 +44,7 @@ draft models against the baseline without speculative decoding.
 ## Usage
 
 Launch an SGLang server with a target model and its SpecBundle draft. Add
-`--tp`, `--ep` and `--mem-fraction-static` when you run into memory limits.
+`--tp-size`, `--ep` and `--mem-fraction-static` when you run into memory limits.
 
 ::: code-group
 


### PR DESCRIPTION
## Summary
In `docs/web/specbundle.md` Usage prose, replace the stale SGLang flag `--tp` with `--tp-size`. Leave `--ep` and `--mem-fraction-static` unchanged.

## Repro
Against `main` @ `b4e6b2675a5c732e6412aa9df249329ab6f057b9` and SGLang `v0.5.18` ServerArgs:

- `tp_size` → CLI `--tp-size` (aliases: `--tensor-parallel-size`). There is no bare `--tp`.
- SpecForge pin: `sglang==0.5.18` in `pyproject.toml`
- Live docs page after the VitePress migration is `docs/web/specbundle.md`

```bash
curl -sL https://raw.githubusercontent.com/sgl-project/SpecForge/main/docs/web/specbundle.md \
  | rg -n -- '--tp[^-]|--tp-size|--ep|mem-fraction'
# before: prose mentions `--tp`
# after: prose mentions `--tp-size`
```

## Test plan
- [x] Prose-only one-token change in `docs/web/specbundle.md`
- [x] Verified against SGLang `v0.5.18` ServerArgs field `tp_size` → `--tp-size`
- [ ] Docs render / review