### PR TITLE
docs: align SpecBundle method tags with supported methods

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -206,7 +206,7 @@ array:
 | `id`                 | Hugging Face repo id of the draft model                                  |
 | `name`               | the part of `id` after the slash                                         |
 | `provider.name`      | Hugging Face account; `fullname` is the display name, `avatar` may be `null` |
-| `method`             | `EAGLE3`, `DFlash`, `DSpark`, `Domino` or `Other`                        |
+| `method`             | `EAGLE3`, `P-EAGLE`, `DFlash`, `DFlash2`, `DSpark`, `Domino`, `MTP` or `Other` |
 | `target`             | Hugging Face id of the model the draft was trained for                   |
 | `dataset`            | regenerated training dataset on Hugging Face, or `null`                  |
 | counters             | `downloads`, `likes`, `numParameters`, `lastModified` may be left at `0` / `null`; the page refreshes them from Hugging Face in the browser |

--- a/docs/web/.vitepress/theme/components/ModelGallery.vue
+++ b/docs/web/.vitepress/theme/components/ModelGallery.vue
@@ -35,7 +35,7 @@ interface Model {
 
 type SortKey = 'downloads' | 'likes' | 'recent' | 'name'
 
-const METHOD_ORDER = ['EAGLE3', 'DFlash', 'DSpark', 'Domino', 'Other']
+const METHOD_ORDER = ['EAGLE3', 'P-EAGLE', 'DFlash', 'DFlash2', 'DSpark', 'Domino', 'MTP', 'Other']
 
 const models = ref<Model[]>(snapshot.models as Model[])
 const updated = ref<string>(snapshot.updated)
@@ -53,7 +53,10 @@ function detectMethod(id: string): string {
   const s = id.toLowerCase()
   if (s.includes('dspark')) return 'DSpark'
   if (s.includes('domino')) return 'Domino'
+  if (s.includes('dflash2')) return 'DFlash2'
   if (s.includes('dflash')) return 'DFlash'
+  if (s.includes('mtp')) return 'MTP'
+  if (s.includes('peagle') || s.includes('p-eagle')) return 'P-EAGLE'
   if (s.includes('eagle')) return 'EAGLE3'
   return 'Other'
 }
@@ -528,9 +531,11 @@ function clear() {
   background: var(--vp-c-text-3);
 }
 .mg-method[data-method='EAGLE3'] { background: #1f7fc0; }
-.mg-method[data-method='DFlash'] { background: #7c3aed; }
+.mg-method[data-method='P-EAGLE'] { background: #4f46e5; }
+.mg-method[data-method='DFlash'], .mg-method[data-method='DFlash2'] { background: #7c3aed; }
 .mg-method[data-method='DSpark'] { background: #d97706; }
 .mg-method[data-method='Domino'] { background: #059669; }
+.mg-method[data-method='MTP'] { background: #db2777; }
 
 .mg-title {
   margin: 0;

--- a/docs/web/scripts/update_specbundle.py
+++ b/docs/web/scripts/update_specbundle.py
@@ -35,7 +35,10 @@ OUTPUT = Path(__file__).resolve().parents[2] / "data" / "specbundle_models.json"
 METHOD_PATTERNS = [
     ("DSpark", re.compile(r"dspark", re.I)),
     ("Domino", re.compile(r"domino", re.I)),
+    ("DFlash2", re.compile(r"dflash2", re.I)),
     ("DFlash", re.compile(r"dflash", re.I)),
+    ("MTP", re.compile(r"mtp", re.I)),
+    ("P-EAGLE", re.compile(r"p-?eagle|peagle", re.I)),
     ("EAGLE3", re.compile(r"eagle-?3|eagle", re.I)),
 ]
 


### PR DESCRIPTION
## Summary
- Extend SpecBundle contribute docs (`docs/README.md`) so the hand-edited `method` field lists `P-EAGLE`, `DFlash2`, and `MTP` alongside the existing methods/`Other`.
- Update `ModelGallery.vue` filter order, `detectMethod`, and tag colors so new method names render distinctly (aligned with RecipeIndex colors).
- Update `docs/web/scripts/update_specbundle.py` auto-detect patterns: match `dflash2` before `dflash`, `p-eagle`/`peagle` before `eagle`, and recognize `mtp`.

## Repro
On `main` @ `333cffe675b240691e73965a4b01aa32f1b8fe3a`:

1. `Landing.vue` already lists `EAGLE3`, `P-EAGLE`, `DFlash`, `DFlash2`, `DSpark`, `Domino`, `MTP`.
2. SpecBundle contribute table still documents only `EAGLE3`, `DFlash`, `DSpark`, `Domino` or `Other`.
3. `ModelGallery.vue` `METHOD_ORDER` / CSS / `detectMethod` omit `P-EAGLE`, `DFlash2`, `MTP`; `dflash2` would classify as `DFlash` and `peagle` as `EAGLE3`.
4. `update_specbundle.py` `METHOD_PATTERNS` has the same ordering gap.

Local pattern checks after this change:
- `…-peagle` / `…-p-eagle` → `P-EAGLE`
- `…-dflash2` → `DFlash2` (not `DFlash`)
- `…-mtp` → `MTP`

Does not change recipe frontmatter docs or VitePress landing meta (covered elsewhere).