### PR TITLE
perf(eagle3): reuse tiled compact-teacher logits

### DIFF
--- a/specforge/core/compact_teacher.py
+++ b/specforge/core/compact_teacher.py
@@ -5,9 +5,8 @@
 Reproduces the teacher quantities of
 ``specforge.algorithms.eagle3.model._compute_target_p`` from the target's last hidden
 states and ``lm_head`` weight without materializing the full ``[B, S, vocab_size]``
-fp32 logits: the draft-vocab logits come from a ``t2d``-sliced head, and the
-full-vocab ``logsumexp``/``argmax`` from a streaming reduction over vocabulary
-chunks.
+fp32 logits: the draft-vocab logits are retained while the full-vocab
+``logsumexp``/``argmax`` streams over vocabulary chunks.
 
 Scope: offline training only. The teacher uses the full (unsharded, rank-replicated)
 target ``lm_head`` weight, so the computation is a pure function of
@@ -16,6 +15,7 @@ head; every rank computes identical teacher tensors from identical inputs. Onlin
 compact training is not supported in this release.
 """
 
+from bisect import bisect_left
 from typing import Optional, Tuple
 
 import torch
@@ -54,18 +54,13 @@ def validate_compact_teacher_config(
 
 
 @torch.no_grad()
-def tiled_logsumexp_argmax(
+def _tiled_logsumexp_argmax(
     hidden: torch.Tensor,
     weight: torch.Tensor,
     *,
     chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Full-vocabulary fp32 ``logsumexp`` (``[..., 1]``) and ``argmax`` (``[...]``).
-
-    Streams over vocabulary chunks without allocating ``[..., vocab_size]``. Chunk
-    logits are upcast to fp32 to match ``target.float()``; ties resolve to the lowest
-    index like ``torch.argmax``.
-    """
+    selected_token_ids: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     if chunk_size <= 0:
         raise ValueError(f"chunk_size must be positive, got {chunk_size}.")
 
@@ -81,9 +76,31 @@ def tiled_logsumexp_argmax(
     running_argval = torch.full(lead_shape, neg_inf, dtype=torch.float32, device=device)
     running_argmax = torch.zeros(lead_shape, dtype=torch.long, device=device)
 
+    selected_logits = None
+    selected_ids_host = None
+    selected_start = 0
+    if selected_token_ids is not None:
+        # Copy once so chunk boundaries do not synchronize the device inside the loop.
+        selected_ids_host = selected_token_ids.tolist()
+        selected_logits = torch.empty(
+            (*lead_shape, len(selected_ids_host)), dtype=torch.float32, device=device
+        )
+
     for start in range(0, vocab_size, chunk_size):
         end = min(start + chunk_size, vocab_size)
         chunk_logits = F.linear(hidden, weight[start:end]).float()
+
+        if selected_ids_host is not None:
+            selected_end = bisect_left(selected_ids_host, end, lo=selected_start)
+            if selected_end > selected_start:
+                chunk_indices = selected_token_ids[selected_start:selected_end] - start
+                torch.index_select(
+                    chunk_logits,
+                    -1,
+                    chunk_indices,
+                    out=selected_logits[..., selected_start:selected_end],
+                )
+            selected_start = selected_end
 
         chunk_max = chunk_logits.max(dim=-1, keepdim=True).values
         new_max = torch.maximum(running_max, chunk_max)
@@ -100,7 +117,24 @@ def tiled_logsumexp_argmax(
         running_argval = torch.where(take, chunk_val, running_argval)
 
     log_z = running_max + torch.log(running_sumexp)
-    return log_z, running_argmax
+    return log_z, running_argmax, selected_logits
+
+
+@torch.no_grad()
+def tiled_logsumexp_argmax(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    chunk_size: int = DEFAULT_VOCAB_CHUNK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Full-vocabulary fp32 ``logsumexp`` (``[..., 1]``) and ``argmax`` (``[...]``).
+
+    Streams over vocabulary chunks without allocating ``[..., vocab_size]``. Chunk
+    logits are upcast to fp32 to match ``target.float()``; ties resolve to the lowest
+    index like ``torch.argmax``.
+    """
+    log_z, argmax, _ = _tiled_logsumexp_argmax(hidden, weight, chunk_size=chunk_size)
+    return log_z, argmax
 
 
 @torch.no_grad()
@@ -130,13 +164,15 @@ def compute_target_from_hidden(
             f"{lm_head_weight.shape[1]}."
         )
 
-    # weight[t2d] keeps the same row order as (full_logits)[..., t2d] column slicing.
-    draft_logits = F.linear(hidden, lm_head_weight[t2d]).float()
-    target_p = torch.softmax(draft_logits, dim=-1)
-
-    log_z, target_token_ids = tiled_logsumexp_argmax(
-        hidden, lm_head_weight, chunk_size=chunk_size
+    selected_token_ids = torch.nonzero(t2d, as_tuple=False).flatten()
+    log_z, target_token_ids, draft_logits = _tiled_logsumexp_argmax(
+        hidden,
+        lm_head_weight,
+        chunk_size=chunk_size,
+        selected_token_ids=selected_token_ids,
     )
+    assert draft_logits is not None
+    target_p = torch.softmax(draft_logits, dim=-1)
     target_p_on_draft = torch.exp(draft_logits - log_z)
 
     target_mask = t2d[target_token_ids][..., None].int()

--- a/tests/test_runtime/test_compact_teacher_strategy.py
+++ b/tests/test_runtime/test_compact_teacher_strategy.py
@@ -3,6 +3,7 @@
 
 import types
 import unittest
+from unittest import mock
 
 import torch
 
@@ -161,6 +162,20 @@ class CompactTeacherStrategyTest(unittest.TestCase):
         _assert_teacher_close(
             self, actual, _reference_teacher(full_logits, t2d, loss_mask)
         )
+
+    def test_compact_teacher_projects_each_vocab_row_once(self):
+        hidden, weight, t2d, loss_mask = _numerical_inputs()
+        linear = torch.nn.functional.linear
+
+        with mock.patch(
+            "specforge.core.compact_teacher.F.linear", wraps=linear
+        ) as mock_linear:
+            compute_target_from_hidden(hidden, weight, t2d, loss_mask, chunk_size=7)
+
+        projected_rows = sum(
+            call.args[1].shape[0] for call in mock_linear.call_args_list
+        )
+        self.assertEqual(projected_rows, weight.shape[0])
 
     def test_argmax_tie_across_chunks_uses_lowest_vocab_id(self):
         hidden = torch.ones(1, 1, 4)


### PR DESCRIPTION
## Motivation

The compact teacher currently computes draft-vocabulary logits with a separate
LM-head projection before scanning the full vocabulary for `logsumexp` and
`argmax`. This projects `vocab_size + draft_vocab_size` rows in total. PR #581
identified retaining the draft rows from the tiled scan as a possible follow-up.

This change projects every vocabulary row once while preserving the compact
teacher's public API and memory-bounded full-vocabulary reduction.

## Modifications

- Retain selected draft-vocabulary logits from each full-vocabulary tile and
  assemble them in target-token order.
- Keep the public `tiled_logsumexp_argmax` return contract unchanged.
- Add a regression test that verifies the compact teacher projects exactly
  `vocab_size` LM-head rows.

## Related Issues

Follow-up to #581.

## Accuracy Test

- `python -m unittest tests.test_runtime.test_compact_teacher_strategy`: 13/13
  tests passed locally and on the RTX 5090 target machine.
- A fixed-input BF16 evaluator produced identical target token IDs and position
  masks, with maximum absolute error `0.0` for both `target_p` and
  `target_p_on_draft`.

## Benchmark & Profiling

RTX 5090, PyTorch 2.11.0+cu128, BF16 synthetic tensors with Qwen3-8B dimensions
(`B=1`, `H=4096`, `V=151936`, `D=32000`). Times are medians of 7 synchronized
CUDA-event measurements after 2 warmups.

| Sequence length | Chunk size | Before | After | Speedup | Peak memory change |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 512 | 4,096 | 6.971 ms | 6.539 ms | 1.066x | -33.3 MB |
| 2,048 | 4,096 | 20.885 ms | 18.788 ms | 1.112x | +0.3 MB |
| 512 | 32,768 | 5.465 ms | 4.858 ms | 1.125x | -65.2 MB |
| 2,048 | 32,768 | 21.166 ms | 19.754 ms | 1.071x | -261.8 MB |

The default chunk size is 32,768. This is a teacher-construction microbenchmark;
no benchmark harness is added to the repository.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.io/docs/developer_guide/contribution_guide).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.io/docs/developer_guide/benchmark_and_profiling) and [Accuracy Results](https://docs.sglang.io/docs/developer_guide/evaluating_new_models).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://sgl-fru7574.slack.com/archives/C09784E3EN6 to discuss your PR.
