### PR TITLE
docs: add MTP to recipe method docs and RecipeIndex tag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ sidebar.
    | `title`       | card title on the Recipes page and the sidebar entry         |
    | `description` | card text                                                    |
    | `target`      | Hugging Face id of the target model, shown on the card       |
-   | `method`      | `EAGLE3`, `DFlash`, `DFlash2`, `DSpark` or `Domino`; colors the tag |
+   | `method`      | `EAGLE3`, `DFlash`, `DFlash2`, `DSpark`, `Domino` or `MTP`; colors the tag |
    | `topology`    | free text such as `Disaggregated` or `Colocated`             |
 
 3. Build or run the dev server. The card and the sidebar entry are generated

--- a/docs/web/.vitepress/theme/components/RecipeIndex.vue
+++ b/docs/web/.vitepress/theme/components/RecipeIndex.vue
@@ -82,6 +82,7 @@ import { data as recipes } from '../recipes.data'
 .rx-tag[data-method='DFlash'], .rx-tag[data-method='DFlash2'] { background: #7c3aed; }
 .rx-tag[data-method='DSpark'] { background: #d97706; }
 .rx-tag[data-method='Domino'] { background: #059669; }
+.rx-tag[data-method='MTP'] { background: #db2777; }
 
 .rx-title {
   font-size: 17px;


### PR DESCRIPTION
## Summary
- Document `MTP` as an allowed recipe frontmatter `method` value in `docs/README.md`, matching the supported-method list on the VitePress landing page.
- Add an `MTP` tag color in `RecipeIndex.vue` so MTP recipe cards are styled like the other methods.

## Test plan
- [ ] Confirm `docs/README.md` recipe method table lists `MTP`
- [ ] Confirm RecipeIndex CSS includes `.rx-tag[data-method='MTP']`
- [ ] Optional: add a local recipe with `method: MTP` and check the Recipes page tag color