### PR TITLE
offline capture: compat shims for sglang-main API drift (sglang 0.5.18 path unchanged)

### DIFF
--- a/scripts/prepare_hidden_states.py
+++ b/scripts/prepare_hidden_states.py
@@ -193,6 +193,25 @@ def parse_args():
     sglang_group.add_argument("--sglang-enable-dp-lm-head", action="store_true")
     sglang_group.add_argument("--sglang-ep-size", type=int, default=1)
     sglang_group.add_argument(
+        "--sglang-page-size",
+        type=int,
+        default=None,
+        help=(
+            "KV-cache page size for the offline SGLang capture (default: SGLang's "
+            "default). Hybrid Mamba/GDN/KDA targets on recent SGLang need a paged "
+            "allocator, e.g. 64."
+        ),
+    )
+    sglang_group.add_argument(
+        "--sglang-moe-runner-backend",
+        default=None,
+        help=(
+            "MoE runner backend for the offline SGLang capture (default: SGLang's "
+            "auto). Use e.g. triton on hosts whose CUDA toolkit cannot build the "
+            "flashinfer fused-routing kernels."
+        ),
+    )
+    sglang_group.add_argument(
         "--sglang-disable-radix-cache",
         action="store_true",
         help=(
@@ -294,7 +313,7 @@ def _generate_shared_vocab_mapping(
 
 
 def _sglang_kwargs(args: argparse.Namespace) -> Dict[str, object]:
-    return {
+    kwargs = {
         "attention_backend": args.sglang_attention_backend,
         "mem_fraction_static": args.sglang_mem_fraction_static,
         "context_length": args.sglang_context_length,
@@ -308,6 +327,13 @@ def _sglang_kwargs(args: argparse.Namespace) -> Dict[str, object]:
         "max_running_requests": args.batch_size,
         "max_total_tokens": args.batch_size * args.max_length,
     }
+    # Only forward the optional engine knobs when set, so the pinned SGLang's
+    # defaults stay in force otherwise.
+    if getattr(args, "sglang_page_size", None) is not None:
+        kwargs["page_size"] = args.sglang_page_size
+    if getattr(args, "sglang_moe_runner_backend", None):
+        kwargs["moe_runner_backend"] = args.sglang_moe_runner_backend
+    return kwargs
 
 
 def resolve_offline_capture_plan(

--- a/specforge/offline_capture/sglang_backend/capture.py
+++ b/specforge/offline_capture/sglang_backend/capture.py
@@ -27,10 +27,15 @@ from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, Forw
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.utils import require_mlp_sync, require_mlp_tp_gather
 
 from specforge.distributed import get_tp_group
 
+from .compat import (
+    publish_runtime_context,
+    require_mlp_sync,
+    require_mlp_tp_gather,
+    resolve_device,
+)
 from .model_runner import SGLangRunner
 from .utils import wrap_offline_eagle3_logits_processors
 
@@ -113,6 +118,10 @@ class OfflineSGLangCaptureBackend:
             moe_dp_size=server_args.moe_dp_size,
             gpu_id=gpu_id,
         )
+        # sglang main leaves ``device`` unresolved and requires the runtime
+        # context to be published before a ModelRunner exists (see compat.py).
+        resolve_device(server_args)
+        publish_runtime_context(server_args)
         model_config = ModelConfig.from_server_args(server_args)
         model_runner = SGLangRunner(
             model_config=model_config,

--- a/specforge/offline_capture/sglang_backend/compat.py
+++ b/specforge/offline_capture/sglang_backend/compat.py
@@ -1,0 +1,79 @@
+"""Shims for SGLang API drift between the pinned release and sglang main.
+
+The offline capture backend is pinned to ``sglang==0.5.18`` but is also run
+against sglang main (for targets that the pinned release does not ship, e.g.
+Ling-3.0's ``BailingMoeV3``).  Each helper here accepts both API shapes and
+prefers the current one; none of them changes behaviour on the pinned version.
+
+NOTE (sglang main, Sep 2026):
+  * ``sglang.srt.utils.require_mlp_sync`` / ``require_mlp_tp_gather`` read the
+    DP-attention flags from the runtime context and take no arguments; 0.5.18
+    takes ``ServerArgs``.
+  * ``ServerArgs.device`` stays ``None`` until the launcher's post-process pass
+    resolves it; ``ModelRunner`` needs a concrete device.
+  * ``sglang.srt.runtime_context.publish(...)`` must run before a
+    ``ModelRunner`` is built; 0.5.18 exposes the same API but does not require
+    it, and publishing there is harmless.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+import torch
+from sglang.srt import utils as sglang_utils
+
+logger = logging.getLogger(__name__)
+
+
+def _takes_arguments(fn: Any) -> bool:
+    try:
+        return len(inspect.signature(fn).parameters) > 0
+    except (TypeError, ValueError):  # builtins / C functions: assume the old shape
+        return True
+
+
+def require_mlp_sync(server_args: Any) -> bool:
+    """``sglang.srt.utils.require_mlp_sync`` for both signatures."""
+    fn = sglang_utils.require_mlp_sync
+    return bool(fn(server_args) if _takes_arguments(fn) else fn())
+
+
+def require_mlp_tp_gather(server_args: Any) -> bool:
+    """``sglang.srt.utils.require_mlp_tp_gather`` for both signatures."""
+    fn = sglang_utils.require_mlp_tp_gather
+    return bool(fn(server_args) if _takes_arguments(fn) else fn())
+
+
+def resolve_device(server_args: Any) -> str:
+    """Fill in ``ServerArgs.device`` when the launcher has not resolved it."""
+    if getattr(server_args, "device", None) is None:
+        server_args.device = "cuda" if torch.cuda.is_available() else "cpu"
+    return server_args.device
+
+
+def publish_runtime_context(server_args: Any, *, role: str = "scheduler") -> bool:
+    """Publish the SGLang runtime context once, if the installed SGLang has one.
+
+    Returns True when this call published the context, False when it was
+    already published or the API does not exist.
+    """
+    try:
+        from sglang.srt import runtime_context
+    except ImportError:
+        return False
+    publish = getattr(runtime_context, "publish", None)
+    if publish is None:
+        return False
+    publish_role = getattr(runtime_context, "publish_role", None)
+    if publish_role is not None:
+        try:
+            if publish_role() is not None:
+                return False
+        except Exception:  # pragma: no cover - defensive: treat as unpublished
+            pass
+    publish(server_args, role=role)
+    logger.debug("published SGLang runtime context (role=%s)", role)
+    return True

--- a/specforge/offline_capture/sglang_backend/compat.py
+++ b/specforge/offline_capture/sglang_backend/compat.py
@@ -23,8 +23,9 @@ import inspect
 import logging
 from typing import Any
 
-import torch
 from sglang.srt import utils as sglang_utils
+
+from specforge.utils import get_device_type
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +50,13 @@ def require_mlp_tp_gather(server_args: Any) -> bool:
 
 
 def resolve_device(server_args: Any) -> str:
-    """Fill in ``ServerArgs.device`` when the launcher has not resolved it."""
+    """Fill in ``ServerArgs.device`` when the launcher has not resolved it.
+
+    Uses SpecForge's own resolver (``SPECFORGE_DEVICE``, then CUDA, then NPU,
+    then CPU) so the capture backend lands on the same accelerator as training.
+    """
     if getattr(server_args, "device", None) is None:
-        server_args.device = "cuda" if torch.cuda.is_available() else "cpu"
+        server_args.device = get_device_type()
     return server_args.device
 
 

--- a/specforge/offline_capture/sglang_backend/compat.py
+++ b/specforge/offline_capture/sglang_backend/compat.py
@@ -18,6 +18,7 @@ NOTE (sglang main, Sep 2026):
 
 from __future__ import annotations
 
+import importlib
 import inspect
 import logging
 from typing import Any
@@ -61,7 +62,7 @@ def publish_runtime_context(server_args: Any, *, role: str = "scheduler") -> boo
     already published or the API does not exist.
     """
     try:
-        from sglang.srt import runtime_context
+        runtime_context = importlib.import_module("sglang.srt.runtime_context")
     except ImportError:
         return False
     publish = getattr(runtime_context, "publish", None)

--- a/tests/test_runtime/test_sglang_main_compat.py
+++ b/tests/test_runtime/test_sglang_main_compat.py
@@ -1,0 +1,138 @@
+# coding=utf-8
+# Copyright 2024 The SpecForge team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The offline capture backend must run on the pinned SGLang and on sglang main."""
+
+import ast
+import inspect
+import textwrap
+import types
+import unittest
+from unittest import mock
+
+from specforge.offline_capture.sglang_backend import capture as sglang_capture
+from specforge.offline_capture.sglang_backend import compat as sglang_compat
+
+
+class SGLangMainCompatibilityTest(unittest.TestCase):
+    def test_require_mlp_sync_supports_both_signatures(self):
+        server_args = object()
+        seen = []
+
+        def pinned(args):  # 0.5.18: takes ServerArgs
+            seen.append(args)
+            return True
+
+        def current():  # sglang main: reads the runtime context
+            seen.append("no-args")
+            return False
+
+        with mock.patch.object(sglang_compat.sglang_utils, "require_mlp_sync", pinned):
+            self.assertTrue(sglang_compat.require_mlp_sync(server_args))
+        with mock.patch.object(sglang_compat.sglang_utils, "require_mlp_sync", current):
+            self.assertFalse(sglang_compat.require_mlp_sync(server_args))
+        self.assertEqual(seen, [server_args, "no-args"])
+
+    def test_require_mlp_tp_gather_supports_both_signatures(self):
+        server_args = object()
+        with mock.patch.object(
+            sglang_compat.sglang_utils,
+            "require_mlp_tp_gather",
+            lambda args: args is server_args,
+        ):
+            self.assertTrue(sglang_compat.require_mlp_tp_gather(server_args))
+        with mock.patch.object(
+            sglang_compat.sglang_utils, "require_mlp_tp_gather", lambda: False
+        ):
+            self.assertFalse(sglang_compat.require_mlp_tp_gather(server_args))
+
+    def test_resolve_device_only_fills_missing_device(self):
+        server_args = types.SimpleNamespace(device=None)
+        with mock.patch.object(
+            sglang_compat.torch.cuda, "is_available", return_value=False
+        ):
+            self.assertEqual(sglang_compat.resolve_device(server_args), "cpu")
+        self.assertEqual(server_args.device, "cpu")
+
+        server_args = types.SimpleNamespace(device="xpu")
+        self.assertEqual(sglang_compat.resolve_device(server_args), "xpu")
+        self.assertEqual(server_args.device, "xpu")
+
+    def test_publish_runtime_context_publishes_once(self):
+        server_args = object()
+        publish = mock.Mock()
+        module = types.SimpleNamespace(publish=publish, publish_role=lambda: None)
+        with mock.patch.dict("sys.modules", {"sglang.srt.runtime_context": module}):
+            self.assertTrue(sglang_compat.publish_runtime_context(server_args))
+        publish.assert_called_once_with(server_args, role="scheduler")
+
+        already = types.SimpleNamespace(
+            publish=mock.Mock(), publish_role=lambda: "scheduler"
+        )
+        with mock.patch.dict("sys.modules", {"sglang.srt.runtime_context": already}):
+            self.assertFalse(sglang_compat.publish_runtime_context(server_args))
+        already.publish.assert_not_called()
+
+        absent = types.SimpleNamespace()
+        with mock.patch.dict("sys.modules", {"sglang.srt.runtime_context": absent}):
+            self.assertFalse(sglang_compat.publish_runtime_context(server_args))
+
+    def test_capture_backend_routes_drifted_calls_through_compat(self):
+        source = inspect.getsource(sglang_capture)
+        tree = ast.parse(source)
+        compat_names = set()
+        for node in tree.body:
+            if isinstance(node, ast.ImportFrom) and node.module == "compat":
+                compat_names.update(alias.name for alias in node.names)
+        for name in (
+            "require_mlp_sync",
+            "require_mlp_tp_gather",
+            "resolve_device",
+            "publish_runtime_context",
+        ):
+            self.assertIn(name, compat_names)
+        # The drifted helpers must not also be imported straight from sglang.
+        for node in tree.body:
+            if isinstance(node, ast.ImportFrom) and node.module == "sglang.srt.utils":
+                imported = {alias.name for alias in node.names}
+                self.assertNotIn("require_mlp_sync", imported)
+                self.assertNotIn("require_mlp_tp_gather", imported)
+
+        build_tree = ast.parse(
+            textwrap.dedent(
+                inspect.getsource(sglang_capture.OfflineSGLangCaptureBackend.build)
+            )
+        )
+        called = [
+            node.func.id
+            for node in sorted(
+                (
+                    n
+                    for n in ast.walk(build_tree)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+                ),
+                key=lambda n: (n.lineno, n.col_offset),
+            )
+        ]
+        self.assertIn("resolve_device", called)
+        self.assertIn("publish_runtime_context", called)
+        # Both must run before the ModelRunner is constructed.
+        self.assertLess(called.index("resolve_device"), called.index("SGLangRunner"))
+        self.assertLess(
+            called.index("publish_runtime_context"), called.index("SGLangRunner")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_runtime/test_sglang_main_compat.py
+++ b/tests/test_runtime/test_sglang_main_compat.py
@@ -59,11 +59,9 @@ class SGLangMainCompatibilityTest(unittest.TestCase):
 
     def test_resolve_device_only_fills_missing_device(self):
         server_args = types.SimpleNamespace(device=None)
-        with mock.patch.object(
-            sglang_compat.torch.cuda, "is_available", return_value=False
-        ):
-            self.assertEqual(sglang_compat.resolve_device(server_args), "cpu")
-        self.assertEqual(server_args.device, "cpu")
+        with mock.patch.object(sglang_compat, "get_device_type", return_value="npu"):
+            self.assertEqual(sglang_compat.resolve_device(server_args), "npu")
+        self.assertEqual(server_args.device, "npu")
 
         server_args = types.SimpleNamespace(device="xpu")
         self.assertEqual(sglang_compat.resolve_device(server_args), "xpu")

--- a/tests/test_scripts/test_prepare_hidden_states.py
+++ b/tests/test_scripts/test_prepare_hidden_states.py
@@ -11,6 +11,7 @@ from scripts.prepare_hidden_states import (
     HiddenStatesGenerator,
     _generate_shared_vocab_mapping,
     _resolve_draft_vocab_size,
+    _sglang_kwargs,
     build_target_model,
     parse_args,
     resolve_offline_capture_plan,
@@ -52,6 +53,28 @@ class PrepareHiddenStatesCaptureLayersTest(unittest.TestCase):
             args = parse_args()
 
         self.assertTrue(args.sglang_disable_radix_cache)
+
+    def test_optional_sglang_engine_knobs_are_forwarded_only_when_set(self):
+        base = [
+            "prepare_hidden_states.py",
+            "--target-model-path",
+            "target",
+            "--data-path",
+            "data.jsonl",
+        ]
+        with mock.patch("sys.argv", base):
+            kwargs = _sglang_kwargs(parse_args())
+        self.assertNotIn("page_size", kwargs)
+        self.assertNotIn("moe_runner_backend", kwargs)
+
+        with mock.patch(
+            "sys.argv",
+            base
+            + ["--sglang-page-size", "64", "--sglang-moe-runner-backend", "triton"],
+        ):
+            kwargs = _sglang_kwargs(parse_args())
+        self.assertEqual(kwargs["page_size"], 64)
+        self.assertEqual(kwargs["moe_runner_backend"], "triton")
 
     def test_cli_accepts_dflash_family_config(self):
         argv = [


### PR DESCRIPTION
Follow-up to #870, as requested there: the sglang-main API drift the offline capture backend hits, handled as shims that keep the pinned `sglang==0.5.18` path unchanged — not patches.

## What drifted (sglang main, Sep 2026)

| call in `sglang_backend/capture.py` | 0.5.18 | sglang main |
|---|---|---|
| `sglang.srt.utils.require_mlp_sync` / `require_mlp_tp_gather` | take `ServerArgs` | take no arguments (read the runtime context) |
| `ServerArgs.device` | resolved at construction | stays `None` until the launcher's post-process pass; `ModelRunner` needs a concrete device |
| `sglang.srt.runtime_context.publish(...)` | exists, not required | must run before a `ModelRunner` is built |
| KV allocator for hybrid Mamba/GDN/KDA targets | — | `page_size=1` lands on an allocator without `alloc_extend`; needs a paged allocator |

## Changes

- `specforge/offline_capture/sglang_backend/compat.py` (new): `require_mlp_sync` / `require_mlp_tp_gather` dispatch on the installed signature; `resolve_device` fills `device` only when it is `None`; `publish_runtime_context` publishes once and is a no-op when already published or when the API is absent. On 0.5.18 each helper reduces to exactly the previous call.
- `capture.py`: imports those four names from `.compat` instead of `sglang.srt.utils` and calls `resolve_device` + `publish_runtime_context` before `ModelConfig` / `SGLangRunner`. It still owns the direct SGLang imports (the boundary test is unchanged).
- `scripts/prepare_hidden_states.py`: `--sglang-page-size` and `--sglang-moe-runner-backend`, forwarded to `ServerArgs` only when set, so the pinned defaults stay in force otherwise. The page size is what hybrid targets on recent SGLang need (`64` worked for Ling-3.0-tiny); the MoE backend is for hosts whose CUDA toolkit cannot build the flashinfer fused-routing kernels.
- `tests/test_runtime/test_sglang_main_compat.py`: both signatures for the two predicates, device fill-in only when missing, single publish / no-op when already published or absent, and an AST check that `capture.py` routes the drifted calls through `compat` and runs the two setup shims before `SGLangRunner`.

## Verified

- Unit tests: `test_sglang_main_compat`, `test_sglang_0518_compat`, `test_sglang_capture_backend` — 14/14 on sglang 0.5.18 and 14/14 on sglang main (`de0fa171`).
- Real `ServerArgs` on both versions (CPU): `resolve_device`, publish twice (True then False), `publish_role() == "scheduler"`, both predicates return.
- Offline capture end to end on sglang main with Ling-3.0-tiny (`--strategy dspark`, `--sglang-page-size 64 --sglang-moe-runner-backend triton --sglang-attention-backend triton`, 16 rows) with **no local edits** — this is the run that previously needed hand-applied shims (#870).
- Offline capture on 0.5.18 could not be exercised on my host: its JIT kernels (`qknorm`, `store_cache`) fail with `CUDA error: invalid resource handle` there regardless of this PR (CUDA-11 system toolkit). The 0.5.18 code path is covered by the unit tests above and by the existing CI unit-test job.
