### PR TITLE
docs: align VitePress landing hero with supported methods

### DIFF
--- a/docs/web/.vitepress/config.mts
+++ b/docs/web/.vitepress/config.mts
@@ -39,7 +39,7 @@ const repo = 'https://github.com/sgl-project/SpecForge'
 export default defineConfig({
   title: 'SpecForge',
   description:
-    'SpecForge is the SGLang-native framework for training speculative decoding draft models (EAGLE3, DFlash, DSpark, Domino).',
+    'SpecForge is the SGLang-native framework for training speculative decoding draft models (EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark, Domino, MTP).',
   base: '/SpecForge/',
   lang: 'en-US',
   lastUpdated: true,

--- a/docs/web/.vitepress/theme/components/Landing.vue
+++ b/docs/web/.vitepress/theme/components/Landing.vue
@@ -88,8 +88,8 @@ const p = (path: string) => withBase(path + '.html')
             <span class="sf-accent">Forge Draft Models</span> for Speculative Decoding
           </h1>
           <p class="sf-sub">
-            SpecForge is the SGLang-native framework for training EAGLE3, DFlash, DSpark and Domino
-            draft models. Train once, export once, serve at speed.
+            SpecForge is the SGLang-native framework for training EAGLE3, P-EAGLE, DFlash, DFlash2,
+            DSpark, Domino and MTP draft models. Train once, export once, serve at speed.
           </p>
           <div class="sf-actions">
             <a class="sf-btn sf-btn-brand" :href="p('/get_started/installation')">Get Started <span aria-hidden="true">→</span></a>


### PR DESCRIPTION
## Summary
- Update the VitePress landing hero subtitle so it lists the same draft families as the method tiles (EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark, Domino, MTP).
- Update the site meta `description` in `docs/web/.vitepress/config.mts` to match.

## Why
After MTP was added to the landing method tiles, the hero copy and site description still omitted P-EAGLE, DFlash2, and MTP, which disagrees with the registered draft families and the tiles on the same page.

## Test plan
- [x] Diff checked against `main` HEAD
- [x] Landing hero text matches `methods` / feature-card list
- [x] Site description lists the same families