### PR TITLE
feat(dflash): add experimental Draft-OPD replay support

### DIFF
--- a/docs/sections/concepts/DFlash2.md
+++ b/docs/sections/concepts/DFlash2.md
@@ -18,6 +18,10 @@ This reuse is intentional. The convolution and selector run entirely in the
 draft, so the target server captures the same layers and the trainer consumes
 the same tensors as standard DFlash.
 
+Experimental [Draft-OPD replay support](DraftOPD.md) adds loss and forward
+primitives for actual speculative verification records. It is a library API;
+the standard training strategy and feature protocol above remain unchanged.
+
 ## Architecture
 
 Every attention and MLP sublayer is wrapped by a grouped, dynamic depthwise

--- a/docs/sections/concepts/DraftOPD.md
+++ b/docs/sections/concepts/DraftOPD.md
@@ -2,13 +2,16 @@
 
 **Experimental library support.** This provides the loss and DFlash2 replay
 forward for a future on-policy training pipeline. It does not register a new
-training strategy or provide a runnable rollout/training launcher. Existing
-DFlash training defaults are unchanged.
+training strategy or provide a runnable rollout/training launcher. Sliding
+attention honors an explicit draft configuration `is_causal=False`; absent or
+unspecified causality retains the legacy causal sliding mask.
 
 The objective is an adaptation of the
 [Draft-OPD TV variant](https://github.com/Simplified-Reasoning/Draft-OPD/tree/e81a8bc488ef762f178f8708ffbc49bd92c3a93d)
 to DFlash2's sparse, predecessor-conditioned selector. It is not a reproduction
 of the authors' training setup or a claim of measured acceptance improvement.
+The paper's accepted-token forward KL and rejected-suffix reverse KL are a
+different objective; this module implements the TV/first-rejection variant.
 
 ## Rollout contract
 
@@ -45,6 +48,22 @@ The producer must bind every record to the current draft policy and exact
 teacher sampling/filtering configuration. Final accepted text alone cannot
 reconstruct the rejected proposal or its verifier distribution.
 
+### Serving and replay must describe the same policy
+
+The frozen head supplied to replay must reproduce the head used to generate
+the draft proposals. For a quantized serving head, a separate BF16 checkpoint
+or a BF16 dequantization is not sufficient evidence of equivalence. Check both
+the natural candidate IDs and their conditional probabilities against actual
+serving captures. The same requirement applies to attention causality, KV
+precision, rotary computation and fused operations. Do not force the captured
+candidate IDs or relax the probability gate to hide a forward mismatch.
+
+With `is_causal=False`, draft positions can attend to future positions within
+their own block, while the sliding lower bound still excludes old positions.
+They cannot attend to another draft block or to target taps at or after the
+anchor. Both dense and FlexAttention masks enforce this contract. Full-attention
+behavior and the default causal sliding mask are unchanged.
+
 ## Objective and normalization
 
 `first_rejection_mask` retains accepted proposals plus the first rejection,
@@ -60,8 +79,13 @@ the candidate set.
 For a block with `N` exposed positions, minimize
 `1 - sum(cumprod(A)) / N`. With a predecessor-conditioned selector, this is a
 replay-path surrogate, not exact unconditional serving acceptance length.
-Teacher probabilities are detached. A zero-overlap block remains finite;
-its overlap gradient can be zero when all teacher mass misses the candidates.
+Teacher probabilities are detached. A zero-overlap block remains finite.
+Sparse TV can also have positive overlap and zero score gradient: when every
+selected `q(v)` exceeds `p(v)`, overlap is the constant teacher mass on the
+candidate set. For example, `q=(0.5, 0.5)` and `p(C)=(0.2, 0.2)` give overlap
+`0.4` and a one-position loss of `0.6` with zero score gradient. Report teacher
+coverage and this plateau frequency when diagnosing a weak learning signal;
+the example alone does not establish its frequency or performance impact.
 
 The wrapper returns an **unnormalized block sum**, additive block statistics,
 and replay agreement diagnostics. By default it adds `0.1` times the inherited
@@ -85,6 +109,8 @@ scheduler, rollout RNG, data cursor and policy identity together. These parts
 are not implemented by this module.
 
 CPU tests cover dense-reference values/gradients, first rejection and censoring,
-unequal rank/accumulation counts, selector/backbone gradients, and prevention
-of future-context leakage. Native backend parity, distributed optimizer
-recovery, performance and held-out acceptance gains remain unvalidated.
+unequal rank/accumulation counts, sparse-support plateaus, selector/backbone
+gradients, and prevention of future-context leakage, including noncausal sliding
+blocks. Passing these tests does not establish native backend parity,
+distributed optimizer recovery, performance or held-out acceptance gains for
+an integration using this library.

--- a/docs/sections/concepts/DraftOPD.md
+++ b/docs/sections/concepts/DraftOPD.md
@@ -1,0 +1,90 @@
+# Draft-OPD replay support
+
+**Experimental library support.** This provides the loss and DFlash2 replay
+forward for a future on-policy training pipeline. It does not register a new
+training strategy or provide a runnable rollout/training launcher. Existing
+DFlash training defaults are unchanged.
+
+The objective is an adaptation of the
+[Draft-OPD TV variant](https://github.com/Simplified-Reasoning/Draft-OPD/tree/e81a8bc488ef762f178f8708ffbc49bd92c3a93d)
+to DFlash2's sparse, predecessor-conditioned selector. It is not a reproduction
+of the authors' training setup or a claim of measured acceptance improvement.
+
+## Rollout contract
+
+`OPDDFlash2Model` in `specforge.algorithms.common.dflash_opd` accepts one audited
+rollout per forward. Its constructor takes the same draft, frozen target head,
+frozen target embedding and objective options as `OnlineDFlashModel`. Keep
+`selector_stop_gradient=False` for coupled gradients.
+
+The caller supplies `input_ids[1, S]`, committed target taps
+`hidden_states[1, H, D]`, a verified-continuation `loss_mask[1, S]`, and a
+`replay` dictionary. `H` may equal `S` or `S - 1`: a final residual/bonus token
+can be returned before the target has processed it. The missing tap is padded
+and must never be used as earlier context.
+
+Let `B` be the number of verification blocks, `L = block_size - 1`, `K` the
+selector width, and `T` the complete sparse teacher support width.
+
+| Replay field | Shape | Meaning |
+| --- | --- | --- |
+| `anchor_positions` | `[B]` | Unique absolute positions of the clean anchor token |
+| `proposed_ids` | `[B, L]` | Actual proposals, including the first rejection |
+| `accepted_lengths` | `[B]` | Accepted proposal count, excluding anchor and bonus |
+| `exposed_lengths` | `[B]` | Proposal exposure after EOS/length censoring |
+| `candidate_ids` | `[B, L, K]` | Natural unary candidates in their serving order |
+| `q` | `[B, L, K]` | Actual conditional selector probabilities at temperature 1 |
+| `target_ids` | `[B, L, T]` | Complete filtered teacher support at each proposal |
+| `target_probs` | `[B, L, T]` | Original teacher probabilities, summing to one |
+
+Replay recomputes natural candidates and selector scores, conditioning each
+position on the actual preceding proposal. It requires candidate identity and
+order to match and the maximum probability difference to be at most `0.01`.
+That threshold is a provisional validation gate, not measured backend parity.
+The producer must bind every record to the current draft policy and exact
+teacher sampling/filtering configuration. Final accepted text alone cannot
+reconstruct the rejected proposal or its verifier distribution.
+
+## Objective and normalization
+
+`first_rejection_mask` retains accepted proposals plus the first rejection,
+clipped by exposure. Rejected suffixes and residual/bonus tokens are excluded.
+Zero-exposure blocks contribute zero to the loss and its denominator.
+
+For each retained position, the overlap is
+`A = sum(v in C, min(p(v), q(v)))`, with `C` the natural candidate set.
+`1 - A` is the exact total variation distance for a draft supported on `C`.
+Teacher mass outside `C` is retained implicitly; do not renormalize `p` into
+the candidate set.
+
+For a block with `N` exposed positions, minimize
+`1 - sum(cumprod(A)) / N`. With a predecessor-conditioned selector, this is a
+replay-path surrogate, not exact unconditional serving acceptance length.
+Teacher probabilities are detached. A zero-overlap block remains finite;
+its overlap gradient can be zero when all teacher mass misses the candidates.
+
+The wrapper returns an **unnormalized block sum**, additive block statistics,
+and replay agreement diagnostics. By default it adds `0.1` times the inherited
+auxiliary objective, weighted by the record's valid-block count. Configure that
+objective through the inherited DFlash/D-PACE, LK and selector options. Set
+`auxiliary_coefficient=0` to skip its forward entirely.
+
+Normalize across the complete optimizer accumulation window. For averaged
+DDP/FSDP reductions, `global_block_loss` scales local sums by
+`world_size / global_valid_blocks`; do not divide by accumulation again.
+Alternatively, scale accumulated synchronized gradients by that factor before
+clipping. Unequal numbers of blocks across ranks must not become an unweighted
+average of local means.
+
+## Integration still required
+
+An end-to-end trainer must supply actual speculative verifier records, fully
+audit each generated input, synchronize only draft weights at every optimizer
+boundary, and reject stale policies. Checkpoints must recover optimizer,
+scheduler, rollout RNG, data cursor and policy identity together. These parts
+are not implemented by this module.
+
+CPU tests cover dense-reference values/gradients, first rejection and censoring,
+unequal rank/accumulation counts, selector/backbone gradients, and prevention
+of future-context leakage. Native backend parity, distributed optimizer
+recovery, performance and held-out acceptance gains remain unvalidated.

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -626,7 +626,8 @@ class OnlineDFlashModel(nn.Module):
                     sliding_window=sliding_window,
                     sliding_draft_causal=getattr(
                         self.draft_model.config, "is_causal", None
-                    ) is not False,
+                    )
+                    is not False,
                 ),
             }
 

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -191,6 +191,7 @@ def create_dflash_sdpa_mask(
     block_size,
     device,
     sliding_window: Optional[int] = None,
+    sliding_draft_causal: bool = True,
 ):
     """Construct a full or sliding dense boolean DFlash mask."""
 
@@ -223,7 +224,12 @@ def create_dflash_sdpa_mask(
     mask_draft = is_draft & (q_block_ids == kv_block_ids)
     if sliding_window is not None:
         kv_block_offsets = (kv_indices - S) % block_size
-        mask_draft = mask_draft & (kv_block_offsets <= q_block_offsets)
+        if sliding_draft_causal:
+            mask_draft = mask_draft & (kv_block_offsets <= q_block_offsets)
+        else:
+            mask_draft = mask_draft & (
+                kv_block_offsets >= q_block_offsets - (sliding_window - 1)
+            )
 
     valid_block = block_keep_mask.view(B, 1, N, 1).repeat_interleave(block_size, dim=2)
 
@@ -239,6 +245,7 @@ def create_dflash_block_mask(
     device: torch.device,
     flex_block_size=None,
     sliding_window: Optional[int] = None,
+    sliding_draft_causal: bool = True,
 ):
     """Construct a full or sliding Flex Attention mask for DFlash training."""
 
@@ -265,7 +272,12 @@ def create_dflash_block_mask(
         mask_draft = is_draft & (q_block_id == kv_block_id)
         if sliding_window is not None:
             kv_block_offset = (kv_idx - S) % block_size
-            mask_draft = mask_draft & (kv_block_offset <= q_block_offset)
+            if sliding_draft_causal:
+                mask_draft = mask_draft & (kv_block_offset <= q_block_offset)
+            else:
+                mask_draft = mask_draft & (
+                    kv_block_offset >= q_block_offset - (sliding_window - 1)
+                )
 
         is_valid_block = block_keep_mask[b, safe_q_block_id]
         in_bounds = q_block_id < N
@@ -612,6 +624,9 @@ class OnlineDFlashModel(nn.Module):
                 "sliding_attention": mask_builder(
                     **mask_args,
                     sliding_window=sliding_window,
+                    sliding_draft_causal=getattr(
+                        self.draft_model.config, "is_causal", None
+                    ) is not False,
                 ),
             }
 

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -543,16 +543,30 @@ class OnlineDFlashModel(nn.Module):
         hidden_states: torch.Tensor,
         loss_mask: torch.Tensor,
         max_valid_anchors: Optional[int] = None,
+        anchor_positions: Optional[torch.Tensor] = None,
+        block_keep_mask: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         bsz, seq_len = input_ids.shape
         device = input_ids.device
 
-        anchor_positions, block_keep_mask = self._sample_anchor_positions(
-            seq_len,
-            loss_mask,
-            device,
-            max_valid_anchors=max_valid_anchors,
-        )
+        if anchor_positions is None and block_keep_mask is None:
+            anchor_positions, block_keep_mask = self._sample_anchor_positions(
+                seq_len,
+                loss_mask,
+                device,
+                max_valid_anchors=max_valid_anchors,
+            )
+        else:
+            if anchor_positions is None or block_keep_mask is None:
+                raise ValueError("Replay requires both anchors and block validity")
+            if (anchor_positions.ndim != 2 or anchor_positions.shape[0] != bsz
+                    or block_keep_mask.shape != anchor_positions.shape
+                    or block_keep_mask.dtype != torch.bool
+                    or anchor_positions.dtype != torch.int64):
+                raise ValueError("Invalid replay anchor shape or dtype")
+            if bool((((anchor_positions < 0) | (anchor_positions >= seq_len))
+                     & block_keep_mask).any()):
+                raise ValueError("Replay anchor outside the captured input")
 
         noise_embedding = self._create_noise_embed(
             input_ids, anchor_positions, block_keep_mask

--- a/specforge/algorithms/common/dflash_family_model.py
+++ b/specforge/algorithms/common/dflash_family_model.py
@@ -559,13 +559,20 @@ class OnlineDFlashModel(nn.Module):
         else:
             if anchor_positions is None or block_keep_mask is None:
                 raise ValueError("Replay requires both anchors and block validity")
-            if (anchor_positions.ndim != 2 or anchor_positions.shape[0] != bsz
-                    or block_keep_mask.shape != anchor_positions.shape
-                    or block_keep_mask.dtype != torch.bool
-                    or anchor_positions.dtype != torch.int64):
+            if (
+                anchor_positions.ndim != 2
+                or anchor_positions.shape[0] != bsz
+                or block_keep_mask.shape != anchor_positions.shape
+                or block_keep_mask.dtype != torch.bool
+                or anchor_positions.dtype != torch.int64
+            ):
                 raise ValueError("Invalid replay anchor shape or dtype")
-            if bool((((anchor_positions < 0) | (anchor_positions >= seq_len))
-                     & block_keep_mask).any()):
+            if bool(
+                (
+                    ((anchor_positions < 0) | (anchor_positions >= seq_len))
+                    & block_keep_mask
+                ).any()
+            ):
                 raise ValueError("Replay anchor outside the captured input")
 
         noise_embedding = self._create_noise_embed(

--- a/specforge/algorithms/common/dflash_opd.py
+++ b/specforge/algorithms/common/dflash_opd.py
@@ -5,6 +5,7 @@ selector distribution; target mass outside its natural candidates is retained
 implicitly by TV = 1 - overlap. The prefix product is a replay-path surrogate,
 not an estimate of unconditional acceptance for a Markov selector.
 """
+
 from __future__ import annotations
 
 from typing import NamedTuple
@@ -61,7 +62,10 @@ def sparse_overlap(
     adapter. DFlash2 serving applies temperature to selector scores and samples
     from all natural K candidates; target filtering is done by the verifier.
     """
-    if selector_logits.shape != target_candidate_probs.shape or selector_logits.ndim < 2:
+    if (
+        selector_logits.shape != target_candidate_probs.shape
+        or selector_logits.ndim < 2
+    ):
         raise ValueError("Matching [..., K] scores and teacher probabilities required")
     if not isinstance(temperature, (float, int)) or not 0 < temperature < float("inf"):
         raise ValueError("Temperature must be finite and positive")
@@ -71,7 +75,9 @@ def sparse_overlap(
         raise ValueError("Nonfinite replay probabilities or logits")
     mass = p.sum(dim=-1)
     if bool((p < 0).any()) or bool((mass > 1.00001).any()):
-        raise ValueError("Teacher candidate probabilities must retain their original mass")
+        raise ValueError(
+            "Teacher candidate probabilities must retain their original mass"
+        )
     q = torch.softmax(logits / temperature, dim=-1)
     return torch.minimum(p, q).sum(dim=-1), mass
 
@@ -85,7 +91,9 @@ def opd_block_terms(
 ) -> OPDBlockTerms:
     """Return additive block statistics for a globally normalized update."""
     if selector_logits.ndim != 3 or position_mask.shape != selector_logits.shape[:-1]:
-        raise ValueError("Expected [blocks, positions, candidates] and [blocks, positions]")
+        raise ValueError(
+            "Expected [blocks, positions, candidates] and [blocks, positions]"
+        )
     if position_mask.dtype != torch.bool:
         raise ValueError("Replay position mask must be boolean")
     if bool((position_mask[:, 1:] & ~position_mask[:, :-1]).any()):
@@ -94,17 +102,25 @@ def opd_block_terms(
     # contribution and zero gradient, including NaN padding from empty records.
     mask = position_mask.unsqueeze(-1)
     logits = torch.where(mask, selector_logits, torch.zeros_like(selector_logits))
-    p = torch.where(mask, target_candidate_probs, torch.zeros_like(target_candidate_probs))
+    p = torch.where(
+        mask, target_candidate_probs, torch.zeros_like(target_candidate_probs)
+    )
     overlap, mass = sparse_overlap(logits, p, temperature=temperature)
-    survival = torch.cumprod(torch.where(position_mask, overlap, torch.ones_like(overlap)), dim=-1)
+    survival = torch.cumprod(
+        torch.where(position_mask, overlap, torch.ones_like(overlap)), dim=-1
+    )
     survival = torch.where(position_mask, survival, torch.zeros_like(survival))
     lengths = position_mask.sum(dim=-1)
     active = lengths > 0
     block_loss = 1 - survival.sum(dim=-1) / lengths.clamp_min(1)
     loss_sum = torch.where(active, block_loss, torch.zeros_like(block_loss)).sum()
     return OPDBlockTerms(
-        loss_sum, active.sum().float(), (overlap * position_mask).sum().detach(),
-        lengths.sum().float(), survival.sum().detach(), (mass * position_mask).sum().detach(),
+        loss_sum,
+        active.sum().float(),
+        (overlap * position_mask).sum().detach(),
+        lengths.sum().float(),
+        survival.sum().detach(),
+        (mass * position_mask).sum().detach(),
     )
 
 
@@ -127,7 +143,10 @@ def global_block_loss(
 
 def probabilities_on_candidates(candidate_ids, target_ids, target_probs):
     """Join the verifier's complete sparse support onto fresh draft candidates."""
-    if target_ids.shape != target_probs.shape or candidate_ids.shape[:-1] != target_ids.shape[:-1]:
+    if (
+        target_ids.shape != target_probs.shape
+        or candidate_ids.shape[:-1] != target_ids.shape[:-1]
+    ):
         raise ValueError("Sparse teacher and candidate shape mismatch")
     if not bool(torch.isfinite(target_probs).all()) or bool((target_probs < 0).any()):
         raise ValueError("Invalid sparse teacher probabilities")
@@ -137,8 +156,14 @@ def probabilities_on_candidates(candidate_ids, target_ids, target_probs):
         ordered = ids.sort(dim=-1).values
         if bool((ordered[..., 1:] == ordered[..., :-1]).any()):
             raise ValueError("Sparse support contains duplicate token IDs")
-    if not bool(torch.allclose(target_probs.sum(-1), torch.ones_like(target_probs[..., 0]),
-                               atol=2e-5, rtol=0)):
+    if not bool(
+        torch.allclose(
+            target_probs.sum(-1),
+            torch.ones_like(target_probs[..., 0]),
+            atol=2e-5,
+            rtol=0,
+        )
+    ):
         raise ValueError("Teacher sparse support is incomplete")
     matches = candidate_ids.unsqueeze(-1) == target_ids.unsqueeze(-2)
     return (matches * target_probs.detach().unsqueeze(-2)).sum(-1)
@@ -152,56 +177,112 @@ class OPDDFlash2Model(OnlineDFlashModel):
     gradients by the globally reduced valid-block count BEFORE gradient clip.
     """
 
-    def forward(self, *, input_ids, hidden_states, loss_mask, replay,
-                auxiliary_coefficient: float = 0.1):
+    def forward(
+        self,
+        *,
+        input_ids,
+        hidden_states,
+        loss_mask,
+        replay,
+        auxiliary_coefficient: float = 0.1,
+    ):
         if input_ids.ndim != 2 or input_ids.shape[0] != 1 or self.block_size < 2:
-            raise ValueError("OPD replay requires one rollout and at least one proposal per block")
+            raise ValueError(
+                "OPD replay requires one rollout and at least one proposal per block"
+            )
         if self.selector_stop_gradient:
-            raise ValueError("OPD replay requires coupled selector and backbone gradients")
+            raise ValueError(
+                "OPD replay requires coupled selector and backbone gradients"
+            )
         if not 0 <= auxiliary_coefficient <= 1:
             raise ValueError("Invalid auxiliary coefficient")
-        anchors = replay['anchor_positions']
+        anchors = replay["anchor_positions"]
         n = anchors.numel()
         if anchors.ndim != 1 or n == 0 or torch.unique(anchors).numel() != n:
             raise ValueError("Need nonempty unique actual rollout anchors")
         captured_length = hidden_states.shape[1]
         if bool((anchors < 0).any()) or bool((anchors > captured_length).any()):
             raise ValueError("An OPD anchor refers to uncaptured target context")
-        if captured_length > input_ids.shape[1] or input_ids.shape[1] - captured_length > 1:
+        if (
+            captured_length > input_ids.shape[1]
+            or input_ids.shape[1] - captured_length > 1
+        ):
             raise ValueError("Unexpected target tap/returned-token alignment")
         if captured_length < input_ids.shape[1]:
-            hidden_states = torch.cat([hidden_states, hidden_states.new_zeros(
-                1, input_ids.shape[1] - captured_length, hidden_states.shape[-1])], dim=1)
-        _, _, hidden = self._forward_draft_blocks(input_ids, hidden_states, loss_mask,
-            anchor_positions=anchors[None], block_keep_mask=torch.ones_like(anchors[None], dtype=torch.bool))
+            hidden_states = torch.cat(
+                [
+                    hidden_states,
+                    hidden_states.new_zeros(
+                        1, input_ids.shape[1] - captured_length, hidden_states.shape[-1]
+                    ),
+                ],
+                dim=1,
+            )
+        _, _, hidden = self._forward_draft_blocks(
+            input_ids,
+            hidden_states,
+            loss_mask,
+            anchor_positions=anchors[None],
+            block_keep_mask=torch.ones_like(anchors[None], dtype=torch.bool),
+        )
         hidden = hidden.reshape(1, n, self.block_size, -1)[0, :, 1:]
         logits = self.draft_model.transform_unary_logits(self.lm_head(hidden))
         unary, ids = logits.topk(self.draft_model.candidate_selector.top_k, dim=-1)
-        predecessors = torch.cat([input_ids[0, anchors, None], replay['proposed_ids'][:, :-1]], dim=-1)
-        scores = self.draft_model.candidate_selector.score_candidates(candidate_ids=ids,
-            unary_logits=unary, hidden_states=hidden, predecessor_ids=predecessors)
-        mask = first_rejection_mask(replay['accepted_lengths'], replay['exposed_lengths'],
-                                    proposal_width=self.block_size - 1)
+        predecessors = torch.cat(
+            [input_ids[0, anchors, None], replay["proposed_ids"][:, :-1]], dim=-1
+        )
+        scores = self.draft_model.candidate_selector.score_candidates(
+            candidate_ids=ids,
+            unary_logits=unary,
+            hidden_states=hidden,
+            predecessor_ids=predecessors,
+        )
+        mask = first_rejection_mask(
+            replay["accepted_lengths"],
+            replay["exposed_lengths"],
+            proposal_width=self.block_size - 1,
+        )
         # Reusing stale candidates would train a different policy from the rollout.
-        if bool(((ids != replay['candidate_ids']).any(-1) & mask).any()):
-            raise ValueError("Current-policy replay candidate identity differs from serving")
-        recorded_q = replay['q']
-        if recorded_q.shape != scores.shape or not bool(torch.isfinite(recorded_q[mask]).all()):
+        if bool(((ids != replay["candidate_ids"]).any(-1) & mask).any()):
+            raise ValueError(
+                "Current-policy replay candidate identity differs from serving"
+            )
+        recorded_q = replay["q"]
+        if recorded_q.shape != scores.shape or not bool(
+            torch.isfinite(recorded_q[mask]).all()
+        ):
             raise ValueError("Invalid recorded replay probabilities")
         if bool((recorded_q[mask] < 0).any()) or not torch.allclose(
-                recorded_q[mask].sum(-1), torch.ones_like(recorded_q[mask][:, 0]), atol=2e-5, rtol=0):
+            recorded_q[mask].sum(-1),
+            torch.ones_like(recorded_q[mask][:, 0]),
+            atol=2e-5,
+            rtol=0,
+        ):
             raise ValueError("Recorded replay probability mass differs from one")
         q = scores.float().softmax(-1)
-        max_error = (torch.where(mask[..., None], (q.detach() - replay['q']).abs(), 0.)).max()
+        max_error = (
+            torch.where(mask[..., None], (q.detach() - replay["q"]).abs(), 0.0)
+        ).max()
         if float(max_error) > 0.01:
             raise ValueError("Current-policy replay probability drift exceeds 0.01")
-        p = probabilities_on_candidates(ids, replay['target_ids'], replay['target_probs'])
+        p = probabilities_on_candidates(
+            ids, replay["target_ids"], replay["target_probs"]
+        )
         terms = opd_block_terms(scores, p, mask)
         auxiliary_loss = terms.loss_sum.new_zeros(())
         if auxiliary_coefficient:
-            auxiliary_loss, _, _ = super().forward(input_ids=input_ids, hidden_states=hidden_states,
-                loss_mask=loss_mask, collect_detailed_metrics=False)
+            auxiliary_loss, _, _ = super().forward(
+                input_ids=input_ids,
+                hidden_states=hidden_states,
+                loss_mask=loss_mask,
+                collect_detailed_metrics=False,
+            )
         # Equal block weighting of each record's prior auxiliary objective.
-        total = terms.loss_sum + auxiliary_coefficient * terms.block_count * auxiliary_loss
-        return total, {'opd_terms': terms, 'auxiliary_loss': auxiliary_loss.detach(),
-                       'replay_probability_max_error': max_error.detach()}
+        total = (
+            terms.loss_sum + auxiliary_coefficient * terms.block_count * auxiliary_loss
+        )
+        return total, {
+            "opd_terms": terms,
+            "auxiliary_loss": auxiliary_loss.detach(),
+            "replay_probability_max_error": max_error.detach(),
+        }

--- a/specforge/algorithms/common/dflash_opd.py
+++ b/specforge/algorithms/common/dflash_opd.py
@@ -1,0 +1,207 @@
+"""DFlash2 draft-policy replay losses, independent of rollout transport.
+
+The block objective follows the Draft-OPD TV variant. DFlash2 has a sparse
+selector distribution; target mass outside its natural candidates is retained
+implicitly by TV = 1 - overlap. The prefix product is a replay-path surrogate,
+not an estimate of unconditional acceptance for a Markov selector.
+"""
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+
+from specforge.algorithms.common.dflash_family_model import OnlineDFlashModel
+
+
+class OPDBlockTerms(NamedTuple):
+    loss_sum: torch.Tensor
+    block_count: torch.Tensor
+    overlap_sum: torch.Tensor
+    position_count: torch.Tensor
+    prefix_survival_sum: torch.Tensor
+    target_candidate_mass_sum: torch.Tensor
+
+
+def first_rejection_mask(
+    accepted_lengths: torch.Tensor,
+    exposed_lengths: torch.Tensor,
+    *,
+    proposal_width: int = 7,
+) -> torch.Tensor:
+    """Select accepted proposals plus the first reject, respecting censoring.
+
+    Lengths count draft proposals only, excluding the anchor and bonus token.
+    exposed_lengths excludes positions beyond the request's EOS/length limit.
+    accepted_lengths may exceed exposure when serving reports pre-censor counts.
+    """
+    if type(proposal_width) is not int or proposal_width < 1:
+        raise ValueError("proposal_width must be a positive integer")
+    if accepted_lengths.shape != exposed_lengths.shape:
+        raise ValueError("Accepted and exposed lengths must have the same shape")
+    for value in (accepted_lengths, exposed_lengths):
+        if value.dtype not in (torch.int32, torch.int64):
+            raise ValueError("Replay lengths must be integer tensors")
+        if bool(((value < 0) | (value > proposal_width)).any()):
+            raise ValueError("Replay length outside the proposal block")
+    length = torch.minimum(accepted_lengths + 1, exposed_lengths)
+    positions = torch.arange(proposal_width, device=length.device)
+    return positions < length.unsqueeze(-1)
+
+
+def sparse_overlap(
+    selector_logits: torch.Tensor,
+    target_candidate_probs: torch.Tensor,
+    *,
+    temperature: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Exact overlap against a target distribution with arbitrary outside mass.
+
+    Inputs contain unique candidate IDs in matching order, checked by the replay
+    adapter. DFlash2 serving applies temperature to selector scores and samples
+    from all natural K candidates; target filtering is done by the verifier.
+    """
+    if selector_logits.shape != target_candidate_probs.shape or selector_logits.ndim < 2:
+        raise ValueError("Matching [..., K] scores and teacher probabilities required")
+    if not isinstance(temperature, (float, int)) or not 0 < temperature < float("inf"):
+        raise ValueError("Temperature must be finite and positive")
+    p = target_candidate_probs.detach().float()
+    logits = selector_logits.float()
+    if not bool(torch.isfinite(p).all()) or not bool(torch.isfinite(logits).all()):
+        raise ValueError("Nonfinite replay probabilities or logits")
+    mass = p.sum(dim=-1)
+    if bool((p < 0).any()) or bool((mass > 1.00001).any()):
+        raise ValueError("Teacher candidate probabilities must retain their original mass")
+    q = torch.softmax(logits / temperature, dim=-1)
+    return torch.minimum(p, q).sum(dim=-1), mass
+
+
+def opd_block_terms(
+    selector_logits: torch.Tensor,
+    target_candidate_probs: torch.Tensor,
+    position_mask: torch.Tensor,
+    *,
+    temperature: float = 1.0,
+) -> OPDBlockTerms:
+    """Return additive block statistics for a globally normalized update."""
+    if selector_logits.ndim != 3 or position_mask.shape != selector_logits.shape[:-1]:
+        raise ValueError("Expected [blocks, positions, candidates] and [blocks, positions]")
+    if position_mask.dtype != torch.bool:
+        raise ValueError("Replay position mask must be boolean")
+    if bool((position_mask[:, 1:] & ~position_mask[:, :-1]).any()):
+        raise ValueError("Replay positions must form a contiguous prefix")
+    # Mask padding before evaluating it; arbitrary padding must have zero
+    # contribution and zero gradient, including NaN padding from empty records.
+    mask = position_mask.unsqueeze(-1)
+    logits = torch.where(mask, selector_logits, torch.zeros_like(selector_logits))
+    p = torch.where(mask, target_candidate_probs, torch.zeros_like(target_candidate_probs))
+    overlap, mass = sparse_overlap(logits, p, temperature=temperature)
+    survival = torch.cumprod(torch.where(position_mask, overlap, torch.ones_like(overlap)), dim=-1)
+    survival = torch.where(position_mask, survival, torch.zeros_like(survival))
+    lengths = position_mask.sum(dim=-1)
+    active = lengths > 0
+    block_loss = 1 - survival.sum(dim=-1) / lengths.clamp_min(1)
+    loss_sum = torch.where(active, block_loss, torch.zeros_like(block_loss)).sum()
+    return OPDBlockTerms(
+        loss_sum, active.sum().float(), (overlap * position_mask).sum().detach(),
+        lengths.sum().float(), survival.sum().detach(), (mass * position_mask).sum().detach(),
+    )
+
+
+def global_block_loss(
+    terms: OPDBlockTerms, *, global_block_count: int, gradient_average_world_size: int
+) -> torch.Tensor:
+    """Scale a local SUM before a DDP/FSDP averaged gradient reduction.
+
+    global_block_count includes the complete accumulation window, not just the
+    current microbatch. The caller must not divide by accumulation again.
+    """
+    if type(global_block_count) is not int or global_block_count < 0:
+        raise ValueError("Global block count must be a nonnegative integer")
+    if type(gradient_average_world_size) is not int or gradient_average_world_size < 1:
+        raise ValueError("Gradient average world size must be positive")
+    if global_block_count < int(terms.block_count):
+        raise ValueError("Global block count is smaller than local block count")
+    return terms.loss_sum * (gradient_average_world_size / max(global_block_count, 1))
+
+
+def probabilities_on_candidates(candidate_ids, target_ids, target_probs):
+    """Join the verifier's complete sparse support onto fresh draft candidates."""
+    if target_ids.shape != target_probs.shape or candidate_ids.shape[:-1] != target_ids.shape[:-1]:
+        raise ValueError("Sparse teacher and candidate shape mismatch")
+    if not bool(torch.isfinite(target_probs).all()) or bool((target_probs < 0).any()):
+        raise ValueError("Invalid sparse teacher probabilities")
+    for ids in (candidate_ids, target_ids):
+        if ids.dtype not in (torch.int32, torch.int64) or bool((ids < 0).any()):
+            raise ValueError("Sparse support requires nonnegative integer token IDs")
+        ordered = ids.sort(dim=-1).values
+        if bool((ordered[..., 1:] == ordered[..., :-1]).any()):
+            raise ValueError("Sparse support contains duplicate token IDs")
+    if not bool(torch.allclose(target_probs.sum(-1), torch.ones_like(target_probs[..., 0]),
+                               atol=2e-5, rtol=0)):
+        raise ValueError("Teacher sparse support is incomplete")
+    matches = candidate_ids.unsqueeze(-1) == target_ids.unsqueeze(-2)
+    return (matches * target_probs.detach().unsqueeze(-2)).sum(-1)
+
+
+class OPDDFlash2Model(OnlineDFlashModel):
+    """Replay actual verified blocks with coupled selector/backbone gradients.
+
+    The adapter passes a single, audited variable-length rollout per rank. This
+    implementation returns an unnormalized block sum; normalize accumulated
+    gradients by the globally reduced valid-block count BEFORE gradient clip.
+    """
+
+    def forward(self, *, input_ids, hidden_states, loss_mask, replay,
+                auxiliary_coefficient: float = 0.1):
+        if input_ids.ndim != 2 or input_ids.shape[0] != 1 or self.block_size < 2:
+            raise ValueError("OPD replay requires one rollout and at least one proposal per block")
+        if self.selector_stop_gradient:
+            raise ValueError("OPD replay requires coupled selector and backbone gradients")
+        if not 0 <= auxiliary_coefficient <= 1:
+            raise ValueError("Invalid auxiliary coefficient")
+        anchors = replay['anchor_positions']
+        n = anchors.numel()
+        if anchors.ndim != 1 or n == 0 or torch.unique(anchors).numel() != n:
+            raise ValueError("Need nonempty unique actual rollout anchors")
+        captured_length = hidden_states.shape[1]
+        if bool((anchors < 0).any()) or bool((anchors > captured_length).any()):
+            raise ValueError("An OPD anchor refers to uncaptured target context")
+        if captured_length > input_ids.shape[1] or input_ids.shape[1] - captured_length > 1:
+            raise ValueError("Unexpected target tap/returned-token alignment")
+        if captured_length < input_ids.shape[1]:
+            hidden_states = torch.cat([hidden_states, hidden_states.new_zeros(
+                1, input_ids.shape[1] - captured_length, hidden_states.shape[-1])], dim=1)
+        _, _, hidden = self._forward_draft_blocks(input_ids, hidden_states, loss_mask,
+            anchor_positions=anchors[None], block_keep_mask=torch.ones_like(anchors[None], dtype=torch.bool))
+        hidden = hidden.reshape(1, n, self.block_size, -1)[0, :, 1:]
+        logits = self.draft_model.transform_unary_logits(self.lm_head(hidden))
+        unary, ids = logits.topk(self.draft_model.candidate_selector.top_k, dim=-1)
+        predecessors = torch.cat([input_ids[0, anchors, None], replay['proposed_ids'][:, :-1]], dim=-1)
+        scores = self.draft_model.candidate_selector.score_candidates(candidate_ids=ids,
+            unary_logits=unary, hidden_states=hidden, predecessor_ids=predecessors)
+        mask = first_rejection_mask(replay['accepted_lengths'], replay['exposed_lengths'],
+                                    proposal_width=self.block_size - 1)
+        # Reusing stale candidates would train a different policy from the rollout.
+        if bool(((ids != replay['candidate_ids']).any(-1) & mask).any()):
+            raise ValueError("Current-policy replay candidate identity differs from serving")
+        recorded_q = replay['q']
+        if recorded_q.shape != scores.shape or not bool(torch.isfinite(recorded_q[mask]).all()):
+            raise ValueError("Invalid recorded replay probabilities")
+        if bool((recorded_q[mask] < 0).any()) or not torch.allclose(
+                recorded_q[mask].sum(-1), torch.ones_like(recorded_q[mask][:, 0]), atol=2e-5, rtol=0):
+            raise ValueError("Recorded replay probability mass differs from one")
+        q = scores.float().softmax(-1)
+        max_error = (torch.where(mask[..., None], (q.detach() - replay['q']).abs(), 0.)).max()
+        if float(max_error) > 0.01:
+            raise ValueError("Current-policy replay probability drift exceeds 0.01")
+        p = probabilities_on_candidates(ids, replay['target_ids'], replay['target_probs'])
+        terms = opd_block_terms(scores, p, mask)
+        auxiliary_loss = terms.loss_sum.new_zeros(())
+        if auxiliary_coefficient:
+            auxiliary_loss, _, _ = super().forward(input_ids=input_ids, hidden_states=hidden_states,
+                loss_mask=loss_mask, collect_detailed_metrics=False)
+        # Equal block weighting of each record's prior auxiliary objective.
+        total = terms.loss_sum + auxiliary_coefficient * terms.block_count * auxiliary_loss
+        return total, {'opd_terms': terms, 'auxiliary_loss': auxiliary_loss.detach(),
+                       'replay_probability_max_error': max_error.detach()}

--- a/tests/test_modeling/test_dflash_opd_model.py
+++ b/tests/test_modeling/test_dflash_opd_model.py
@@ -1,4 +1,5 @@
 """Replay alignment tests with the real small DFlash2 backbone and selector."""
+
 import copy
 import unittest
 
@@ -13,121 +14,241 @@ from specforge.modeling.draft.dflash2 import DFlash2DraftModel
 class ReplayModelTests(unittest.TestCase):
     def setUp(self):
         torch.manual_seed(91)
-        config = Qwen3Config(hidden_size=16, intermediate_size=32,
-            num_attention_heads=4, num_key_value_heads=2, num_hidden_layers=1,
-            num_target_layers=4, head_dim=4, max_position_embeddings=64,
-            vocab_size=32, layer_types=['full_attention'],
-            dflash_config=dict(block_size=8, conv_group_size=4, conv_kernel_size=2,
-                mask_token_id=31, selector_rank=4, selector_top_k=3, target_layer_ids=[1]))
+        config = Qwen3Config(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            num_hidden_layers=1,
+            num_target_layers=4,
+            head_dim=4,
+            max_position_embeddings=64,
+            vocab_size=32,
+            layer_types=["full_attention"],
+            dflash_config=dict(
+                block_size=8,
+                conv_group_size=4,
+                conv_kernel_size=2,
+                mask_token_id=31,
+                selector_rank=4,
+                selector_top_k=3,
+                target_layer_ids=[1],
+            ),
+        )
         draft = DFlash2DraftModel(config)
-        draft.config._attn_implementation = 'eager'
+        draft.config._attn_implementation = "eager"
         # A trained selector has a nonzero successor codebook.
         with torch.no_grad():
-            draft.candidate_selector.successor_codebook.normal_(std=.1)
-        self.model = OPDDFlash2Model(draft, nn.Linear(16, 32, bias=False).requires_grad_(False),
-            nn.Embedding(32, 16).requires_grad_(False), 31, block_size=8,
-            attention_backend='eager', num_anchors=2, loss_type='dpace', lk_loss_type='lambda')
+            draft.candidate_selector.successor_codebook.normal_(std=0.1)
+        self.model = OPDDFlash2Model(
+            draft,
+            nn.Linear(16, 32, bias=False).requires_grad_(False),
+            nn.Embedding(32, 16).requires_grad_(False),
+            31,
+            block_size=8,
+            attention_backend="eager",
+            num_anchors=2,
+            loss_type="dpace",
+            lk_loss_type="lambda",
+        )
         self.ids = torch.arange(12)[None]
         self.taps = torch.randn(1, 12, 16)
-        self.mask = torch.tensor([[0]*4 + [1]*8])
+        self.mask = torch.tensor([[0] * 4 + [1] * 8])
         self.anchors = torch.tensor([4])
 
     def replay(self):
         with torch.no_grad():
-            _, _, h = self.model._forward_draft_blocks(self.ids, self.taps, self.mask,
-                anchor_positions=self.anchors[None], block_keep_mask=torch.tensor([[True]]))
+            _, _, h = self.model._forward_draft_blocks(
+                self.ids,
+                self.taps,
+                self.mask,
+                anchor_positions=self.anchors[None],
+                block_keep_mask=torch.tensor([[True]]),
+            )
             h = h.reshape(1, 8, 16)[:, 1:]
-            unary, ids = self.model.draft_model.transform_unary_logits(self.model.lm_head(h)).topk(3)
+            unary, ids = self.model.draft_model.transform_unary_logits(
+                self.model.lm_head(h)
+            ).topk(3)
             proposed = ids[..., 0]
-            previous = torch.cat([self.ids[0, self.anchors, None], proposed[:, :-1]], -1)
+            previous = torch.cat(
+                [self.ids[0, self.anchors, None], proposed[:, :-1]], -1
+            )
             scores = self.model.draft_model.candidate_selector.score_candidates(
-                candidate_ids=ids, unary_logits=unary, hidden_states=h, predecessor_ids=previous)
-        p = torch.full((1, 7, 32), .3/31)
-        p.scatter_(-1, ids[..., :1], .7)
-        return dict(anchor_positions=self.anchors, proposed_ids=proposed,
-            candidate_ids=ids, q=scores.softmax(-1), accepted_lengths=torch.tensor([1]),
-            exposed_lengths=torch.tensor([7]), target_ids=torch.arange(32).expand(1, 7, 32),
-            target_probs=p)
+                candidate_ids=ids,
+                unary_logits=unary,
+                hidden_states=h,
+                predecessor_ids=previous,
+            )
+        p = torch.full((1, 7, 32), 0.3 / 31)
+        p.scatter_(-1, ids[..., :1], 0.7)
+        return dict(
+            anchor_positions=self.anchors,
+            proposed_ids=proposed,
+            candidate_ids=ids,
+            q=scores.softmax(-1),
+            accepted_lengths=torch.tensor([1]),
+            exposed_lengths=torch.tensor([7]),
+            target_ids=torch.arange(32).expand(1, 7, 32),
+            target_probs=p,
+        )
 
     def test_full_backbone_and_selector_receive_finite_gradients(self):
-        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
-            loss_mask=self.mask, replay=self.replay())
+        loss, metrics = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps,
+            loss_mask=self.mask,
+            replay=self.replay(),
+        )
         loss.backward()
-        self.assertEqual(metrics['opd_terms'].block_count, 1)
-        self.assertEqual(metrics['opd_terms'].position_count, 2)
+        self.assertEqual(metrics["opd_terms"].block_count, 1)
+        self.assertEqual(metrics["opd_terms"].position_count, 2)
         for name, p in self.model.draft_model.named_parameters():
             self.assertIsNotNone(p.grad, name)
             self.assertTrue(torch.isfinite(p.grad).all(), name)
         selector = self.model.draft_model.candidate_selector
         self.assertGreater(selector.hidden_projection.weight.grad.abs().sum(), 0)
-        self.assertGreater(self.model.draft_model.layers[0].self_attn.q_proj.weight.grad.abs().sum(), 0)
+        self.assertGreater(
+            self.model.draft_model.layers[0].self_attn.q_proj.weight.grad.abs().sum(), 0
+        )
 
     def test_future_target_context_cannot_change_earlier_block(self):
         replay = self.replay()
-        before = self.model(input_ids=self.ids, hidden_states=self.taps,
-            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        before = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps,
+            loss_mask=self.mask,
+            replay=replay,
+            auxiliary_coefficient=0,
+        )[0]
         poisoned = self.taps.clone()
         poisoned[:, 4:] = torch.randn_like(poisoned[:, 4:]) * 1000
-        after = self.model(input_ids=self.ids, hidden_states=poisoned,
-            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        after = self.model(
+            input_ids=self.ids,
+            hidden_states=poisoned,
+            loss_mask=self.mask,
+            replay=replay,
+            auxiliary_coefficient=0,
+        )[0]
         torch.testing.assert_close(before, after, rtol=0, atol=0)
 
     def test_candidate_and_policy_probability_drift_rejected(self):
         replay = self.replay()
         changed = copy.deepcopy(replay)
-        changed['candidate_ids'][0, 0, 0] = (changed['candidate_ids'][0, 0, 0]+1)%32
-        with self.assertRaisesRegex(ValueError, 'candidate identity'):
-            self.model(input_ids=self.ids, hidden_states=self.taps, loss_mask=self.mask, replay=changed)
+        changed["candidate_ids"][0, 0, 0] = (changed["candidate_ids"][0, 0, 0] + 1) % 32
+        with self.assertRaisesRegex(ValueError, "candidate identity"):
+            self.model(
+                input_ids=self.ids,
+                hidden_states=self.taps,
+                loss_mask=self.mask,
+                replay=changed,
+            )
         changed = copy.deepcopy(replay)
-        changed['q'][0, 0] = torch.tensor([1., 0., 0.])
-        with self.assertRaisesRegex(ValueError, 'probability drift'):
-            self.model(input_ids=self.ids, hidden_states=self.taps, loss_mask=self.mask, replay=changed)
+        changed["q"][0, 0] = torch.tensor([1.0, 0.0, 0.0])
+        with self.assertRaisesRegex(ValueError, "probability drift"):
+            self.model(
+                input_ids=self.ids,
+                hidden_states=self.taps,
+                loss_mask=self.mask,
+                replay=changed,
+            )
 
     def test_final_uncaptured_bonus_is_never_used_as_context(self):
         replay = self.replay()
-        before = self.model(input_ids=self.ids, hidden_states=self.taps,
-            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
-        after = self.model(input_ids=self.ids, hidden_states=self.taps[:, :-1],
-            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        before = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps,
+            loss_mask=self.mask,
+            replay=replay,
+            auxiliary_coefficient=0,
+        )[0]
+        after = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps[:, :-1],
+            loss_mask=self.mask,
+            replay=replay,
+            auxiliary_coefficient=0,
+        )[0]
         torch.testing.assert_close(before, after, rtol=0, atol=0)
 
     def test_nonfinite_recorded_probability_cannot_bypass_parity_check(self):
         replay = self.replay()
-        replay['q'][0, 0, 0] = float('nan')
-        with self.assertRaisesRegex(ValueError, 'Invalid recorded replay probabilities'):
-            self.model(input_ids=self.ids, hidden_states=self.taps,
-                loss_mask=self.mask, replay=replay)
+        replay["q"][0, 0, 0] = float("nan")
+        with self.assertRaisesRegex(
+            ValueError, "Invalid recorded replay probabilities"
+        ):
+            self.model(
+                input_ids=self.ids,
+                hidden_states=self.taps,
+                loss_mask=self.mask,
+                replay=replay,
+            )
 
     def test_disabled_auxiliary_does_not_require_supervised_anchor_sampling(self):
-        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
-            loss_mask=torch.zeros_like(self.mask), replay=self.replay(), auxiliary_coefficient=0)
+        loss, metrics = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps,
+            loss_mask=torch.zeros_like(self.mask),
+            replay=self.replay(),
+            auxiliary_coefficient=0,
+        )
         self.assertTrue(torch.isfinite(loss))
-        self.assertEqual(metrics['auxiliary_loss'], 0)
+        self.assertEqual(metrics["auxiliary_loss"], 0)
 
     def test_replay_uses_configured_block_width(self):
         config = copy.deepcopy(self.model.draft_model.config)
-        config.dflash_config['block_size'] = 4
+        config.dflash_config["block_size"] = 4
         draft = DFlash2DraftModel(config)
-        self.model = OPDDFlash2Model(draft, self.model.lm_head, self.model.embed_tokens,
-            31, block_size=4, attention_backend='eager', num_anchors=2)
+        self.model = OPDDFlash2Model(
+            draft,
+            self.model.lm_head,
+            self.model.embed_tokens,
+            31,
+            block_size=4,
+            attention_backend="eager",
+            num_anchors=2,
+        )
         with torch.no_grad():
-            _, _, h = self.model._forward_draft_blocks(self.ids, self.taps, self.mask,
-                anchor_positions=self.anchors[None], block_keep_mask=torch.tensor([[True]]))
+            _, _, h = self.model._forward_draft_blocks(
+                self.ids,
+                self.taps,
+                self.mask,
+                anchor_positions=self.anchors[None],
+                block_keep_mask=torch.tensor([[True]]),
+            )
             h = h.reshape(1, 4, 16)[:, 1:]
-            unary, ids = self.model.draft_model.transform_unary_logits(self.model.lm_head(h)).topk(3)
+            unary, ids = self.model.draft_model.transform_unary_logits(
+                self.model.lm_head(h)
+            ).topk(3)
             proposed = ids[..., 0]
-            previous = torch.cat([self.ids[0, self.anchors, None], proposed[:, :-1]], -1)
+            previous = torch.cat(
+                [self.ids[0, self.anchors, None], proposed[:, :-1]], -1
+            )
             scores = self.model.draft_model.candidate_selector.score_candidates(
-                candidate_ids=ids, unary_logits=unary, hidden_states=h, predecessor_ids=previous)
-        replay = dict(anchor_positions=self.anchors, proposed_ids=proposed,
-            candidate_ids=ids, q=scores.softmax(-1), accepted_lengths=torch.tensor([1]),
-            exposed_lengths=torch.tensor([3]), target_ids=torch.arange(32).expand(1, 3, 32),
-            target_probs=torch.full((1, 3, 32), 1/32))
-        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
-            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)
+                candidate_ids=ids,
+                unary_logits=unary,
+                hidden_states=h,
+                predecessor_ids=previous,
+            )
+        replay = dict(
+            anchor_positions=self.anchors,
+            proposed_ids=proposed,
+            candidate_ids=ids,
+            q=scores.softmax(-1),
+            accepted_lengths=torch.tensor([1]),
+            exposed_lengths=torch.tensor([3]),
+            target_ids=torch.arange(32).expand(1, 3, 32),
+            target_probs=torch.full((1, 3, 32), 1 / 32),
+        )
+        loss, metrics = self.model(
+            input_ids=self.ids,
+            hidden_states=self.taps,
+            loss_mask=self.mask,
+            replay=replay,
+            auxiliary_coefficient=0,
+        )
         self.assertTrue(torch.isfinite(loss))
-        self.assertEqual(metrics['opd_terms'].position_count, 2)
+        self.assertEqual(metrics["opd_terms"].position_count, 2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modeling/test_dflash_opd_model.py
+++ b/tests/test_modeling/test_dflash_opd_model.py
@@ -1,0 +1,133 @@
+"""Replay alignment tests with the real small DFlash2 backbone and selector."""
+import copy
+import unittest
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from specforge.algorithms.common.dflash_opd import OPDDFlash2Model
+from specforge.modeling.draft.dflash2 import DFlash2DraftModel
+
+
+class ReplayModelTests(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(91)
+        config = Qwen3Config(hidden_size=16, intermediate_size=32,
+            num_attention_heads=4, num_key_value_heads=2, num_hidden_layers=1,
+            num_target_layers=4, head_dim=4, max_position_embeddings=64,
+            vocab_size=32, layer_types=['full_attention'],
+            dflash_config=dict(block_size=8, conv_group_size=4, conv_kernel_size=2,
+                mask_token_id=31, selector_rank=4, selector_top_k=3, target_layer_ids=[1]))
+        draft = DFlash2DraftModel(config)
+        draft.config._attn_implementation = 'eager'
+        # A trained selector has a nonzero successor codebook.
+        with torch.no_grad():
+            draft.candidate_selector.successor_codebook.normal_(std=.1)
+        self.model = OPDDFlash2Model(draft, nn.Linear(16, 32, bias=False).requires_grad_(False),
+            nn.Embedding(32, 16).requires_grad_(False), 31, block_size=8,
+            attention_backend='eager', num_anchors=2, loss_type='dpace', lk_loss_type='lambda')
+        self.ids = torch.arange(12)[None]
+        self.taps = torch.randn(1, 12, 16)
+        self.mask = torch.tensor([[0]*4 + [1]*8])
+        self.anchors = torch.tensor([4])
+
+    def replay(self):
+        with torch.no_grad():
+            _, _, h = self.model._forward_draft_blocks(self.ids, self.taps, self.mask,
+                anchor_positions=self.anchors[None], block_keep_mask=torch.tensor([[True]]))
+            h = h.reshape(1, 8, 16)[:, 1:]
+            unary, ids = self.model.draft_model.transform_unary_logits(self.model.lm_head(h)).topk(3)
+            proposed = ids[..., 0]
+            previous = torch.cat([self.ids[0, self.anchors, None], proposed[:, :-1]], -1)
+            scores = self.model.draft_model.candidate_selector.score_candidates(
+                candidate_ids=ids, unary_logits=unary, hidden_states=h, predecessor_ids=previous)
+        p = torch.full((1, 7, 32), .3/31)
+        p.scatter_(-1, ids[..., :1], .7)
+        return dict(anchor_positions=self.anchors, proposed_ids=proposed,
+            candidate_ids=ids, q=scores.softmax(-1), accepted_lengths=torch.tensor([1]),
+            exposed_lengths=torch.tensor([7]), target_ids=torch.arange(32).expand(1, 7, 32),
+            target_probs=p)
+
+    def test_full_backbone_and_selector_receive_finite_gradients(self):
+        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
+            loss_mask=self.mask, replay=self.replay())
+        loss.backward()
+        self.assertEqual(metrics['opd_terms'].block_count, 1)
+        self.assertEqual(metrics['opd_terms'].position_count, 2)
+        for name, p in self.model.draft_model.named_parameters():
+            self.assertIsNotNone(p.grad, name)
+            self.assertTrue(torch.isfinite(p.grad).all(), name)
+        selector = self.model.draft_model.candidate_selector
+        self.assertGreater(selector.hidden_projection.weight.grad.abs().sum(), 0)
+        self.assertGreater(self.model.draft_model.layers[0].self_attn.q_proj.weight.grad.abs().sum(), 0)
+
+    def test_future_target_context_cannot_change_earlier_block(self):
+        replay = self.replay()
+        before = self.model(input_ids=self.ids, hidden_states=self.taps,
+            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        poisoned = self.taps.clone()
+        poisoned[:, 4:] = torch.randn_like(poisoned[:, 4:]) * 1000
+        after = self.model(input_ids=self.ids, hidden_states=poisoned,
+            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        torch.testing.assert_close(before, after, rtol=0, atol=0)
+
+    def test_candidate_and_policy_probability_drift_rejected(self):
+        replay = self.replay()
+        changed = copy.deepcopy(replay)
+        changed['candidate_ids'][0, 0, 0] = (changed['candidate_ids'][0, 0, 0]+1)%32
+        with self.assertRaisesRegex(ValueError, 'candidate identity'):
+            self.model(input_ids=self.ids, hidden_states=self.taps, loss_mask=self.mask, replay=changed)
+        changed = copy.deepcopy(replay)
+        changed['q'][0, 0] = torch.tensor([1., 0., 0.])
+        with self.assertRaisesRegex(ValueError, 'probability drift'):
+            self.model(input_ids=self.ids, hidden_states=self.taps, loss_mask=self.mask, replay=changed)
+
+    def test_final_uncaptured_bonus_is_never_used_as_context(self):
+        replay = self.replay()
+        before = self.model(input_ids=self.ids, hidden_states=self.taps,
+            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        after = self.model(input_ids=self.ids, hidden_states=self.taps[:, :-1],
+            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)[0]
+        torch.testing.assert_close(before, after, rtol=0, atol=0)
+
+    def test_nonfinite_recorded_probability_cannot_bypass_parity_check(self):
+        replay = self.replay()
+        replay['q'][0, 0, 0] = float('nan')
+        with self.assertRaisesRegex(ValueError, 'Invalid recorded replay probabilities'):
+            self.model(input_ids=self.ids, hidden_states=self.taps,
+                loss_mask=self.mask, replay=replay)
+
+    def test_disabled_auxiliary_does_not_require_supervised_anchor_sampling(self):
+        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
+            loss_mask=torch.zeros_like(self.mask), replay=self.replay(), auxiliary_coefficient=0)
+        self.assertTrue(torch.isfinite(loss))
+        self.assertEqual(metrics['auxiliary_loss'], 0)
+
+    def test_replay_uses_configured_block_width(self):
+        config = copy.deepcopy(self.model.draft_model.config)
+        config.dflash_config['block_size'] = 4
+        draft = DFlash2DraftModel(config)
+        self.model = OPDDFlash2Model(draft, self.model.lm_head, self.model.embed_tokens,
+            31, block_size=4, attention_backend='eager', num_anchors=2)
+        with torch.no_grad():
+            _, _, h = self.model._forward_draft_blocks(self.ids, self.taps, self.mask,
+                anchor_positions=self.anchors[None], block_keep_mask=torch.tensor([[True]]))
+            h = h.reshape(1, 4, 16)[:, 1:]
+            unary, ids = self.model.draft_model.transform_unary_logits(self.model.lm_head(h)).topk(3)
+            proposed = ids[..., 0]
+            previous = torch.cat([self.ids[0, self.anchors, None], proposed[:, :-1]], -1)
+            scores = self.model.draft_model.candidate_selector.score_candidates(
+                candidate_ids=ids, unary_logits=unary, hidden_states=h, predecessor_ids=previous)
+        replay = dict(anchor_positions=self.anchors, proposed_ids=proposed,
+            candidate_ids=ids, q=scores.softmax(-1), accepted_lengths=torch.tensor([1]),
+            exposed_lengths=torch.tensor([3]), target_ids=torch.arange(32).expand(1, 3, 32),
+            target_probs=torch.full((1, 3, 32), 1/32))
+        loss, metrics = self.model(input_ids=self.ids, hidden_states=self.taps,
+            loss_mask=self.mask, replay=replay, auxiliary_coefficient=0)
+        self.assertTrue(torch.isfinite(loss))
+        self.assertEqual(metrics['opd_terms'].position_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_modeling/test_dflash_opd_swa.py
+++ b/tests/test_modeling/test_dflash_opd_swa.py
@@ -1,0 +1,110 @@
+"""Serving causality must survive the OPD replay mask construction."""
+
+import unittest
+
+import torch
+from torch import nn
+from transformers import Qwen3Config
+
+from specforge.algorithms.common.dflash_family_model import (
+    create_dflash_block_mask,
+    create_dflash_sdpa_mask,
+)
+from specforge.algorithms.common.dflash_opd import OPDDFlash2Model
+from specforge.modeling.draft.dflash2 import DFlash2DraftModel
+
+
+class OPDSlidingCausalityTests(unittest.TestCase):
+    def test_noncausal_block_keeps_future_draft_but_not_future_target(self):
+        anchors = torch.tensor([[6, 10]])
+        keep = torch.tensor([[True, False]])
+        args = dict(anchor_positions=anchors, block_keep_mask=keep,
+                    S=12, block_size=8, device='cpu', sliding_window=8,
+                    sliding_draft_causal=False)
+        dense = create_dflash_sdpa_mask(**args)
+        flex = create_dflash_block_mask(**args)
+        for q in range(16):
+            for k in range(28):
+                self.assertEqual(bool(dense[0, 0, q, k]), bool(flex.mask_mod(
+                    torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(k))))
+        self.assertTrue(bool(dense[0, 0, :8, 12:20].all()))
+        self.assertFalse(bool(dense[0, 0, :, 6:12].any()))
+        self.assertFalse(bool(dense[0, 0, :, 20:].any()))
+        self.assertFalse(bool(dense[0, 0, 8:].any()))
+        self.assertFalse(bool(dense[0, 0, 7, :6].any()))
+
+    def test_legacy_causal_default_preserved(self):
+        args = dict(anchor_positions=torch.tensor([[6]]),
+                    block_keep_mask=torch.tensor([[True]]),
+                    S=12, block_size=8, device='cpu', sliding_window=8)
+        default = create_dflash_sdpa_mask(**args)
+        explicit = create_dflash_sdpa_mask(**args, sliding_draft_causal=True)
+        self.assertTrue(torch.equal(default, explicit))
+        self.assertTrue(torch.equal(default[0, 0, :, 12:],
+                                    torch.ones(8, 8, dtype=torch.bool).tril()))
+
+    def test_noncausal_small_window_still_excludes_old_draft_positions(self):
+        args = dict(anchor_positions=torch.tensor([[6]]),
+                    block_keep_mask=torch.tensor([[True]]),
+                    S=12, block_size=8, device='cpu', sliding_window=1,
+                    sliding_draft_causal=False)
+        dense = create_dflash_sdpa_mask(**args)
+        flex = create_dflash_block_mask(**args)
+        self.assertTrue(torch.equal(dense[0, 0, :, 12:],
+                                    torch.ones(8, 8, dtype=torch.bool).triu()))
+        for q in range(8):
+            for k in range(20):
+                self.assertEqual(bool(dense[0, 0, q, k]), bool(flex.mask_mod(
+                    torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(k))))
+
+    def test_noncausal_config_changes_replayed_hidden_states(self):
+        torch.manual_seed(19)
+        config = Qwen3Config(
+            hidden_size=16,
+            intermediate_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=4,
+            num_hidden_layers=1,
+            num_target_layers=4,
+            vocab_size=32,
+            max_position_embeddings=64,
+            layer_types=["sliding_attention"],
+            sliding_window=16,
+            use_sliding_window=True,
+            dflash_config=dict(
+                block_size=8,
+                mask_token_id=31,
+                conv_group_size=4,
+                conv_kernel_size=2,
+                selector_rank=4,
+                selector_top_k=3,
+                target_layer_ids=[1],
+            ),
+        )
+        draft = DFlash2DraftModel(config)
+        draft.config._attn_implementation = "eager"
+        model = OPDDFlash2Model(
+            draft, nn.Linear(16, 32, bias=False), nn.Embedding(32, 16),
+            31, block_size=8, attention_backend="eager",
+        ).eval()
+        taps = torch.randn(1, 12, 16)
+        replayed = {}
+        with torch.no_grad():
+            for causal in (False, True, None, "absent"):
+                if causal == "absent":
+                    del draft.config.is_causal
+                else:
+                    draft.config.is_causal = causal
+                _, _, replayed[causal] = model._forward_draft_blocks(
+                    torch.arange(12)[None], taps, torch.ones(1, 12),
+                    anchor_positions=torch.tensor([[4]]),
+                    block_keep_mask=torch.tensor([[True]]),
+                )
+        self.assertFalse(torch.allclose(replayed[False], replayed[True]))
+        for default in (None, "absent"):
+            torch.testing.assert_close(replayed[default], replayed[True], rtol=0, atol=0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_modeling/test_dflash_opd_swa.py
+++ b/tests/test_modeling/test_dflash_opd_swa.py
@@ -18,15 +18,30 @@ class OPDSlidingCausalityTests(unittest.TestCase):
     def test_noncausal_block_keeps_future_draft_but_not_future_target(self):
         anchors = torch.tensor([[6, 10]])
         keep = torch.tensor([[True, False]])
-        args = dict(anchor_positions=anchors, block_keep_mask=keep,
-                    S=12, block_size=8, device='cpu', sliding_window=8,
-                    sliding_draft_causal=False)
+        args = dict(
+            anchor_positions=anchors,
+            block_keep_mask=keep,
+            S=12,
+            block_size=8,
+            device="cpu",
+            sliding_window=8,
+            sliding_draft_causal=False,
+        )
         dense = create_dflash_sdpa_mask(**args)
         flex = create_dflash_block_mask(**args)
         for q in range(16):
             for k in range(28):
-                self.assertEqual(bool(dense[0, 0, q, k]), bool(flex.mask_mod(
-                    torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(k))))
+                self.assertEqual(
+                    bool(dense[0, 0, q, k]),
+                    bool(
+                        flex.mask_mod(
+                            torch.tensor(0),
+                            torch.tensor(0),
+                            torch.tensor(q),
+                            torch.tensor(k),
+                        )
+                    ),
+                )
         self.assertTrue(bool(dense[0, 0, :8, 12:20].all()))
         self.assertFalse(bool(dense[0, 0, :, 6:12].any()))
         self.assertFalse(bool(dense[0, 0, :, 20:].any()))
@@ -34,28 +49,51 @@ class OPDSlidingCausalityTests(unittest.TestCase):
         self.assertFalse(bool(dense[0, 0, 7, :6].any()))
 
     def test_legacy_causal_default_preserved(self):
-        args = dict(anchor_positions=torch.tensor([[6]]),
-                    block_keep_mask=torch.tensor([[True]]),
-                    S=12, block_size=8, device='cpu', sliding_window=8)
+        args = dict(
+            anchor_positions=torch.tensor([[6]]),
+            block_keep_mask=torch.tensor([[True]]),
+            S=12,
+            block_size=8,
+            device="cpu",
+            sliding_window=8,
+        )
         default = create_dflash_sdpa_mask(**args)
         explicit = create_dflash_sdpa_mask(**args, sliding_draft_causal=True)
         self.assertTrue(torch.equal(default, explicit))
-        self.assertTrue(torch.equal(default[0, 0, :, 12:],
-                                    torch.ones(8, 8, dtype=torch.bool).tril()))
+        self.assertTrue(
+            torch.equal(
+                default[0, 0, :, 12:], torch.ones(8, 8, dtype=torch.bool).tril()
+            )
+        )
 
     def test_noncausal_small_window_still_excludes_old_draft_positions(self):
-        args = dict(anchor_positions=torch.tensor([[6]]),
-                    block_keep_mask=torch.tensor([[True]]),
-                    S=12, block_size=8, device='cpu', sliding_window=1,
-                    sliding_draft_causal=False)
+        args = dict(
+            anchor_positions=torch.tensor([[6]]),
+            block_keep_mask=torch.tensor([[True]]),
+            S=12,
+            block_size=8,
+            device="cpu",
+            sliding_window=1,
+            sliding_draft_causal=False,
+        )
         dense = create_dflash_sdpa_mask(**args)
         flex = create_dflash_block_mask(**args)
-        self.assertTrue(torch.equal(dense[0, 0, :, 12:],
-                                    torch.ones(8, 8, dtype=torch.bool).triu()))
+        self.assertTrue(
+            torch.equal(dense[0, 0, :, 12:], torch.ones(8, 8, dtype=torch.bool).triu())
+        )
         for q in range(8):
             for k in range(20):
-                self.assertEqual(bool(dense[0, 0, q, k]), bool(flex.mask_mod(
-                    torch.tensor(0), torch.tensor(0), torch.tensor(q), torch.tensor(k))))
+                self.assertEqual(
+                    bool(dense[0, 0, q, k]),
+                    bool(
+                        flex.mask_mod(
+                            torch.tensor(0),
+                            torch.tensor(0),
+                            torch.tensor(q),
+                            torch.tensor(k),
+                        )
+                    ),
+                )
 
     def test_noncausal_config_changes_replayed_hidden_states(self):
         torch.manual_seed(19)
@@ -85,8 +123,12 @@ class OPDSlidingCausalityTests(unittest.TestCase):
         draft = DFlash2DraftModel(config)
         draft.config._attn_implementation = "eager"
         model = OPDDFlash2Model(
-            draft, nn.Linear(16, 32, bias=False), nn.Embedding(32, 16),
-            31, block_size=8, attention_backend="eager",
+            draft,
+            nn.Linear(16, 32, bias=False),
+            nn.Embedding(32, 16),
+            31,
+            block_size=8,
+            attention_backend="eager",
         ).eval()
         taps = torch.randn(1, 12, 16)
         replayed = {}
@@ -97,14 +139,18 @@ class OPDSlidingCausalityTests(unittest.TestCase):
                 else:
                     draft.config.is_causal = causal
                 _, _, replayed[causal] = model._forward_draft_blocks(
-                    torch.arange(12)[None], taps, torch.ones(1, 12),
+                    torch.arange(12)[None],
+                    taps,
+                    torch.ones(1, 12),
                     anchor_positions=torch.tensor([[4]]),
                     block_keep_mask=torch.tensor([[True]]),
                 )
         self.assertFalse(torch.allclose(replayed[False], replayed[True]))
         for default in (None, "absent"):
-            torch.testing.assert_close(replayed[default], replayed[True], rtol=0, atol=0)
+            torch.testing.assert_close(
+                replayed[default], replayed[True], rtol=0, atol=0
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_utils/test_dflash_opd.py
+++ b/tests/test_utils/test_dflash_opd.py
@@ -1,0 +1,132 @@
+import unittest
+
+import torch
+
+from specforge.algorithms.common.dflash_opd import (
+    first_rejection_mask, global_block_loss, opd_block_terms, sparse_overlap,
+    probabilities_on_candidates,
+)
+from specforge.modeling.draft.dflash2 import CandidateSelector
+
+
+class DraftOPDTests(unittest.TestCase):
+    def test_sparse_tv_matches_dense_with_outside_mass_and_gradients(self):
+        torch.manual_seed(17)
+        scores = torch.randn(4, 7, 3, requires_grad=True)
+        target = torch.rand(4, 7, 11)
+        target /= target.sum(-1, keepdim=True)
+        ids = torch.tensor([2, 5, 8]).expand(4, 7, -1)
+        p = target.gather(-1, ids)
+        overlap, _ = sparse_overlap(scores, p)
+        q_dense = torch.zeros_like(target).scatter(-1, ids, scores.softmax(-1))
+        expected = 1 - 0.5 * (q_dense - target).abs().sum(-1)
+        torch.testing.assert_close(overlap, expected)
+        sparse_grad = torch.autograd.grad(overlap.sum(), scores, retain_graph=True)[0]
+        dense_grad = torch.autograd.grad(expected.sum(), scores)[0]
+        torch.testing.assert_close(sparse_grad, dense_grad)
+
+    def test_first_rejection_all_accepted_and_request_censoring(self):
+        accepted = torch.tensor([0, 1, 6, 7, 7, 0])
+        exposed = torch.tensor([7, 7, 7, 7, 3, 0])
+        masks = first_rejection_mask(accepted, exposed)
+        self.assertEqual(masks.sum(-1).tolist(), [1, 2, 7, 7, 3, 0])
+        with self.assertRaises(ValueError):
+            first_rejection_mask(torch.tensor([8]), torch.tensor([7]))
+
+    def test_analytic_block_loss_and_early_gradient(self):
+        # q=.5/.5; p(C)=.8, with a strict over/under direction at each slot.
+        scores = torch.zeros(1, 3, 2, requires_grad=True)
+        p = torch.tensor([[[.2, .6], [.2, .6], [.2, .6]]])
+        terms = opd_block_terms(scores, p, torch.ones(1, 3, dtype=torch.bool))
+        self.assertAlmostEqual(terms.loss_sum.item(), 1 - (.7 + .49 + .343) / 3, places=6)
+        grad = torch.autograd.grad(terms.loss_sum, scores)[0][0, :, 0]
+        torch.testing.assert_close(grad, torch.tensor([.25 * (1 + .7 + .49) / 3,
+                                                       .25 * (.7 + .49) / 3,
+                                                       .25 * .49 / 3]))
+
+    def test_empty_padding_does_not_change_loss_or_gradient(self):
+        scores = torch.tensor([[[.4, -.2], [float('nan'), float('nan')]],
+                               [[float('nan'), float('nan')], [float('nan'), float('nan')]]],
+                              requires_grad=True)
+        p = torch.tensor([[[.2, .6], [float('nan'), float('nan')]],
+                          [[float('nan'), float('nan')], [float('nan'), float('nan')]]])
+        mask = torch.tensor([[True, False], [False, False]])
+        terms = opd_block_terms(scores, p, mask)
+        expected = 1 - (.2 + scores[0, 0].softmax(0)[1])
+        torch.testing.assert_close(terms.loss_sum, expected)
+        grad = torch.autograd.grad(terms.loss_sum, scores)[0]
+        self.assertTrue(torch.isfinite(grad).all())
+        self.assertEqual(grad[~mask].abs().sum().item(), 0)
+
+    def test_teacher_is_detached_and_zero_overlap_is_finite(self):
+        scores = torch.randn(2, 7, 3, requires_grad=True)
+        p = torch.zeros_like(scores, requires_grad=True)
+        terms = opd_block_terms(scores, p, torch.ones(2, 7, dtype=torch.bool))
+        terms.loss_sum.backward()
+        self.assertEqual(terms.loss_sum.item(), 2)
+        self.assertTrue(torch.isfinite(scores.grad).all())
+        self.assertIsNone(p.grad)
+
+    def test_global_normalization_with_unequal_rank_and_microbatch_counts(self):
+        torch.manual_seed(23)
+        scores = torch.randn(5, 7, 3, requires_grad=True)
+        p = torch.softmax(torch.randn(5, 7, 5), -1)[..., :3]
+        masks = first_rejection_mask(torch.tensor([0, 1, 6, 0, 3]), torch.tensor([7]*5))
+        full = opd_block_terms(scores, p, masks).loss_sum / 5
+        reference = torch.autograd.grad(full, scores, retain_graph=True)[0]
+        # Two ranks, with 1 versus4 valid blocks split across microbatches.
+        losses = []
+        for start, end in [(0, 1), (1, 3), (3, 5)]:
+            t = opd_block_terms(scores[start:end], p[start:end], masks[start:end])
+            losses.append(global_block_loss(t, global_block_count=5, gradient_average_world_size=2))
+        distributed = sum(losses) / 2
+        observed = torch.autograd.grad(distributed, scores)[0]
+        torch.testing.assert_close(reference, observed)
+
+    def test_selector_backbone_and_predecessor_gradients(self):
+        torch.manual_seed(33)
+        selector = CandidateSelector(hidden_size=4, vocab_size=13, state_rank=3, top_k=3,
+                                     initializer_range=.2)
+        torch.nn.init.normal_(selector.successor_codebook, std=.2)
+        hidden = torch.randn(2, 3, 4, requires_grad=True)
+        unary = torch.randn(2, 3, 3, requires_grad=True)
+        ids = torch.tensor([1, 2, 3]).expand(2, 3, 3)
+        predecessors = torch.tensor([[9, 1, 2], [8, 3, 1]])
+        scores = selector.score_candidates(candidate_ids=ids, unary_logits=unary,
+                                          hidden_states=hidden, predecessor_ids=predecessors)
+        p = torch.softmax(torch.randn(2, 3, 5), -1)[..., :3]
+        terms = opd_block_terms(scores, p, torch.ones(2, 3, dtype=torch.bool))
+        terms.loss_sum.backward()
+        self.assertGreater(hidden.grad.abs().sum().item(), 0)
+        self.assertGreater(unary.grad.abs().sum().item(), 0)
+        for param in selector.parameters():
+            self.assertGreater(param.grad.abs().sum().item(), 0)
+        changed = selector.score_candidates(candidate_ids=ids, unary_logits=unary,
+                                             hidden_states=hidden, predecessor_ids=predecessors.flip(0))
+        self.assertFalse(torch.allclose(scores, changed))
+
+    def test_invalid_mass_nonfinite_and_nonprefix_masks_fail(self):
+        scores = torch.zeros(1, 3, 2)
+        p = torch.full_like(scores, .6)
+        with self.assertRaises(ValueError):
+            sparse_overlap(scores, p)
+        with self.assertRaises(ValueError):
+            opd_block_terms(scores, p * .5, torch.tensor([[True, False, True]]))
+        with self.assertRaises(ValueError):
+            sparse_overlap(scores * float('nan'), p * .5)
+
+    def test_sparse_support_join_preserves_original_mass_and_detaches_teacher(self):
+        candidates = torch.tensor([[[1, 4, 7]]])
+        target_ids = torch.tensor([[[7, 8, 1]]])
+        target_probs = torch.tensor([[[.2, .5, .3]]], requires_grad=True)
+        result = probabilities_on_candidates(candidates, target_ids, target_probs)
+        torch.testing.assert_close(result, torch.tensor([[[.3, 0, .2]]]))
+        self.assertFalse(result.requires_grad)
+        for probabilities in (torch.tensor([[[float('nan'), .5, .5]]]),
+                              torch.tensor([[[-.1, .5, .6]]])):
+            with self.assertRaisesRegex(ValueError, 'Invalid sparse teacher'):
+                probabilities_on_candidates(candidates, target_ids, probabilities)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils/test_dflash_opd.py
+++ b/tests/test_utils/test_dflash_opd.py
@@ -36,6 +36,15 @@ class DraftOPDTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             first_rejection_mask(torch.tensor([8]), torch.tensor([7]))
 
+    def test_partial_teacher_coverage_can_have_positive_loss_and_zero_gradient(self):
+        scores = torch.zeros(1, 1, 2, requires_grad=True)
+        p = torch.tensor([[[0.2, 0.2]]])
+        terms = opd_block_terms(scores, p, torch.ones(1, 1, dtype=torch.bool))
+        self.assertAlmostEqual(terms.loss_sum.item(), 0.6)
+        self.assertAlmostEqual(terms.overlap_sum.item(), 0.4)
+        terms.loss_sum.backward()
+        torch.testing.assert_close(scores.grad, torch.zeros_like(scores))
+
     def test_analytic_block_loss_and_early_gradient(self):
         # q=.5/.5; p(C)=.8, with a strict over/under direction at each slot.
         scores = torch.zeros(1, 3, 2, requires_grad=True)

--- a/tests/test_utils/test_dflash_opd.py
+++ b/tests/test_utils/test_dflash_opd.py
@@ -3,8 +3,11 @@ import unittest
 import torch
 
 from specforge.algorithms.common.dflash_opd import (
-    first_rejection_mask, global_block_loss, opd_block_terms, sparse_overlap,
+    first_rejection_mask,
+    global_block_loss,
+    opd_block_terms,
     probabilities_on_candidates,
+    sparse_overlap,
 )
 from specforge.modeling.draft.dflash2 import CandidateSelector
 
@@ -36,23 +39,36 @@ class DraftOPDTests(unittest.TestCase):
     def test_analytic_block_loss_and_early_gradient(self):
         # q=.5/.5; p(C)=.8, with a strict over/under direction at each slot.
         scores = torch.zeros(1, 3, 2, requires_grad=True)
-        p = torch.tensor([[[.2, .6], [.2, .6], [.2, .6]]])
+        p = torch.tensor([[[0.2, 0.6], [0.2, 0.6], [0.2, 0.6]]])
         terms = opd_block_terms(scores, p, torch.ones(1, 3, dtype=torch.bool))
-        self.assertAlmostEqual(terms.loss_sum.item(), 1 - (.7 + .49 + .343) / 3, places=6)
+        self.assertAlmostEqual(
+            terms.loss_sum.item(), 1 - (0.7 + 0.49 + 0.343) / 3, places=6
+        )
         grad = torch.autograd.grad(terms.loss_sum, scores)[0][0, :, 0]
-        torch.testing.assert_close(grad, torch.tensor([.25 * (1 + .7 + .49) / 3,
-                                                       .25 * (.7 + .49) / 3,
-                                                       .25 * .49 / 3]))
+        torch.testing.assert_close(
+            grad,
+            torch.tensor(
+                [0.25 * (1 + 0.7 + 0.49) / 3, 0.25 * (0.7 + 0.49) / 3, 0.25 * 0.49 / 3]
+            ),
+        )
 
     def test_empty_padding_does_not_change_loss_or_gradient(self):
-        scores = torch.tensor([[[.4, -.2], [float('nan'), float('nan')]],
-                               [[float('nan'), float('nan')], [float('nan'), float('nan')]]],
-                              requires_grad=True)
-        p = torch.tensor([[[.2, .6], [float('nan'), float('nan')]],
-                          [[float('nan'), float('nan')], [float('nan'), float('nan')]]])
+        scores = torch.tensor(
+            [
+                [[0.4, -0.2], [float("nan"), float("nan")]],
+                [[float("nan"), float("nan")], [float("nan"), float("nan")]],
+            ],
+            requires_grad=True,
+        )
+        p = torch.tensor(
+            [
+                [[0.2, 0.6], [float("nan"), float("nan")]],
+                [[float("nan"), float("nan")], [float("nan"), float("nan")]],
+            ]
+        )
         mask = torch.tensor([[True, False], [False, False]])
         terms = opd_block_terms(scores, p, mask)
-        expected = 1 - (.2 + scores[0, 0].softmax(0)[1])
+        expected = 1 - (0.2 + scores[0, 0].softmax(0)[1])
         torch.testing.assert_close(terms.loss_sum, expected)
         grad = torch.autograd.grad(terms.loss_sum, scores)[0]
         self.assertTrue(torch.isfinite(grad).all())
@@ -71,29 +87,40 @@ class DraftOPDTests(unittest.TestCase):
         torch.manual_seed(23)
         scores = torch.randn(5, 7, 3, requires_grad=True)
         p = torch.softmax(torch.randn(5, 7, 5), -1)[..., :3]
-        masks = first_rejection_mask(torch.tensor([0, 1, 6, 0, 3]), torch.tensor([7]*5))
+        masks = first_rejection_mask(
+            torch.tensor([0, 1, 6, 0, 3]), torch.tensor([7] * 5)
+        )
         full = opd_block_terms(scores, p, masks).loss_sum / 5
         reference = torch.autograd.grad(full, scores, retain_graph=True)[0]
         # Two ranks, with 1 versus4 valid blocks split across microbatches.
         losses = []
         for start, end in [(0, 1), (1, 3), (3, 5)]:
             t = opd_block_terms(scores[start:end], p[start:end], masks[start:end])
-            losses.append(global_block_loss(t, global_block_count=5, gradient_average_world_size=2))
+            losses.append(
+                global_block_loss(
+                    t, global_block_count=5, gradient_average_world_size=2
+                )
+            )
         distributed = sum(losses) / 2
         observed = torch.autograd.grad(distributed, scores)[0]
         torch.testing.assert_close(reference, observed)
 
     def test_selector_backbone_and_predecessor_gradients(self):
         torch.manual_seed(33)
-        selector = CandidateSelector(hidden_size=4, vocab_size=13, state_rank=3, top_k=3,
-                                     initializer_range=.2)
-        torch.nn.init.normal_(selector.successor_codebook, std=.2)
+        selector = CandidateSelector(
+            hidden_size=4, vocab_size=13, state_rank=3, top_k=3, initializer_range=0.2
+        )
+        torch.nn.init.normal_(selector.successor_codebook, std=0.2)
         hidden = torch.randn(2, 3, 4, requires_grad=True)
         unary = torch.randn(2, 3, 3, requires_grad=True)
         ids = torch.tensor([1, 2, 3]).expand(2, 3, 3)
         predecessors = torch.tensor([[9, 1, 2], [8, 3, 1]])
-        scores = selector.score_candidates(candidate_ids=ids, unary_logits=unary,
-                                          hidden_states=hidden, predecessor_ids=predecessors)
+        scores = selector.score_candidates(
+            candidate_ids=ids,
+            unary_logits=unary,
+            hidden_states=hidden,
+            predecessor_ids=predecessors,
+        )
         p = torch.softmax(torch.randn(2, 3, 5), -1)[..., :3]
         terms = opd_block_terms(scores, p, torch.ones(2, 3, dtype=torch.bool))
         terms.loss_sum.backward()
@@ -101,32 +128,38 @@ class DraftOPDTests(unittest.TestCase):
         self.assertGreater(unary.grad.abs().sum().item(), 0)
         for param in selector.parameters():
             self.assertGreater(param.grad.abs().sum().item(), 0)
-        changed = selector.score_candidates(candidate_ids=ids, unary_logits=unary,
-                                             hidden_states=hidden, predecessor_ids=predecessors.flip(0))
+        changed = selector.score_candidates(
+            candidate_ids=ids,
+            unary_logits=unary,
+            hidden_states=hidden,
+            predecessor_ids=predecessors.flip(0),
+        )
         self.assertFalse(torch.allclose(scores, changed))
 
     def test_invalid_mass_nonfinite_and_nonprefix_masks_fail(self):
         scores = torch.zeros(1, 3, 2)
-        p = torch.full_like(scores, .6)
+        p = torch.full_like(scores, 0.6)
         with self.assertRaises(ValueError):
             sparse_overlap(scores, p)
         with self.assertRaises(ValueError):
-            opd_block_terms(scores, p * .5, torch.tensor([[True, False, True]]))
+            opd_block_terms(scores, p * 0.5, torch.tensor([[True, False, True]]))
         with self.assertRaises(ValueError):
-            sparse_overlap(scores * float('nan'), p * .5)
+            sparse_overlap(scores * float("nan"), p * 0.5)
 
     def test_sparse_support_join_preserves_original_mass_and_detaches_teacher(self):
         candidates = torch.tensor([[[1, 4, 7]]])
         target_ids = torch.tensor([[[7, 8, 1]]])
-        target_probs = torch.tensor([[[.2, .5, .3]]], requires_grad=True)
+        target_probs = torch.tensor([[[0.2, 0.5, 0.3]]], requires_grad=True)
         result = probabilities_on_candidates(candidates, target_ids, target_probs)
-        torch.testing.assert_close(result, torch.tensor([[[.3, 0, .2]]]))
+        torch.testing.assert_close(result, torch.tensor([[[0.3, 0, 0.2]]]))
         self.assertFalse(result.requires_grad)
-        for probabilities in (torch.tensor([[[float('nan'), .5, .5]]]),
-                              torch.tensor([[[-.1, .5, .6]]])):
-            with self.assertRaisesRegex(ValueError, 'Invalid sparse teacher'):
+        for probabilities in (
+            torch.tensor([[[float("nan"), 0.5, 0.5]]]),
+            torch.tensor([[[-0.1, 0.5, 0.6]]]),
+        ):
+            with self.assertRaisesRegex(ValueError, "Invalid sparse teacher"):
                 probabilities_on_candidates(candidates, target_ids, probabilities)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Standard DFlash feature batches keep accepted tokens and target taps but lose the rejected proposals and conditional verifier distributions required for Draft-OPD. This adds experimental DFlash2 replay/loss primitives for actual verification records.

Sliding-window replay also ignored an explicit `is_causal=False` draft configuration. For a block of eight, it removed 28 within-block attention edges that noncausal serving uses. Replay now honors that configuration while keeping the sliding lower bound, target-prefix isolation and block isolation. Absent or unspecified causality preserves the legacy causal sliding mask.

**Draft PR:** this is the replay/loss foundation. A production collector, policy-refresh path, trainer registration and full-state recovery integration remain required for end-to-end use.

## Modifications

- Add sparse overlap/TV, accepted-prefix-plus-first-rejection masking, request censoring, and global valid-block normalization across unequal ranks and accumulation windows.
- Add `OPDDFlash2Model`: replay explicit anchors with coupled backbone/selector gradients, recompute natural candidates, check candidate/probability agreement, retain original teacher mass, and optionally mix the inherited auxiliary objective.
- Honor explicit noncausal sliding attention in both dense and FlexAttention masks. Preserve the sampled-anchor path, full-attention behavior and causal sliding default.
- Reject nonfinite recorded probabilities, skip disabled auxiliary computation, and support the configured block width.
- Document the serving-head/numerical parity contract and a sparse-support plateau where positive TV loss has zero score gradient.

The objective adapts the [Draft-OPD TV variant](https://github.com/Simplified-Reasoning/Draft-OPD/tree/e81a8bc488ef762f178f8708ffbc49bd92c3a93d). It differs from the [paper's mixed-KL objective](https://arxiv.org/html/2605.29343v2), which uses accepted-token forward KL and rejected-suffix reverse KL. With DFlash2's predecessor-conditioned selector, the prefix-product objective is a replay-path surrogate rather than exact unconditional serving acceptance length. No acceptance improvement is claimed.

## Related Issues

No linked issue. The sliding-mask behavior predates this PR and is inherited by its replay path.

## Accuracy Test

CPU validation with PyTorch 2.13.0 and Transformers 5.12.1:

```bash
python -m unittest discover -s tests/test_modeling -p 'test_dflash*.py' -v
# 63 tests: 62 passed, 1 skipped
python -m unittest discover -s tests/test_utils -p 'test_dflash*.py' -v
# 61 passed
```

**123 passed, 1 skipped.** The new hidden-state regression fails against the original PR head `611df543` and passes with the fix. Coverage includes dense/Flex mask agreement, retained future-draft attention, isolation from future target taps and other blocks, small-window bounds, and True/None/absent-config compatibility. Existing coverage checks dense-reference loss/gradients, rejection/EOS censoring, unequal rank/microbatch counts, coupled gradients, uncaptured final bonus handling, and stale/nonfinite replay rejection. The new TV plateau example also catches accidental renormalization of teacher mass onto draft candidates.

H200 attention-operator audit, Qwen geometry (32 query/8 KV heads, head dimension 128, block 8, window 2048):

| Prefix tokens | Native vs original-mask reference RMSE | Native vs corrected-mask reference RMSE |
| --- | ---: | ---: |
| 32 | 0.065826 | 0.000511 |
| 2048 | 0.001768 | 0.000083 |
| 2056 | 0.001700 | 0.000083 |

This validates the attention-mask correction. Full replay also depends on the actual serving output head and numerical operators: in a separate Qwen NVFP4 audit, the serving head reproduced all 977 captured candidate lists from native hidden states, while the historical BF16 head reproduced 12. A BF16 dequantization also failed the probability check. The documentation now requires measuring these contracts without forcing recorded candidate IDs or relaxing the gate.

A separate Qwen-specific native adapter passed 64-request probability admission and a four-rank interrupted/resumed optimizer test. That adapter is outside this PR; those results do not certify the generic `OPDDFlash2Model` as an end-to-end Qwen training integration. Its exact candidate-order check and provisional `0.01` probability gate remain intact.

## Benchmark & Profiling

No completed acceptance-gain, target-only speedup or throughput benchmark for this PR. The Qwen continuation ablation is separate from the library change. Model-specific serving parity, production rollout/refresh and full recovery must be validated for each integration.

## Checklist

- [x] Format code: `pre-commit run --all-files` passed all applicable hooks.
- [x] Add regression tests, including a test that fails on the original PR.
- [x] Document the API, objective differences and integration requirements.
- [ ] Provide complete native integration and held-out accuracy/performance results before marking ready for end-to-end use.
