### PR TITLE
docs: add P-EAGLE to recipe method docs and RecipeIndex tag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,7 @@ sidebar.
    | `title`       | card title on the Recipes page and the sidebar entry         |
    | `description` | card text                                                    |
    | `target`      | Hugging Face id of the target model, shown on the card       |
-   | `method`      | `EAGLE3`, `DFlash`, `DFlash2`, `DSpark` or `Domino`; colors the tag |
+   | `method`      | `EAGLE3`, `DFlash`, `DFlash2`, `DSpark`, `Domino` or `P-EAGLE`; colors the tag |
    | `topology`    | free text such as `Disaggregated` or `Colocated`             |
 
 3. Build or run the dev server. The card and the sidebar entry are generated

--- a/docs/web/.vitepress/theme/components/RecipeIndex.vue
+++ b/docs/web/.vitepress/theme/components/RecipeIndex.vue
@@ -82,6 +82,7 @@ import { data as recipes } from '../recipes.data'
 .rx-tag[data-method='DFlash'], .rx-tag[data-method='DFlash2'] { background: #7c3aed; }
 .rx-tag[data-method='DSpark'] { background: #d97706; }
 .rx-tag[data-method='Domino'] { background: #059669; }
+.rx-tag[data-method='P-EAGLE'] { background: #4f46e5; }
 
 .rx-title {
   font-size: 17px;


### PR DESCRIPTION
## Summary
- Add `P-EAGLE` to the recipe frontmatter `method` list in `docs/README.md`.
- Add `[data-method='P-EAGLE']` tag styling in `RecipeIndex.vue` (indigo `#4f46e5`, distinct from existing method colors).

## Repro
On `main` @ `333cffe675b240691e73965a4b01aa32f1b8fe3a`:

1. `docs/web/.vitepress/theme/components/Landing.vue` already includes P-EAGLE:
   `const methods = ['EAGLE3', 'P-EAGLE', 'DFlash', 'DFlash2', 'DSpark', 'Domino', 'MTP']`
2. Live config exists: `examples/configs/online/disaggregated/external/qwen3-8b-peagle-disaggregated.yaml` with `training.strategy: peagle`
3. `docs/README.md` recipe `method` field still documents only `EAGLE3`, `DFlash`, `DFlash2`, `DSpark` or `Domino`
4. `RecipeIndex.vue` has CSS for EAGLE3 / DFlash / DFlash2 / DSpark / Domino only — no `[data-method='P-EAGLE']`
5. Open #865 adds MTP to the same two surfaces; it does not add P-EAGLE. #866 is unrelated landing meta.

## Test plan
- [ ] Confirm README method row lists `P-EAGLE`
- [ ] Confirm RecipeIndex CSS includes `.rx-tag[data-method='P-EAGLE']`
- [ ] Diff is limited to the two docs surfaces above