### PR TITLE
docs: align VitePress landing page meta description with supported methods

### DIFF
--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -5,7 +5,7 @@ aside: false
 pageClass: sf-landing
 title: SpecForge
 titleTemplate: Train speculative decoding draft models for SGLang
-description: SpecForge is the SGLang-native framework for training speculative decoding draft models (EAGLE3, DFlash, DSpark, Domino).
+description: SpecForge is the SGLang-native framework for training speculative decoding draft models (EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark, Domino, MTP).
 ---
 
 <Landing />


### PR DESCRIPTION
## Summary
- Update `docs/web/index.md` frontmatter `description` so the landing page meta lists the same draft families as the homepage method tiles: EAGLE3, P-EAGLE, DFlash, DFlash2, DSpark, Domino, and MTP.

## Why
After MTP was added to the VitePress landing method tiles (#862), the landing page frontmatter description still said only `EAGLE3, DFlash, DSpark, Domino`. That disagrees with `Landing.vue`'s `methods` array and the feature-card copy on the same page.

## Repro
```bash
# at main HEAD 333cffe675b240691e73965a4b01aa32f1b8fe3a
curl -fsSL https://raw.githubusercontent.com/sgl-project/SpecForge/333cffe675b240691e73965a4b01aa32f1b8fe3a/docs/web/index.md
# frontmatter description omits P-EAGLE, DFlash2, MTP

curl -fsSL https://raw.githubusercontent.com/sgl-project/SpecForge/333cffe675b240691e73965a4b01aa32f1b8fe3a/docs/web/.vitepress/theme/components/Landing.vue | rg "methods = "
# methods = ['EAGLE3', 'P-EAGLE', 'DFlash', 'DFlash2', 'DSpark', 'Domino', 'MTP']
```

## Test plan
- [x] Diff is one line in `docs/web/index.md` frontmatter
- [x] Description string matches the landing `methods` / feature-card families
- [x] No clone; verified against raw HEAD contents via API