### PR TITLE
fix(export): honor explicit vocabulary mappings in HF exports

### DIFF
--- a/specforge/export/to_hf.py
+++ b/specforge/export/to_hf.py
@@ -112,7 +112,15 @@ def export_to_hf(
         full_state["embed_tokens.weight"] = _load_embedding_tensor(
             embedding_source, embedding_key
         )
-    full_state.update(state["draft_state_dict"])  # trained keys win
+    # Preserve checkpoint weights at their original precision, but keep the
+    # mapping explicitly loaded by materialize_draft when one was requested.
+    full_state.update(
+        {
+            key: value
+            for key, value in state["draft_state_dict"].items()
+            if not (vocab_mapping_path and key in {"t2d", "d2t"})
+        }
+    )
     model.save_pretrained(output_dir, state_dict=full_state)
     apply_legacy_rope_scaling(output_dir)
     return output_dir

--- a/tests/test_runtime/test_export.py
+++ b/tests/test_runtime/test_export.py
@@ -165,6 +165,143 @@ class TestLegacyVocabMappingCompatibility(unittest.TestCase):
             )
 
 
+class TestHFVocabMappingExport(unittest.TestCase):
+    """Exercise serialized and reloaded exports on CPU, without model downloads."""
+
+    def setUp(self):
+        from specforge.modeling.auto import AutoDraftModel, AutoDraftModelConfig
+        from tests.test_runtime import _fixtures as fx
+
+        self.tempdir = tempfile.TemporaryDirectory(prefix="hf_mapping_export_")
+        self.addCleanup(self.tempdir.cleanup)
+        self.cfg_path = fx.write_draft_config(
+            os.path.join(self.tempdir.name, "draft.json")
+        )
+        old_path = fx.write_vocab_mapping(
+            os.path.join(self.tempdir.name, "old.pt"), seed=0
+        )
+        self.mapping_path = fx.write_vocab_mapping(
+            os.path.join(self.tempdir.name, "replacement.pt"), seed=1
+        )
+        self.replacement = torch.load(self.mapping_path, weights_only=True)
+        with torch.random.fork_rng(devices=[]):
+            model = AutoDraftModel.from_config(
+                AutoDraftModelConfig.from_file(self.cfg_path), torch_dtype=torch.float32
+            )
+        model.load_vocab_mapping(old_path)
+        self.weights = model.state_dict()
+        # Materialization uses BF16; exporting must retain checkpoint precision.
+        self.weights["fc.weight"][0, 0] = 0.1234567
+        self.checkpoint = os.path.join(self.tempdir.name, "training_state.pt")
+        self.output = os.path.join(self.tempdir.name, "export")
+        self._save_checkpoint(self.weights)
+
+    def _save_checkpoint(self, weights):
+        torch.save({"strategy": "eagle3", "draft_state_dict": weights}, self.checkpoint)
+
+    def _assert_export(self, expected_mapping):
+        from safetensors.torch import load_file
+
+        from specforge.modeling.auto import AutoDraftModel
+
+        saved = load_file(os.path.join(self.output, "model.safetensors"))
+        reloaded, info = AutoDraftModel.from_pretrained(
+            self.output, torch_dtype=torch.float32, output_loading_info=True
+        )
+        self.assertEqual(info["missing_keys"], [])
+        self.assertEqual(info["unexpected_keys"], [])
+        self.assertEqual(set(saved), set(self.weights))
+        reloaded_weights = reloaded.state_dict()
+        for key, original in self.weights.items():
+            expected = expected_mapping[key] if key in {"t2d", "d2t"} else original
+            self.assertEqual(saved[key].dtype, expected.dtype, key)
+            self.assertTrue(torch.equal(saved[key], expected), key)
+            self.assertTrue(torch.equal(reloaded_weights[key], expected), key)
+
+    def test_explicit_mapping_replaces_checkpoint_buffers(self):
+        from specforge.export import export_to_hf
+
+        for key in ("t2d", "d2t"):
+            self.assertFalse(torch.equal(self.weights[key], self.replacement[key]))
+        export_to_hf(
+            self.checkpoint,
+            self.cfg_path,
+            self.output,
+            vocab_mapping_path=self.mapping_path,
+        )
+        self._assert_export(self.replacement)
+
+    def test_no_override_preserves_checkpoint_buffers(self):
+        from specforge.export import export_to_hf
+
+        export_to_hf(self.checkpoint, self.cfg_path, self.output)
+        self._assert_export(self.weights)
+
+    def test_explicit_mapping_restores_legacy_checkpoint_buffers(self):
+        from specforge.export import export_to_hf
+
+        self._save_checkpoint(
+            {
+                key: value
+                for key, value in self.weights.items()
+                if key not in {"t2d", "d2t"}
+            }
+        )
+        export_to_hf(
+            self.checkpoint,
+            self.cfg_path,
+            self.output,
+            vocab_mapping_path=self.mapping_path,
+        )
+        self._assert_export(self.replacement)
+
+    def test_cli_mapping_override_with_external_embedding(self):
+        from click.testing import CliRunner
+        from safetensors.torch import save_file
+
+        from specforge.cli import cli
+
+        self._save_checkpoint(
+            {
+                key: value
+                for key, value in self.weights.items()
+                if key != "embed_tokens.weight"
+            }
+        )
+        source = os.path.join(self.tempdir.name, "target")
+        os.mkdir(source)
+        # Use an exactly representable embedding to isolate mapping precedence.
+        self.weights["embed_tokens.weight"].fill_(0.5)
+        save_file(
+            {"model.embed_tokens.weight": self.weights["embed_tokens.weight"]},
+            os.path.join(source, "model.safetensors"),
+        )
+        result = CliRunner().invoke(
+            cli,
+            [
+                "export",
+                "--to",
+                "hf",
+                "--checkpoint",
+                self.checkpoint,
+                "--draft-config",
+                self.cfg_path,
+                "--output-dir",
+                self.output,
+                "--vocab-mapping",
+                self.mapping_path,
+                "--embedding-source",
+                source,
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, result.output)
+        # The embedding loader intentionally materializes in the model dtype.
+        self.weights["embed_tokens.weight"] = self.weights["embed_tokens.weight"].to(
+            torch.bfloat16
+        )
+        self._assert_export(self.replacement)
+
+
 @unittest.skipUnless(CUDA, "export round-trip requires CUDA")
 class TestExporters(unittest.TestCase):
     @classmethod

--- a/tests/test_runtime/test_export.py
+++ b/tests/test_runtime/test_export.py
@@ -208,8 +208,8 @@ class TestHFVocabMappingExport(unittest.TestCase):
         reloaded, info = AutoDraftModel.from_pretrained(
             self.output, torch_dtype=torch.float32, output_loading_info=True
         )
-        self.assertEqual(info["missing_keys"], [])
-        self.assertEqual(info["unexpected_keys"], [])
+        self.assertFalse(info["missing_keys"])
+        self.assertFalse(info["unexpected_keys"])
         self.assertEqual(set(saved), set(self.weights))
         reloaded_weights = reloaded.state_dict()
         for key, original in self.weights.items():


### PR DESCRIPTION
When a checkpoint already contains `t2d`/`d2t`, `specforge export --to hf --vocab-mapping replacement.pt` loads the requested mapping, then silently overwrites it with the checkpoint buffers before saving. The resulting draft decodes output indices using the old target-token IDs. The SGLang exporter honors the same override.

Preserve the explicitly loaded mapping when restoring checkpoint tensors for serialization. All other checkpoint tensors keep their original values and precision. Exports without an override and legacy checkpoints missing mapping buffers retain their existing behavior.

Four CPU regression tests inspect saved safetensors and reload the actual draft with no missing/unexpected keys. They cover an existing mapping override, a legacy checkpoint, no override, and the real CLI with an external frozen embedding. Non-mapping weights are checked bit-for-bit, including FP32 values that BF16 materialization would round. Loading-info assertions require empty key collections and accept the lists returned by Transformers 4 or the sets returned by Transformers 5.

Validation on `a4dd2ff663a31bab3e7a82ebe6620a33a4e39fbf`:

- [Hosted lint](https://github.com/sgl-project/SpecForge/actions/runs/34407339291): passed.
- [Hosted PR Test](https://github.com/sgl-project/SpecForge/actions/runs/34407339298): both live CUDA server-capture tests passed; full discovery completed successfully with 1,173 tests, 10 skips and 1 expected failure. The checkout was the merge of this exact head with main `fcc0c36750dce1c9b505d83ee318bd70134c2a46`.
- Fresh local checkout: 86 focused/neighbor tests completed successfully under each of Transformers 4.57.6 and 5.12.1 (7 skips per run). Full `pre-commit run --all-files` passed.
- The two mapping-override regressions still fail against unmodified main with Transformers 5.12.1, while the legacy and no-override controls pass. All four pass on this head.

The previous CI failure was reproduced locally with Transformers 5.12.1: the test compared an empty set of missing keys to an empty list. Checking collection emptiness fixes that assertion without relaxing the missing/unexpected-key or tensor-equality checks. The production exporter change is unchanged.
