### PR TITLE
docs: add MTP to VitePress landing method list

### DIFF
--- a/docs/web/.vitepress/theme/components/Landing.vue
+++ b/docs/web/.vitepress/theme/components/Landing.vue
@@ -19,12 +19,12 @@ const features = [
   {
     title: 'SGLang-ready',
     icon: 'M13 3 4 14h6l-1 7 9-11h-6l1-7Z',
-    text: 'Draft models trained with SpecForge export straight into SGLang serving. No porting scripts, no method-specific conversion.',
+    text: 'Draft models trained with SpecForge export straight into SGLang serving. Most methods use specforge export; MTP merges via scripts/merge_mtp_to_base.py.',
   },
   {
     title: 'Every draft family',
     icon: 'M4 6h16M4 12h10M4 18h7M19 15v6m-3-3h6',
-    text: 'EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark and Domino drafts all train through one runtime with shared data, evaluation and export.',
+    text: 'EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark, Domino and MTP drafts all train through one runtime with shared data, evaluation and export.',
   },
   {
     title: 'Any scale, any accelerator',
@@ -40,7 +40,7 @@ const steps = [
   { title: 'Export and serve', text: 'Run <code>specforge export</code> and launch SGLang with the draft for faster decoding.', link: '/get_started/about' },
 ]
 
-const methods = ['EAGLE3', 'P-EAGLE', 'DFlash', 'DFlash2', 'DSpark', 'Domino']
+const methods = ['EAGLE3', 'P-EAGLE', 'DFlash', 'DFlash2', 'DSpark', 'Domino', 'MTP']
 const hardware = ['NVIDIA GPUs', 'AMD GPUs', 'Ascend NPUs']
 const families = ['Llama', 'Qwen', 'Kimi', 'DeepSeek', 'GLM', 'gpt-oss', 'Step', 'Ling', 'Inkling']
 


### PR DESCRIPTION
## Summary

After the VitePress docs migration, the landing page in `docs/web/.vitepress/theme/components/Landing.vue` drifted vs the registered training algorithms:

- The draft-family tiles listed EAGLE3 / P-EAGLE / DFlash / DFlash2 / DSpark / Domino but omitted **MTP**, which is registered in `specforge/algorithms/builtin.py` and shipped with `configs/qwen3.5-4b-mtp.json` plus the Ascend managed-local recipe.
- The SGLang-ready card claimed there is **no method-specific conversion**; MTP serving instead merges via `scripts/merge_mtp_to_base.py` (already documented under Export in the training guide).
- The "Every draft family" blurb had the same MTP omission.

## Fix

- Append `MTP` to `const methods`.
- Soften the SGLang-ready sentence: most methods use `specforge export`; MTP merges via `scripts/merge_mtp_to_base.py`.
- Include MTP in the "Every draft family" sentence.

## Local repro

```bash
HEAD=b4e6b2675a5c732e6412aa9df249329ab6f057b9

# Landing omits MTP and claims no method-specific conversion:
curl -sL "https://raw.githubusercontent.com/sgl-project/SpecForge/${HEAD}/docs/web/.vitepress/theme/components/Landing.vue" \
  | rg -n "const methods|method-specific|merge_mtp|Every draft family" -A1

# MTP is a first-class registered algorithm:
curl -sL "https://raw.githubusercontent.com/sgl-project/SpecForge/${HEAD}/specforge/algorithms/builtin.py" \
  | rg -n "mtp|eagle3|dflash|domino|dspark|peagle"

# MTP merge path exists (contradicts the old landing claim):
curl -sL "https://raw.githubusercontent.com/sgl-project/SpecForge/${HEAD}/scripts/merge_mtp_to_base.py" \
  | rg -n "merge_mtp_into_base|Example"

# Checked-in MTP recipe:
curl -sI "https://raw.githubusercontent.com/sgl-project/SpecForge/${HEAD}/examples/configs/online/disaggregated/managed-local/qwen3.5-4b-mtp-disaggregated-npu.yaml" \
  | head -n1
```

Expected before this PR: `const methods` has no `MTP`; SGLang-ready text contains `no method-specific conversion`.
Expected after: tiles include MTP; export wording mentions `merge_mtp_to_base.py`.